### PR TITLE
feat: return more detailed errors from validation api (#11)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -36,6 +36,9 @@ make validate-sheet-id SHEET_ID=your-sheet-id
 # Validate all schemas
 make validate-schema
 
+# Generate derived schema models (e.g. Pydantic classes)
+make gen-schema
+
 # Generate data dictionary
 make generate-data-dictionary
 ```

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ help:
 	@echo "  validate-verbose - Validate dataset schema with warnings"
 	@echo "  lint-schema      - Run LinkML linter on all schema files"
 	@echo "  lint-schema-errors - Run LinkML linter (critical errors only)"
-	@echo "  generate-pydantic-models - Generate Pydantic models from all LinkML schemas"
+	@echo "  gen-schema - Generate derived models from LinkML schema"
 	@echo "  generate-data-dictionary - Generate data dictionary JSON from core schema to standard path"
 	@echo "  generate-data-dictionary-file - Generate data dictionary from schema to specified file"
 	@echo "  test-dataset-validation - Run dataset validation tests"
@@ -98,6 +98,13 @@ lint-schema-errors:
 	@echo "Linting schema files (errors only)..."
 	@$(POETRY) linkml lint $(SCHEMA_DIR) --validate --ignore-warnings || (echo "❌ Schema has critical errors" && exit 1)
 	@echo "✓ No critical errors found in schema files"
+
+# Generate derived models from schema
+.PHONY: gen-schema
+gen-schema:
+	@echo "Generating models..."
+	@$(POETRY) gen-pydantic src/hca_validation/schema/core.yaml --meta AUTO > src/hca_validation/schema/generated/core.py
+	@echo "Done"
 
 # Run validator tests
 .PHONY: test-validator

--- a/deployment/docker-build/README.md
+++ b/deployment/docker-build/README.md
@@ -110,7 +110,6 @@ This target:
 ```json
 {
   "sheet_id": "YOUR_GOOGLE_SHEET_ID",
-  "sheet_index": 0
 }
 ```
 

--- a/src/hca_validation/entry_sheet_validator/validate_sheet.py
+++ b/src/hca_validation/entry_sheet_validator/validate_sheet.py
@@ -27,7 +27,7 @@ class ValidationErrorInfo:
 
 @dataclass
 class SheetErrorInfo:
-    entity_type: str
+    entity_type: Optional[str]
     worksheet_id: Optional[int]
     message: str
     row: Optional[int] = None

--- a/src/hca_validation/entry_sheet_validator/validate_sheet.py
+++ b/src/hca_validation/entry_sheet_validator/validate_sheet.py
@@ -45,6 +45,7 @@ class ReadErrorSheetInfo:
 
 @dataclass
 class SheetErrorInfo:
+    """Container for info regarding an error that occurred while reading and validating a Google Sheet."""
     entity_type: Optional[str]
     worksheet_id: Optional[int]
     message: str

--- a/src/hca_validation/entry_sheet_validator/validate_sheet.py
+++ b/src/hca_validation/entry_sheet_validator/validate_sheet.py
@@ -7,6 +7,34 @@ import time
 import os
 import json
 from pathlib import Path
+from typing import Any, Optional
+from dataclasses import dataclass
+
+@dataclass
+class SheetInfo:
+    """Container for Google Sheet data and metadata."""
+    data: Optional[pd.DataFrame] = None
+    spreadsheet_title: Optional[str] = None
+    worksheet_id: Optional[int] = None
+    error_code: Optional[str] = None
+
+@dataclass
+class ValidationErrorInfo:
+    type: str
+    severity: str
+    instance: Optional[Any] = None
+    instantiates: Optional[str] = None
+
+@dataclass
+class SheetErrorInfo:
+    entity_type: str
+    worksheet_id: Optional[int]
+    message: str
+    row: Optional[int] = None
+    column: Optional[str] = None
+    cell: Optional[str] = None
+    primary_key: Optional[str] = None
+    validation: Optional[ValidationErrorInfo] = None
 
 # Import dotenv for loading environment variables
 from dotenv import load_dotenv
@@ -60,7 +88,7 @@ def get_secret_from_extension(secret_name):
         logger.error(f"Error retrieving secret from extension: {e}")
         return None
 
-def read_sheet_with_service_account(sheet_id, sheet_index=0):
+def read_sheet_with_service_account(sheet_id, sheet_index=0) -> SheetInfo:
     """
     Read data from a Google Sheet using a service account for authentication.
     
@@ -69,10 +97,7 @@ def read_sheet_with_service_account(sheet_id, sheet_index=0):
         sheet_index (int, optional): The index of the worksheet to read. Defaults to 0.
         
     Returns:
-        tuple: A tuple containing (DataFrame, sheet_title, error_code).
-            - DataFrame: pandas DataFrame containing the sheet data, or None if there was an error.
-            - sheet_title: The title of the sheet, or None if there was an error.
-            - error_code: An error code string if there was an error, or None if successful.
+        SheetInfo: A dataclass containing the sheet data, title, and any error code.
     """
     import os
     import json
@@ -104,7 +129,7 @@ def read_sheet_with_service_account(sheet_id, sheet_index=0):
     if not service_account_json:
         error_msg = "No service account credentials found in GOOGLE_SERVICE_ACCOUNT environment variable or Secrets Extension"
         logger.error(error_msg)
-        return None, None, 'auth_missing'
+        return SheetInfo(error_code='auth_missing')
     
     # Log the length and first few characters of the credentials to verify they're present
     logger.info(f"Service account credentials found: Length={len(service_account_json)} chars")
@@ -114,13 +139,13 @@ def read_sheet_with_service_account(sheet_id, sheet_index=0):
     if service_account_json.startswith('{{resolve:'):
         logger.error(f"Service account credentials were not resolved from Secrets Manager (CloudFormation syntax): {service_account_json[:50]}...")
         logger.error("Check that the Lambda function has the correct permissions to access the secret and that the secret exists.")
-        return None, None, 'auth_unresolved'
+        return SheetInfo(error_code='auth_unresolved')
     
     # Check for AWS shorthand syntax
     if service_account_json.startswith('aws:secretsmanager:'):
         logger.error(f"Service account credentials were not resolved from Secrets Manager (AWS shorthand syntax): {service_account_json[:50]}...")
         logger.error("Check that the Lambda function has the correct permissions to access the secret and that the secret exists.")
-        return None, None, 'auth_unresolved'
+        return SheetInfo(error_code='auth_unresolved')
     
     try:
         # Parse the service account JSON
@@ -139,7 +164,7 @@ def read_sheet_with_service_account(sheet_id, sheet_index=0):
             error_msg = f"Service account credentials missing required fields: {missing_fields}"
             logger.error(error_msg)
             logger.error(f"Error: {error_msg}. Check that the service account JSON has the correct format and contains all required fields.")
-            return None, None, 'auth_invalid_format'
+            return SheetInfo(error_code='auth_invalid_format')
         
         logger.info(f"Creating credentials object for service account: {credentials_dict.get('client_email')}")
         
@@ -152,7 +177,7 @@ def read_sheet_with_service_account(sheet_id, sheet_index=0):
             logger.info("Successfully created credentials object")
         except Exception as cred_error:
             logger.error(f"Error creating Google credentials object: {cred_error}")
-            return None, None, 'auth_error'
+            return SheetInfo(error_code='auth_error')
         
         # Authenticate with gspread
         logger.info("Authorizing with gspread...")
@@ -161,7 +186,7 @@ def read_sheet_with_service_account(sheet_id, sheet_index=0):
             logger.info("Successfully authorized with gspread")
         except Exception as auth_error:
             logger.error(f"Error authorizing with Google Sheets API: {auth_error}")
-            return None, None, 'auth_error'
+            return SheetInfo(error_code='auth_error')
         
         try:
             # Open the spreadsheet and get the worksheet
@@ -176,6 +201,10 @@ def read_sheet_with_service_account(sheet_id, sheet_index=0):
             logger.info(f"Attempting to get worksheet at index {sheet_index}")
             worksheet = spreadsheet.get_worksheet(sheet_index)
             
+            # Get the worksheet ID
+            worksheet_id = worksheet.id
+            logger.info(f"Successfully retrieved worksheet with ID: {worksheet_id}")
+            
             # Get all values from the worksheet
             logger.info("Retrieving worksheet data...")
             data = worksheet.get_all_values()
@@ -184,36 +213,36 @@ def read_sheet_with_service_account(sheet_id, sheet_index=0):
             if data:
                 logger.info(f"Successfully retrieved data: {len(data)} rows, {len(data[0]) if data[0] else 0} columns")
                 df = pd.DataFrame(data[1:], columns=data[0])  # First row as header
-                return df, sheet_title, None
+                return SheetInfo(data=df, spreadsheet_title=sheet_title, worksheet_id=worksheet_id)
             else:
                 logger.warning(f"Sheet {sheet_id} (index {sheet_index}) appears to be empty")
-                return pd.DataFrame(), sheet_title, None
+                return SheetInfo()
                 
         except gspread.exceptions.SpreadsheetNotFound:
             logger.error(f"Sheet {sheet_id} not found. Check if the sheet ID is correct.")
             logger.error(f"Error accessing Google Sheet with service account: Sheet {sheet_id} not found or not accessible with provided credentials")
-            return None, None, 'sheet_not_found'
+            return SheetInfo(error_code='sheet_not_found')
         except gspread.exceptions.WorksheetNotFound:
             logger.error(f"Worksheet index {sheet_index} not found in sheet {sheet_id}")
             logger.error(f"Error accessing Google Sheet with service account: Worksheet index {sheet_index} not found in sheet {sheet_id}")
-            return None, None, 'worksheet_not_found'
+            return SheetInfo(error_code='worksheet_not_found')
         except gspread.exceptions.APIError as e:
             if "PERMISSION_DENIED" in str(e):
                 logger.error(f"Permission denied accessing sheet {sheet_id}: {e}")
                 logger.error(f"Make sure the service account has access to the sheet.")
-                return None, None, 'permission_denied'
+                return SheetInfo(error_code='permission_denied')
             else:
                 logger.error(f"Google Sheets API error: {e}")
-                return None, None, 'api_error'
+                return SheetInfo(error_code='api_error')
             
     except json.JSONDecodeError as json_error:
         logger.error(f"Invalid JSON format in service account credentials: {json_error}")
-        return None, None, 'auth_invalid'
+        return SheetInfo(error_code='auth_invalid_format')
     except Exception as e:
         logger.error(f"Unexpected error accessing Google Sheet with service account: {e}")
         logger.error(f"Exception type: {type(e).__name__}")
         logger.error(f"Traceback: {traceback.format_exc()}")
-        return None, None, 'api_error'
+        return SheetInfo(error_code='api_error')
 
 def validate_google_sheet(sheet_id="1oPFb6qb0Y2HeoQqjSGRe_TlsZPRLwq-HUlVF0iqtVlY", sheet_index=0, error_handler=None):
     """
@@ -223,7 +252,7 @@ def validate_google_sheet(sheet_id="1oPFb6qb0Y2HeoQqjSGRe_TlsZPRLwq-HUlVF0iqtVlY
     Args:
         sheet_id: The ID of the Google Sheet
         sheet_index: The index of the sheet (0-based)
-        error_handler: Optional callback function that takes (row_index, error) parameters
+        error_handler: Optional callback function that takes a SheetErrorInfo object
                       to handle validation errors externally
                       
     Returns:
@@ -235,22 +264,31 @@ def validate_google_sheet(sheet_id="1oPFb6qb0Y2HeoQqjSGRe_TlsZPRLwq-HUlVF0iqtVlY
     from hca_validation.validator import validate
     import logging
     logger = logging.getLogger()
+
+    # TODO derive entity type properly
+    entity_type = "Dataset"
     
     logger.info(f"Reading sheet: {sheet_id}")
     
     # Read the sheet with service account credentials
-    df, sheet_title, error_code = read_sheet_with_service_account(sheet_id, sheet_index)
+    sheet_info = read_sheet_with_service_account(sheet_id, sheet_index)
+    df = sheet_info.data
     
     if df is None or df.empty:
         error_msg = f"Could not access or read data from sheet {sheet_id}"
-        if error_code:
-            error_msg += f" (Error: {error_code})"
-            logger.error(f"Sheet access failed with error code: {error_code}")
+        if sheet_info.error_code:
+            error_msg += f" (Error: {sheet_info.error_code})"
+            logger.error(f"Sheet access failed with error code: {sheet_info.error_code}")
         
         logger.error(f"{error_msg}")
         if error_handler:
-            error_handler(0, error_msg)
-        return False, sheet_title, error_code
+            error_info = SheetErrorInfo(
+                entity_type=entity_type,
+                worksheet_id=sheet_info.worksheet_id,
+                message=error_msg
+            )
+            error_handler(error_info)
+        return False, sheet_info.spreadsheet_title, sheet_info.error_code
     
     # Skip the first column as it has no slot name
     if len(df.columns) > 1:
@@ -312,7 +350,7 @@ def validate_google_sheet(sheet_id="1oPFb6qb0Y2HeoQqjSGRe_TlsZPRLwq-HUlVF0iqtVlY
     
     if not rows_to_validate:
         logger.warning("No data found to validate starting from row 6.")
-        return False, sheet_title, 'no_data'
+        return False, sheet_info.spreadsheet_title, 'no_data'
     
     logger.info(f"Found {len(rows_to_validate)} rows to validate.")
     
@@ -339,6 +377,9 @@ def validate_google_sheet(sheet_id="1oPFb6qb0Y2HeoQqjSGRe_TlsZPRLwq-HUlVF0iqtVlY
             else:
                 row_dict[key] = value
         
+        # TODO generalize
+        row_primary_key = f"dataset_id:{row_dict['dataset_id']}" if "dataset_id" in row_dict else None
+
         # Validate the data
         logger.info(f"Validating row {row_index}...")
         try:
@@ -352,7 +393,22 @@ def validate_google_sheet(sheet_id="1oPFb6qb0Y2HeoQqjSGRe_TlsZPRLwq-HUlVF0iqtVlY
                     logger.warning(f"  - {error.message}")
                     # Call error handler if provided
                     if error_handler:
-                        error_handler(row_index, error)
+                        error_info = SheetErrorInfo(
+                            entity_type=entity_type,
+                            worksheet_id=sheet_info.worksheet_id,
+                            message=error.message,
+                            row=row_index,
+                            column=None, # TODO is this even possible with the validator api
+                            cell=None, # TODO see above
+                            primary_key=row_primary_key,
+                            validation=ValidationErrorInfo(
+                                type=error.type,
+                                severity=error.severity.value,
+                                instance=error.instance,
+                                instantiates=error.instantiates
+                            )
+                        )
+                        error_handler(error_info)
             else:
                 logger.info(f"Row {row_index} is valid")
         except Exception as e:
@@ -360,18 +416,24 @@ def validate_google_sheet(sheet_id="1oPFb6qb0Y2HeoQqjSGRe_TlsZPRLwq-HUlVF0iqtVlY
             logger.error(f"Error validating row {row_index}: {e}")
             # Call error handler for exceptions if provided
             if error_handler:
-                error = type('ValidationError', (), {'message': str(e), 'field': None, 'value': None})
-                error_handler(row_index, error)
+                error_info = SheetErrorInfo(
+                    entity_type=entity_type,
+                    worksheet_id=sheet_info.worksheet_id,
+                    message=str(e),
+                    row=row_index,
+                    primary_key=row_primary_key
+                )
+                error_handler(error_info)
     
     # Summary
     if all_valid:
         logger.info(f"All {len(rows_to_validate)} rows are valid!")
-        return True, sheet_title, None
+        return True, sheet_info.spreadsheet_title, None
     else:
         logger.warning(f"Validation found errors in some of the {len(rows_to_validate)} rows.")
         logger.warning("Please check the schema requirements and update the data accordingly.")
         logger.info(f"Schema location: {os.path.join(os.path.dirname(__file__), '../../schema/dataset.yaml')}")
-        return False, sheet_title, 'validation_error'
+        return False, sheet_info.spreadsheet_title, 'validation_error'
 
 
 if __name__ == "__main__":

--- a/src/hca_validation/lambda_functions/entry_sheet_validator_lambda/README.md
+++ b/src/hca_validation/lambda_functions/entry_sheet_validator_lambda/README.md
@@ -99,14 +99,12 @@ aws lambda update-function-code \
 The Lambda function accepts the following parameters:
 
 - `sheet_id` (required): The ID of the Google Sheet to validate
-- `sheet_index` (optional, default: 0): The index of the sheet to validate (0-based)
 
 ### Example Event
 
 ```json
 {
-  "sheet_id": "1oPFb6qb0Y2HeoQqjSGRe_TlsZPRLwq-HUlVF0iqtVlY",
-  "sheet_index": 0
+  "sheet_id": "1oPFb6qb0Y2HeoQqjSGRe_TlsZPRLwq-HUlVF0iqtVlY"
 }
 ```
 
@@ -117,7 +115,6 @@ The Lambda function accepts the following parameters:
   "statusCode": 200,
   "body": {
     "sheet_id": "1oPFb6qb0Y2HeoQqjSGRe_TlsZPRLwq-HUlVF0iqtVlY",
-    "sheet_index": 0,
     "valid": false,
     "errors": [
       {

--- a/src/hca_validation/lambda_functions/entry_sheet_validator_lambda/README.md
+++ b/src/hca_validation/lambda_functions/entry_sheet_validator_lambda/README.md
@@ -115,15 +115,38 @@ The Lambda function accepts the following parameters:
   "statusCode": 200,
   "body": {
     "sheet_id": "1oPFb6qb0Y2HeoQqjSGRe_TlsZPRLwq-HUlVF0iqtVlY",
-    "valid": false,
+    "sheet_title": "Test Copy of AgaceHelmsley_HCA_tier 1_metadata",
     "errors": [
       {
-        "row": 4,
-        "message": "Validation error: Missing required field 'title'",
-        "field": "title",
-        "value": null
+        "entity_type": "dataset",
+        "worksheet_id": 1895379728,
+        "message": "Input should be a valid list",
+        "row": 7,
+        "column": "batch_condition",
+        "cell": "F8",
+        "primary_key": "dataset_id:AgaceHelmsley3",
+        "input": "donor_id"
       }
-    ]
+    ],
+    "valid": false,
+    "error_code": "validation_error",
+    "memory_usage": {
+      "initial": {
+        "memory_used_mb": 80.5,
+        "memory_limit_mb": 0,
+        "memory_utilization_percent": null
+      },
+      "pre_validation": {
+        "memory_used_mb": 80.53,
+        "memory_limit_mb": 0,
+        "memory_utilization_percent": null
+      },
+      "post_validation": {
+        "memory_used_mb": 87.62,
+        "memory_limit_mb": 0,
+        "memory_utilization_percent": null
+      }
+    }
   }
 }
 ```

--- a/src/hca_validation/lambda_functions/entry_sheet_validator_lambda/handler.py
+++ b/src/hca_validation/lambda_functions/entry_sheet_validator_lambda/handler.py
@@ -24,13 +24,12 @@ logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 
-def extract_validation_errors(sheet_id: str, sheet_index: int = 0) -> Tuple[List[SheetErrorInfo], str, str, int]:
+def extract_validation_errors(sheet_id: str) -> Tuple[List[SheetErrorInfo], str, str, int]:
     """
     Extract validation errors from a Google Sheet.
     
     Args:
         sheet_id: The ID of the Google Sheet
-        sheet_index: The index of the sheet (0-based)
         
     Returns:
         Tuple containing (list of validation error objects, sheet title, error_code, http_status_code)
@@ -55,7 +54,7 @@ def extract_validation_errors(sheet_id: str, sheet_index: int = 0) -> Tuple[List
         
         # Call the existing validate_google_sheet function with our error handler
         # The function now returns a tuple of (validation_success, sheet_title, error_code)
-        validation_result, sheet_title, error_code = validate_google_sheet(sheet_id, sheet_index, error_handler=validation_handler)
+        validation_result, sheet_title, error_code = validate_google_sheet(sheet_id, error_handler=validation_handler)
         
         # Restore stdout
         sys.stdout = original_stdout
@@ -123,7 +122,6 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                     body = event['body']
                     
                 sheet_id = body.get('sheet_id')
-                sheet_index = body.get('sheet_index', 0)
             except Exception as e:
                 logger.error(f"Error parsing request body: {str(e)}")
                 return {
@@ -139,7 +137,6 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         else:
             # Direct Lambda invocation
             sheet_id = event.get('sheet_id')
-            sheet_index = event.get('sheet_index', 0)
         
         if not sheet_id:
             return {
@@ -158,7 +155,7 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         logger.info(f"Memory usage before validation: {pre_validation_memory}")
         
         # Extract validation errors using the entry sheet validator
-        validation_errors, sheet_title, error_code, http_status_code = extract_validation_errors(sheet_id, sheet_index)
+        validation_errors, sheet_title, error_code, http_status_code = extract_validation_errors(sheet_id)
         
         # Log memory usage after validation
         post_validation_memory = get_memory_usage()

--- a/src/hca_validation/lambda_functions/entry_sheet_validator_lambda/test_lambda.py
+++ b/src/hca_validation/lambda_functions/entry_sheet_validator_lambda/test_lambda.py
@@ -60,11 +60,10 @@ def main():
     
     # Create a test event
     test_event = {
-        'sheet_id': args.sheet_id,
-        'sheet_index': args.sheet_index
+        'sheet_id': args.sheet_id
     }
     
-    print(f"Testing Lambda function with sheet ID: {args.sheet_id}, index: {args.sheet_index}")
+    print(f"Testing Lambda function with sheet ID: {args.sheet_id}")
     
     # Call the Lambda function
     result = handler(test_event, None)

--- a/src/hca_validation/schema/generated/__init__.py
+++ b/src/hca_validation/schema/generated/__init__.py
@@ -1,0 +1,3 @@
+"""
+Generated models derived from HCA schema.
+"""

--- a/src/hca_validation/schema/generated/core.py
+++ b/src/hca_validation/schema/generated/core.py
@@ -1,0 +1,277 @@
+from __future__ import annotations 
+
+import re
+import sys
+from datetime import (
+    date,
+    datetime,
+    time
+)
+from decimal import Decimal 
+from enum import Enum 
+from typing import (
+    Any,
+    ClassVar,
+    Literal,
+    Optional,
+    Union
+)
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    RootModel,
+    field_validator
+)
+
+
+metamodel_version = "None"
+version = "0.1.0"
+
+
+class ConfiguredBaseModel(BaseModel):
+    model_config = ConfigDict(
+        validate_assignment = True,
+        validate_default = True,
+        extra = "forbid",
+        arbitrary_types_allowed = True,
+        use_enum_values = True,
+        strict = False,
+    )
+    pass
+
+
+
+
+class LinkMLMeta(RootModel):
+    root: dict[str, Any] = {}
+    model_config = ConfigDict(frozen=True)
+
+    def __getattr__(self, key:str):
+        return getattr(self.root, key)
+
+    def __getitem__(self, key:str):
+        return self.root[key]
+
+    def __setitem__(self, key:str, value):
+        self.root[key] = value
+
+    def __contains__(self, key:str) -> bool:
+        return key in self.root
+
+
+linkml_meta = LinkMLMeta({'default_prefix': 'hca',
+     'default_range': 'string',
+     'description': 'Core schema for validating Human Cell Atlas (HCA) data',
+     'id': 'https://github.com/clevercanary/hca-validation-tools/schema/core',
+     'imports': ['linkml:types', 'dataset', 'donor', 'sample', 'cell'],
+     'license': 'MIT',
+     'name': 'hca-validation-core',
+     'prefixes': {'hca': {'prefix_prefix': 'hca',
+                          'prefix_reference': 'https://github.com/clevercanary/hca-validation-tools/schema/'},
+                  'linkml': {'prefix_prefix': 'linkml',
+                             'prefix_reference': 'https://w3id.org/linkml/'}},
+     'source_file': 'src/hca_validation/schema/core.yaml',
+     'title': 'HCA Validation Core Schema'} )
+
+class ReferenceGenomeEnum(str, Enum):
+    GRCh38 = "GRCh38"
+    """
+    Human reference genome version 38
+    """
+    GRCh37 = "GRCh37"
+    """
+    Human reference genome version 37
+    """
+    GRCm39 = "GRCm39"
+    """
+    Mouse reference genome version 39
+    """
+    GRCm38 = "GRCm38"
+    """
+    Mouse reference genome version 38
+    """
+    GRCm37 = "GRCm37"
+    """
+    Mouse reference genome version 37
+    """
+    not_applicable = "not applicable"
+    """
+    No reference genome was used
+    """
+
+
+class IntronInclusionEnum(str, Enum):
+    yes = "yes"
+    """
+    Introns were included
+    """
+    no = "no"
+    """
+    Introns were not included
+    """
+
+
+class SequencedFragmentEnum(str, Enum):
+    number_3_prime_tag = "3 prime tag"
+    """
+    3' end of the transcript
+    """
+    number_5_prime_tag = "5 prime tag"
+    """
+    5' end of the transcript
+    """
+    probe_based = "probe-based"
+    """
+    Probe-based sequencing
+    """
+    full_length = "full length"
+    """
+    Entire transcript
+    """
+    not_applicable = "not applicable"
+    """
+    Not applicable to this dataset
+    """
+
+
+
+class Dataset(ConfiguredBaseModel):
+    """
+    A collection of data from a single experiment or study in the Human Cell Atlas
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/dataset'})
+
+    study_pi: list[str] = Field(default=..., title="Study Pi", description="""Principal Investigator(s) leading the study where the data is/was used.""", json_schema_extra = { "linkml_meta": {'alias': 'study_pi',
+         'domain_of': ['Dataset'],
+         'examples': [{'description': 'Principal Investigator in Last '
+                                      'Name,MiddleInitial, FirstName format',
+                       'value': '["Teichmann,Sarah,A."]'}]} })
+    batch_condition: Optional[list[str]] = Field(default=None, title="Batch Condition", description="""Name of the covariate that confers the dominant batch effect in the data as judged by the data contributor.  The name provided here should be the label by which this covariate is stored in the AnnData object.""", json_schema_extra = { "linkml_meta": {'alias': 'batch_condition',
+         'annotations': {'cxg': {'tag': 'cxg', 'value': 'batch_condition'}},
+         'domain_of': ['Dataset'],
+         'examples': [{'description': 'Multiple batch conditions as a JSON array',
+                       'value': '["patient", "seqBatch"]'}],
+         'notes': ['Values must refer to cell metadata keys in obs. Together, these '
+                   'keys define the batches that a normalisation or integration '
+                   'algorithm should be aware of. For example if "patient" and '
+                   '"seqBatch" are keys of vectors of cell metadata, either '
+                   '["patient"], ["seqBatch"], or ["patient", "seqBatch"] are valid '
+                   'values.']} })
+    default_embedding: Optional[str] = Field(default=None, title="Default Embedding", description="""The value must match a key to an embedding in obsm for the embedding to display by default in CELLxGENE Explorer.""", json_schema_extra = { "linkml_meta": {'alias': 'default_embedding',
+         'annotations': {'cxg': {'tag': 'cxg', 'value': 'default_embedding'}},
+         'domain_of': ['Dataset']} })
+    sequencing_platform: Optional[str] = Field(default=None, title="Sequencing Platform", description="""Platform used for sequencing.""", json_schema_extra = { "linkml_meta": {'alias': 'sequencing_platform',
+         'comments': ['This captures potential strand hopping which may cause data '
+                      'quality issues.'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'EFO:0008563'}],
+         'notes': ['Values should be "subClassOf" ["EFO:0002699"] - '
+                   'https://www.ebi.ac.uk/ols/ontologies/efo/terms?iri=http%3A%2F%2Fwww.ebi.ac.uk%2Fefo%2FEFO_0002699']} })
+    assay_ontology_term_id: str = Field(default=..., title="Assay Ontology Term Id", description="""Platform used for single cell library construction.""", json_schema_extra = { "linkml_meta": {'alias': 'assay_ontology_term_id',
+         'annotations': {'cxg': {'tag': 'cxg', 'value': 'assay_ontology_term_id'}},
+         'comments': ['Major source of batch effect and dataset filtering criterion'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'EFO:0009922'}],
+         'notes': ['This must be an EFO term and either:\n'
+                   '- "EFO:0002772" for assay by molecule or preferably its most '
+                   'accurate child\n'
+                   '- "EFO:0010183" for single cell library construction or preferably '
+                   'its most accurate child\n'
+                   '- An assay based on 10X Genomics products should either be '
+                   '"EFO:0008995" for 10x technology or preferably its most accurate '
+                   'child. \n'
+                   "- An assay based on SMART (Switching Mechanism at the 5' end of "
+                   'the RNA Template) or SMARTer technology SHOULD either be '
+                   '"EFO:0010184" for Smart-like or preferably its most accurate '
+                   'child.\n'
+                   'Recommended:\n'
+                   '- 10x 3\' v2 "EFO:0009899"\n'
+                   '- 10x 3\' v3 "EFO:0009922"\n'
+                   '- 10x 5\' v1 "EFO:0011025"\n'
+                   '- 10x 5\' v2 "EFO:0009900"\n'
+                   '- Smart-seq2 "EFO:0008931"\n'
+                   '- Visium Spatial Gene Expression "EFO:0010961"\n']} })
+    reference_genome: ReferenceGenomeEnum = Field(default=..., title="Reference Genome", description="""Reference genome used for alignment.""", json_schema_extra = { "linkml_meta": {'alias': 'reference_genome',
+         'comments': ['Possible source of batch effect and confounder for some '
+                      'biological analysis'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'GRCm37'}, {'value': 'GRCh37'}]} })
+    alignment_software: str = Field(default=..., title="Alignment Software", description="""Protocol used for alignment analysis, please specify which version was used e.g. cell ranger 2.0, 2.1.1 etc.""", json_schema_extra = { "linkml_meta": {'alias': 'alignment_software',
+         'comments': ['Affects which cells are filtered per dataset, and which reads '
+                      '(introns and exons or only exons) are counted as part of the '
+                      'reported transcriptome. This can convey batch effects.'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'cellranger_8.0.0'}]} })
+    intron_inclusion: Optional[IntronInclusionEnum] = Field(default=None, title="Intron Inclusion", description="""Were introns included during read counting in the alignment process?""", json_schema_extra = { "linkml_meta": {'alias': 'intron_inclusion',
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'yes'}]} })
+    sequenced_fragment: SequencedFragmentEnum = Field(default=..., title="Sequenced Fragment", description="""Which part of the RNA transcript was targeted for sequencing.""", json_schema_extra = { "linkml_meta": {'alias': 'sequenced_fragment',
+         'comments': ['May be a source of batch effect that has to be tested.'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': '3 prime tag'}, {'value': 'full length'}]} })
+    gene_annotation_version: str = Field(default=..., title="Gene Annotation Version", description="""Ensembl release version accession number. Some common codes include: GRCh38.p12 = GCF_000001405.38 GRCh38.p13 = GCF_000001405.39 GRCh38.p14 = GCF_000001405.40
+""", json_schema_extra = { "linkml_meta": {'alias': 'gene_annotation_version',
+         'comments': ['Possible source of batch effect and confounder for some '
+                      'biological analysis'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'GCF_000001405.40'}],
+         'notes': ['http://www.ensembl.org/info/website/archives/index.html or '
+                   'NCBI/RefSeq']} })
+    comments: Optional[str] = Field(default=None, title="Comments", description="""Other technical or experimental covariates that could affect the quality or batch of the sample.  Must not contain identifiers. This field is designed to capture potential challenges for data integration not captured elsewhere.
+""", json_schema_extra = { "linkml_meta": {'alias': 'comments', 'domain_of': ['Dataset']} })
+    protocol_url: Optional[str] = Field(default=None, title="Protocol URL", description="""The protocols.io URL (if none exists, please use the BioRxiv URL) for the full experimental protocol;  or if multiple protocols exist please list them e.g. sample preparation protocol / sequencing protocol.
+""", json_schema_extra = { "linkml_meta": {'alias': 'protocol_url',
+         'comments': ['Useful to look up protocol data that can provide insight on '
+                      'batch effects. As protocols can sometimes apply to a subset of '
+                      'the study, we capture this at a sample level. This information '
+                      'may not always be available.'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'https://www.biorxiv.org/content/early/2017/09/24/193219'}]} })
+    title: str = Field(default=..., title="Title", description="""This text describes and differentiates the dataset from other datasets in the same collection.  It is strongly recommended that each dataset title in a collection is unique and does not depend on other metadata  such as a different assay to disambiguate it from other datasets in the collection.
+""", json_schema_extra = { "linkml_meta": {'alias': 'title',
+         'annotations': {'cxg': {'tag': 'cxg', 'value': 'title'}},
+         'comments': ['Useful to look up protocol data that can provide insight on '
+                      'batch effects. As protocols can sometimes apply to a subset of '
+                      'the study, we capture this at a sample level. This information '
+                      'may not always be available.'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': "Cells of the adult human heart collection is 'All — "
+                                "Cells of the adult human heart'"}]} })
+
+
+class Donor(ConfiguredBaseModel):
+    """
+    An individual organism from which biological samples have been derived
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/donor'})
+
+    pass
+
+
+class Sample(ConfiguredBaseModel):
+    """
+    A biological sample derived from a donor or another sample
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/sample'})
+
+    pass
+
+
+class Cell(ConfiguredBaseModel):
+    """
+    A single cell derived from a sample
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/cell'})
+
+    pass
+
+
+# Model rebuild
+# see https://pydantic-docs.helpmanual.io/usage/models/#rebuilding-a-model
+Dataset.model_rebuild()
+Donor.model_rebuild()
+Sample.model_rebuild()
+Cell.model_rebuild()
+

--- a/src/hca_validation/validator/__init__.py
+++ b/src/hca_validation/validator/__init__.py
@@ -4,4 +4,4 @@ HCA Validation Tools - Validator Module
 This module provides reusable validation components for HCA data validation.
 """
 
-from .validator import validate, clear_cache
+from .validator import validate

--- a/src/hca_validation/validator/validator.py
+++ b/src/hca_validation/validator/validator.py
@@ -4,7 +4,7 @@ HCA Validation Tools - Main Validator Module
 This module provides the main validation functionality for HCA data using Pydantic models.
 """
 from typing import Dict, Any, Optional
-from pydantic_core import ValidationError
+from pydantic import ValidationError
 
 from hca_validation.schema.generated.core import Dataset, Donor, Sample, Cell
 

--- a/src/hca_validation/validator/validator.py
+++ b/src/hca_validation/validator/validator.py
@@ -1,71 +1,46 @@
 """
 HCA Validation Tools - Main Validator Module
 
-This module provides the main validation functionality for HCA data.
+This module provides the main validation functionality for HCA data using Pydantic models.
 """
-from typing import Dict, Any, Optional, Union, TextIO, BinaryIO, IO
-import os
+from typing import Dict, Any, Optional
+from pydantic_core import ValidationError
 
-from linkml.validator import Validator
-from linkml.validator.plugins import PydanticValidationPlugin
-
-
-# Module-level cache for validators
-_validators = {}
+from hca_validation.schema.generated.core import Dataset, Donor, Sample, Cell
 
 
-def _create_validator(schema_type: str):
+def validate(data: Dict[str, Any], schema_type: str = "dataset") -> Optional[ValidationError]:
     """
-    Create a validator for the specified schema type.
-    
-    Args:
-        schema_type: Type of schema to validate against ('dataset', 'donor', 'sample', 'cell')
-        
-    Returns:
-        A LinkML validator configured with the appropriate Pydantic plugin
-    """
-    # Validate schema type
-    supported_types = ['dataset', 'donor', 'sample', 'cell']
-    if schema_type not in supported_types:
-        raise ValueError(f"Unsupported schema type: {schema_type}. "
-                         f"Supported types are: {', '.join(supported_types)}")
-    
-    # Get the schema path
-    module_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    schema_path = os.path.join(module_dir, 'schema', f"{schema_type}.yaml")
-    
-    # Create and return the validator
-    return Validator(
-        schema=schema_path,
-        validation_plugins=[PydanticValidationPlugin(closed=False)]
-    )
-
-
-def validate(data: Dict[str, Any], schema_type: str = "dataset") -> Any:
-    """
-    Validate HCA data against a schema.
+    Validate HCA data against a schema using Pydantic models.
     
     Args:
         data: The data to validate as a dictionary
         schema_type: Type of schema to validate against ('dataset', 'donor', 'sample', 'cell')
         
     Returns:
-        The validation report from LinkML
+        Returns a Pydantic ValidationError if validation fails, or None if validation succeeds
+        
+    Raises:
+        ValueError: If an unsupported schema type is provided
     """
-    # Get or create validator
-    if schema_type not in _validators:
-        _validators[schema_type] = _create_validator(schema_type)
+    # Map schema types to their corresponding Pydantic models
+    schema_models = {
+        'dataset': Dataset,
+        'donor': Donor,
+        'sample': Sample,
+        'cell': Cell
+    }
     
-    # Use validator
-    validator = _validators[schema_type]
-    return validator.validate(data, target_class=schema_type.capitalize())
-
-
-def clear_cache():
-    """
-    Clear the validator cache.
+    # Validate schema type
+    if schema_type not in schema_models:
+        raise ValueError(f"Unsupported schema type: {schema_type}. "
+                       f"Supported types are: {', '.join(schema_models.keys())}")
     
-    This can be useful in testing or when you want to force recreation of validators.
-    """
-    global _validators
-    _validators = {}
+    try:
+        # Validate using the appropriate Pydantic model
+        model = schema_models[schema_type]
+        model.model_validate(data)
+        return None
+    except ValidationError as e:
+        # Return validation error
+        return e

--- a/src/hca_validation/validator/validator.py
+++ b/src/hca_validation/validator/validator.py
@@ -9,7 +9,7 @@ from pydantic_core import ValidationError
 from hca_validation.schema.generated.core import Dataset, Donor, Sample, Cell
 
 
-def validate(data: Dict[str, Any], schema_type: str = "dataset") -> Optional[ValidationError]:
+def validate(data: Dict[str, Any], schema_type: str) -> Optional[ValidationError]:
     """
     Validate HCA data against a schema using Pydantic models.
     

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pytest
 
-from hca_validation.validator import validate, clear_cache
+from hca_validation.validator import validate
 
 # Get the path to the test data directory
 TEST_DIR = Path(__file__).parent / "data"
@@ -34,48 +34,24 @@ def invalid_dataset():
 def test_validate_valid_dataset(valid_dataset):
     """Test validation of a valid dataset."""
     # Validate the dataset
-    report = validate(valid_dataset, schema_type="dataset")
+    validation_error = validate(valid_dataset, schema_type="dataset")
 
     # Assert that validation passed
-    assert not report.results, "Valid dataset should have no validation errors"
+    assert not validation_error, "Valid dataset should have no validation errors"
 
 
 def test_validate_invalid_dataset(invalid_dataset):
     """Test validation of an invalid dataset."""
     # Validate the dataset
-    report = validate(invalid_dataset, schema_type="dataset")
+    validation_error = validate(invalid_dataset, schema_type="dataset")
 
     # Assert that validation failed
-    assert report.results, "Invalid dataset should have validation errors"
+    assert validation_error, "Invalid dataset should have validation errors"
 
     # Assert specific errors are present
-    error_messages = [result.message for result in report.results]
-    error_text = '\n'.join(error_messages)
+    error_fields = {e["loc"][0] for e in validation_error.errors()}
 
     # Check for specific validation errors
-    assert "reference_genome" in error_text, "Should have an error for reference_genome"
-    assert "sequenced_fragment" in error_text, "Should have an error for sequenced_fragment"
+    assert "reference_genome" in error_fields, "Should have an error for reference_genome"
+    assert "sequenced_fragment" in error_fields, "Should have an error for sequenced_fragment"
 
-
-def test_validator_caching(valid_dataset):
-    """Test that the validator is cached properly."""
-    # Clear the cache to start fresh
-    clear_cache()
-    
-    # First validation call should create a new validator
-    report1 = validate(valid_dataset, schema_type="dataset")
-    assert not report1.results, "First validation should pass"
-    
-    # Second validation call should use the cached validator
-    report2 = validate(valid_dataset, schema_type="dataset")
-    assert not report2.results, "Second validation should pass"
-    
-    # Clear the cache
-    clear_cache()
-    
-    # Third validation call should create a new validator again
-    report3 = validate(valid_dataset, schema_type="dataset")
-    assert not report3.results, "Third validation should pass"
-    
-    # We can't directly test that caching works from the outside,
-    # but we can verify that clearing the cache and revalidating still works


### PR DESCRIPTION
Closes #11

Example error from response:
```
{
  "entity_type": "dataset",
  "worksheet_id": 1895379728,
  "message": "Input should be a valid list",
  "row": 7,
  "column": "batch_condition",
  "cell": "F8",
  "primary_key": "dataset_id:AgaceHelmsley3",
  "input": "donor_id"
}
```

Misc notes:
- Switched to using pre-generated Pydantic models rather than the Validator API
- Removed the `sheet_index` parameter from the Lambda function (because it didn't make sense with the generalized way in which I set up stuff related to entity type) -- the impression I get is that we'll be validating all the entity types during a single API call so presumably it doesn't make sense to have sheet index as a parameter?

Notes on validation output:
- Since the Validator is no longer involved, the "validation" field listed in the ticket is not included
- Fields may be null depending on available information (e.g. whether the error is associated with a specific cell, or whether the primary key is present)
- I've kept the existing behavior for determining the value for `row`, which means it's calculated as a 1-based index _excluding the header row_, and so doesn't match up with the A1 notation used for `cell`
- I haven't changed the settings for how required/extra fields are handled, which means that a missing column will be accepted as long as it's an optional field, and columns not in the schema will be reported as errors
- I've added an `input` field derived from the corresponding Pydantic error field, which contains the input value from the cell if applicable, or the data for the entire row if the column is missing