### PR TITLE
feat: add basic sample schema slots (#40)

### DIFF
--- a/src/hca_validation/schema/bionetwork/gut.yaml
+++ b/src/hca_validation/schema/bionetwork/gut.yaml
@@ -24,6 +24,6 @@ classes:
     slots:
       - ambient_count_correction
       - doublet_detection
-         
-      
-    
+      - radial_tissue_term
+
+  

--- a/src/hca_validation/schema/bionetwork/gut.yaml
+++ b/src/hca_validation/schema/bionetwork/gut.yaml
@@ -24,7 +24,13 @@ classes:
     slots:
       - ambient_count_correction
       - doublet_detection
+    
+  GutSample:
+    is_a: Sample
+    description: Sample with Gut BioNetwork–specific metadata requirements.
+    slots:
       - radial_tissue_term
       - dissociation_protocol
+    
 
   

--- a/src/hca_validation/schema/bionetwork/gut.yaml
+++ b/src/hca_validation/schema/bionetwork/gut.yaml
@@ -25,5 +25,6 @@ classes:
       - ambient_count_correction
       - doublet_detection
       - radial_tissue_term
+      - dissociation_protocol
 
   

--- a/src/hca_validation/schema/dataset.yaml
+++ b/src/hca_validation/schema/dataset.yaml
@@ -28,7 +28,9 @@ classes:
       - batch_condition
       - comments
       - consortia
+      - contact_email
       - default_embedding
+      - description
       - gene_annotation_version
       - intron_inclusion
       - protocol_url
@@ -113,6 +115,12 @@ slots:
     annotations:
       annDataLocation: uns
 
+  contact_email:
+    title: Contact Email
+    description: Contact name and email of the submitting person
+    range: Email
+    required: true
+
   consortia:
     is_a: deprecated_slot
     title: Consortia
@@ -125,6 +133,14 @@ slots:
     required: false
     annotations:
       cxg: default_embedding
+      annDataLocation: uns
+
+  description:
+    title: Description
+    description: Short description of the dataset
+    range: string
+    required: true
+    annotations:
       annDataLocation: uns
 
   gene_annotation_version:
@@ -223,13 +239,13 @@ slots:
       annDataLocation: uns
 
   title:
+    is_a: deprecated_slot
     title: Title
     description: >
       This text describes and differentiates the dataset from other datasets in the same collection. 
       It is strongly recommended that each dataset title in a collection is unique and does not depend on other metadata 
       such as a different assay to disambiguate it from other datasets in the collection.
     range: string
-    required: true
     examples:
       - value: "Cells of the adult human heart collection is 'All — Cells of the adult human heart'"
     comments:

--- a/src/hca_validation/schema/dataset.yaml
+++ b/src/hca_validation/schema/dataset.yaml
@@ -24,8 +24,10 @@ classes:
     slots:
       - alignment_software
       - assay_ontology_term_id
+      - assay_ontology_term
       - batch_condition
       - comments
+      - consortia
       - default_embedding
       - gene_annotation_version
       - intron_inclusion
@@ -77,6 +79,11 @@ slots:
       cxg: assay_ontology_term_id
       annDataLocation: obs
 
+  assay_ontology_term:
+    is_a: deprecated_slot
+    title: Assay Ontology Term
+    description: Deprecated placeholder for assay ontology term.
+
   batch_condition:
     title: Batch Condition
     description: >-
@@ -105,6 +112,11 @@ slots:
     required: false
     annotations:
       annDataLocation: uns
+
+  consortia:
+    is_a: deprecated_slot
+    title: Consortia
+    description: Deprecated placeholder for consortia information.
 
   default_embedding:
     title: Default Embedding

--- a/src/hca_validation/schema/dataset.yaml
+++ b/src/hca_validation/schema/dataset.yaml
@@ -34,6 +34,7 @@ classes:
       - gene_annotation_version
       - intron_inclusion
       - protocol_url
+      - publication_doi
       - reference_genome
       - sequenced_fragment
       - sequencing_platform
@@ -185,6 +186,15 @@ slots:
       - Useful to look up protocol data that can provide insight on batch effects. As protocols can sometimes apply to a subset of the study, we capture this at a sample level. This information may not always be available.
     annotations:
       annDataLocation: obs
+
+  publication_doi:
+    title: Publication DOI
+    description: >
+      The publication digital object identifier (doi) for the protocol. If no pre-print nor publication exists, please write 'not applicable'.
+    range: string
+    required: false
+    examples:
+      - value: "10.1016/j.cell.2016.07.054"
 
   reference_genome:
     title: Reference Genome

--- a/src/hca_validation/schema/donor.yaml
+++ b/src/hca_validation/schema/donor.yaml
@@ -22,6 +22,7 @@ classes:
       An individual organism from which biological samples have been derived
     slots:
       - donor_id
+      - organism_ontology_term_id
       - sex_ontology_term_id
       - sex_ontology_term
       - manner_of_death
@@ -69,3 +70,14 @@ slots:
     notes: "1; 2; 3; 4; 0; unknown; not applicable"
     annotations:
       annDataLocation: obs
+
+  organism_ontology_term_id:
+    title: Organism Ontology Term ID
+    description: The name given to the type of organism, collected in NCBITaxon:0000 format.
+    range: Organism
+    required: true
+    notes: "\"NCBITaxon:9606\" for Homo sapiens or \"NCBITaxon:10090\" for Mus musculus."
+    annotations:
+      annDataLocation: obs
+      cxg: organism_ontology_term_id
+      tier: Tier 1

--- a/src/hca_validation/schema/donor.yaml
+++ b/src/hca_validation/schema/donor.yaml
@@ -55,7 +55,7 @@ slots:
       * Unknown = The cause of death is unknown.
       * Not applicable = Subject is alive.
       [Leave blank for embryonic/fetal tissue.]
-    range: string
+    range: MannerOfDeath
     required: true
     examples:
       - value: "1"

--- a/src/hca_validation/schema/donor.yaml
+++ b/src/hca_validation/schema/donor.yaml
@@ -23,6 +23,7 @@ classes:
     slots:
       - donor_id
       - sex_ontology_term_id
+      - sex_ontology_term
       - manner_of_death
       - dataset_id
 
@@ -43,6 +44,12 @@ slots:
     annotations:
       annDataLocation: obs
       cxg: sex_ontology_term_id
+  
+  sex_ontology_term:
+    is_a: deprecated_slot
+    title: Sex Ontology Term
+    description: Deprecated placeholder for sex ontology term.
+  
   manner_of_death:
     title: Manner of Death
     description: |

--- a/src/hca_validation/schema/donor.yaml
+++ b/src/hca_validation/schema/donor.yaml
@@ -27,13 +27,6 @@ classes:
       - dataset_id
 
 slots:
-  donor_id:
-    title: Donor ID
-    description: This must be free-text that identifies a unique individual that data were derived from.
-    notes: >
-      It is strongly recommended that this identifier be designed so that it is unique to: a given individual within the collection of datasets that includes this dataset, and a given individual across all collections in CELLxGENE Discover. It is strongly recommended that "pooled" be used for observations from a sample of multiple individuals that were not confidently assigned to a single individual through demultiplexing. It is strongly recommended that "unknown" ONLY be used for observations in a dataset when it is not known which observations are from the same individual.
-    range: string
-    required: true
   sex_ontology_term_id:
     title: Sex Ontology Term ID
     description: Reported sex of the donor.

--- a/src/hca_validation/schema/enums.yaml
+++ b/src/hca_validation/schema/enums.yaml
@@ -28,6 +28,8 @@ enums:
       EPI: {}
       LP: {}
       MUSC: {}
+      EPI_LP: {}
+      LP_MUSC: {}
       EPI_LP_MUSC: {}
       MLN: {}
       SUB: {}

--- a/src/hca_validation/schema/enums.yaml
+++ b/src/hca_validation/schema/enums.yaml
@@ -40,9 +40,9 @@ enums:
       brush: {}
       scraping: {}
       biopsy: {}
-      "surgical resection": {}
-      "blood draw": {}
-      "body fluid": {}
+      "surgical_resection": {}
+      "blood_draw": {}
+      "body_fluid": {}
       other: {}
       
   TissueType:
@@ -81,9 +81,9 @@ enums:
  
   SampleSource:
     permissible_values:
-      "surgical donor": {}
-      "postmortem donor": {}
-      "living organ donor": {}
+      "surgical_donor": {}
+      "postmortem_donor": {}
+      "living_organ_donor": {}
       
   MannerOfDeath:
     permissible_values:
@@ -93,7 +93,7 @@ enums:
       "4": {}
       "0": {}
       unknown: {}
-      "not applicable": {}
+      "not_applicable": {}
       
   DevelopmentStage:
     permissible_values:

--- a/src/hca_validation/schema/enums.yaml
+++ b/src/hca_validation/schema/enums.yaml
@@ -44,3 +44,37 @@ enums:
       "blood draw": {}
       "body fluid": {}
       other: {}
+      
+  TissueType:
+    permissible_values:
+      tissue: {}
+      organoid: {}
+      "cell culture": {}
+      
+  SuspensionType:
+    permissible_values:
+       cell: {}
+       nucleus: {}
+       na: {}
+       
+  SampledSiteCondition:
+    permissible_values:
+       healthy: {}
+       diseased: {}
+       adjacent: {}
+       
+  SamplePreservationMethod:
+    permissible_values:
+      "ambient temperature": {}
+      "cut slide": {}
+      fresh: {}
+      "frozen at -70C": {}
+      "frozen at -80C": {}
+      "frozen at -150C": {}
+      "frozen in liquid nitrogen": {}
+      "frozen in vapor phase": {}
+      "paraffin block": {}
+      "RNAlater at 4C": {}
+      "RNAlater at 25C": {}
+      "RNAlater at -20C": {}
+      other: {}

--- a/src/hca_validation/schema/enums.yaml
+++ b/src/hca_validation/schema/enums.yaml
@@ -34,3 +34,13 @@ enums:
       "Peyers patch": {}
       "Mucosal ILF": {}
       "Submucosal ILF": {}
+      
+  SampleCollectionMethod:
+    permissible_values:
+      brush: {}
+      scraping: {}
+      biopsy: {}
+      "surgical resection": {}
+      "blood draw": {}
+      "body fluid": {}
+      other: {}

--- a/src/hca_validation/schema/enums.yaml
+++ b/src/hca_validation/schema/enums.yaml
@@ -111,3 +111,8 @@ enums:
       MmusDv:0000001: {}
       MmusDv:0000002: {}
       unknown: {}
+      
+  Organism:
+    permissible_values:
+      "NCBITaxon:9606": {}
+      "NCBITaxon:10090": {}

--- a/src/hca_validation/schema/enums.yaml
+++ b/src/hca_validation/schema/enums.yaml
@@ -22,3 +22,15 @@ enums:
         description: Negative / false
       "yes":
         description: Affirmative / true
+        
+  RadialTissueTerm:
+    permissible_values:
+      EPI: {}
+      LP: {}
+      MUSC: {}
+      EPI_LP_MUSC: {}
+      MLN: {}
+      SUB: {}
+      "Peyers patch": {}
+      "Mucosal ILF": {}
+      "Submucosal ILF": {}

--- a/src/hca_validation/schema/enums.yaml
+++ b/src/hca_validation/schema/enums.yaml
@@ -85,6 +85,16 @@ enums:
       "postmortem donor": {}
       "living organ donor": {}
       
+  MannerOfDeath:
+    permissible_values:
+      "1": {}
+      "2": {}
+      "3": {}
+      "4": {}
+      "0": {}
+      unknown: {}
+      "not applicable": {}
+      
   DevelopmentStage:
     permissible_values:
       HsapDv:0000003: {}

--- a/src/hca_validation/schema/enums.yaml
+++ b/src/hca_validation/schema/enums.yaml
@@ -78,3 +78,26 @@ enums:
       "RNAlater at 25C": {}
       "RNAlater at -20C": {}
       other: {}
+ 
+  SampleSource:
+    permissible_values:
+      "surgical donor": {}
+      "postmortem donor": {}
+      "living organ donor": {}
+      
+  DevelopmentStage:
+    permissible_values:
+      HsapDv:0000003: {}
+      HsapDv:0000046: {}
+      HsapDv:0000264: {}
+      HsapDv:0000268: {}
+      HsapDv:0000237: {}
+      HsapDv:0000238: {}
+      HsapDv:0000239: {}
+      HsapDv:0000240: {}
+      HsapDv:0000241: {}
+      HsapDv:0000242: {}
+      HsapDv:0000243: {}
+      MmusDv:0000001: {}
+      MmusDv:0000002: {}
+      unknown: {}

--- a/src/hca_validation/schema/generated/core.py
+++ b/src/hca_validation/schema/generated/core.py
@@ -431,6 +431,12 @@ class Sample(ConfiguredBaseModel):
     sample_id: str = Field(default=..., title="Sample ID", json_schema_extra = { "linkml_meta": {'alias': 'sample_id', 'domain_of': ['Sample']} })
     donor_id: str = Field(default=..., title="Donor ID", json_schema_extra = { "linkml_meta": {'alias': 'donor_id', 'domain_of': ['Donor', 'Sample']} })
     dataset_id: str = Field(default=..., title="Dataset ID", description="""A unique identifier for each dataset in the study. This should be unique to the study.""", json_schema_extra = { "linkml_meta": {'alias': 'dataset_id', 'domain_of': ['Dataset', 'Donor', 'Sample']} })
+    author_batch_notes: Optional[str] = Field(default=None, title="Author Batch Notes", description="""Encoding of author knowledge on any further information related to likely batch effects.""", json_schema_extra = { "linkml_meta": {'alias': 'author_batch_notes',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Space for author intuition of batch effects in their dataset'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'Batch run by different personnel on different days'}]} })
 
 
 class Cell(ConfiguredBaseModel):

--- a/src/hca_validation/schema/generated/core.py
+++ b/src/hca_validation/schema/generated/core.py
@@ -380,10 +380,6 @@ class GutDataset(Dataset):
          'examples': [{'value': 'none'},
                       {'value': 'doublet_finder'},
                       {'value': 'manual'}]} })
-    radial_tissue_term: RadialTissueTerm = Field(default=..., title="Radial Tissue Term", description="""Radial compartment/location of the tissue sample.""", json_schema_extra = { "linkml_meta": {'alias': 'radial_tissue_term', 'domain_of': ['GutDataset']} })
-    dissociation_protocol: str = Field(default=..., title="Dissociation Protocol", description="""Dissociation chemicals used during sample preparation""", json_schema_extra = { "linkml_meta": {'alias': 'dissociation_protocol',
-         'domain_of': ['GutDataset'],
-         'notes': ['trypsin; trypLE; collagenase']} })
     alignment_software: str = Field(default=..., title="Alignment Software", description="""Protocol used for alignment analysis, please specify which version was used e.g. cell ranger 2.0, 2.1.1 etc.""", json_schema_extra = { "linkml_meta": {'alias': 'alignment_software',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
          'comments': ['Affects which cells are filtered per dataset, and which reads '
@@ -765,6 +761,211 @@ class Sample(ConfiguredBaseModel):
          'is_a': 'deprecated_slot'} })
 
 
+class GutSample(Sample):
+    """
+    Sample with Gut BioNetwork–specific metadata requirements.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/bionetwork/gut'})
+
+    radial_tissue_term: RadialTissueTerm = Field(default=..., title="Radial Tissue Term", description="""Radial compartment/location of the tissue sample.""", json_schema_extra = { "linkml_meta": {'alias': 'radial_tissue_term', 'domain_of': ['GutSample']} })
+    dissociation_protocol: str = Field(default=..., title="Dissociation Protocol", description="""Dissociation chemicals used during sample preparation""", json_schema_extra = { "linkml_meta": {'alias': 'dissociation_protocol',
+         'domain_of': ['GutSample'],
+         'notes': ['trypsin; trypLE; collagenase']} })
+    sample_id: str = Field(default=..., title="Sample ID", description="""Identification number of the sample. This is the fundamental unit of sampling the tissue (the specimen taken from the subject), which can be the same as the 'subject_ID', but is often different if multiple samples are taken from the same subject. Note: this is NOT a unit of multiplexing of donor samples, which should be stored in \"library\".""", json_schema_extra = { "linkml_meta": {'alias': 'sample_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'SC24; SC25; SC28'}]} })
+    donor_id: str = Field(default=..., title="Donor ID", description="""This must be free-text that identifies a unique individual that data were derived from.""", json_schema_extra = { "linkml_meta": {'alias': 'donor_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'donor_id'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Fundamental unit of biological variation of the data. It is '
+                      'strongly recommended that this identifier be designed so that '
+                      'it is unique to: a given individual within the collection of '
+                      'datasets that includes this dataset, and a given individual '
+                      'across all collections in CELLxGENE Discover. It is strongly '
+                      'recommended that "pooled" be used for observations from a '
+                      'sample of multiple individuals that were not confidently '
+                      'assigned to a single individual through demultiplexing. It is '
+                      'strongly recommended that "unknown" ONLY be used for '
+                      'observations in a dataset when it is not known which '
+                      'observations are from the same individual.'],
+         'domain_of': ['Donor', 'Sample'],
+         'examples': [{'value': 'CR_donor_1; MM_donor_1; LR_donor_2'}]} })
+    dataset_id: str = Field(default=..., title="Dataset ID", description="""A unique identifier for each dataset in the study. This should be unique to the study.""", json_schema_extra = { "linkml_meta": {'alias': 'dataset_id', 'domain_of': ['Dataset', 'Donor', 'Sample']} })
+    author_batch_notes: Optional[str] = Field(default=None, title="Author Batch Notes", description="""Encoding of author knowledge on any further information related to likely batch effects.""", json_schema_extra = { "linkml_meta": {'alias': 'author_batch_notes',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Space for author intuition of batch effects in their dataset'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'Batch run by different personnel on different days'}]} })
+    age_range: Optional[str] = Field(default=None, title="Age Range", description="""Deprecated placeholder for age range metadata.""", json_schema_extra = { "linkml_meta": {'alias': 'age_range', 'domain_of': ['Sample'], 'is_a': 'deprecated_slot'} })
+    cell_number_loaded: Optional[int] = Field(default=None, title="Cell Number Loaded", description="""Estimated number of cells loaded for library construction.""", json_schema_extra = { "linkml_meta": {'alias': 'cell_number_loaded',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Can explain the number of doublets found in samples'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': '5000; 4000'}]} })
+    cell_viability_percentage: Optional[Union[Decimal, str]] = Field(default=None, title="Cell Viability Percentage", description="""If measured, per sample cell viability before library preparation (as a percentage).""", json_schema_extra = { "linkml_meta": {'alias': 'cell_viability_percentage',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'any_of': [{'range': 'decimal'}, {'range': 'string'}],
+         'comments': ['Is a measure of sample quality that could be used to explain '
+                      'outlier samples'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': '88; 95; 93.5'}, {'value': 'unknown'}]} })
+    cell_enrichment: str = Field(default=..., title="Cell Enrichment", description="""Specifies the cell types targeted for enrichment or depletion beyond the selection of live cells.""", json_schema_extra = { "linkml_meta": {'alias': 'cell_enrichment',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'CL:0000057+'}],
+         'notes': ['This must be a Cell Ontology (CL) term '
+                   '(http://www.ebi.ac.uk/ols4/ontologies/cl). For cells that are '
+                   "enriched, list the CL code followed by a '+'. For cells that were "
+                   "depleted, list the CL code followed by a '-'. If no enrichment or "
+                   "depletion occurred, please use 'na' (not applicable)"]} })
+    development_stage_ontology_term_id: DevelopmentStage = Field(default=..., title="Development Stage Ontology Term ID", description="""Age of the subject.""", json_schema_extra = { "linkml_meta": {'alias': 'development_stage_ontology_term_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg',
+                                 'value': 'development_stage_ontology_term_id'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'HsapDv:0000237'}],
+         'notes': ['If organism_ontolology_term_id is "NCBITaxon:9606" for Homo '
+                   'sapiens, this should be an HsapDv term. If '
+                   'organism_ontolology_term_id is "NCBITaxon:10090" for Mus musculus, '
+                   'this should be an MmusDv term. Refer to broader age bracket terms '
+                   'as needed.']} })
+    disease_ontology_term: Optional[str] = Field(default=None, title="Disease Ontology Term", description="""Deprecated placeholder for disease ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'disease_ontology_term',
+         'domain_of': ['Sample'],
+         'is_a': 'deprecated_slot'} })
+    institute: str = Field(default=..., title="Institute", description="""Institution where the samples were processed.""", json_schema_extra = { "linkml_meta": {'alias': 'institute',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['To be able to link to other studies from the same institution '
+                      'as sometimes samples from different labs in the same institute '
+                      'are processed via similar core facilities. Thus batch effects '
+                      'may be smaller for datasets from the same institute even if '
+                      'other factors differ.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'EMBL-EBI; Genome Institute of Singapore'}]} })
+    is_primary_data: Optional[str] = Field(default=None, title="Is Primary Data", description="""Deprecated placeholder indicating whether sample represents primary data.""", json_schema_extra = { "linkml_meta": {'alias': 'is_primary_data', 'domain_of': ['Sample'], 'is_a': 'deprecated_slot'} })
+    library_id: str = Field(default=..., title="Library ID", description="""The unique ID that is used to track libraries in the investigator's institution (should align with the publication).""", json_schema_extra = { "linkml_meta": {'alias': 'library_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['A way to track the unit of data generation. This should include '
+                      'sample pooling'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'A24; NK_healthy_001'}]} })
+    library_id_repository: Optional[str] = Field(default=None, title="Library ID Repository", description="""The unique ID used to track libraries from one of the following public data repositories: EGAX*, GSM*, SRX*, ERX*, DRX, HRX, CRX.""", json_schema_extra = { "linkml_meta": {'alias': 'library_id_repository',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Links a dataset back to the source from which it was ingested, '
+                      'optional only if this is the same as the library_id.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'GSM1684095'}]} })
+    library_preparation_batch: str = Field(default=..., title="Library Preparation Batch", description="""Indicating which samples' libraries were prepared in the same chip/plate/etc., e.g. batch1, batch2.""", json_schema_extra = { "linkml_meta": {'alias': 'library_preparation_batch',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Sample preparation is a major source of batch effects.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'batch01; batch02'}]} })
+    library_sequencing_run: str = Field(default=..., title="Library Sequencing Run", description="""The identifier (or accession number) that indicates which samples' libraries were sequenced in the same run.""", json_schema_extra = { "linkml_meta": {'alias': 'library_sequencing_run',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Library sequencing is a major source of batch effects'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'run1; NV0087'}]} })
+    sample_collection_method: SampleCollectionMethod = Field(default=..., title="Sample Collection Method", description="""The method the sample was physically obtained from the donor.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_method',
+         'domain_of': ['Sample'],
+         'notes': ['brush; scraping; biopsy; surgical resection; blood draw; body '
+                   'fluid; other']} })
+    sample_collection_year: Optional[str] = Field(default=None, title="Sample Collection Year", description="""Year of sample collection. Should not be detailed further (to exact month and day), to prevent identifiability.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_year',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['May explain whether a dataset was separated into smaller '
+                      'batches.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': '2018'}]} })
+    sample_collection_site: Optional[str] = Field(default=None, title="Sample Collection Site", description="""The pseudonymised name of the site where the sample was collected.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_site',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['To understand whether the collection site contributes to batch '
+                      'effects. It is strongly recommended that this identifier be '
+                      'designed so that it is unique to a given site within the '
+                      'collection of datasets that includes this site (for example, '
+                      "the labels 'site1', 'site2' may appear in other datasets thus "
+                      'rendering them indistinguishable).'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'AIDA_site_1; AIDA_site_2'}]} })
+    sample_collection_relative_time_point: Optional[str] = Field(default=None, title="Sample Collection Relative Time Point", description="""Time point when the sample was collected. This field is only needed if multiple samples from the same subject are available and collected at different time points. Sample collection dates (e.g. 23/09/22) cannot be used due to patient data protection, only relative time points should be used here (e.g. day3).""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_relative_time_point',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Explains variability in the data between samples from the same '
+                      'subject.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'sampleX_day1'}]} })
+    tissue_free_text: Optional[str] = Field(default=None, title="Tissue Free Text", description="""The detailed anatomical location of the sample - this does not have to tie to an ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'tissue_free_text',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['To help the integration team understand the anatomical location '
+                      'of the sample, specifically to solve the problem when the '
+                      'UBERON ontology terms are insufficiently precise.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'terminal ileum'}]} })
+    tissue_type: TissueType = Field(default=..., title="Tissue Type", description="""Whether the tissue is \"tissue\", \"organoid\", or \"cell culture\".""", json_schema_extra = { "linkml_meta": {'alias': 'tissue_type',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'tissue_type'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'tissue'}],
+         'notes': ['tissue; organoid; cell culture']} })
+    suspension_type: SuspensionType = Field(default=..., title="Suspension Type", description="""Specifies whether the sample contains single cells or single nuclei data.""", json_schema_extra = { "linkml_meta": {'alias': 'suspension_type',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'suspension_type'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'cell'}],
+         'notes': ['This must be "cell", "nucleus", or "na".\n'
+                   'This must be the correct type for the corresponding assay:\n'
+                   '* 10x transcription profiling [EFO:0030080] and its children = '
+                   '"cell" or "nucleus"\n'
+                   '* ATAC-seq [EFO:0007045] and its children = "nucleus"\n'
+                   '* BD Rhapsody Whole Transcriptome Analysis [EFO:0700003] = "cell"\n'
+                   '* BD Rhapsody Targeted mRNA [EFO:0700004] = "cell"\n'
+                   '* CEL-seq2 [EFO:0010010] = "cell" or "nucleus"\n'
+                   '* CITE-seq [EFO:0009294] and its children = "cell"\n'
+                   '* DroNc-seq [EFO:0008720] = "nucleus"\n'
+                   '* Drop-seq [EFO:0008722] = "cell" or "nucleus"\n'
+                   '* GEXSCOPE technology [EFO:0700011] = "cell" or "nucleus"\n'
+                   '* inDrop [EFO:0008780] = "cell" or "nucleus"\n']} })
+    sampled_site_condition: SampledSiteCondition = Field(default=..., title="Sampled Site Condition", description="""Whether the site is considered healthy, diseased or adjacent to disease.""", json_schema_extra = { "linkml_meta": {'alias': 'sampled_site_condition',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'healthy'}],
+         'notes': ['healthy; diseased; adjacent']} })
+    sample_preservation_method: SamplePreservationMethod = Field(default=..., title="Sample Preservation Method", description="""Indicating if tissue was frozen, or not, at any point before library preparation.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_preservation_method',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'fresh'}],
+         'notes': ['ambient temperature; cut slide; fresh; frozen at -70C; frozen at '
+                   '-80C; frozen at -150C; frozen in liquid nitrogen; frozen in vapor '
+                   'phase; paraffin block; RNAlater at 4C; RNAlater at 25C; RNAlater '
+                   'at -20C; other']} })
+    sample_source: SampleSource = Field(default=..., title="Sample Source", description="""The study subgroup that the participant belongs to, indicating whether the participant was a surgical donor, a postmortem donor, or an organ donor.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_source',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'surgical donor'}],
+         'notes': ['surgical donor; postmortem donor; living organ donor']} })
+    tissue_ontology_term: Optional[str] = Field(default=None, title="Tissue Ontology Term", description="""Deprecated placeholder for tissue ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'tissue_ontology_term',
+         'domain_of': ['Sample'],
+         'is_a': 'deprecated_slot'} })
+
+
 class Cell(ConfiguredBaseModel):
     """
     A single cell derived from a sample
@@ -780,5 +981,6 @@ Dataset.model_rebuild()
 GutDataset.model_rebuild()
 Donor.model_rebuild()
 Sample.model_rebuild()
+GutSample.model_rebuild()
 Cell.model_rebuild()
 

--- a/src/hca_validation/schema/generated/core.py
+++ b/src/hca_validation/schema/generated/core.py
@@ -486,6 +486,39 @@ class Sample(ConfiguredBaseModel):
          'comments': ['Library sequencing is a major source of batch effects'],
          'domain_of': ['Sample'],
          'examples': [{'value': 'run1; NV0087'}]} })
+    sample_collection_year: Optional[str] = Field(default=None, title="Sample Collection Year", description="""Year of sample collection. Should not be detailed further (to exact month and day), to prevent identifiability.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_year',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['May explain whether a dataset was separated into smaller '
+                      'batches.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': '2018'}]} })
+    sample_collection_site: Optional[str] = Field(default=None, title="Sample Collection Site", description="""The pseudonymised name of the site where the sample was collected.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_site',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['To understand whether the collection site contributes to batch '
+                      'effects. It is strongly recommended that this identifier be '
+                      'designed so that it is unique to a given site within the '
+                      'collection of datasets that includes this site (for example, '
+                      "the labels 'site1', 'site2' may appear in other datasets thus "
+                      'rendering them indistinguishable).'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'AIDA_site_1; AIDA_site_2'}]} })
+    sample_collection_relative_time_point: Optional[str] = Field(default=None, title="Sample Collection Relative Time Point", description="""Time point when the sample was collected. This field is only needed if multiple samples from the same subject are available and collected at different time points. Sample collection dates (e.g. 23/09/22) cannot be used due to patient data protection, only relative time points should be used here (e.g. day3).""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_relative_time_point',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Explains variability in the data between samples from the same '
+                      'subject.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'sampleX_day1'}]} })
+    tissue_free_text: Optional[str] = Field(default=None, title="Tissue Free Text", description="""The detailed anatomical location of the sample - this does not have to tie to an ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'tissue_free_text',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['To help the integration team understand the anatomical location '
+                      'of the sample, specifically to solve the problem when the '
+                      'UBERON ontology terms are insufficiently precise.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'terminal ileum'}]} })
 
 
 class Cell(ConfiguredBaseModel):

--- a/src/hca_validation/schema/generated/core.py
+++ b/src/hca_validation/schema/generated/core.py
@@ -203,6 +203,16 @@ class SampleSource(str, Enum):
     living_organ_donor = "living organ donor"
 
 
+class MannerOfDeath(str, Enum):
+    number_1 = "1"
+    number_2 = "2"
+    number_3 = "3"
+    number_4 = "4"
+    number_0 = "0"
+    unknown = "unknown"
+    not_applicable = "not applicable"
+
+
 class DevelopmentStage(str, Enum):
     HsapDvCOLON0000003 = "HsapDv:0000003"
     HsapDvCOLON0000046 = "HsapDv:0000046"
@@ -259,6 +269,9 @@ class Dataset(ConfiguredBaseModel):
                    '- 10x 5\' v2 "EFO:0009900"\n'
                    '- Smart-seq2 "EFO:0008931"\n'
                    '- Visium Spatial Gene Expression "EFO:0010961"\n']} })
+    assay_ontology_term: Optional[str] = Field(default=None, title="Assay Ontology Term", description="""Deprecated placeholder for assay ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'assay_ontology_term',
+         'domain_of': ['Dataset'],
+         'is_a': 'deprecated_slot'} })
     batch_condition: Optional[list[str]] = Field(default=None, title="Batch Condition", description="""Name of the covariate that confers the dominant batch effect in the data as judged by the data contributor.  The name provided here should be the label by which this covariate is stored in the AnnData object.""", json_schema_extra = { "linkml_meta": {'alias': 'batch_condition',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'},
                          'cxg': {'tag': 'cxg', 'value': 'batch_condition'}},
@@ -275,6 +288,7 @@ class Dataset(ConfiguredBaseModel):
 """, json_schema_extra = { "linkml_meta": {'alias': 'comments',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
          'domain_of': ['Dataset']} })
+    consortia: Optional[str] = Field(default=None, title="Consortia", description="""Deprecated placeholder for consortia information.""", json_schema_extra = { "linkml_meta": {'alias': 'consortia', 'domain_of': ['Dataset'], 'is_a': 'deprecated_slot'} })
     default_embedding: Optional[str] = Field(default=None, title="Default Embedding", description="""The value must match a key to an embedding in obsm for the embedding to display by default in CELLxGENE Explorer.""", json_schema_extra = { "linkml_meta": {'alias': 'default_embedding',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'},
                          'cxg': {'tag': 'cxg', 'value': 'default_embedding'}},
@@ -501,7 +515,7 @@ class Donor(ConfiguredBaseModel):
                       {'description': 'male', 'value': 'PATO:0000384'}],
          'notes': ['This must be a child of PATO:0001894 for phenotypic sex or '
                    '"unknown" if unavailable.\n']} })
-    manner_of_death: str = Field(default=..., title="Manner of Death", description="""Manner of death classification based on the Hardy Scale or \"unknown\" or \"not applicable\":
+    manner_of_death: MannerOfDeath = Field(default=..., title="Manner of Death", description="""Manner of death classification based on the Hardy Scale or \"unknown\" or \"not applicable\":
 * Category 1 = Violent and fast death — deaths due to accident, blunt force trauma or suicide, terminal phase < 10 min.
 * Category 2 = Fast death of natural causes — sudden unexpected deaths of reasonably healthy people, terminal phase < 1 h.
 * Category 3 = Intermediate death — terminal phase 1–24 h, patients ill but death unexpected.
@@ -560,13 +574,14 @@ class Sample(ConfiguredBaseModel):
          'comments': ['Can explain the number of doublets found in samples'],
          'domain_of': ['Sample'],
          'examples': [{'value': '5000; 4000'}]} })
-    cell_viability_percentage: Optional[Decimal] = Field(default=None, title="Cell Viability Percentage", description="""If measured, per sample cell viability before library preparation (as a percentage).""", json_schema_extra = { "linkml_meta": {'alias': 'cell_viability_percentage',
+    cell_viability_percentage: Optional[Union[Decimal, str]] = Field(default=None, title="Cell Viability Percentage", description="""If measured, per sample cell viability before library preparation (as a percentage).""", json_schema_extra = { "linkml_meta": {'alias': 'cell_viability_percentage',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'any_of': [{'range': 'decimal'}, {'range': 'string'}],
          'comments': ['Is a measure of sample quality that could be used to explain '
                       'outlier samples'],
          'domain_of': ['Sample'],
-         'examples': [{'value': '88; 95; 93.5'}]} })
+         'examples': [{'value': '88; 95; 93.5'}, {'value': 'unknown'}]} })
     cell_enrichment: str = Field(default=..., title="Cell Enrichment", description="""Specifies the cell types targeted for enrichment or depletion beyond the selection of live cells.""", json_schema_extra = { "linkml_meta": {'alias': 'cell_enrichment',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
@@ -602,6 +617,7 @@ class Sample(ConfiguredBaseModel):
                       'other factors differ.'],
          'domain_of': ['Sample'],
          'examples': [{'value': 'EMBL-EBI; Genome Institute of Singapore'}]} })
+    is_primary_data: Optional[str] = Field(default=None, title="Is Primary Data", description="""Deprecated placeholder indicating whether sample represents primary data.""", json_schema_extra = { "linkml_meta": {'alias': 'is_primary_data', 'domain_of': ['Sample'], 'is_a': 'deprecated_slot'} })
     library_id: str = Field(default=..., title="Library ID", description="""The unique ID that is used to track libraries in the investigator's institution (should align with the publication).""", json_schema_extra = { "linkml_meta": {'alias': 'library_id',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},

--- a/src/hca_validation/schema/generated/core.py
+++ b/src/hca_validation/schema/generated/core.py
@@ -460,6 +460,32 @@ class Sample(ConfiguredBaseModel):
                       'other factors differ.'],
          'domain_of': ['Sample'],
          'examples': [{'value': 'EMBL-EBI; Genome Institute of Singapore'}]} })
+    library_id: str = Field(default=..., title="Library ID", description="""The unique ID that is used to track libraries in the investigator's institution (should align with the publication).""", json_schema_extra = { "linkml_meta": {'alias': 'library_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['A way to track the unit of data generation. This should include '
+                      'sample pooling'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'A24; NK_healthy_001'}]} })
+    library_id_repository: Optional[str] = Field(default=None, title="Library ID Repository", description="""The unique ID used to track libraries from one of the following public data repositories: EGAX*, GSM*, SRX*, ERX*, DRX, HRX, CRX.""", json_schema_extra = { "linkml_meta": {'alias': 'library_id_repository',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Links a dataset back to the source from which it was ingested, '
+                      'optional only if this is the same as the library_id.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'GSM1684095'}]} })
+    library_preparation_batch: str = Field(default=..., title="Library Preparation Batch", description="""Indicating which samples' libraries were prepared in the same chip/plate/etc., e.g. batch1, batch2.""", json_schema_extra = { "linkml_meta": {'alias': 'library_preparation_batch',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Sample preparation is a major source of batch effects.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'batch01; batch02'}]} })
+    library_sequencing_run: str = Field(default=..., title="Library Sequencing Run", description="""The identifier (or accession number) that indicates which samples' libraries were sequenced in the same run.""", json_schema_extra = { "linkml_meta": {'alias': 'library_sequencing_run',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Library sequencing is a major source of batch effects'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'run1; NV0087'}]} })
 
 
 class Cell(ConfiguredBaseModel):

--- a/src/hca_validation/schema/generated/core.py
+++ b/src/hca_validation/schema/generated/core.py
@@ -157,9 +157,9 @@ class SampleCollectionMethod(str, Enum):
     brush = "brush"
     scraping = "scraping"
     biopsy = "biopsy"
-    surgical_resection = "surgical resection"
-    blood_draw = "blood draw"
-    body_fluid = "body fluid"
+    surgical_resection = "surgical_resection"
+    blood_draw = "blood_draw"
+    body_fluid = "body_fluid"
     other = "other"
 
 
@@ -198,9 +198,9 @@ class SamplePreservationMethod(str, Enum):
 
 
 class SampleSource(str, Enum):
-    surgical_donor = "surgical donor"
-    postmortem_donor = "postmortem donor"
-    living_organ_donor = "living organ donor"
+    surgical_donor = "surgical_donor"
+    postmortem_donor = "postmortem_donor"
+    living_organ_donor = "living_organ_donor"
 
 
 class MannerOfDeath(str, Enum):
@@ -210,7 +210,7 @@ class MannerOfDeath(str, Enum):
     number_4 = "4"
     number_0 = "0"
     unknown = "unknown"
-    not_applicable = "not applicable"
+    not_applicable = "not_applicable"
 
 
 class DevelopmentStage(str, Enum):
@@ -289,9 +289,13 @@ class Dataset(ConfiguredBaseModel):
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
          'domain_of': ['Dataset']} })
     consortia: Optional[str] = Field(default=None, title="Consortia", description="""Deprecated placeholder for consortia information.""", json_schema_extra = { "linkml_meta": {'alias': 'consortia', 'domain_of': ['Dataset'], 'is_a': 'deprecated_slot'} })
+    contact_email: str = Field(default=..., title="Contact Email", description="""Contact name and email of the submitting person""", json_schema_extra = { "linkml_meta": {'alias': 'contact_email', 'domain_of': ['Dataset']} })
     default_embedding: Optional[str] = Field(default=None, title="Default Embedding", description="""The value must match a key to an embedding in obsm for the embedding to display by default in CELLxGENE Explorer.""", json_schema_extra = { "linkml_meta": {'alias': 'default_embedding',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'},
                          'cxg': {'tag': 'cxg', 'value': 'default_embedding'}},
+         'domain_of': ['Dataset']} })
+    description: str = Field(default=..., title="Description", description="""Short description of the dataset""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
          'domain_of': ['Dataset']} })
     gene_annotation_version: str = Field(default=..., title="Gene Annotation Version", description="""Ensembl release version accession number. Some common codes include: GRCh38.p12 = GCF_000001405.38 GRCh38.p13 = GCF_000001405.39 GRCh38.p14 = GCF_000001405.40
 """, json_schema_extra = { "linkml_meta": {'alias': 'gene_annotation_version',
@@ -340,7 +344,7 @@ class Dataset(ConfiguredBaseModel):
          'examples': [{'description': 'Principal Investigator in Last '
                                       'Name,MiddleInitial, FirstName format',
                        'value': '["Teichmann,Sarah,A."]'}]} })
-    title: str = Field(default=..., title="Title", description="""This text describes and differentiates the dataset from other datasets in the same collection.  It is strongly recommended that each dataset title in a collection is unique and does not depend on other metadata  such as a different assay to disambiguate it from other datasets in the collection.
+    title: Optional[str] = Field(default=None, title="Title", description="""This text describes and differentiates the dataset from other datasets in the same collection.  It is strongly recommended that each dataset title in a collection is unique and does not depend on other metadata  such as a different assay to disambiguate it from other datasets in the collection.
 """, json_schema_extra = { "linkml_meta": {'alias': 'title',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'},
                          'cxg': {'tag': 'cxg', 'value': 'title'}},
@@ -350,7 +354,8 @@ class Dataset(ConfiguredBaseModel):
                       'may not always be available.'],
          'domain_of': ['Dataset'],
          'examples': [{'value': "Cells of the adult human heart collection is 'All — "
-                                "Cells of the adult human heart'"}]} })
+                                "Cells of the adult human heart'"}],
+         'is_a': 'deprecated_slot'} })
     dataset_id: str = Field(default=..., title="Dataset ID", description="""A unique identifier for each dataset in the study. This should be unique to the study.""", json_schema_extra = { "linkml_meta": {'alias': 'dataset_id', 'domain_of': ['Dataset', 'Donor', 'Sample']} })
 
 
@@ -515,6 +520,9 @@ class Donor(ConfiguredBaseModel):
                       {'description': 'male', 'value': 'PATO:0000384'}],
          'notes': ['This must be a child of PATO:0001894 for phenotypic sex or '
                    '"unknown" if unavailable.\n']} })
+    sex_ontology_term: Optional[str] = Field(default=None, title="Sex Ontology Term", description="""Deprecated placeholder for sex ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'sex_ontology_term',
+         'domain_of': ['Donor'],
+         'is_a': 'deprecated_slot'} })
     manner_of_death: MannerOfDeath = Field(default=..., title="Manner of Death", description="""Manner of death classification based on the Hardy Scale or \"unknown\" or \"not applicable\":
 * Category 1 = Violent and fast death — deaths due to accident, blunt force trauma or suicide, terminal phase < 10 min.
 * Category 2 = Fast death of natural causes — sudden unexpected deaths of reasonably healthy people, terminal phase < 1 h.

--- a/src/hca_validation/schema/generated/core.py
+++ b/src/hca_validation/schema/generated/core.py
@@ -450,6 +450,16 @@ class Sample(ConfiguredBaseModel):
                       'outlier samples'],
          'domain_of': ['Sample'],
          'examples': [{'value': '88; 95; 93.5'}]} })
+    institute: str = Field(default=..., title="Institute", description="""Institution where the samples were processed.""", json_schema_extra = { "linkml_meta": {'alias': 'institute',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['To be able to link to other studies from the same institution '
+                      'as sometimes samples from different labs in the same institute '
+                      'are processed via similar core facilities. Thus batch effects '
+                      'may be smaller for datasets from the same institute even if '
+                      'other factors differ.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'EMBL-EBI; Genome Institute of Singapore'}]} })
 
 
 class Cell(ConfiguredBaseModel):

--- a/src/hca_validation/schema/generated/core.py
+++ b/src/hca_validation/schema/generated/core.py
@@ -396,7 +396,23 @@ class Donor(ConfiguredBaseModel):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/donor'})
 
-    donor_id: str = Field(default=..., title="Donor ID", json_schema_extra = { "linkml_meta": {'alias': 'donor_id', 'domain_of': ['Donor', 'Sample']} })
+    donor_id: str = Field(default=..., title="Donor ID", description="""This must be free-text that identifies a unique individual that data were derived from.""", json_schema_extra = { "linkml_meta": {'alias': 'donor_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'donor_id'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Fundamental unit of biological variation of the data. It is '
+                      'strongly recommended that this identifier be designed so that '
+                      'it is unique to: a given individual within the collection of '
+                      'datasets that includes this dataset, and a given individual '
+                      'across all collections in CELLxGENE Discover. It is strongly '
+                      'recommended that "pooled" be used for observations from a '
+                      'sample of multiple individuals that were not confidently '
+                      'assigned to a single individual through demultiplexing. It is '
+                      'strongly recommended that "unknown" ONLY be used for '
+                      'observations in a dataset when it is not known which '
+                      'observations are from the same individual.'],
+         'domain_of': ['Donor', 'Sample'],
+         'examples': [{'value': 'CR_donor_1; MM_donor_1; LR_donor_2'}]} })
     sex_ontology_term_id: str = Field(default=..., title="Sex Ontology Term ID", description="""Reported sex of the donor.""", json_schema_extra = { "linkml_meta": {'alias': 'sex_ontology_term_id',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'cxg': {'tag': 'cxg', 'value': 'sex_ontology_term_id'}},
@@ -428,8 +444,28 @@ class Sample(ConfiguredBaseModel):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/sample'})
 
-    sample_id: str = Field(default=..., title="Sample ID", json_schema_extra = { "linkml_meta": {'alias': 'sample_id', 'domain_of': ['Sample']} })
-    donor_id: str = Field(default=..., title="Donor ID", json_schema_extra = { "linkml_meta": {'alias': 'donor_id', 'domain_of': ['Donor', 'Sample']} })
+    sample_id: str = Field(default=..., title="Sample ID", description="""Identification number of the sample. This is the fundamental unit of sampling the tissue (the specimen taken from the subject), which can be the same as the 'subject_ID', but is often different if multiple samples are taken from the same subject. Note: this is NOT a unit of multiplexing of donor samples, which should be stored in \"library\".""", json_schema_extra = { "linkml_meta": {'alias': 'sample_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'SC24; SC25; SC28'}]} })
+    donor_id: str = Field(default=..., title="Donor ID", description="""This must be free-text that identifies a unique individual that data were derived from.""", json_schema_extra = { "linkml_meta": {'alias': 'donor_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'donor_id'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Fundamental unit of biological variation of the data. It is '
+                      'strongly recommended that this identifier be designed so that '
+                      'it is unique to: a given individual within the collection of '
+                      'datasets that includes this dataset, and a given individual '
+                      'across all collections in CELLxGENE Discover. It is strongly '
+                      'recommended that "pooled" be used for observations from a '
+                      'sample of multiple individuals that were not confidently '
+                      'assigned to a single individual through demultiplexing. It is '
+                      'strongly recommended that "unknown" ONLY be used for '
+                      'observations in a dataset when it is not known which '
+                      'observations are from the same individual.'],
+         'domain_of': ['Donor', 'Sample'],
+         'examples': [{'value': 'CR_donor_1; MM_donor_1; LR_donor_2'}]} })
     dataset_id: str = Field(default=..., title="Dataset ID", description="""A unique identifier for each dataset in the study. This should be unique to the study.""", json_schema_extra = { "linkml_meta": {'alias': 'dataset_id', 'domain_of': ['Dataset', 'Donor', 'Sample']} })
     author_batch_notes: Optional[str] = Field(default=None, title="Author Batch Notes", description="""Encoding of author knowledge on any further information related to likely batch effects.""", json_schema_extra = { "linkml_meta": {'alias': 'author_batch_notes',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},

--- a/src/hca_validation/schema/generated/core.py
+++ b/src/hca_validation/schema/generated/core.py
@@ -553,6 +553,7 @@ class Sample(ConfiguredBaseModel):
          'comments': ['Space for author intuition of batch effects in their dataset'],
          'domain_of': ['Sample'],
          'examples': [{'value': 'Batch run by different personnel on different days'}]} })
+    age_range: Optional[str] = Field(default=None, title="Age Range", description="""Deprecated placeholder for age range metadata.""", json_schema_extra = { "linkml_meta": {'alias': 'age_range', 'domain_of': ['Sample'], 'is_a': 'deprecated_slot'} })
     cell_number_loaded: Optional[int] = Field(default=None, title="Cell Number Loaded", description="""Estimated number of cells loaded for library construction.""", json_schema_extra = { "linkml_meta": {'alias': 'cell_number_loaded',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
@@ -566,6 +567,16 @@ class Sample(ConfiguredBaseModel):
                       'outlier samples'],
          'domain_of': ['Sample'],
          'examples': [{'value': '88; 95; 93.5'}]} })
+    cell_enrichment: str = Field(default=..., title="Cell Enrichment", description="""Specifies the cell types targeted for enrichment or depletion beyond the selection of live cells.""", json_schema_extra = { "linkml_meta": {'alias': 'cell_enrichment',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'CL:0000057+'}],
+         'notes': ['This must be a Cell Ontology (CL) term '
+                   '(http://www.ebi.ac.uk/ols4/ontologies/cl). For cells that are '
+                   "enriched, list the CL code followed by a '+'. For cells that were "
+                   "depleted, list the CL code followed by a '-'. If no enrichment or "
+                   "depletion occurred, please use 'na' (not applicable)"]} })
     development_stage_ontology_term_id: DevelopmentStage = Field(default=..., title="Development Stage Ontology Term ID", description="""Age of the subject.""", json_schema_extra = { "linkml_meta": {'alias': 'development_stage_ontology_term_id',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'cxg': {'tag': 'cxg',
@@ -578,6 +589,9 @@ class Sample(ConfiguredBaseModel):
                    'organism_ontolology_term_id is "NCBITaxon:10090" for Mus musculus, '
                    'this should be an MmusDv term. Refer to broader age bracket terms '
                    'as needed.']} })
+    disease_ontology_term: Optional[str] = Field(default=None, title="Disease Ontology Term", description="""Deprecated placeholder for disease ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'disease_ontology_term',
+         'domain_of': ['Sample'],
+         'is_a': 'deprecated_slot'} })
     institute: str = Field(default=..., title="Institute", description="""Institution where the samples were processed.""", json_schema_extra = { "linkml_meta": {'alias': 'institute',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
@@ -698,6 +712,9 @@ class Sample(ConfiguredBaseModel):
          'domain_of': ['Sample'],
          'examples': [{'value': 'surgical donor'}],
          'notes': ['surgical donor; postmortem donor; living organ donor']} })
+    tissue_ontology_term: Optional[str] = Field(default=None, title="Tissue Ontology Term", description="""Deprecated placeholder for tissue ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'tissue_ontology_term',
+         'domain_of': ['Sample'],
+         'is_a': 'deprecated_slot'} })
 
 
 class Cell(ConfiguredBaseModel):

--- a/src/hca_validation/schema/generated/core.py
+++ b/src/hca_validation/schema/generated/core.py
@@ -153,6 +153,16 @@ class RadialTissueTerm(str, Enum):
     Submucosal_ILF = "Submucosal ILF"
 
 
+class SampleCollectionMethod(str, Enum):
+    brush = "brush"
+    scraping = "scraping"
+    biopsy = "biopsy"
+    surgical_resection = "surgical resection"
+    blood_draw = "blood draw"
+    body_fluid = "body fluid"
+    other = "other"
+
+
 
 class Dataset(ConfiguredBaseModel):
     """

--- a/src/hca_validation/schema/generated/core.py
+++ b/src/hca_validation/schema/generated/core.py
@@ -141,6 +141,18 @@ class YesNoEnum(str, Enum):
     """
 
 
+class RadialTissueTerm(str, Enum):
+    EPI = "EPI"
+    LP = "LP"
+    MUSC = "MUSC"
+    EPI_LP_MUSC = "EPI_LP_MUSC"
+    MLN = "MLN"
+    SUB = "SUB"
+    Peyers_patch = "Peyers patch"
+    Mucosal_ILF = "Mucosal ILF"
+    Submucosal_ILF = "Submucosal ILF"
+
+
 
 class Dataset(ConfiguredBaseModel):
     """
@@ -277,6 +289,7 @@ class GutDataset(Dataset):
          'examples': [{'value': 'none'},
                       {'value': 'doublet_finder'},
                       {'value': 'manual'}]} })
+    radial_tissue_term: RadialTissueTerm = Field(default=..., title="Radial Tissue Term", description="""Radial compartment/location of the tissue sample.""", json_schema_extra = { "linkml_meta": {'alias': 'radial_tissue_term', 'domain_of': ['GutDataset']} })
     alignment_software: str = Field(default=..., title="Alignment Software", description="""Protocol used for alignment analysis, please specify which version was used e.g. cell ranger 2.0, 2.1.1 etc.""", json_schema_extra = { "linkml_meta": {'alias': 'alignment_software',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
          'comments': ['Affects which cells are filtered per dataset, and which reads '

--- a/src/hca_validation/schema/generated/core.py
+++ b/src/hca_validation/schema/generated/core.py
@@ -230,6 +230,11 @@ class DevelopmentStage(str, Enum):
     unknown = "unknown"
 
 
+class Organism(str, Enum):
+    NCBITaxonCOLON9606 = "NCBITaxon:9606"
+    NCBITaxonCOLON10090 = "NCBITaxon:10090"
+
+
 
 class Dataset(ConfiguredBaseModel):
     """
@@ -376,6 +381,9 @@ class GutDataset(Dataset):
                       {'value': 'doublet_finder'},
                       {'value': 'manual'}]} })
     radial_tissue_term: RadialTissueTerm = Field(default=..., title="Radial Tissue Term", description="""Radial compartment/location of the tissue sample.""", json_schema_extra = { "linkml_meta": {'alias': 'radial_tissue_term', 'domain_of': ['GutDataset']} })
+    dissociation_protocol: str = Field(default=..., title="Dissociation Protocol", description="""Dissociation chemicals used during sample preparation""", json_schema_extra = { "linkml_meta": {'alias': 'dissociation_protocol',
+         'domain_of': ['GutDataset'],
+         'notes': ['trypsin; trypLE; collagenase']} })
     alignment_software: str = Field(default=..., title="Alignment Software", description="""Protocol used for alignment analysis, please specify which version was used e.g. cell ranger 2.0, 2.1.1 etc.""", json_schema_extra = { "linkml_meta": {'alias': 'alignment_software',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
          'comments': ['Affects which cells are filtered per dataset, and which reads '
@@ -408,6 +416,9 @@ class GutDataset(Dataset):
                    '- 10x 5\' v2 "EFO:0009900"\n'
                    '- Smart-seq2 "EFO:0008931"\n'
                    '- Visium Spatial Gene Expression "EFO:0010961"\n']} })
+    assay_ontology_term: Optional[str] = Field(default=None, title="Assay Ontology Term", description="""Deprecated placeholder for assay ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'assay_ontology_term',
+         'domain_of': ['Dataset'],
+         'is_a': 'deprecated_slot'} })
     batch_condition: Optional[list[str]] = Field(default=None, title="Batch Condition", description="""Name of the covariate that confers the dominant batch effect in the data as judged by the data contributor.  The name provided here should be the label by which this covariate is stored in the AnnData object.""", json_schema_extra = { "linkml_meta": {'alias': 'batch_condition',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'},
                          'cxg': {'tag': 'cxg', 'value': 'batch_condition'}},
@@ -424,9 +435,14 @@ class GutDataset(Dataset):
 """, json_schema_extra = { "linkml_meta": {'alias': 'comments',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
          'domain_of': ['Dataset']} })
+    consortia: Optional[str] = Field(default=None, title="Consortia", description="""Deprecated placeholder for consortia information.""", json_schema_extra = { "linkml_meta": {'alias': 'consortia', 'domain_of': ['Dataset'], 'is_a': 'deprecated_slot'} })
+    contact_email: str = Field(default=..., title="Contact Email", description="""Contact name and email of the submitting person""", json_schema_extra = { "linkml_meta": {'alias': 'contact_email', 'domain_of': ['Dataset']} })
     default_embedding: Optional[str] = Field(default=None, title="Default Embedding", description="""The value must match a key to an embedding in obsm for the embedding to display by default in CELLxGENE Explorer.""", json_schema_extra = { "linkml_meta": {'alias': 'default_embedding',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'},
                          'cxg': {'tag': 'cxg', 'value': 'default_embedding'}},
+         'domain_of': ['Dataset']} })
+    description: str = Field(default=..., title="Description", description="""Short description of the dataset""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
          'domain_of': ['Dataset']} })
     gene_annotation_version: str = Field(default=..., title="Gene Annotation Version", description="""Ensembl release version accession number. Some common codes include: GRCh38.p12 = GCF_000001405.38 GRCh38.p13 = GCF_000001405.39 GRCh38.p14 = GCF_000001405.40
 """, json_schema_extra = { "linkml_meta": {'alias': 'gene_annotation_version',
@@ -475,7 +491,7 @@ class GutDataset(Dataset):
          'examples': [{'description': 'Principal Investigator in Last '
                                       'Name,MiddleInitial, FirstName format',
                        'value': '["Teichmann,Sarah,A."]'}]} })
-    title: str = Field(default=..., title="Title", description="""This text describes and differentiates the dataset from other datasets in the same collection.  It is strongly recommended that each dataset title in a collection is unique and does not depend on other metadata  such as a different assay to disambiguate it from other datasets in the collection.
+    title: Optional[str] = Field(default=None, title="Title", description="""This text describes and differentiates the dataset from other datasets in the same collection.  It is strongly recommended that each dataset title in a collection is unique and does not depend on other metadata  such as a different assay to disambiguate it from other datasets in the collection.
 """, json_schema_extra = { "linkml_meta": {'alias': 'title',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'},
                          'cxg': {'tag': 'cxg', 'value': 'title'}},
@@ -485,7 +501,8 @@ class GutDataset(Dataset):
                       'may not always be available.'],
          'domain_of': ['Dataset'],
          'examples': [{'value': "Cells of the adult human heart collection is 'All — "
-                                "Cells of the adult human heart'"}]} })
+                                "Cells of the adult human heart'"}],
+         'is_a': 'deprecated_slot'} })
     dataset_id: str = Field(default=..., title="Dataset ID", description="""A unique identifier for each dataset in the study. This should be unique to the study.""", json_schema_extra = { "linkml_meta": {'alias': 'dataset_id', 'domain_of': ['Dataset', 'Donor', 'Sample']} })
 
 
@@ -512,6 +529,13 @@ class Donor(ConfiguredBaseModel):
                       'observations are from the same individual.'],
          'domain_of': ['Donor', 'Sample'],
          'examples': [{'value': 'CR_donor_1; MM_donor_1; LR_donor_2'}]} })
+    organism_ontology_term_id: Organism = Field(default=..., title="Organism Ontology Term ID", description="""The name given to the type of organism, collected in NCBITaxon:0000 format.""", json_schema_extra = { "linkml_meta": {'alias': 'organism_ontology_term_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'organism_ontology_term_id'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Donor'],
+         'notes': ['"NCBITaxon:9606" for Homo sapiens or "NCBITaxon:10090" for Mus '
+                   'musculus.']} })
     sex_ontology_term_id: str = Field(default=..., title="Sex Ontology Term ID", description="""Reported sex of the donor.""", json_schema_extra = { "linkml_meta": {'alias': 'sex_ontology_term_id',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'cxg': {'tag': 'cxg', 'value': 'sex_ontology_term_id'}},

--- a/src/hca_validation/schema/generated/core.py
+++ b/src/hca_validation/schema/generated/core.py
@@ -197,6 +197,29 @@ class SamplePreservationMethod(str, Enum):
     other = "other"
 
 
+class SampleSource(str, Enum):
+    surgical_donor = "surgical donor"
+    postmortem_donor = "postmortem donor"
+    living_organ_donor = "living organ donor"
+
+
+class DevelopmentStage(str, Enum):
+    HsapDvCOLON0000003 = "HsapDv:0000003"
+    HsapDvCOLON0000046 = "HsapDv:0000046"
+    HsapDvCOLON0000264 = "HsapDv:0000264"
+    HsapDvCOLON0000268 = "HsapDv:0000268"
+    HsapDvCOLON0000237 = "HsapDv:0000237"
+    HsapDvCOLON0000238 = "HsapDv:0000238"
+    HsapDvCOLON0000239 = "HsapDv:0000239"
+    HsapDvCOLON0000240 = "HsapDv:0000240"
+    HsapDvCOLON0000241 = "HsapDv:0000241"
+    HsapDvCOLON0000242 = "HsapDv:0000242"
+    HsapDvCOLON0000243 = "HsapDv:0000243"
+    MmusDvCOLON0000001 = "MmusDv:0000001"
+    MmusDvCOLON0000002 = "MmusDv:0000002"
+    unknown = "unknown"
+
+
 
 class Dataset(ConfiguredBaseModel):
     """
@@ -543,6 +566,18 @@ class Sample(ConfiguredBaseModel):
                       'outlier samples'],
          'domain_of': ['Sample'],
          'examples': [{'value': '88; 95; 93.5'}]} })
+    development_stage_ontology_term_id: DevelopmentStage = Field(default=..., title="Development Stage Ontology Term ID", description="""Age of the subject.""", json_schema_extra = { "linkml_meta": {'alias': 'development_stage_ontology_term_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg',
+                                 'value': 'development_stage_ontology_term_id'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'HsapDv:0000237'}],
+         'notes': ['If organism_ontolology_term_id is "NCBITaxon:9606" for Homo '
+                   'sapiens, this should be an HsapDv term. If '
+                   'organism_ontolology_term_id is "NCBITaxon:10090" for Mus musculus, '
+                   'this should be an MmusDv term. Refer to broader age bracket terms '
+                   'as needed.']} })
     institute: str = Field(default=..., title="Institute", description="""Institution where the samples were processed.""", json_schema_extra = { "linkml_meta": {'alias': 'institute',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
@@ -579,6 +614,10 @@ class Sample(ConfiguredBaseModel):
          'comments': ['Library sequencing is a major source of batch effects'],
          'domain_of': ['Sample'],
          'examples': [{'value': 'run1; NV0087'}]} })
+    sample_collection_method: SampleCollectionMethod = Field(default=..., title="Sample Collection Method", description="""The method the sample was physically obtained from the donor.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_method',
+         'domain_of': ['Sample'],
+         'notes': ['brush; scraping; biopsy; surgical resection; blood draw; body '
+                   'fluid; other']} })
     sample_collection_year: Optional[str] = Field(default=None, title="Sample Collection Year", description="""Year of sample collection. Should not be detailed further (to exact month and day), to prevent identifiability.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_year',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
@@ -653,6 +692,12 @@ class Sample(ConfiguredBaseModel):
                    '-80C; frozen at -150C; frozen in liquid nitrogen; frozen in vapor '
                    'phase; paraffin block; RNAlater at 4C; RNAlater at 25C; RNAlater '
                    'at -20C; other']} })
+    sample_source: SampleSource = Field(default=..., title="Sample Source", description="""The study subgroup that the participant belongs to, indicating whether the participant was a surgical donor, a postmortem donor, or an organ donor.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_source',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'surgical donor'}],
+         'notes': ['surgical donor; postmortem donor; living organ donor']} })
 
 
 class Cell(ConfiguredBaseModel):

--- a/src/hca_validation/schema/generated/core.py
+++ b/src/hca_validation/schema/generated/core.py
@@ -443,6 +443,13 @@ class Sample(ConfiguredBaseModel):
          'comments': ['Can explain the number of doublets found in samples'],
          'domain_of': ['Sample'],
          'examples': [{'value': '5000; 4000'}]} })
+    cell_viability_percentage: Optional[Decimal] = Field(default=None, title="Cell Viability Percentage", description="""If measured, per sample cell viability before library preparation (as a percentage).""", json_schema_extra = { "linkml_meta": {'alias': 'cell_viability_percentage',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Is a measure of sample quality that could be used to explain '
+                      'outlier samples'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': '88; 95; 93.5'}]} })
 
 
 class Cell(ConfiguredBaseModel):

--- a/src/hca_validation/schema/generated/core.py
+++ b/src/hca_validation/schema/generated/core.py
@@ -437,6 +437,12 @@ class Sample(ConfiguredBaseModel):
          'comments': ['Space for author intuition of batch effects in their dataset'],
          'domain_of': ['Sample'],
          'examples': [{'value': 'Batch run by different personnel on different days'}]} })
+    cell_number_loaded: Optional[int] = Field(default=None, title="Cell Number Loaded", description="""Estimated number of cells loaded for library construction.""", json_schema_extra = { "linkml_meta": {'alias': 'cell_number_loaded',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Can explain the number of doublets found in samples'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': '5000; 4000'}]} })
 
 
 class Cell(ConfiguredBaseModel):

--- a/src/hca_validation/schema/generated/core.py
+++ b/src/hca_validation/schema/generated/core.py
@@ -163,6 +163,40 @@ class SampleCollectionMethod(str, Enum):
     other = "other"
 
 
+class TissueType(str, Enum):
+    tissue = "tissue"
+    organoid = "organoid"
+    cell_culture = "cell culture"
+
+
+class SuspensionType(str, Enum):
+    cell = "cell"
+    nucleus = "nucleus"
+    na = "na"
+
+
+class SampledSiteCondition(str, Enum):
+    healthy = "healthy"
+    diseased = "diseased"
+    adjacent = "adjacent"
+
+
+class SamplePreservationMethod(str, Enum):
+    ambient_temperature = "ambient temperature"
+    cut_slide = "cut slide"
+    fresh = "fresh"
+    frozen_at__70C = "frozen at -70C"
+    frozen_at__80C = "frozen at -80C"
+    frozen_at__150C = "frozen at -150C"
+    frozen_in_liquid_nitrogen = "frozen in liquid nitrogen"
+    frozen_in_vapor_phase = "frozen in vapor phase"
+    paraffin_block = "paraffin block"
+    RNAlater_at_4C = "RNAlater at 4C"
+    RNAlater_at_25C = "RNAlater at 25C"
+    RNAlater_at__20C = "RNAlater at -20C"
+    other = "other"
+
+
 
 class Dataset(ConfiguredBaseModel):
     """
@@ -578,6 +612,47 @@ class Sample(ConfiguredBaseModel):
                       'UBERON ontology terms are insufficiently precise.'],
          'domain_of': ['Sample'],
          'examples': [{'value': 'terminal ileum'}]} })
+    tissue_type: TissueType = Field(default=..., title="Tissue Type", description="""Whether the tissue is \"tissue\", \"organoid\", or \"cell culture\".""", json_schema_extra = { "linkml_meta": {'alias': 'tissue_type',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'tissue_type'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'tissue'}],
+         'notes': ['tissue; organoid; cell culture']} })
+    suspension_type: SuspensionType = Field(default=..., title="Suspension Type", description="""Specifies whether the sample contains single cells or single nuclei data.""", json_schema_extra = { "linkml_meta": {'alias': 'suspension_type',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'suspension_type'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'cell'}],
+         'notes': ['This must be "cell", "nucleus", or "na".\n'
+                   'This must be the correct type for the corresponding assay:\n'
+                   '* 10x transcription profiling [EFO:0030080] and its children = '
+                   '"cell" or "nucleus"\n'
+                   '* ATAC-seq [EFO:0007045] and its children = "nucleus"\n'
+                   '* BD Rhapsody Whole Transcriptome Analysis [EFO:0700003] = "cell"\n'
+                   '* BD Rhapsody Targeted mRNA [EFO:0700004] = "cell"\n'
+                   '* CEL-seq2 [EFO:0010010] = "cell" or "nucleus"\n'
+                   '* CITE-seq [EFO:0009294] and its children = "cell"\n'
+                   '* DroNc-seq [EFO:0008720] = "nucleus"\n'
+                   '* Drop-seq [EFO:0008722] = "cell" or "nucleus"\n'
+                   '* GEXSCOPE technology [EFO:0700011] = "cell" or "nucleus"\n'
+                   '* inDrop [EFO:0008780] = "cell" or "nucleus"\n']} })
+    sampled_site_condition: SampledSiteCondition = Field(default=..., title="Sampled Site Condition", description="""Whether the site is considered healthy, diseased or adjacent to disease.""", json_schema_extra = { "linkml_meta": {'alias': 'sampled_site_condition',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'healthy'}],
+         'notes': ['healthy; diseased; adjacent']} })
+    sample_preservation_method: SamplePreservationMethod = Field(default=..., title="Sample Preservation Method", description="""Indicating if tissue was frozen, or not, at any point before library preparation.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_preservation_method',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'fresh'}],
+         'notes': ['ambient temperature; cut slide; fresh; frozen at -70C; frozen at '
+                   '-80C; frozen at -150C; frozen in liquid nitrogen; frozen in vapor '
+                   'phase; paraffin block; RNAlater at 4C; RNAlater at 25C; RNAlater '
+                   'at -20C; other']} })
 
 
 class Cell(ConfiguredBaseModel):

--- a/src/hca_validation/schema/generated/core.py
+++ b/src/hca_validation/schema/generated/core.py
@@ -145,6 +145,8 @@ class RadialTissueTerm(str, Enum):
     EPI = "EPI"
     LP = "LP"
     MUSC = "MUSC"
+    EPI_LP = "EPI_LP"
+    LP_MUSC = "LP_MUSC"
     EPI_LP_MUSC = "EPI_LP_MUSC"
     MLN = "MLN"
     SUB = "SUB"
@@ -324,6 +326,10 @@ class Dataset(ConfiguredBaseModel):
                       'may not always be available.'],
          'domain_of': ['Dataset'],
          'examples': [{'value': 'https://www.biorxiv.org/content/early/2017/09/24/193219'}]} })
+    publication_doi: Optional[str] = Field(default=None, title="Publication DOI", description="""The publication digital object identifier (doi) for the protocol. If no pre-print nor publication exists, please write 'not applicable'.
+""", json_schema_extra = { "linkml_meta": {'alias': 'publication_doi',
+         'domain_of': ['Dataset'],
+         'examples': [{'value': '10.1016/j.cell.2016.07.054'}]} })
     reference_genome: ReferenceGenomeEnum = Field(default=..., title="Reference Genome", description="""Reference genome used for alignment.""", json_schema_extra = { "linkml_meta": {'alias': 'reference_genome',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
          'comments': ['Possible source of batch effect and confounder for some '
@@ -462,6 +468,10 @@ class GutDataset(Dataset):
                       'may not always be available.'],
          'domain_of': ['Dataset'],
          'examples': [{'value': 'https://www.biorxiv.org/content/early/2017/09/24/193219'}]} })
+    publication_doi: Optional[str] = Field(default=None, title="Publication DOI", description="""The publication digital object identifier (doi) for the protocol. If no pre-print nor publication exists, please write 'not applicable'.
+""", json_schema_extra = { "linkml_meta": {'alias': 'publication_doi',
+         'domain_of': ['Dataset'],
+         'examples': [{'value': '10.1016/j.cell.2016.07.054'}]} })
     reference_genome: ReferenceGenomeEnum = Field(default=..., title="Reference Genome", description="""Reference genome used for alignment.""", json_schema_extra = { "linkml_meta": {'alias': 'reference_genome',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
          'comments': ['Possible source of batch effect and confounder for some '
@@ -632,6 +642,19 @@ class Sample(ConfiguredBaseModel):
                    'organism_ontolology_term_id is "NCBITaxon:10090" for Mus musculus, '
                    'this should be an MmusDv term. Refer to broader age bracket terms '
                    'as needed.']} })
+    disease_ontology_term_id: str = Field(default=..., title="Disease Ontology Term ID", description="""Disease, if expected to impact the sample.""", json_schema_extra = { "linkml_meta": {'alias': 'disease_ontology_term_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'disease_ontology_term_id'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'MONDO:0005385'}, {'value': 'PATO:0000461'}],
+         'notes': ['This must be a MONDO term or "PATO:0000461" for normal or '
+                   'healthy.\n'
+                   '\n'
+                   'Requirements for data contributors adhering to GDPR or like '
+                   'standards: In the case of disease, HCA requests that you submit a '
+                   'higher order ontology term - this is especially important in the '
+                   'case of rare disease.\n']} })
     disease_ontology_term: Optional[str] = Field(default=None, title="Disease Ontology Term", description="""Deprecated placeholder for disease ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'disease_ontology_term',
          'domain_of': ['Sample'],
          'is_a': 'deprecated_slot'} })
@@ -716,6 +739,16 @@ class Sample(ConfiguredBaseModel):
          'domain_of': ['Sample'],
          'examples': [{'value': 'tissue'}],
          'notes': ['tissue; organoid; cell culture']} })
+    tissue_ontology_term_id: str = Field(default=..., title="Tissue Ontology Term ID", description="""The detailed anatomical location of the sample, please provide a specific UBERON term.""", json_schema_extra = { "linkml_meta": {'alias': 'tissue_ontology_term_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'tissue_ontology_term_id'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'UBERON:0001828'}, {'value': 'UBERON:0000966'}],
+         'notes': ['If tissue_type is "tissue" or "organoid", this must be the most '
+                   'accurate child of UBERON:0001062 for anatomical entity. If '
+                   'tissue_type is "cell culture" this must follow the requirements '
+                   'for cell_type_ontology_term_id.\n']} })
     suspension_type: SuspensionType = Field(default=..., title="Suspension Type", description="""Specifies whether the sample contains single cells or single nuclei data.""", json_schema_extra = { "linkml_meta": {'alias': 'suspension_type',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'cxg': {'tag': 'cxg', 'value': 'suspension_type'},
@@ -837,6 +870,19 @@ class GutSample(Sample):
                    'organism_ontolology_term_id is "NCBITaxon:10090" for Mus musculus, '
                    'this should be an MmusDv term. Refer to broader age bracket terms '
                    'as needed.']} })
+    disease_ontology_term_id: str = Field(default=..., title="Disease Ontology Term ID", description="""Disease, if expected to impact the sample.""", json_schema_extra = { "linkml_meta": {'alias': 'disease_ontology_term_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'disease_ontology_term_id'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'MONDO:0005385'}, {'value': 'PATO:0000461'}],
+         'notes': ['This must be a MONDO term or "PATO:0000461" for normal or '
+                   'healthy.\n'
+                   '\n'
+                   'Requirements for data contributors adhering to GDPR or like '
+                   'standards: In the case of disease, HCA requests that you submit a '
+                   'higher order ontology term - this is especially important in the '
+                   'case of rare disease.\n']} })
     disease_ontology_term: Optional[str] = Field(default=None, title="Disease Ontology Term", description="""Deprecated placeholder for disease ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'disease_ontology_term',
          'domain_of': ['Sample'],
          'is_a': 'deprecated_slot'} })
@@ -921,6 +967,16 @@ class GutSample(Sample):
          'domain_of': ['Sample'],
          'examples': [{'value': 'tissue'}],
          'notes': ['tissue; organoid; cell culture']} })
+    tissue_ontology_term_id: str = Field(default=..., title="Tissue Ontology Term ID", description="""The detailed anatomical location of the sample, please provide a specific UBERON term.""", json_schema_extra = { "linkml_meta": {'alias': 'tissue_ontology_term_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'tissue_ontology_term_id'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'UBERON:0001828'}, {'value': 'UBERON:0000966'}],
+         'notes': ['If tissue_type is "tissue" or "organoid", this must be the most '
+                   'accurate child of UBERON:0001062 for anatomical entity. If '
+                   'tissue_type is "cell culture" this must follow the requirements '
+                   'for cell_type_ontology_term_id.\n']} })
     suspension_type: SuspensionType = Field(default=..., title="Suspension Type", description="""Specifies whether the sample contains single cells or single nuclei data.""", json_schema_extra = { "linkml_meta": {'alias': 'suspension_type',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'cxg': {'tag': 'cxg', 'value': 'suspension_type'},

--- a/src/hca_validation/schema/sample.yaml
+++ b/src/hca_validation/schema/sample.yaml
@@ -28,6 +28,10 @@ classes:
       - cell_number_loaded
       - cell_viability_percentage
       - institute
+      - library_id
+      - library_id_repository
+      - library_preparation_batch
+      - library_sequencing_run
 
 slots:
   sample_id:
@@ -99,3 +103,63 @@ slots:
     multivalued: false
     comments: >-
       To be able to link to other studies from the same institution as sometimes samples from different labs in the same institute are processed via similar core facilities. Thus batch effects may be smaller for datasets from the same institute even if other factors differ.
+
+  library_id:
+    title: Library ID
+    description: >-
+      The unique ID that is used to track libraries in the investigator's institution (should align with the publication).
+    examples:
+      - value: A24; NK_healthy_001
+    annotations:
+      annDataLocation: obs
+      tier: Tier 1
+    range: string
+    required: true
+    multivalued: false
+    comments: >-
+      A way to track the unit of data generation. This should include sample pooling
+
+  library_id_repository:
+    title: Library ID Repository
+    description: >-
+      The unique ID used to track libraries from one of the following public data repositories: EGAX*, GSM*, SRX*, ERX*, DRX, HRX, CRX.
+    examples:
+      - value: GSM1684095
+    annotations:
+      annDataLocation: obs
+      tier: Tier 1
+    range: string
+    required: false
+    multivalued: false
+    comments: >-
+      Links a dataset back to the source from which it was ingested, optional only if this is the same as the library_id.
+
+  library_preparation_batch:
+    title: Library Preparation Batch
+    description: >-
+      Indicating which samples' libraries were prepared in the same chip/plate/etc., e.g. batch1, batch2.
+    examples:
+      - value: batch01; batch02
+    annotations:
+      annDataLocation: obs
+      tier: Tier 1
+    range: string
+    required: true
+    multivalued: false
+    comments: >-
+      Sample preparation is a major source of batch effects.
+
+  library_sequencing_run:
+    title: Library Sequencing Run
+    description: >-
+      The identifier (or accession number) that indicates which samples' libraries were sequenced in the same run.
+    examples:
+      - value: run1; NV0087
+    annotations:
+      annDataLocation: obs
+      tier: Tier 1
+    range: string
+    required: true
+    multivalued: false
+    comments: >-
+      Library sequencing is a major source of batch effects

--- a/src/hca_validation/schema/sample.yaml
+++ b/src/hca_validation/schema/sample.yaml
@@ -26,6 +26,7 @@ classes:
       - dataset_id
       - author_batch_notes
       - cell_number_loaded
+      - cell_viability_percentage
 
 slots:
   sample_id:
@@ -67,3 +68,18 @@ slots:
     multivalued: false
     comments: >-
       Can explain the number of doublets found in samples
+
+  cell_viability_percentage:
+    title: Cell Viability Percentage
+    description: >-
+      If measured, per sample cell viability before library preparation (as a percentage).
+    examples:
+      - value: "88; 95; 93.5"
+    annotations:
+      annDataLocation: obs
+      tier: Tier 1
+    range: decimal
+    required: false
+    multivalued: false
+    comments: >-
+      Is a measure of sample quality that could be used to explain outlier samples

--- a/src/hca_validation/schema/sample.yaml
+++ b/src/hca_validation/schema/sample.yaml
@@ -27,11 +27,13 @@ classes:
       - author_batch_notes
       - cell_number_loaded
       - cell_viability_percentage
+      - development_stage_ontology_term_id
       - institute
       - library_id
       - library_id_repository
       - library_preparation_batch
       - library_sequencing_run
+      - sample_collection_method
       - sample_collection_year
       - sample_collection_site
       - sample_collection_relative_time_point
@@ -40,6 +42,7 @@ classes:
       - suspension_type
       - sampled_site_condition
       - sample_preservation_method
+      - sample_source
 
 slots:
   author_batch_notes:
@@ -287,6 +290,36 @@ slots:
     required: true
     multivalued: false
     notes: "ambient temperature; cut slide; fresh; frozen at -70C; frozen at -80C; frozen at -150C; frozen in liquid nitrogen; frozen in vapor phase; paraffin block; RNAlater at 4C; RNAlater at 25C; RNAlater at -20C; other"
+
+  sample_source:
+    title: Sample Source
+    description: The study subgroup that the participant belongs to, indicating whether the participant was a surgical donor, a postmortem donor, or an organ donor.
+    examples:
+      - value: surgical donor
+    annotations:
+      annDataLocation: obs
+      tier: Tier 1
+    range: SampleSource
+    required: true
+    multivalued: false
+    notes: "surgical donor; postmortem donor; living organ donor"
+
+  development_stage_ontology_term_id:
+    title: Development Stage Ontology Term ID
+    description: Age of the subject.
+    examples:
+      - value: HsapDv:0000237
+    annotations:
+      annDataLocation: obs
+      cxg: development_stage_ontology_term_id
+      tier: Tier 1
+    range: DevelopmentStage
+    required: true
+    multivalued: false
+    notes: >-
+      If organism_ontolology_term_id is "NCBITaxon:9606" for Homo sapiens, this should be an HsapDv term.
+      If organism_ontolology_term_id is "NCBITaxon:10090" for Mus musculus, this should be an MmusDv term.
+      Refer to broader age bracket terms as needed.
 
   sample_collection_method:
     title: Sample Collection Method

--- a/src/hca_validation/schema/sample.yaml
+++ b/src/hca_validation/schema/sample.yaml
@@ -27,6 +27,7 @@ classes:
       - author_batch_notes
       - cell_number_loaded
       - cell_viability_percentage
+      - institute
 
 slots:
   sample_id:
@@ -83,3 +84,18 @@ slots:
     multivalued: false
     comments: >-
       Is a measure of sample quality that could be used to explain outlier samples
+
+  institute:
+    title: Institute
+    description: >-
+      Institution where the samples were processed.
+    examples:
+      - value: EMBL-EBI; Genome Institute of Singapore
+    annotations:
+      annDataLocation: obs
+      tier: Tier 1
+    range: string
+    required: true
+    multivalued: false
+    comments: >-
+      To be able to link to other studies from the same institution as sometimes samples from different labs in the same institute are processed via similar core facilities. Thus batch effects may be smaller for datasets from the same institute even if other factors differ.

--- a/src/hca_validation/schema/sample.yaml
+++ b/src/hca_validation/schema/sample.yaml
@@ -25,9 +25,12 @@ classes:
       - donor_id
       - dataset_id
       - author_batch_notes
+      - age_range
       - cell_number_loaded
       - cell_viability_percentage
+      - cell_enrichment
       - development_stage_ontology_term_id
+      - disease_ontology_term
       - institute
       - library_id
       - library_id_repository
@@ -43,6 +46,7 @@ classes:
       - sampled_site_condition
       - sample_preservation_method
       - sample_source
+      - tissue_ontology_term
 
 slots:
   author_batch_notes:
@@ -59,6 +63,11 @@ slots:
     multivalued: false
     comments: >-
       Space for author intuition of batch effects in their dataset
+
+  age_range:
+    is_a: deprecated_slot
+    title: Age Range
+    description: Deprecated placeholder for age range metadata.
 
   cell_number_loaded:
     title: Cell Number Loaded
@@ -89,6 +98,19 @@ slots:
     multivalued: false
     comments: >-
       Is a measure of sample quality that could be used to explain outlier samples
+
+  cell_enrichment:
+    title: Cell Enrichment
+    description: Specifies the cell types targeted for enrichment or depletion beyond the selection of live cells.
+    examples:
+      - value: CL:0000057+
+    annotations:
+      annDataLocation: obs
+      tier: Tier 1
+    range: string
+    required: true
+    multivalued: false
+    notes: "This must be a Cell Ontology (CL) term (http://www.ebi.ac.uk/ols4/ontologies/cl). For cells that are enriched, list the CL code followed by a '+'. For cells that were depleted, list the CL code followed by a '-'. If no enrichment or depletion occurred, please use 'na' (not applicable)"
 
   institute:
     title: Institute
@@ -327,3 +349,13 @@ slots:
     range: SampleCollectionMethod
     required: true
     notes: "brush; scraping; biopsy; surgical resection; blood draw; body fluid; other"
+
+  tissue_ontology_term:
+    is_a: deprecated_slot
+    title: Tissue Ontology Term
+    description: Deprecated placeholder for tissue ontology term.
+
+  disease_ontology_term:
+    is_a: deprecated_slot
+    title: Disease Ontology Term
+    description: Deprecated placeholder for disease ontology term.

--- a/src/hca_validation/schema/sample.yaml
+++ b/src/hca_validation/schema/sample.yaml
@@ -30,6 +30,7 @@ classes:
       - cell_viability_percentage
       - cell_enrichment
       - development_stage_ontology_term_id
+      - disease_ontology_term_id
       - disease_ontology_term
       - institute
       - is_primary_data
@@ -43,6 +44,7 @@ classes:
       - sample_collection_relative_time_point
       - tissue_free_text
       - tissue_type
+      - tissue_ontology_term_id
       - suspension_type
       - sampled_site_condition
       - sample_preservation_method
@@ -270,6 +272,21 @@ slots:
     multivalued: false
     notes: "tissue; organoid; cell culture"
 
+  tissue_ontology_term_id:
+    title: Tissue Ontology Term ID
+    description: The detailed anatomical location of the sample, please provide a specific UBERON term.
+    range: string
+    required: true
+    examples:
+      - value: "UBERON:0001828"
+      - value: "UBERON:0000966"
+    notes: |
+      If tissue_type is "tissue" or "organoid", this must be the most accurate child of UBERON:0001062 for anatomical entity. If tissue_type is "cell culture" this must follow the requirements for cell_type_ontology_term_id.
+    annotations:
+      annDataLocation: obs
+      cxg: tissue_ontology_term_id
+      tier: Tier 1
+
   suspension_type:
     title: Suspension Type
     description: Specifies whether the sample contains single cells or single nuclei data.
@@ -368,3 +385,20 @@ slots:
     is_a: deprecated_slot
     title: Disease Ontology Term
     description: Deprecated placeholder for disease ontology term.
+
+  disease_ontology_term_id:
+    title: Disease Ontology Term ID
+    description: Disease, if expected to impact the sample.
+    range: string
+    required: true
+    examples:
+      - value: "MONDO:0005385"
+      - value: "PATO:0000461"
+    notes: |
+      This must be a MONDO term or "PATO:0000461" for normal or healthy.
+      
+      Requirements for data contributors adhering to GDPR or like standards: In the case of disease, HCA requests that you submit a higher order ontology term - this is especially important in the case of rare disease.
+    annotations:
+      annDataLocation: obs
+      cxg: disease_ontology_term_id
+      tier: Tier 1

--- a/src/hca_validation/schema/sample.yaml
+++ b/src/hca_validation/schema/sample.yaml
@@ -32,6 +32,7 @@ classes:
       - development_stage_ontology_term_id
       - disease_ontology_term
       - institute
+      - is_primary_data
       - library_id
       - library_id_repository
       - library_preparation_batch
@@ -90,10 +91,13 @@ slots:
       If measured, per sample cell viability before library preparation (as a percentage).
     examples:
       - value: "88; 95; 93.5"
+      - value: unknown
     annotations:
       annDataLocation: obs
       tier: Tier 1
-    range: decimal
+    any_of:
+      - range: decimal
+      - range: string
     required: false
     multivalued: false
     comments: >-
@@ -126,6 +130,11 @@ slots:
     multivalued: false
     comments: >-
       To be able to link to other studies from the same institution as sometimes samples from different labs in the same institute are processed via similar core facilities. Thus batch effects may be smaller for datasets from the same institute even if other factors differ.
+
+  is_primary_data:
+    is_a: deprecated_slot
+    title: Is Primary Data
+    description: Deprecated placeholder indicating whether sample represents primary data.
 
   library_id:
     title: Library ID

--- a/src/hca_validation/schema/sample.yaml
+++ b/src/hca_validation/schema/sample.yaml
@@ -25,16 +25,19 @@ classes:
       - donor_id
       - dataset_id
       - author_batch_notes
+      - cell_number_loaded
 
 slots:
   sample_id:
     title: Sample ID
     range: string
     required: true
+
   donor_id:
     title: Donor ID
     range: string
     required: true
+
   author_batch_notes:
     title: Author Batch Notes
     description: >-
@@ -49,3 +52,18 @@ slots:
     multivalued: false
     comments: >-
       Space for author intuition of batch effects in their dataset
+
+  cell_number_loaded:
+    title: Cell Number Loaded
+    description: >-
+      Estimated number of cells loaded for library construction.
+    examples:
+      - value: "5000; 4000"
+    annotations:
+      annDataLocation: obs
+      tier: Tier 1
+    range: integer
+    required: false
+    multivalued: false
+    comments: >-
+      Can explain the number of doublets found in samples

--- a/src/hca_validation/schema/sample.yaml
+++ b/src/hca_validation/schema/sample.yaml
@@ -217,3 +217,10 @@ slots:
     multivalued: false
     comments: >-
       To help the integration team understand the anatomical location of the sample, specifically to solve the problem when the UBERON ontology terms are insufficiently precise.
+
+  sample_collection_method:
+    title: Sample Collection Method
+    description: The method the sample was physically obtained from the donor.
+    range: SampleCollectionMethod
+    required: true
+    notes: "brush; scraping; biopsy; surgical resection; blood draw; body fluid; other"

--- a/src/hca_validation/schema/sample.yaml
+++ b/src/hca_validation/schema/sample.yaml
@@ -36,6 +36,10 @@ classes:
       - sample_collection_site
       - sample_collection_relative_time_point
       - tissue_free_text
+      - tissue_type
+      - suspension_type
+      - sampled_site_condition
+      - sample_preservation_method
 
 slots:
   author_batch_notes:
@@ -217,6 +221,72 @@ slots:
     multivalued: false
     comments: >-
       To help the integration team understand the anatomical location of the sample, specifically to solve the problem when the UBERON ontology terms are insufficiently precise.
+
+  tissue_type:
+    title: Tissue Type
+    description: Whether the tissue is "tissue", "organoid", or "cell culture".
+    examples:
+      - value: tissue
+    annotations:
+      annDataLocation: obs
+      cxg: tissue_type
+      tier: Tier 1
+    range: TissueType
+    required: true
+    multivalued: false
+    notes: "tissue; organoid; cell culture"
+
+  suspension_type:
+    title: Suspension Type
+    description: Specifies whether the sample contains single cells or single nuclei data.
+    examples:
+      - value: cell
+    annotations:
+      annDataLocation: obs
+      cxg: suspension_type
+      tier: Tier 1
+    range: SuspensionType
+    required: true
+    multivalued: false
+    notes: |
+      This must be "cell", "nucleus", or "na".
+      This must be the correct type for the corresponding assay:
+      * 10x transcription profiling [EFO:0030080] and its children = "cell" or "nucleus"
+      * ATAC-seq [EFO:0007045] and its children = "nucleus"
+      * BD Rhapsody Whole Transcriptome Analysis [EFO:0700003] = "cell"
+      * BD Rhapsody Targeted mRNA [EFO:0700004] = "cell"
+      * CEL-seq2 [EFO:0010010] = "cell" or "nucleus"
+      * CITE-seq [EFO:0009294] and its children = "cell"
+      * DroNc-seq [EFO:0008720] = "nucleus"
+      * Drop-seq [EFO:0008722] = "cell" or "nucleus"
+      * GEXSCOPE technology [EFO:0700011] = "cell" or "nucleus"
+      * inDrop [EFO:0008780] = "cell" or "nucleus"
+
+  sampled_site_condition:
+    title: Sampled Site Condition
+    description: Whether the site is considered healthy, diseased or adjacent to disease.
+    examples:
+      - value: healthy
+    annotations:
+      annDataLocation: obs
+      tier: Tier 1
+    range: SampledSiteCondition
+    required: true
+    multivalued: false
+    notes: "healthy; diseased; adjacent"
+
+  sample_preservation_method:
+    title: Sample Preservation Method
+    description: Indicating if tissue was frozen, or not, at any point before library preparation.
+    examples:
+      - value: fresh
+    annotations:
+      annDataLocation: obs
+      tier: Tier 1
+    range: SamplePreservationMethod
+    required: true
+    multivalued: false
+    notes: "ambient temperature; cut slide; fresh; frozen at -70C; frozen at -80C; frozen at -150C; frozen in liquid nitrogen; frozen in vapor phase; paraffin block; RNAlater at 4C; RNAlater at 25C; RNAlater at -20C; other"
 
   sample_collection_method:
     title: Sample Collection Method

--- a/src/hca_validation/schema/sample.yaml
+++ b/src/hca_validation/schema/sample.yaml
@@ -32,6 +32,10 @@ classes:
       - library_id_repository
       - library_preparation_batch
       - library_sequencing_run
+      - sample_collection_year
+      - sample_collection_site
+      - sample_collection_relative_time_point
+      - tissue_free_text
 
 slots:
   sample_id:
@@ -163,3 +167,63 @@ slots:
     multivalued: false
     comments: >-
       Library sequencing is a major source of batch effects
+
+  sample_collection_year:
+    title: Sample Collection Year
+    description: >-
+      Year of sample collection. Should not be detailed further (to exact month and day), to prevent identifiability.
+    examples:
+      - value: "2018"
+    annotations:
+      annDataLocation: obs
+      tier: Tier 1
+    range: string
+    required: false
+    multivalued: false
+    comments: >-
+      May explain whether a dataset was separated into smaller batches.
+
+  sample_collection_site:
+    title: Sample Collection Site
+    description: >-
+      The pseudonymised name of the site where the sample was collected.
+    examples:
+      - value: AIDA_site_1; AIDA_site_2
+    annotations:
+      annDataLocation: obs
+      tier: Tier 1
+    range: string
+    required: false
+    multivalued: false
+    comments: >-
+      To understand whether the collection site contributes to batch effects. It is strongly recommended that this identifier be designed so that it is unique to a given site within the collection of datasets that includes this site (for example, the labels 'site1', 'site2' may appear in other datasets thus rendering them indistinguishable).
+
+  sample_collection_relative_time_point:
+    title: Sample Collection Relative Time Point
+    description: >-
+      Time point when the sample was collected. This field is only needed if multiple samples from the same subject are available and collected at different time points. Sample collection dates (e.g. 23/09/22) cannot be used due to patient data protection, only relative time points should be used here (e.g. day3).
+    examples:
+      - value: sampleX_day1
+    annotations:
+      annDataLocation: obs
+      tier: Tier 1
+    range: string
+    required: false
+    multivalued: false
+    comments: >-
+      Explains variability in the data between samples from the same subject.
+
+  tissue_free_text:
+    title: Tissue Free Text
+    description: >-
+      The detailed anatomical location of the sample - this does not have to tie to an ontology term.
+    examples:
+      - value: terminal ileum
+    annotations:
+      annDataLocation: obs
+      tier: Tier 1
+    range: string
+    required: false
+    multivalued: false
+    comments: >-
+      To help the integration team understand the anatomical location of the sample, specifically to solve the problem when the UBERON ontology terms are insufficiently precise.

--- a/src/hca_validation/schema/sample.yaml
+++ b/src/hca_validation/schema/sample.yaml
@@ -14,6 +14,7 @@ default_range: string
 
 imports:
   - linkml:types
+  - ./slots
 
 classes:
   Sample:
@@ -23,6 +24,7 @@ classes:
       - sample_id
       - donor_id
       - dataset_id
+      - author_batch_notes
 
 slots:
   sample_id:
@@ -33,4 +35,17 @@ slots:
     title: Donor ID
     range: string
     required: true
-
+  author_batch_notes:
+    title: Author Batch Notes
+    description: >-
+      Encoding of author knowledge on any further information related to likely batch effects.
+    examples:
+      - value: Batch run by different personnel on different days
+    annotations:
+      annDataLocation: obs
+      tier: Tier 1
+    range: string
+    required: false
+    multivalued: false
+    comments: >-
+      Space for author intuition of batch effects in their dataset

--- a/src/hca_validation/schema/sample.yaml
+++ b/src/hca_validation/schema/sample.yaml
@@ -38,16 +38,6 @@ classes:
       - tissue_free_text
 
 slots:
-  sample_id:
-    title: Sample ID
-    range: string
-    required: true
-
-  donor_id:
-    title: Donor ID
-    range: string
-    required: true
-
   author_batch_notes:
     title: Author Batch Notes
     description: >-

--- a/src/hca_validation/schema/slots.yaml
+++ b/src/hca_validation/schema/slots.yaml
@@ -85,6 +85,13 @@ slots:
     range: RadialTissueTerm
     required: true
 
+  dissociation_protocol:
+    title: Dissociation Protocol
+    description: Dissociation chemicals used during sample preparation
+    range: string
+    required: true
+    notes: "trypsin; trypLE; collagenase"
+
   deprecated_slot:
     title: Deprecated Slot
     description: Placeholder string slot that can be extended (via is_a) for deprecated or transitional metadata fields.

--- a/src/hca_validation/schema/slots.yaml
+++ b/src/hca_validation/schema/slots.yaml
@@ -79,3 +79,10 @@ slots:
     description: Radial compartment/location of the tissue sample.
     range: RadialTissueTerm
     required: true
+
+  deprecated_slot:
+    title: Deprecated Slot
+    description: Placeholder string slot that can be extended (via is_a) for deprecated or transitional metadata fields.
+    range: string
+    required: false
+    multivalued: false

--- a/src/hca_validation/schema/slots.yaml
+++ b/src/hca_validation/schema/slots.yaml
@@ -16,6 +16,11 @@ imports:
   - linkml:types
   - ./enums
 
+types:
+  Email:
+    typeof: string
+    pattern: '^[^@\s]+@[^@\s]+\.[^@\s]+$'
+
 slots:
   ambient_count_correction:
     title: Ambient Count Correction

--- a/src/hca_validation/schema/slots.yaml
+++ b/src/hca_validation/schema/slots.yaml
@@ -45,3 +45,30 @@ slots:
     description: A unique identifier for each dataset in the study. This should be unique to the study.
     range: string
     required: true
+
+  sample_id:
+    title: Sample ID
+    description: >-
+      Identification number of the sample. This is the fundamental unit of sampling the tissue (the specimen taken from the subject), which can be the same as the 'subject_ID', but is often different if multiple samples are taken from the same subject. Note: this is NOT a unit of multiplexing of donor samples, which should be stored in "library".
+    examples:
+      - value: SC24; SC25; SC28
+    annotations:
+      annDataLocation: obs
+      tier: Tier 1
+    range: string
+    required: true
+
+  donor_id:
+    title: Donor ID
+    description: >-
+      This must be free-text that identifies a unique individual that data were derived from.
+    examples:
+      - value: CR_donor_1; MM_donor_1; LR_donor_2
+    annotations:
+      annDataLocation: obs
+      tier: Tier 1
+      cxg: donor_id
+    range: string
+    required: true
+    comments: >-
+      Fundamental unit of biological variation of the data. It is strongly recommended that this identifier be designed so that it is unique to: a given individual within the collection of datasets that includes this dataset, and a given individual across all collections in CELLxGENE Discover. It is strongly recommended that "pooled" be used for observations from a sample of multiple individuals that were not confidently assigned to a single individual through demultiplexing. It is strongly recommended that "unknown" ONLY be used for observations in a dataset when it is not known which observations are from the same individual.

--- a/src/hca_validation/schema/slots.yaml
+++ b/src/hca_validation/schema/slots.yaml
@@ -14,6 +14,7 @@ default_range: string
 
 imports:
   - linkml:types
+  - ./enums
 
 slots:
   ambient_count_correction:
@@ -72,3 +73,9 @@ slots:
     required: true
     comments: >-
       Fundamental unit of biological variation of the data. It is strongly recommended that this identifier be designed so that it is unique to: a given individual within the collection of datasets that includes this dataset, and a given individual across all collections in CELLxGENE Discover. It is strongly recommended that "pooled" be used for observations from a sample of multiple individuals that were not confidently assigned to a single individual through demultiplexing. It is strongly recommended that "unknown" ONLY be used for observations in a dataset when it is not known which observations are from the same individual.
+
+  radial_tissue_term:
+    title: Radial Tissue Term
+    description: Radial compartment/location of the tissue sample.
+    range: RadialTissueTerm
+    required: true

--- a/src/hca_validation/validator/validator.py
+++ b/src/hca_validation/validator/validator.py
@@ -6,7 +6,7 @@ This module provides the main validation functionality for HCA data using Pydant
 from typing import Dict, Any, Optional
 from pydantic import ValidationError
 
-from hca_validation.schema.generated.core import Dataset, GutDataset, Donor, Sample, Cell
+from hca_validation.schema.generated.core import Dataset, GutDataset, Donor, Sample, GutSample, Cell
 
 # Map schema types and bionetworks to their corresponding Pydantic models
 schema_models = {
@@ -18,7 +18,8 @@ schema_models = {
       "DEFAULT": Donor
     },
     "sample": {
-      "DEFAULT": Sample
+      "DEFAULT": Sample,
+      "gut": GutSample
     },
     "cell": {
       "DEFAULT": Cell

--- a/tests/data/valid_dataset.json
+++ b/tests/data/valid_dataset.json
@@ -12,5 +12,7 @@
   "comments": "Sample dataset for testing validation",
   "protocol_url": "https://www.biorxiv.org/content/early/2017/09/24/193219",
   "title": "Human Heart Cell Atlas - Test Dataset",
-  "dataset_id": "HCA-TEST-1"
+  "dataset_id": "HCA-TEST-1",
+  "contact_email": "sam@sneed.com",
+  "description": "Sample dataset for testing validation"
 }

--- a/tests/data/valid_or_invalid_by_model_dataset.json
+++ b/tests/data/valid_or_invalid_by_model_dataset.json
@@ -12,5 +12,7 @@
   "comments": "Sample dataset for testing validation",
   "protocol_url": "https://www.biorxiv.org/content/early/2017/09/24/193219",
   "title": "Human Heart Cell Atlas - Test Dataset",
-  "dataset_id": "HCA-TEST-2"
+  "dataset_id": "HCA-TEST-2",
+  "contact_email": "sam@sneed.com",
+  "description": "Sample dataset for testing validation"
 }


### PR DESCRIPTION
This could be tightened up further, in a few places, but it seems a good stopping point for this ticket.  I need to get some refinements on the requirements to continue. Also, this adds a bit to the GutDataset, so it will be good to have this merged to test out the Gut-specific validations.

I did check that it validates with `make validate-schema` tests, run and it works on dev.  I am not 1000% sure the GutDataset gets generated but if not hopefully that can get resolved in the GutSpecific functionality PR if needed.