### PR TITLE
feat: mark schema slots as identifiers and references as appropriate (#62)

### DIFF
--- a/src/hca_validation/schema/dataset.yaml
+++ b/src/hca_validation/schema/dataset.yaml
@@ -41,13 +41,6 @@ classes:
       - study_pi
       - title
       - dataset_id
-    attributes:
-      dataset_id:
-        title: Dataset ID
-        description: A unique identifier for each dataset in the study. This should be unique to the study.
-        range: string
-        required: true
-        identifier: true
 
 slots:
   alignment_software:

--- a/src/hca_validation/schema/dataset.yaml
+++ b/src/hca_validation/schema/dataset.yaml
@@ -41,6 +41,13 @@ classes:
       - study_pi
       - title
       - dataset_id
+    attributes:
+      dataset_id:
+        title: Dataset ID
+        description: A unique identifier for each dataset in the study. This should be unique to the study.
+        range: string
+        required: true
+        identifier: true
 
 slots:
   alignment_software:

--- a/src/hca_validation/schema/dataset.yaml
+++ b/src/hca_validation/schema/dataset.yaml
@@ -41,6 +41,10 @@ classes:
       - study_pi
       - title
       - dataset_id
+    slot_usage:
+      dataset_id:
+        range: string
+        identifier: true
 
 slots:
   alignment_software:

--- a/src/hca_validation/schema/donor.yaml
+++ b/src/hca_validation/schema/donor.yaml
@@ -27,6 +27,22 @@ classes:
       - sex_ontology_term
       - manner_of_death
       - dataset_id
+    attributes:
+      donor_id:
+        title: Donor ID
+        description: >-
+          This must be free-text that identifies a unique individual that data were derived from.
+        examples:
+          - value: CR_donor_1; MM_donor_1; LR_donor_2
+        annotations:
+          annDataLocation: obs
+          tier: Tier 1
+          cxg: donor_id
+        range: string
+        required: true
+        identifier: true
+        comments: >-
+          Fundamental unit of biological variation of the data. It is strongly recommended that this identifier be designed so that it is unique to: a given individual within the collection of datasets that includes this dataset, and a given individual across all collections in CELLxGENE Discover. It is strongly recommended that "pooled" be used for observations from a sample of multiple individuals that were not confidently assigned to a single individual through demultiplexing. It is strongly recommended that "unknown" ONLY be used for observations in a dataset when it is not known which observations are from the same individual.
 
 slots:
   sex_ontology_term_id:

--- a/src/hca_validation/schema/donor.yaml
+++ b/src/hca_validation/schema/donor.yaml
@@ -31,6 +31,11 @@ classes:
       donor_id:
         range: string
         identifier: true
+        # Annotations are duplicated here to get around an apparent bug in inheriting them (https://github.com/linkml/linkml/issues/2805)
+        annotations:
+          annDataLocation: obs
+          tier: Tier 1
+          cxg: donor_id
 
 slots:
   sex_ontology_term_id:

--- a/src/hca_validation/schema/donor.yaml
+++ b/src/hca_validation/schema/donor.yaml
@@ -27,22 +27,6 @@ classes:
       - sex_ontology_term
       - manner_of_death
       - dataset_id
-    attributes:
-      donor_id:
-        title: Donor ID
-        description: >-
-          This must be free-text that identifies a unique individual that data were derived from.
-        examples:
-          - value: CR_donor_1; MM_donor_1; LR_donor_2
-        annotations:
-          annDataLocation: obs
-          tier: Tier 1
-          cxg: donor_id
-        range: string
-        required: true
-        identifier: true
-        comments: >-
-          Fundamental unit of biological variation of the data. It is strongly recommended that this identifier be designed so that it is unique to: a given individual within the collection of datasets that includes this dataset, and a given individual across all collections in CELLxGENE Discover. It is strongly recommended that "pooled" be used for observations from a sample of multiple individuals that were not confidently assigned to a single individual through demultiplexing. It is strongly recommended that "unknown" ONLY be used for observations in a dataset when it is not known which observations are from the same individual.
 
 slots:
   sex_ontology_term_id:

--- a/src/hca_validation/schema/donor.yaml
+++ b/src/hca_validation/schema/donor.yaml
@@ -27,6 +27,10 @@ classes:
       - sex_ontology_term
       - manner_of_death
       - dataset_id
+    slot_usage:
+      donor_id:
+        range: string
+        identifier: true
 
 slots:
   sex_ontology_term_id:

--- a/src/hca_validation/schema/generated/core.py
+++ b/src/hca_validation/schema/generated/core.py
@@ -243,150 +243,11 @@ class Dataset(ConfiguredBaseModel):
     """
     A collection of data from a single experiment or study in the Human Cell Atlas
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/dataset'})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/dataset',
+         'slot_usage': {'dataset_id': {'identifier': True,
+                                       'name': 'dataset_id',
+                                       'range': 'string'}}})
 
-    alignment_software: str = Field(default=..., title="Alignment Software", description="""Protocol used for alignment analysis, please specify which version was used e.g. cell ranger 2.0, 2.1.1 etc.""", json_schema_extra = { "linkml_meta": {'alias': 'alignment_software',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
-         'comments': ['Affects which cells are filtered per dataset, and which reads '
-                      '(introns and exons or only exons) are counted as part of the '
-                      'reported transcriptome. This can convey batch effects.'],
-         'domain_of': ['Dataset'],
-         'examples': [{'value': 'cellranger_8.0.0'}]} })
-    assay_ontology_term_id: str = Field(default=..., title="Assay Ontology Term Id", description="""Platform used for single cell library construction.""", json_schema_extra = { "linkml_meta": {'alias': 'assay_ontology_term_id',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
-                         'cxg': {'tag': 'cxg', 'value': 'assay_ontology_term_id'}},
-         'comments': ['Major source of batch effect and dataset filtering criterion'],
-         'domain_of': ['Dataset'],
-         'examples': [{'value': 'EFO:0009922'}],
-         'notes': ['This must be an EFO term and either:\n'
-                   '- "EFO:0002772" for assay by molecule or preferably its most '
-                   'accurate child\n'
-                   '- "EFO:0010183" for single cell library construction or preferably '
-                   'its most accurate child\n'
-                   '- An assay based on 10X Genomics products should either be '
-                   '"EFO:0008995" for 10x technology or preferably its most accurate '
-                   'child.\n'
-                   "- An assay based on SMART (Switching Mechanism at the 5' end of "
-                   'the RNA Template) or SMARTer technology SHOULD either be '
-                   '"EFO:0010184" for Smart-like or preferably its most accurate '
-                   'child.\n'
-                   'Recommended:\n'
-                   '- 10x 3\' v2 "EFO:0009899"\n'
-                   '- 10x 3\' v3 "EFO:0009922"\n'
-                   '- 10x 5\' v1 "EFO:0011025"\n'
-                   '- 10x 5\' v2 "EFO:0009900"\n'
-                   '- Smart-seq2 "EFO:0008931"\n'
-                   '- Visium Spatial Gene Expression "EFO:0010961"\n']} })
-    assay_ontology_term: Optional[str] = Field(default=None, title="Assay Ontology Term", description="""Deprecated placeholder for assay ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'assay_ontology_term',
-         'domain_of': ['Dataset'],
-         'is_a': 'deprecated_slot'} })
-    batch_condition: Optional[list[str]] = Field(default=None, title="Batch Condition", description="""Name of the covariate that confers the dominant batch effect in the data as judged by the data contributor.  The name provided here should be the label by which this covariate is stored in the AnnData object.""", json_schema_extra = { "linkml_meta": {'alias': 'batch_condition',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'},
-                         'cxg': {'tag': 'cxg', 'value': 'batch_condition'}},
-         'domain_of': ['Dataset'],
-         'examples': [{'description': 'Multiple batch conditions as a JSON array',
-                       'value': '["patient", "seqBatch"]'}],
-         'notes': ['Values must refer to cell metadata keys in obs. Together, these '
-                   'keys define the batches that a normalisation or integration '
-                   'algorithm should be aware of. For example if "patient" and '
-                   '"seqBatch" are keys of vectors of cell metadata, either '
-                   '["patient"], ["seqBatch"], or ["patient", "seqBatch"] are valid '
-                   'values.']} })
-    comments: Optional[str] = Field(default=None, title="Comments", description="""Other technical or experimental covariates that could affect the quality or batch of the sample.  Must not contain identifiers. This field is designed to capture potential challenges for data integration not captured elsewhere.
-""", json_schema_extra = { "linkml_meta": {'alias': 'comments',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
-         'domain_of': ['Dataset']} })
-    consortia: Optional[str] = Field(default=None, title="Consortia", description="""Deprecated placeholder for consortia information.""", json_schema_extra = { "linkml_meta": {'alias': 'consortia', 'domain_of': ['Dataset'], 'is_a': 'deprecated_slot'} })
-    contact_email: str = Field(default=..., title="Contact Email", description="""Contact name and email of the submitting person""", json_schema_extra = { "linkml_meta": {'alias': 'contact_email', 'domain_of': ['Dataset']} })
-    default_embedding: Optional[str] = Field(default=None, title="Default Embedding", description="""The value must match a key to an embedding in obsm for the embedding to display by default in CELLxGENE Explorer.""", json_schema_extra = { "linkml_meta": {'alias': 'default_embedding',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'},
-                         'cxg': {'tag': 'cxg', 'value': 'default_embedding'}},
-         'domain_of': ['Dataset']} })
-    description: str = Field(default=..., title="Description", description="""Short description of the dataset""", json_schema_extra = { "linkml_meta": {'alias': 'description',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
-         'domain_of': ['Dataset']} })
-    gene_annotation_version: str = Field(default=..., title="Gene Annotation Version", description="""Ensembl release version accession number. Some common codes include: GRCh38.p12 = GCF_000001405.38 GRCh38.p13 = GCF_000001405.39 GRCh38.p14 = GCF_000001405.40
-""", json_schema_extra = { "linkml_meta": {'alias': 'gene_annotation_version',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
-         'comments': ['Possible source of batch effect and confounder for some '
-                      'biological analysis'],
-         'domain_of': ['Dataset'],
-         'examples': [{'value': 'GCF_000001405.40'}],
-         'notes': ['http://www.ensembl.org/info/website/archives/index.html or '
-                   'NCBI/RefSeq']} })
-    intron_inclusion: Optional[YesNoEnum] = Field(default=None, title="Intron Inclusion", description="""Were introns included during read counting in the alignment process?""", json_schema_extra = { "linkml_meta": {'alias': 'intron_inclusion',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
-         'domain_of': ['Dataset'],
-         'examples': [{'value': 'yes'}, {'value': 'no'}]} })
-    protocol_url: Optional[str] = Field(default=None, title="Protocol URL", description="""The protocols.io URL (if none exists, please use the BioRxiv URL) for the full experimental protocol;  or if multiple protocols exist please list them e.g. sample preparation protocol / sequencing protocol.
-""", json_schema_extra = { "linkml_meta": {'alias': 'protocol_url',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
-         'comments': ['Useful to look up protocol data that can provide insight on '
-                      'batch effects. As protocols can sometimes apply to a subset of '
-                      'the study, we capture this at a sample level. This information '
-                      'may not always be available.'],
-         'domain_of': ['Dataset'],
-         'examples': [{'value': 'https://www.biorxiv.org/content/early/2017/09/24/193219'}]} })
-    publication_doi: Optional[str] = Field(default=None, title="Publication DOI", description="""The publication digital object identifier (doi) for the protocol. If no pre-print nor publication exists, please write 'not applicable'.
-""", json_schema_extra = { "linkml_meta": {'alias': 'publication_doi',
-         'domain_of': ['Dataset'],
-         'examples': [{'value': '10.1016/j.cell.2016.07.054'}]} })
-    reference_genome: ReferenceGenomeEnum = Field(default=..., title="Reference Genome", description="""Reference genome used for alignment.""", json_schema_extra = { "linkml_meta": {'alias': 'reference_genome',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
-         'comments': ['Possible source of batch effect and confounder for some '
-                      'biological analysis'],
-         'domain_of': ['Dataset'],
-         'examples': [{'value': 'GRCm37'}, {'value': 'GRCh37'}]} })
-    sequenced_fragment: SequencedFragmentEnum = Field(default=..., title="Sequenced Fragment", description="""Which part of the RNA transcript was targeted for sequencing.""", json_schema_extra = { "linkml_meta": {'alias': 'sequenced_fragment',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
-         'comments': ['May be a source of batch effect that has to be tested.'],
-         'domain_of': ['Dataset'],
-         'examples': [{'value': '3 prime tag'}, {'value': 'full length'}]} })
-    sequencing_platform: Optional[str] = Field(default=None, title="Sequencing Platform", description="""Platform used for sequencing.""", json_schema_extra = { "linkml_meta": {'alias': 'sequencing_platform',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
-         'comments': ['This captures potential strand hopping which may cause data '
-                      'quality issues.'],
-         'domain_of': ['Dataset'],
-         'examples': [{'value': 'EFO:0008563'}],
-         'notes': ['Values should be "subClassOf" ["EFO:0002699"] - '
-                   'https://www.ebi.ac.uk/ols/ontologies/efo/terms?iri=http%3A%2F%2Fwww.ebi.ac.uk%2Fefo%2FEFO_0002699']} })
-    study_pi: list[str] = Field(default=..., title="Study Pi", description="""Principal Investigator(s) leading the study where the data is/was used.""", json_schema_extra = { "linkml_meta": {'alias': 'study_pi',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
-         'domain_of': ['Dataset'],
-         'examples': [{'description': 'Principal Investigator in Last '
-                                      'Name,MiddleInitial, FirstName format',
-                       'value': '["Teichmann,Sarah,A."]'}]} })
-    title: Optional[str] = Field(default=None, title="Title", description="""This text describes and differentiates the dataset from other datasets in the same collection.  It is strongly recommended that each dataset title in a collection is unique and does not depend on other metadata  such as a different assay to disambiguate it from other datasets in the collection.
-""", json_schema_extra = { "linkml_meta": {'alias': 'title',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'},
-                         'cxg': {'tag': 'cxg', 'value': 'title'}},
-         'comments': ['Useful to look up protocol data that can provide insight on '
-                      'batch effects. As protocols can sometimes apply to a subset of '
-                      'the study, we capture this at a sample level. This information '
-                      'may not always be available.'],
-         'domain_of': ['Dataset'],
-         'examples': [{'value': "Cells of the adult human heart collection is 'All — "
-                                "Cells of the adult human heart'"}],
-         'is_a': 'deprecated_slot'} })
-    dataset_id: str = Field(default=..., title="Dataset ID", description="""A unique identifier for each dataset in the study. This should be unique to the study.""", json_schema_extra = { "linkml_meta": {'alias': 'dataset_id', 'domain_of': ['Dataset', 'Donor', 'Sample']} })
-
-
-class GutDataset(Dataset):
-    """
-    Dataset with Gut BioNetwork–specific metadata requirements.
-    """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/bionetwork/gut'})
-
-    ambient_count_correction: str = Field(default=..., title="Ambient Count Correction", description="""Method used to correct ambient RNA contamination in single-cell data.""", json_schema_extra = { "linkml_meta": {'alias': 'ambient_count_correction',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
-         'domain_of': ['GutDataset'],
-         'examples': [{'value': 'none'}, {'value': 'soupx'}, {'value': 'cellbender'}]} })
-    doublet_detection: str = Field(default=..., title="Doublet Detection", description="""Was doublet detection software used during CELLxGENE processing? If so, which software?""", json_schema_extra = { "linkml_meta": {'alias': 'doublet_detection',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
-         'domain_of': ['GutDataset'],
-         'examples': [{'value': 'none'},
-                      {'value': 'doublet_finder'},
-                      {'value': 'manual'}]} })
     alignment_software: str = Field(default=..., title="Alignment Software", description="""Protocol used for alignment analysis, please specify which version was used e.g. cell ranger 2.0, 2.1.1 etc.""", json_schema_extra = { "linkml_meta": {'alias': 'alignment_software',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
          'comments': ['Affects which cells are filtered per dataset, and which reads '
@@ -517,7 +378,10 @@ class Donor(ConfiguredBaseModel):
     """
     An individual organism from which biological samples have been derived
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/donor'})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/donor',
+         'slot_usage': {'donor_id': {'identifier': True,
+                                     'name': 'donor_id',
+                                     'range': 'string'}}})
 
     donor_id: str = Field(default=..., title="Donor ID", description="""This must be free-text that identifies a unique individual that data were derived from.""", json_schema_extra = { "linkml_meta": {'alias': 'donor_id',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
@@ -575,7 +439,10 @@ class Sample(ConfiguredBaseModel):
     """
     A biological sample derived from a donor or another sample
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/sample'})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/sample',
+         'slot_usage': {'sample_id': {'identifier': True,
+                                      'name': 'sample_id',
+                                      'range': 'string'}}})
 
     sample_id: str = Field(default=..., title="Sample ID", description="""Identification number of the sample. This is the fundamental unit of sampling the tissue (the specimen taken from the subject), which can be the same as the 'subject_ID', but is often different if multiple samples are taken from the same subject. Note: this is NOT a unit of multiplexing of donor samples, which should be stored in \"library\".""", json_schema_extra = { "linkml_meta": {'alias': 'sample_id',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
@@ -793,6 +660,148 @@ class Sample(ConfiguredBaseModel):
     tissue_ontology_term: Optional[str] = Field(default=None, title="Tissue Ontology Term", description="""Deprecated placeholder for tissue ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'tissue_ontology_term',
          'domain_of': ['Sample'],
          'is_a': 'deprecated_slot'} })
+
+
+class GutDataset(Dataset):
+    """
+    Dataset with Gut BioNetwork–specific metadata requirements.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/bionetwork/gut'})
+
+    ambient_count_correction: str = Field(default=..., title="Ambient Count Correction", description="""Method used to correct ambient RNA contamination in single-cell data.""", json_schema_extra = { "linkml_meta": {'alias': 'ambient_count_correction',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'domain_of': ['GutDataset'],
+         'examples': [{'value': 'none'}, {'value': 'soupx'}, {'value': 'cellbender'}]} })
+    doublet_detection: str = Field(default=..., title="Doublet Detection", description="""Was doublet detection software used during CELLxGENE processing? If so, which software?""", json_schema_extra = { "linkml_meta": {'alias': 'doublet_detection',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'domain_of': ['GutDataset'],
+         'examples': [{'value': 'none'},
+                      {'value': 'doublet_finder'},
+                      {'value': 'manual'}]} })
+    alignment_software: str = Field(default=..., title="Alignment Software", description="""Protocol used for alignment analysis, please specify which version was used e.g. cell ranger 2.0, 2.1.1 etc.""", json_schema_extra = { "linkml_meta": {'alias': 'alignment_software',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'comments': ['Affects which cells are filtered per dataset, and which reads '
+                      '(introns and exons or only exons) are counted as part of the '
+                      'reported transcriptome. This can convey batch effects.'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'cellranger_8.0.0'}]} })
+    assay_ontology_term_id: str = Field(default=..., title="Assay Ontology Term Id", description="""Platform used for single cell library construction.""", json_schema_extra = { "linkml_meta": {'alias': 'assay_ontology_term_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'assay_ontology_term_id'}},
+         'comments': ['Major source of batch effect and dataset filtering criterion'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'EFO:0009922'}],
+         'notes': ['This must be an EFO term and either:\n'
+                   '- "EFO:0002772" for assay by molecule or preferably its most '
+                   'accurate child\n'
+                   '- "EFO:0010183" for single cell library construction or preferably '
+                   'its most accurate child\n'
+                   '- An assay based on 10X Genomics products should either be '
+                   '"EFO:0008995" for 10x technology or preferably its most accurate '
+                   'child.\n'
+                   "- An assay based on SMART (Switching Mechanism at the 5' end of "
+                   'the RNA Template) or SMARTer technology SHOULD either be '
+                   '"EFO:0010184" for Smart-like or preferably its most accurate '
+                   'child.\n'
+                   'Recommended:\n'
+                   '- 10x 3\' v2 "EFO:0009899"\n'
+                   '- 10x 3\' v3 "EFO:0009922"\n'
+                   '- 10x 5\' v1 "EFO:0011025"\n'
+                   '- 10x 5\' v2 "EFO:0009900"\n'
+                   '- Smart-seq2 "EFO:0008931"\n'
+                   '- Visium Spatial Gene Expression "EFO:0010961"\n']} })
+    assay_ontology_term: Optional[str] = Field(default=None, title="Assay Ontology Term", description="""Deprecated placeholder for assay ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'assay_ontology_term',
+         'domain_of': ['Dataset'],
+         'is_a': 'deprecated_slot'} })
+    batch_condition: Optional[list[str]] = Field(default=None, title="Batch Condition", description="""Name of the covariate that confers the dominant batch effect in the data as judged by the data contributor.  The name provided here should be the label by which this covariate is stored in the AnnData object.""", json_schema_extra = { "linkml_meta": {'alias': 'batch_condition',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'},
+                         'cxg': {'tag': 'cxg', 'value': 'batch_condition'}},
+         'domain_of': ['Dataset'],
+         'examples': [{'description': 'Multiple batch conditions as a JSON array',
+                       'value': '["patient", "seqBatch"]'}],
+         'notes': ['Values must refer to cell metadata keys in obs. Together, these '
+                   'keys define the batches that a normalisation or integration '
+                   'algorithm should be aware of. For example if "patient" and '
+                   '"seqBatch" are keys of vectors of cell metadata, either '
+                   '["patient"], ["seqBatch"], or ["patient", "seqBatch"] are valid '
+                   'values.']} })
+    comments: Optional[str] = Field(default=None, title="Comments", description="""Other technical or experimental covariates that could affect the quality or batch of the sample.  Must not contain identifiers. This field is designed to capture potential challenges for data integration not captured elsewhere.
+""", json_schema_extra = { "linkml_meta": {'alias': 'comments',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'domain_of': ['Dataset']} })
+    consortia: Optional[str] = Field(default=None, title="Consortia", description="""Deprecated placeholder for consortia information.""", json_schema_extra = { "linkml_meta": {'alias': 'consortia', 'domain_of': ['Dataset'], 'is_a': 'deprecated_slot'} })
+    contact_email: str = Field(default=..., title="Contact Email", description="""Contact name and email of the submitting person""", json_schema_extra = { "linkml_meta": {'alias': 'contact_email', 'domain_of': ['Dataset']} })
+    default_embedding: Optional[str] = Field(default=None, title="Default Embedding", description="""The value must match a key to an embedding in obsm for the embedding to display by default in CELLxGENE Explorer.""", json_schema_extra = { "linkml_meta": {'alias': 'default_embedding',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'},
+                         'cxg': {'tag': 'cxg', 'value': 'default_embedding'}},
+         'domain_of': ['Dataset']} })
+    description: str = Field(default=..., title="Description", description="""Short description of the dataset""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'domain_of': ['Dataset']} })
+    gene_annotation_version: str = Field(default=..., title="Gene Annotation Version", description="""Ensembl release version accession number. Some common codes include: GRCh38.p12 = GCF_000001405.38 GRCh38.p13 = GCF_000001405.39 GRCh38.p14 = GCF_000001405.40
+""", json_schema_extra = { "linkml_meta": {'alias': 'gene_annotation_version',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'comments': ['Possible source of batch effect and confounder for some '
+                      'biological analysis'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'GCF_000001405.40'}],
+         'notes': ['http://www.ensembl.org/info/website/archives/index.html or '
+                   'NCBI/RefSeq']} })
+    intron_inclusion: Optional[YesNoEnum] = Field(default=None, title="Intron Inclusion", description="""Were introns included during read counting in the alignment process?""", json_schema_extra = { "linkml_meta": {'alias': 'intron_inclusion',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'yes'}, {'value': 'no'}]} })
+    protocol_url: Optional[str] = Field(default=None, title="Protocol URL", description="""The protocols.io URL (if none exists, please use the BioRxiv URL) for the full experimental protocol;  or if multiple protocols exist please list them e.g. sample preparation protocol / sequencing protocol.
+""", json_schema_extra = { "linkml_meta": {'alias': 'protocol_url',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'comments': ['Useful to look up protocol data that can provide insight on '
+                      'batch effects. As protocols can sometimes apply to a subset of '
+                      'the study, we capture this at a sample level. This information '
+                      'may not always be available.'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'https://www.biorxiv.org/content/early/2017/09/24/193219'}]} })
+    publication_doi: Optional[str] = Field(default=None, title="Publication DOI", description="""The publication digital object identifier (doi) for the protocol. If no pre-print nor publication exists, please write 'not applicable'.
+""", json_schema_extra = { "linkml_meta": {'alias': 'publication_doi',
+         'domain_of': ['Dataset'],
+         'examples': [{'value': '10.1016/j.cell.2016.07.054'}]} })
+    reference_genome: ReferenceGenomeEnum = Field(default=..., title="Reference Genome", description="""Reference genome used for alignment.""", json_schema_extra = { "linkml_meta": {'alias': 'reference_genome',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'comments': ['Possible source of batch effect and confounder for some '
+                      'biological analysis'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'GRCm37'}, {'value': 'GRCh37'}]} })
+    sequenced_fragment: SequencedFragmentEnum = Field(default=..., title="Sequenced Fragment", description="""Which part of the RNA transcript was targeted for sequencing.""", json_schema_extra = { "linkml_meta": {'alias': 'sequenced_fragment',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'comments': ['May be a source of batch effect that has to be tested.'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': '3 prime tag'}, {'value': 'full length'}]} })
+    sequencing_platform: Optional[str] = Field(default=None, title="Sequencing Platform", description="""Platform used for sequencing.""", json_schema_extra = { "linkml_meta": {'alias': 'sequencing_platform',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'comments': ['This captures potential strand hopping which may cause data '
+                      'quality issues.'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'EFO:0008563'}],
+         'notes': ['Values should be "subClassOf" ["EFO:0002699"] - '
+                   'https://www.ebi.ac.uk/ols/ontologies/efo/terms?iri=http%3A%2F%2Fwww.ebi.ac.uk%2Fefo%2FEFO_0002699']} })
+    study_pi: list[str] = Field(default=..., title="Study Pi", description="""Principal Investigator(s) leading the study where the data is/was used.""", json_schema_extra = { "linkml_meta": {'alias': 'study_pi',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'domain_of': ['Dataset'],
+         'examples': [{'description': 'Principal Investigator in Last '
+                                      'Name,MiddleInitial, FirstName format',
+                       'value': '["Teichmann,Sarah,A."]'}]} })
+    title: Optional[str] = Field(default=None, title="Title", description="""This text describes and differentiates the dataset from other datasets in the same collection.  It is strongly recommended that each dataset title in a collection is unique and does not depend on other metadata  such as a different assay to disambiguate it from other datasets in the collection.
+""", json_schema_extra = { "linkml_meta": {'alias': 'title',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'},
+                         'cxg': {'tag': 'cxg', 'value': 'title'}},
+         'comments': ['Useful to look up protocol data that can provide insight on '
+                      'batch effects. As protocols can sometimes apply to a subset of '
+                      'the study, we capture this at a sample level. This information '
+                      'may not always be available.'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': "Cells of the adult human heart collection is 'All — "
+                                "Cells of the adult human heart'"}],
+         'is_a': 'deprecated_slot'} })
+    dataset_id: str = Field(default=..., title="Dataset ID", description="""A unique identifier for each dataset in the study. This should be unique to the study.""", json_schema_extra = { "linkml_meta": {'alias': 'dataset_id', 'domain_of': ['Dataset', 'Donor', 'Sample']} })
 
 
 class GutSample(Sample):
@@ -1035,9 +1044,9 @@ class Cell(ConfiguredBaseModel):
 # Model rebuild
 # see https://pydantic-docs.helpmanual.io/usage/models/#rebuilding-a-model
 Dataset.model_rebuild()
-GutDataset.model_rebuild()
 Donor.model_rebuild()
 Sample.model_rebuild()
+GutDataset.model_rebuild()
 GutSample.model_rebuild()
 Cell.model_rebuild()
 

--- a/src/hca_validation/schema/generated/core.py
+++ b/src/hca_validation/schema/generated/core.py
@@ -379,7 +379,13 @@ class Donor(ConfiguredBaseModel):
     An individual organism from which biological samples have been derived
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/donor',
-         'slot_usage': {'donor_id': {'identifier': True,
+         'slot_usage': {'donor_id': {'annotations': {'annDataLocation': {'tag': 'annDataLocation',
+                                                                         'value': 'obs'},
+                                                     'cxg': {'tag': 'cxg',
+                                                             'value': 'donor_id'},
+                                                     'tier': {'tag': 'tier',
+                                                              'value': 'Tier 1'}},
+                                     'identifier': True,
                                      'name': 'donor_id',
                                      'range': 'string'}}})
 
@@ -440,7 +446,11 @@ class Sample(ConfiguredBaseModel):
     A biological sample derived from a donor or another sample
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/sample',
-         'slot_usage': {'sample_id': {'identifier': True,
+         'slot_usage': {'sample_id': {'annotations': {'annDataLocation': {'tag': 'annDataLocation',
+                                                                          'value': 'obs'},
+                                                      'tier': {'tag': 'tier',
+                                                               'value': 'Tier 1'}},
+                                      'identifier': True,
                                       'name': 'sample_id',
                                       'range': 'string'}}})
 

--- a/src/hca_validation/schema/generated/core.py
+++ b/src/hca_validation/schema/generated/core.py
@@ -371,64 +371,6 @@ class Dataset(ConfiguredBaseModel):
     dataset_id: str = Field(default=..., title="Dataset ID", description="""A unique identifier for each dataset in the study. This should be unique to the study.""", json_schema_extra = { "linkml_meta": {'alias': 'dataset_id', 'domain_of': ['Dataset', 'Donor', 'Sample']} })
 
 
-class Donor(ConfiguredBaseModel):
-    """
-    An individual organism from which biological samples have been derived
-    """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/donor'})
-
-    donor_id: str = Field(default=..., title="Donor ID", description="""This must be free-text that identifies a unique individual that data were derived from.""", json_schema_extra = { "linkml_meta": {'alias': 'donor_id',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
-                         'cxg': {'tag': 'cxg', 'value': 'donor_id'},
-                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
-         'comments': ['Fundamental unit of biological variation of the data. It is '
-                      'strongly recommended that this identifier be designed so that '
-                      'it is unique to: a given individual within the collection of '
-                      'datasets that includes this dataset, and a given individual '
-                      'across all collections in CELLxGENE Discover. It is strongly '
-                      'recommended that "pooled" be used for observations from a '
-                      'sample of multiple individuals that were not confidently '
-                      'assigned to a single individual through demultiplexing. It is '
-                      'strongly recommended that "unknown" ONLY be used for '
-                      'observations in a dataset when it is not known which '
-                      'observations are from the same individual.'],
-         'domain_of': ['Donor', 'Sample'],
-         'examples': [{'value': 'CR_donor_1; MM_donor_1; LR_donor_2'}]} })
-    organism_ontology_term_id: Organism = Field(default=..., title="Organism Ontology Term ID", description="""The name given to the type of organism, collected in NCBITaxon:0000 format.""", json_schema_extra = { "linkml_meta": {'alias': 'organism_ontology_term_id',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
-                         'cxg': {'tag': 'cxg', 'value': 'organism_ontology_term_id'},
-                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
-         'domain_of': ['Donor'],
-         'notes': ['"NCBITaxon:9606" for Homo sapiens or "NCBITaxon:10090" for Mus '
-                   'musculus.']} })
-    sex_ontology_term_id: str = Field(default=..., title="Sex Ontology Term ID", description="""Reported sex of the donor.""", json_schema_extra = { "linkml_meta": {'alias': 'sex_ontology_term_id',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
-                         'cxg': {'tag': 'cxg', 'value': 'sex_ontology_term_id'}},
-         'domain_of': ['Donor'],
-         'examples': [{'description': 'female', 'value': 'PATO:0000383'},
-                      {'description': 'male', 'value': 'PATO:0000384'}],
-         'notes': ['This must be a child of PATO:0001894 for phenotypic sex or '
-                   '"unknown" if unavailable.\n']} })
-    sex_ontology_term: Optional[str] = Field(default=None, title="Sex Ontology Term", description="""Deprecated placeholder for sex ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'sex_ontology_term',
-         'domain_of': ['Donor'],
-         'is_a': 'deprecated_slot'} })
-    manner_of_death: MannerOfDeath = Field(default=..., title="Manner of Death", description="""Manner of death classification based on the Hardy Scale or \"unknown\" or \"not applicable\":
-* Category 1 = Violent and fast death — deaths due to accident, blunt force trauma or suicide, terminal phase < 10 min.
-* Category 2 = Fast death of natural causes — sudden unexpected deaths of reasonably healthy people, terminal phase < 1 h.
-* Category 3 = Intermediate death — terminal phase 1–24 h, patients ill but death unexpected.
-* Category 4 = Slow death — terminal phase > 1 day (e.g. cancer, chronic pulmonary disease).
-* Category 0 = Ventilator case — on a ventilator immediately before death.
-* Unknown = The cause of death is unknown.
-* Not applicable = Subject is alive.
-[Leave blank for embryonic/fetal tissue.]
-""", json_schema_extra = { "linkml_meta": {'alias': 'manner_of_death',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
-         'domain_of': ['Donor'],
-         'examples': [{'value': '1'}],
-         'notes': ['1; 2; 3; 4; 0; unknown; not applicable']} })
-    dataset_id: str = Field(default=..., title="Dataset ID", description="""A unique identifier for each dataset in the study. This should be unique to the study.""", json_schema_extra = { "linkml_meta": {'alias': 'dataset_id', 'domain_of': ['Dataset', 'Donor', 'Sample']} })
-
-
 class GutDataset(Dataset):
     """
     Dataset with Gut BioNetwork–specific metadata requirements.
@@ -568,6 +510,64 @@ class GutDataset(Dataset):
          'examples': [{'value': "Cells of the adult human heart collection is 'All — "
                                 "Cells of the adult human heart'"}],
          'is_a': 'deprecated_slot'} })
+    dataset_id: str = Field(default=..., title="Dataset ID", description="""A unique identifier for each dataset in the study. This should be unique to the study.""", json_schema_extra = { "linkml_meta": {'alias': 'dataset_id', 'domain_of': ['Dataset', 'Donor', 'Sample']} })
+
+
+class Donor(ConfiguredBaseModel):
+    """
+    An individual organism from which biological samples have been derived
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/donor'})
+
+    donor_id: str = Field(default=..., title="Donor ID", description="""This must be free-text that identifies a unique individual that data were derived from.""", json_schema_extra = { "linkml_meta": {'alias': 'donor_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'donor_id'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Fundamental unit of biological variation of the data. It is '
+                      'strongly recommended that this identifier be designed so that '
+                      'it is unique to: a given individual within the collection of '
+                      'datasets that includes this dataset, and a given individual '
+                      'across all collections in CELLxGENE Discover. It is strongly '
+                      'recommended that "pooled" be used for observations from a '
+                      'sample of multiple individuals that were not confidently '
+                      'assigned to a single individual through demultiplexing. It is '
+                      'strongly recommended that "unknown" ONLY be used for '
+                      'observations in a dataset when it is not known which '
+                      'observations are from the same individual.'],
+         'domain_of': ['Donor', 'Sample'],
+         'examples': [{'value': 'CR_donor_1; MM_donor_1; LR_donor_2'}]} })
+    organism_ontology_term_id: Organism = Field(default=..., title="Organism Ontology Term ID", description="""The name given to the type of organism, collected in NCBITaxon:0000 format.""", json_schema_extra = { "linkml_meta": {'alias': 'organism_ontology_term_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'organism_ontology_term_id'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Donor'],
+         'notes': ['"NCBITaxon:9606" for Homo sapiens or "NCBITaxon:10090" for Mus '
+                   'musculus.']} })
+    sex_ontology_term_id: str = Field(default=..., title="Sex Ontology Term ID", description="""Reported sex of the donor.""", json_schema_extra = { "linkml_meta": {'alias': 'sex_ontology_term_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'sex_ontology_term_id'}},
+         'domain_of': ['Donor'],
+         'examples': [{'description': 'female', 'value': 'PATO:0000383'},
+                      {'description': 'male', 'value': 'PATO:0000384'}],
+         'notes': ['This must be a child of PATO:0001894 for phenotypic sex or '
+                   '"unknown" if unavailable.\n']} })
+    sex_ontology_term: Optional[str] = Field(default=None, title="Sex Ontology Term", description="""Deprecated placeholder for sex ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'sex_ontology_term',
+         'domain_of': ['Donor'],
+         'is_a': 'deprecated_slot'} })
+    manner_of_death: MannerOfDeath = Field(default=..., title="Manner of Death", description="""Manner of death classification based on the Hardy Scale or \"unknown\" or \"not applicable\":
+* Category 1 = Violent and fast death — deaths due to accident, blunt force trauma or suicide, terminal phase < 10 min.
+* Category 2 = Fast death of natural causes — sudden unexpected deaths of reasonably healthy people, terminal phase < 1 h.
+* Category 3 = Intermediate death — terminal phase 1–24 h, patients ill but death unexpected.
+* Category 4 = Slow death — terminal phase > 1 day (e.g. cancer, chronic pulmonary disease).
+* Category 0 = Ventilator case — on a ventilator immediately before death.
+* Unknown = The cause of death is unknown.
+* Not applicable = Subject is alive.
+[Leave blank for embryonic/fetal tissue.]
+""", json_schema_extra = { "linkml_meta": {'alias': 'manner_of_death',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'domain_of': ['Donor'],
+         'examples': [{'value': '1'}],
+         'notes': ['1; 2; 3; 4; 0; unknown; not applicable']} })
     dataset_id: str = Field(default=..., title="Dataset ID", description="""A unique identifier for each dataset in the study. This should be unique to the study.""", json_schema_extra = { "linkml_meta": {'alias': 'dataset_id', 'domain_of': ['Dataset', 'Donor', 'Sample']} })
 
 
@@ -1035,8 +1035,8 @@ class Cell(ConfiguredBaseModel):
 # Model rebuild
 # see https://pydantic-docs.helpmanual.io/usage/models/#rebuilding-a-model
 Dataset.model_rebuild()
-Donor.model_rebuild()
 GutDataset.model_rebuild()
+Donor.model_rebuild()
 Sample.model_rebuild()
 GutSample.model_rebuild()
 Cell.model_rebuild()

--- a/src/hca_validation/schema/generated/core.py
+++ b/src/hca_validation/schema/generated/core.py
@@ -371,6 +371,64 @@ class Dataset(ConfiguredBaseModel):
     dataset_id: str = Field(default=..., title="Dataset ID", description="""A unique identifier for each dataset in the study. This should be unique to the study.""", json_schema_extra = { "linkml_meta": {'alias': 'dataset_id', 'domain_of': ['Dataset', 'Donor', 'Sample']} })
 
 
+class Donor(ConfiguredBaseModel):
+    """
+    An individual organism from which biological samples have been derived
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/donor'})
+
+    donor_id: str = Field(default=..., title="Donor ID", description="""This must be free-text that identifies a unique individual that data were derived from.""", json_schema_extra = { "linkml_meta": {'alias': 'donor_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'donor_id'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Fundamental unit of biological variation of the data. It is '
+                      'strongly recommended that this identifier be designed so that '
+                      'it is unique to: a given individual within the collection of '
+                      'datasets that includes this dataset, and a given individual '
+                      'across all collections in CELLxGENE Discover. It is strongly '
+                      'recommended that "pooled" be used for observations from a '
+                      'sample of multiple individuals that were not confidently '
+                      'assigned to a single individual through demultiplexing. It is '
+                      'strongly recommended that "unknown" ONLY be used for '
+                      'observations in a dataset when it is not known which '
+                      'observations are from the same individual.'],
+         'domain_of': ['Donor', 'Sample'],
+         'examples': [{'value': 'CR_donor_1; MM_donor_1; LR_donor_2'}]} })
+    organism_ontology_term_id: Organism = Field(default=..., title="Organism Ontology Term ID", description="""The name given to the type of organism, collected in NCBITaxon:0000 format.""", json_schema_extra = { "linkml_meta": {'alias': 'organism_ontology_term_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'organism_ontology_term_id'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Donor'],
+         'notes': ['"NCBITaxon:9606" for Homo sapiens or "NCBITaxon:10090" for Mus '
+                   'musculus.']} })
+    sex_ontology_term_id: str = Field(default=..., title="Sex Ontology Term ID", description="""Reported sex of the donor.""", json_schema_extra = { "linkml_meta": {'alias': 'sex_ontology_term_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'sex_ontology_term_id'}},
+         'domain_of': ['Donor'],
+         'examples': [{'description': 'female', 'value': 'PATO:0000383'},
+                      {'description': 'male', 'value': 'PATO:0000384'}],
+         'notes': ['This must be a child of PATO:0001894 for phenotypic sex or '
+                   '"unknown" if unavailable.\n']} })
+    sex_ontology_term: Optional[str] = Field(default=None, title="Sex Ontology Term", description="""Deprecated placeholder for sex ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'sex_ontology_term',
+         'domain_of': ['Donor'],
+         'is_a': 'deprecated_slot'} })
+    manner_of_death: MannerOfDeath = Field(default=..., title="Manner of Death", description="""Manner of death classification based on the Hardy Scale or \"unknown\" or \"not applicable\":
+* Category 1 = Violent and fast death — deaths due to accident, blunt force trauma or suicide, terminal phase < 10 min.
+* Category 2 = Fast death of natural causes — sudden unexpected deaths of reasonably healthy people, terminal phase < 1 h.
+* Category 3 = Intermediate death — terminal phase 1–24 h, patients ill but death unexpected.
+* Category 4 = Slow death — terminal phase > 1 day (e.g. cancer, chronic pulmonary disease).
+* Category 0 = Ventilator case — on a ventilator immediately before death.
+* Unknown = The cause of death is unknown.
+* Not applicable = Subject is alive.
+[Leave blank for embryonic/fetal tissue.]
+""", json_schema_extra = { "linkml_meta": {'alias': 'manner_of_death',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'domain_of': ['Donor'],
+         'examples': [{'value': '1'}],
+         'notes': ['1; 2; 3; 4; 0; unknown; not applicable']} })
+    dataset_id: str = Field(default=..., title="Dataset ID", description="""A unique identifier for each dataset in the study. This should be unique to the study.""", json_schema_extra = { "linkml_meta": {'alias': 'dataset_id', 'domain_of': ['Dataset', 'Donor', 'Sample']} })
+
+
 class GutDataset(Dataset):
     """
     Dataset with Gut BioNetwork–specific metadata requirements.
@@ -510,64 +568,6 @@ class GutDataset(Dataset):
          'examples': [{'value': "Cells of the adult human heart collection is 'All — "
                                 "Cells of the adult human heart'"}],
          'is_a': 'deprecated_slot'} })
-    dataset_id: str = Field(default=..., title="Dataset ID", description="""A unique identifier for each dataset in the study. This should be unique to the study.""", json_schema_extra = { "linkml_meta": {'alias': 'dataset_id', 'domain_of': ['Dataset', 'Donor', 'Sample']} })
-
-
-class Donor(ConfiguredBaseModel):
-    """
-    An individual organism from which biological samples have been derived
-    """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/donor'})
-
-    donor_id: str = Field(default=..., title="Donor ID", description="""This must be free-text that identifies a unique individual that data were derived from.""", json_schema_extra = { "linkml_meta": {'alias': 'donor_id',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
-                         'cxg': {'tag': 'cxg', 'value': 'donor_id'},
-                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
-         'comments': ['Fundamental unit of biological variation of the data. It is '
-                      'strongly recommended that this identifier be designed so that '
-                      'it is unique to: a given individual within the collection of '
-                      'datasets that includes this dataset, and a given individual '
-                      'across all collections in CELLxGENE Discover. It is strongly '
-                      'recommended that "pooled" be used for observations from a '
-                      'sample of multiple individuals that were not confidently '
-                      'assigned to a single individual through demultiplexing. It is '
-                      'strongly recommended that "unknown" ONLY be used for '
-                      'observations in a dataset when it is not known which '
-                      'observations are from the same individual.'],
-         'domain_of': ['Donor', 'Sample'],
-         'examples': [{'value': 'CR_donor_1; MM_donor_1; LR_donor_2'}]} })
-    organism_ontology_term_id: Organism = Field(default=..., title="Organism Ontology Term ID", description="""The name given to the type of organism, collected in NCBITaxon:0000 format.""", json_schema_extra = { "linkml_meta": {'alias': 'organism_ontology_term_id',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
-                         'cxg': {'tag': 'cxg', 'value': 'organism_ontology_term_id'},
-                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
-         'domain_of': ['Donor'],
-         'notes': ['"NCBITaxon:9606" for Homo sapiens or "NCBITaxon:10090" for Mus '
-                   'musculus.']} })
-    sex_ontology_term_id: str = Field(default=..., title="Sex Ontology Term ID", description="""Reported sex of the donor.""", json_schema_extra = { "linkml_meta": {'alias': 'sex_ontology_term_id',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
-                         'cxg': {'tag': 'cxg', 'value': 'sex_ontology_term_id'}},
-         'domain_of': ['Donor'],
-         'examples': [{'description': 'female', 'value': 'PATO:0000383'},
-                      {'description': 'male', 'value': 'PATO:0000384'}],
-         'notes': ['This must be a child of PATO:0001894 for phenotypic sex or '
-                   '"unknown" if unavailable.\n']} })
-    sex_ontology_term: Optional[str] = Field(default=None, title="Sex Ontology Term", description="""Deprecated placeholder for sex ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'sex_ontology_term',
-         'domain_of': ['Donor'],
-         'is_a': 'deprecated_slot'} })
-    manner_of_death: MannerOfDeath = Field(default=..., title="Manner of Death", description="""Manner of death classification based on the Hardy Scale or \"unknown\" or \"not applicable\":
-* Category 1 = Violent and fast death — deaths due to accident, blunt force trauma or suicide, terminal phase < 10 min.
-* Category 2 = Fast death of natural causes — sudden unexpected deaths of reasonably healthy people, terminal phase < 1 h.
-* Category 3 = Intermediate death — terminal phase 1–24 h, patients ill but death unexpected.
-* Category 4 = Slow death — terminal phase > 1 day (e.g. cancer, chronic pulmonary disease).
-* Category 0 = Ventilator case — on a ventilator immediately before death.
-* Unknown = The cause of death is unknown.
-* Not applicable = Subject is alive.
-[Leave blank for embryonic/fetal tissue.]
-""", json_schema_extra = { "linkml_meta": {'alias': 'manner_of_death',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
-         'domain_of': ['Donor'],
-         'examples': [{'value': '1'}],
-         'notes': ['1; 2; 3; 4; 0; unknown; not applicable']} })
     dataset_id: str = Field(default=..., title="Dataset ID", description="""A unique identifier for each dataset in the study. This should be unique to the study.""", json_schema_extra = { "linkml_meta": {'alias': 'dataset_id', 'domain_of': ['Dataset', 'Donor', 'Sample']} })
 
 
@@ -1035,8 +1035,8 @@ class Cell(ConfiguredBaseModel):
 # Model rebuild
 # see https://pydantic-docs.helpmanual.io/usage/models/#rebuilding-a-model
 Dataset.model_rebuild()
-GutDataset.model_rebuild()
 Donor.model_rebuild()
+GutDataset.model_rebuild()
 Sample.model_rebuild()
 GutSample.model_rebuild()
 Cell.model_rebuild()

--- a/src/hca_validation/schema/sample.yaml
+++ b/src/hca_validation/schema/sample.yaml
@@ -50,19 +50,6 @@ classes:
       - sample_preservation_method
       - sample_source
       - tissue_ontology_term
-    attributes:
-      sample_id:
-        title: Sample ID
-        description: >-
-          Identification number of the sample. This is the fundamental unit of sampling the tissue (the specimen taken from the subject), which can be the same as the 'subject_ID', but is often different if multiple samples are taken from the same subject. Note: this is NOT a unit of multiplexing of donor samples, which should be stored in "library".
-        examples:
-          - value: SC24; SC25; SC28
-        annotations:
-          annDataLocation: obs
-          tier: Tier 1
-        range: string
-        required: true
-        identifier: true
 
 slots:
   author_batch_notes:

--- a/src/hca_validation/schema/sample.yaml
+++ b/src/hca_validation/schema/sample.yaml
@@ -50,6 +50,10 @@ classes:
       - sample_preservation_method
       - sample_source
       - tissue_ontology_term
+    slot_usage:
+      sample_id:
+        range: string
+        identifier: true
 
 slots:
   author_batch_notes:

--- a/src/hca_validation/schema/sample.yaml
+++ b/src/hca_validation/schema/sample.yaml
@@ -50,6 +50,19 @@ classes:
       - sample_preservation_method
       - sample_source
       - tissue_ontology_term
+    attributes:
+      sample_id:
+        title: Sample ID
+        description: >-
+          Identification number of the sample. This is the fundamental unit of sampling the tissue (the specimen taken from the subject), which can be the same as the 'subject_ID', but is often different if multiple samples are taken from the same subject. Note: this is NOT a unit of multiplexing of donor samples, which should be stored in "library".
+        examples:
+          - value: SC24; SC25; SC28
+        annotations:
+          annDataLocation: obs
+          tier: Tier 1
+        range: string
+        required: true
+        identifier: true
 
 slots:
   author_batch_notes:

--- a/src/hca_validation/schema/sample.yaml
+++ b/src/hca_validation/schema/sample.yaml
@@ -54,6 +54,10 @@ classes:
       sample_id:
         range: string
         identifier: true
+        # Annotations are duplicated here to get around an apparent bug in inheriting them (https://github.com/linkml/linkml/issues/2805)
+        annotations:
+          annDataLocation: obs
+          tier: Tier 1
 
 slots:
   author_batch_notes:

--- a/src/hca_validation/schema/slots.yaml
+++ b/src/hca_validation/schema/slots.yaml
@@ -15,6 +15,8 @@ default_range: string
 imports:
   - linkml:types
   - ./enums
+  - ./dataset
+  - ./donor
 
 types:
   Email:
@@ -49,19 +51,8 @@ slots:
   dataset_id:
     title: Dataset ID
     description: A unique identifier for each dataset in the study. This should be unique to the study.
-    range: string
-    required: true
-
-  sample_id:
-    title: Sample ID
-    description: >-
-      Identification number of the sample. This is the fundamental unit of sampling the tissue (the specimen taken from the subject), which can be the same as the 'subject_ID', but is often different if multiple samples are taken from the same subject. Note: this is NOT a unit of multiplexing of donor samples, which should be stored in "library".
-    examples:
-      - value: SC24; SC25; SC28
-    annotations:
-      annDataLocation: obs
-      tier: Tier 1
-    range: string
+    range: Dataset
+    inlined: false
     required: true
 
   donor_id:
@@ -74,7 +65,8 @@ slots:
       annDataLocation: obs
       tier: Tier 1
       cxg: donor_id
-    range: string
+    range: Donor
+    inlined: false
     required: true
     comments: >-
       Fundamental unit of biological variation of the data. It is strongly recommended that this identifier be designed so that it is unique to: a given individual within the collection of datasets that includes this dataset, and a given individual across all collections in CELLxGENE Discover. It is strongly recommended that "pooled" be used for observations from a sample of multiple individuals that were not confidently assigned to a single individual through demultiplexing. It is strongly recommended that "unknown" ONLY be used for observations in a dataset when it is not known which observations are from the same individual.

--- a/src/hca_validation/schema/slots.yaml
+++ b/src/hca_validation/schema/slots.yaml
@@ -15,6 +15,9 @@ default_range: string
 imports:
   - linkml:types
   - ./enums
+  - ./dataset
+  - ./donor
+  - ./sample
 
 types:
   Email:
@@ -49,7 +52,8 @@ slots:
   dataset_id:
     title: Dataset ID
     description: A unique identifier for each dataset in the study. This should be unique to the study.
-    range: string
+    range: Dataset
+    inlined: false
     required: true
 
   sample_id:
@@ -61,7 +65,8 @@ slots:
     annotations:
       annDataLocation: obs
       tier: Tier 1
-    range: string
+    range: Sample
+    inlined: false
     required: true
 
   donor_id:
@@ -74,7 +79,8 @@ slots:
       annDataLocation: obs
       tier: Tier 1
       cxg: donor_id
-    range: string
+    range: Donor
+    inlined: false
     required: true
     comments: >-
       Fundamental unit of biological variation of the data. It is strongly recommended that this identifier be designed so that it is unique to: a given individual within the collection of datasets that includes this dataset, and a given individual across all collections in CELLxGENE Discover. It is strongly recommended that "pooled" be used for observations from a sample of multiple individuals that were not confidently assigned to a single individual through demultiplexing. It is strongly recommended that "unknown" ONLY be used for observations in a dataset when it is not known which observations are from the same individual.

--- a/src/hca_validation/schema/slots.yaml
+++ b/src/hca_validation/schema/slots.yaml
@@ -15,8 +15,6 @@ default_range: string
 imports:
   - linkml:types
   - ./enums
-  - ./dataset
-  - ./donor
 
 types:
   Email:
@@ -51,8 +49,19 @@ slots:
   dataset_id:
     title: Dataset ID
     description: A unique identifier for each dataset in the study. This should be unique to the study.
-    range: Dataset
-    inlined: false
+    range: string
+    required: true
+
+  sample_id:
+    title: Sample ID
+    description: >-
+      Identification number of the sample. This is the fundamental unit of sampling the tissue (the specimen taken from the subject), which can be the same as the 'subject_ID', but is often different if multiple samples are taken from the same subject. Note: this is NOT a unit of multiplexing of donor samples, which should be stored in "library".
+    examples:
+      - value: SC24; SC25; SC28
+    annotations:
+      annDataLocation: obs
+      tier: Tier 1
+    range: string
     required: true
 
   donor_id:
@@ -65,8 +74,7 @@ slots:
       annDataLocation: obs
       tier: Tier 1
       cxg: donor_id
-    range: Donor
-    inlined: false
+    range: string
     required: true
     comments: >-
       Fundamental unit of biological variation of the data. It is strongly recommended that this identifier be designed so that it is unique to: a given individual within the collection of datasets that includes this dataset, and a given individual across all collections in CELLxGENE Discover. It is strongly recommended that "pooled" be used for observations from a sample of multiple individuals that were not confidently assigned to a single individual through demultiplexing. It is strongly recommended that "unknown" ONLY be used for observations in a dataset when it is not known which observations are from the same individual.


### PR DESCRIPTION
Closes #62

EDIT -- changed my approach; here are new notes:
- I was reminded of \`slot_usage\` and so I've used that to implement the distinction between the identifier version of a slot and the reference version of a slot
- The generated Python file has some added metadata but the change to `GutDataset` is just that is moved later in the order

Old notes (no longer applicable):
- LinkML isn't really designed to have different slots with the same name (such as `donor_id` as an identifier vs `donor_id` as a reference), but having one of the two be defined in the relevant class's `attributes` seems like a fairly reliable way of making that work (it certainly appears to work with the Pydantic generator and with a schemaview's `class_induced_slots` method)
  - The main potential concern I see is that there might be significant metadata duplication between the two versions of the slot (all I've done here is copy the entire slot definition and edit it slightly; I checked whether `is_a` would be useful here but it seems that LinkML doesn't consider the information in question to be heritable)
- The change to the generated Python file is just that Donor is listed earlier for whatever reason
- `sample_id` is removed from slots.yaml because it only has an identifier version and I put that in the attributes for consistency