### PR TITLE
feat: add very basic validation for donors and samples (#12)

### DIFF
--- a/src/hca_validation/entry_sheet_validator/validate_sheet.py
+++ b/src/hca_validation/entry_sheet_validator/validate_sheet.py
@@ -135,7 +135,6 @@ def read_worksheet(sheet_id, sheet_title, spreadsheet, sheet_index) -> Union[She
             return ReadErrorSheetInfo(error_code="sheet_data_empty", spreadsheet_title=sheet_title, worksheet_id=worksheet_id)
         
     except gspread.exceptions.WorksheetNotFound:
-        logger.error(f"Worksheet index {sheet_index} not found in sheet {sheet_id}")
         logger.error(f"Error accessing Google Sheet with service account: Worksheet index {sheet_index} not found in sheet {sheet_id}")
         return ReadErrorSheetInfo(error_code='worksheet_not_found')
 

--- a/src/hca_validation/entry_sheet_validator/validate_sheet.py
+++ b/src/hca_validation/entry_sheet_validator/validate_sheet.py
@@ -365,7 +365,7 @@ def validate_google_sheet(sheet_id="1oPFb6qb0Y2HeoQqjSGRe_TlsZPRLwq-HUlVF0iqtVlY
                 logger.debug(f"Row {i+1} (index {i}): {first_col}")
         
         # Process from row 6 until the first empty row
-        start_row_index = 4  # Row 6 (1-based including header) is index 5 (0-based excluding header)
+        start_row_index = 4  # Row 6 (1-based including header) is index 4 (0-based excluding header)
         current_row_index = start_row_index
         
         logger.info(f"Processing {entity_type} data rows starting from row 6 (index {start_row_index})...")

--- a/src/hca_validation/entry_sheet_validator/validate_sheet.py
+++ b/src/hca_validation/entry_sheet_validator/validate_sheet.py
@@ -355,22 +355,8 @@ def validate_google_sheet(sheet_id="1oPFb6qb0Y2HeoQqjSGRe_TlsZPRLwq-HUlVF0iqtVlY
                 first_col = df.iloc[i, 0] if not pd.isna(df.iloc[i, 0]) else "<empty>"
                 logger.debug(f"Row {i+1} (index {i}): {first_col}")
         
-        # Process rows 4, 5, and then from row 6 until the first empty row
-        # We'll include rows 4 and 5 as you mentioned they also contain data
-        data_row_indices = [3, 4]  # Rows 4 and 5 (0-based indices 3 and 4)
-        
-        # First add rows 4 and 5
-        for idx in data_row_indices:
-            if idx < len(df):
-                row = df.iloc[idx]
-                # Skip completely empty rows
-                if not row.isna().all() and not all(str(val).strip() == '' for val in row if not pd.isna(val)):
-                    logger.debug(f"Adding row {idx + 1} for validation")
-                    rows_to_validate.append(row)
-                    row_indices.append(idx)
-        
-        # Then process from row 6 until the first empty row
-        start_row_index = 5  # Row 6 (1-based) is index 5 (0-based)
+        # Process from row 6 until the first empty row
+        start_row_index = 4  # Row 6 (1-based including header) is index 5 (0-based excluding header)
         current_row_index = start_row_index
         
         logger.info(f"Processing data rows starting from row 6 (index {start_row_index})...")

--- a/src/hca_validation/entry_sheet_validator/validate_sheet.py
+++ b/src/hca_validation/entry_sheet_validator/validate_sheet.py
@@ -281,7 +281,7 @@ def read_sheet_with_service_account(sheet_id, sheet_indices=[0]) -> Union[List[S
         logger.error(f"Traceback: {traceback.format_exc()}")
         return ReadErrorSheetInfo(error_code='api_error')
 
-def validate_google_sheet(sheet_id="1oPFb6qb0Y2HeoQqjSGRe_TlsZPRLwq-HUlVF0iqtVlY", entity_types=["dataset"], error_handler=None):
+def validate_google_sheet(sheet_id="1oPFb6qb0Y2HeoQqjSGRe_TlsZPRLwq-HUlVF0iqtVlY", entity_types=["dataset", "donor", "sample"], error_handler=None):
     """
     Validate data from a Google Sheet starting at row 6 until the first empty row.
     Uses service account credentials from environment variables to access the sheet.
@@ -306,6 +306,14 @@ def validate_google_sheet(sheet_id="1oPFb6qb0Y2HeoQqjSGRe_TlsZPRLwq-HUlVF0iqtVlY
         "dataset": {
             "sheet_index": 0,
             "primary_key_field": "dataset_id"
+        },
+        "donor": {
+            "sheet_index": 1,
+            "primary_key_field": "donor_id"
+        },
+        "sample": {
+            "sheet_index": 2,
+            "primary_key_field": "sample_id"
         }
     }
 
@@ -337,8 +345,8 @@ def validate_google_sheet(sheet_id="1oPFb6qb0Y2HeoQqjSGRe_TlsZPRLwq-HUlVF0iqtVlY
     for entity_type, sheet_info in zip(entity_types, sheet_read_result):
         df = sheet_info.data
 
-        # Skip the first column as it has no slot name
-        if len(df.columns) > 1:
+        # Skip the first column if it has no slot name
+        if len(df.columns) > 1 and df.columns[0].strip() == "":
             df = df.iloc[:, 1:]
         
         # Print information about the sheet structure

--- a/src/hca_validation/schema/donor.yaml
+++ b/src/hca_validation/schema/donor.yaml
@@ -19,3 +19,17 @@ classes:
   Donor:
     description: >-
       An individual organism from which biological samples have been derived
+    slots:
+      - donor_id
+      - dataset_id
+
+slots:
+  donor_id:
+    title: Donor ID
+    range: string
+    required: true
+  dataset_id:
+    title: Dataset ID
+    range: string
+    required: true
+

--- a/src/hca_validation/schema/generated/core.py
+++ b/src/hca_validation/schema/generated/core.py
@@ -247,7 +247,8 @@ class Donor(ConfiguredBaseModel):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/donor'})
 
-    pass
+    donor_id: str = Field(default=..., title="Donor ID", json_schema_extra = { "linkml_meta": {'alias': 'donor_id', 'domain_of': ['Donor', 'Sample']} })
+    dataset_id: str = Field(default=..., title="Dataset ID", json_schema_extra = { "linkml_meta": {'alias': 'dataset_id', 'domain_of': ['Donor', 'Sample']} })
 
 
 class Sample(ConfiguredBaseModel):
@@ -256,7 +257,9 @@ class Sample(ConfiguredBaseModel):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/sample'})
 
-    pass
+    sample_id: str = Field(default=..., title="Sample ID", json_schema_extra = { "linkml_meta": {'alias': 'sample_id', 'domain_of': ['Sample']} })
+    donor_id: str = Field(default=..., title="Donor ID", json_schema_extra = { "linkml_meta": {'alias': 'donor_id', 'domain_of': ['Donor', 'Sample']} })
+    dataset_id: str = Field(default=..., title="Dataset ID", json_schema_extra = { "linkml_meta": {'alias': 'dataset_id', 'domain_of': ['Donor', 'Sample']} })
 
 
 class Cell(ConfiguredBaseModel):

--- a/src/hca_validation/schema/sample.yaml
+++ b/src/hca_validation/schema/sample.yaml
@@ -19,3 +19,21 @@ classes:
   Sample:
     description: >-
       A biological sample derived from a donor or another sample
+    slots:
+      - sample_id
+      - donor_id
+      - dataset_id
+
+slots:
+  sample_id:
+    title: Sample ID
+    range: string
+    required: true
+  donor_id:
+    title: Donor ID
+    range: string
+    required: true
+  dataset_id:
+    title: Dataset ID
+    range: string
+    required: true

--- a/tests/test_entry_sheet_validator.py
+++ b/tests/test_entry_sheet_validator.py
@@ -244,7 +244,7 @@ class TestValidateGoogleSheet:
         result, title, error_code = validate_google_sheet(PUBLIC_SHEET_ID, error_handler=mock_error_handler)
 
         # Verify service account method was used
-        mock_read_service_account.assert_called_once_with(PUBLIC_SHEET_ID, [0])
+        mock_read_service_account.assert_called_once_with(PUBLIC_SHEET_ID, [0, 1, 2])
         
         # Verify title is returned
         assert title == "Test Sheet Title"
@@ -267,7 +267,7 @@ class TestValidateGoogleSheet:
         result, title, error_code = validate_google_sheet(PUBLIC_SHEET_ID, error_handler=mock_error_handler)
 
         # Verify service account method was used
-        mock_read_service_account.assert_called_once_with(PUBLIC_SHEET_ID, [0])
+        mock_read_service_account.assert_called_once_with(PUBLIC_SHEET_ID, [0, 1, 2])
         
         # Verify that an error was reported via the error handler
         assert len(errors) > 0

--- a/tests/test_entry_sheet_validator.py
+++ b/tests/test_entry_sheet_validator.py
@@ -85,8 +85,9 @@ class TestReadSheetWithServiceAccount:
         mock_sheet.title = "Test Sheet Title"
         
         # Test the function
-        sheet_info = read_sheet_with_service_account(PUBLIC_SHEET_ID)
-        assert isinstance(sheet_info, SheetInfo)
+        sheet_read_result = read_sheet_with_service_account(PUBLIC_SHEET_ID)
+        assert isinstance(sheet_read_result, list)
+        sheet_info = sheet_read_result[0]
         assert sheet_info.data is not None
         assert isinstance(sheet_info.data, pd.DataFrame)
         assert not sheet_info.data.empty
@@ -109,11 +110,11 @@ class TestReadSheetWithServiceAccount:
             del os.environ['GOOGLE_SERVICE_ACCOUNT']
 
         # The function should return read error containing only 'auth_missing' code when no credentials are available
-        sheet_info = read_sheet_with_service_account(PUBLIC_SHEET_ID)
-        assert isinstance(sheet_info, ReadErrorSheetInfo)
-        assert sheet_info.error_code == 'auth_missing'
-        assert sheet_info.spreadsheet_title is None
-        assert sheet_info.worksheet_id is None
+        sheet_read_result = read_sheet_with_service_account(PUBLIC_SHEET_ID)
+        assert isinstance(sheet_read_result, ReadErrorSheetInfo)
+        assert sheet_read_result.error_code == 'auth_missing'
+        assert sheet_read_result.spreadsheet_title is None
+        assert sheet_read_result.worksheet_id is None
         
     def test_with_unresolved_credentials(self):
         """Test reading a sheet with unresolved credentials from Secrets Manager."""
@@ -123,11 +124,11 @@ class TestReadSheetWithServiceAccount:
         
         try:
             # The function should return read error containing only 'auth_unresolved' code when credentials weren't resolved
-            sheet_info = read_sheet_with_service_account(PUBLIC_SHEET_ID)
-            assert isinstance(sheet_info, ReadErrorSheetInfo)
-            assert sheet_info.error_code == 'auth_unresolved'
-            assert sheet_info.spreadsheet_title is None
-            assert sheet_info.worksheet_id is None
+            sheet_read_result = read_sheet_with_service_account(PUBLIC_SHEET_ID)
+            assert isinstance(sheet_read_result, ReadErrorSheetInfo)
+            assert sheet_read_result.error_code == 'auth_unresolved'
+            assert sheet_read_result.spreadsheet_title is None
+            assert sheet_read_result.worksheet_id is None
         finally:
             # Restore original environment
             os.environ.clear()
@@ -145,11 +146,11 @@ class TestReadSheetWithServiceAccount:
         
         try:
             # The function should return read error containing only 'auth_invalid_format' code when credentials are missing required fields
-            sheet_info = read_sheet_with_service_account(PUBLIC_SHEET_ID)
-            assert isinstance(sheet_info, ReadErrorSheetInfo)
-            assert sheet_info.error_code == 'auth_invalid_format'
-            assert sheet_info.spreadsheet_title is None
-            assert sheet_info.worksheet_id is None
+            sheet_read_result = read_sheet_with_service_account(PUBLIC_SHEET_ID)
+            assert isinstance(sheet_read_result, ReadErrorSheetInfo)
+            assert sheet_read_result.error_code == 'auth_invalid_format'
+            assert sheet_read_result.spreadsheet_title is None
+            assert sheet_read_result.worksheet_id is None
         finally:
             # Restore original environment
             os.environ.clear()
@@ -165,11 +166,11 @@ class TestReadSheetWithServiceAccount:
         mock_authorize.return_value = mock_client
 
         # The function should return read error containing only 'sheet_not_found' code when the sheet is not found
-        sheet_info = read_sheet_with_service_account(NONEXISTENT_SHEET_ID)
-        assert isinstance(sheet_info, ReadErrorSheetInfo)
-        assert sheet_info.error_code == 'sheet_not_found'
-        assert sheet_info.spreadsheet_title is None
-        assert sheet_info.worksheet_id is None
+        sheet_read_result = read_sheet_with_service_account(NONEXISTENT_SHEET_ID)
+        assert isinstance(sheet_read_result, ReadErrorSheetInfo)
+        assert sheet_read_result.error_code == 'sheet_not_found'
+        assert sheet_read_result.spreadsheet_title is None
+        assert sheet_read_result.worksheet_id is None
         
         # Verify the mocks were called correctly
         mock_client.open_by_key.assert_called_once_with(NONEXISTENT_SHEET_ID)
@@ -186,11 +187,11 @@ class TestReadSheetWithServiceAccount:
         mock_authorize.return_value = mock_client
 
         # The function should return read error containing only 'worksheet_not_found' code when the worksheet is not found
-        sheet_info = read_sheet_with_service_account(PUBLIC_SHEET_ID)
-        assert isinstance(sheet_info, ReadErrorSheetInfo)
-        assert sheet_info.error_code == 'worksheet_not_found'
-        assert sheet_info.spreadsheet_title is None
-        assert sheet_info.worksheet_id is None
+        sheet_read_result = read_sheet_with_service_account(PUBLIC_SHEET_ID)
+        assert isinstance(sheet_read_result, ReadErrorSheetInfo)
+        assert sheet_read_result.error_code == 'worksheet_not_found'
+        assert sheet_read_result.spreadsheet_title is None
+        assert sheet_read_result.worksheet_id is None
         
         # Verify the mocks were called correctly
         mock_client.open_by_key.assert_called_once_with(PUBLIC_SHEET_ID)
@@ -207,11 +208,11 @@ class TestReadSheetWithServiceAccount:
         mock_authorize.return_value = mock_client
 
         # The function should return read error containing only 'api_error' code when an API error occurs
-        sheet_info = read_sheet_with_service_account(PUBLIC_SHEET_ID)
-        assert isinstance(sheet_info, ReadErrorSheetInfo)
-        assert sheet_info.error_code == 'api_error'
-        assert sheet_info.spreadsheet_title is None
-        assert sheet_info.worksheet_id is None
+        sheet_read_result = read_sheet_with_service_account(PUBLIC_SHEET_ID)
+        assert isinstance(sheet_read_result, ReadErrorSheetInfo)
+        assert sheet_read_result.error_code == 'api_error'
+        assert sheet_read_result.spreadsheet_title is None
+        assert sheet_read_result.worksheet_id is None
         
         # Verify the mocks were called correctly
         mock_client.open_by_key.assert_called_once_with(PUBLIC_SHEET_ID)
@@ -224,13 +225,15 @@ class TestValidateGoogleSheet:
     def test_service_account_access(self, mock_read_service_account):
         """Test validation with service account access."""
         # Mock successful service account read
-        mock_read_service_account.return_value = SheetInfo(
-            data=SAMPLE_SHEET_DATA,
-            spreadsheet_title="Test Sheet Title",
-            worksheet_id=123,
-            source_columns=list(SAMPLE_SHEET_DATA.columns),
-            source_rows_start_index=1
-        )
+        mock_read_service_account.return_value = [
+            SheetInfo(
+                data=SAMPLE_SHEET_DATA,
+                spreadsheet_title="Test Sheet Title",
+                worksheet_id=123,
+                source_columns=list(SAMPLE_SHEET_DATA.columns),
+                source_rows_start_index=1
+            )
+        ]
 
         # Create a mock error handler to capture validation errors
         errors = []
@@ -241,7 +244,7 @@ class TestValidateGoogleSheet:
         result, title, error_code = validate_google_sheet(PUBLIC_SHEET_ID, error_handler=mock_error_handler)
 
         # Verify service account method was used
-        mock_read_service_account.assert_called_once_with(PUBLIC_SHEET_ID, 0)
+        mock_read_service_account.assert_called_once_with(PUBLIC_SHEET_ID, [0])
         
         # Verify title is returned
         assert title == "Test Sheet Title"
@@ -264,7 +267,7 @@ class TestValidateGoogleSheet:
         result, title, error_code = validate_google_sheet(PUBLIC_SHEET_ID, error_handler=mock_error_handler)
 
         # Verify service account method was used
-        mock_read_service_account.assert_called_once_with(PUBLIC_SHEET_ID, 0)
+        mock_read_service_account.assert_called_once_with(PUBLIC_SHEET_ID, [0])
         
         # Verify that an error was reported via the error handler
         assert len(errors) > 0
@@ -297,8 +300,9 @@ class TestIntegration:
         if not os.environ.get('GOOGLE_SERVICE_ACCOUNT'):
             pytest.skip("No service account credentials available for integration test")
             
-        sheet_info = read_sheet_with_service_account(PUBLIC_SHEET_ID)
-        assert isinstance(sheet_info, SheetInfo)
+        sheet_read_result = read_sheet_with_service_account(PUBLIC_SHEET_ID)
+        assert isinstance(sheet_read_result, list)
+        sheet_info = sheet_read_result[0]
         assert sheet_info.data is not None
         assert isinstance(sheet_info.data, pd.DataFrame)
         assert not sheet_info.data.empty
@@ -366,8 +370,9 @@ class TestIntegration:
             pytest.skip("Service account credentials not available")
             
         # This test only runs if GOOGLE_SERVICE_ACCOUNT is set
-        sheet_info = read_sheet_with_service_account(PRIVATE_SHEET_ID)
-        assert isinstance(sheet_info, SheetInfo)
+        sheet_read_result = read_sheet_with_service_account(PRIVATE_SHEET_ID)
+        assert isinstance(sheet_read_result, list)
+        sheet_info = sheet_read_result[0]
         assert sheet_info.data is not None
         assert isinstance(sheet_info.data, pd.DataFrame)
         assert not sheet_info.data.empty


### PR DESCRIPTION
Closes #12

- Added minimal slots to donor and sample schemas
- Updated `read_sheet_with_service_account` to take a list of worksheet indices and return a list with info for each
- Updated `validate_google_sheet` to take a list of entity types and get errors for all of them
  - Largely, this involves moving the logic into two loops, one to identify the rows to validate for each entity type, and one to do the actual validation
  - (The full diff for the PR may not be very useful what with the combination of indentation changes and rearrangement)
- If there's an error related to getting data from a worksheet, only that error will be returned from the API, but if all of the worksheets get to the point of actually validating the data then validation errors will be returned for all worksheets