### PR TITLE
feat: add WM to gut radial tissue term enum

### DIFF
--- a/src/hca_validation/schema/enums.yaml
+++ b/src/hca_validation/schema/enums.yaml
@@ -36,6 +36,7 @@ enums:
       "Peyers patch": {}
       "Mucosal ILF": {}
       "Submucosal ILF": {}
+      WM: {}
       
   SampleCollectionMethod:
     permissible_values:

--- a/src/hca_validation/schema/generated/core.py
+++ b/src/hca_validation/schema/generated/core.py
@@ -153,6 +153,7 @@ class RadialTissueTerm(str, Enum):
     Peyers_patch = "Peyers patch"
     Mucosal_ILF = "Mucosal ILF"
     Submucosal_ILF = "Submucosal ILF"
+    WM = "WM"
 
 
 class SampleCollectionMethod(str, Enum):


### PR DESCRIPTION
This pull request adds a new permissible value to the `RadialTissueTerm` enumeration in the `src/hca_validation/schema/enums.yaml` file.

* [`src/hca_validation/schema/enums.yaml`](diffhunk://#diff-6a997826f6593d1c2f1c0b109525afc9f540566734c97d3be8cf6b56930d950cR39): Added "WM" as a permissible value under the `RadialTissueTerm` enumeration.