### PR TITLE
feat: prod deploy scripts (#68)

### DIFF
--- a/.env.make.example
+++ b/.env.make.example
@@ -1,0 +1,16 @@
+# Example environment overrides for Makefile
+# Copy this file to `.env.make` and replace the placeholder values.
+
+# ------- Development environment -------
+DEV_AWS_ACCOUNT_ID=000000000000
+DEV_REPO_NAME=your-dev-ecr-repo
+DEV_LAMBDA_FUNCTION=your-dev-lambda-function
+DEV_AWS_REGION=us-east-1
+DEV_LAMBDA_ROLE=arn:aws:iam::000000000000:role/your-dev-lambda-exec-role
+
+# ------- Production environment -------
+PROD_AWS_ACCOUNT_ID=000000000000
+PROD_REPO_NAME=your-prod-ecr-repo
+PROD_LAMBDA_FUNCTION=your-prod-lambda-function
+PROD_AWS_REGION=us-east-1
+PROD_LAMBDA_ROLE=arn:aws:iam::000000000000:role/your-prod-lambda-exec-role

--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,7 @@ celerybeat.pid
 
 # Environments
 .env
+.env.make
 .venv
 env/
 venv/

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,9 @@ AWS_REGION       ?= $(DEV_AWS_REGION)
 LAMBDA_ROLE      ?= $(DEV_LAMBDA_ROLE)
 endif
 
-# Derived value used throughout the deploy target
-ECR_REPO := $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/$(REPO_NAME)
+# ECR registry and repository path
+ECR_REGISTRY := $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
+ECR_REPO     := $(ECR_REGISTRY)/$(REPO_NAME)
 
 # Default target
 .PHONY: help
@@ -229,7 +230,7 @@ deploy-lambda-container:
 	fi
 
 	@echo "Logging in to ECR..."
-	@aws ecr get-login-password --region $(AWS_REGION) | docker login --username AWS --password-stdin $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
+	@aws ecr get-login-password --region $(AWS_REGION) | docker login --username AWS --password-stdin $(ECR_REGISTRY)
 
 	@echo "Creating ECR repository if it doesn't exist..."
 	@aws ecr describe-repositories --repository-names $(REPO_NAME) --region $(AWS_REGION) > /dev/null 2>&1 || \

--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ deploy-lambda-container:
 	else \
 		echo "******** DEPLOYING TO DEVELOPMENT ********"; \
 	fi
-	@echo "Checking required environment variables..."
+	@echo "Validating required environment variables: AWS_REGION and LAMBDA_ROLE..."
 	@if [ -z "$(AWS_REGION)" ]; then \
 		echo "Error: AWS_REGION environment variable is not set and could not be derived from .env.make"; \
 		exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ deploy-lambda-container:
 	fi
 	@echo "Checking required environment variables..."
 	@if [ -z "$(AWS_REGION)" ]; then \
-		echo "Error: AWS_REGION environment variable is not set and could not be derived from .env"; \
+		echo "Error: AWS_REGION environment variable is not set and could not be derived from .env.make"; \
 		exit 1; \
 	fi
 	@if [ -z "$(LAMBDA_ROLE)" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ POETRY := poetry run
 SUPPRESS_WARNINGS := 2>/dev/null
 
 # Load Make-specific environment overrides (not checked in)
-# Put only simple KEY=value pairs here (no JSON). Example .env.make is provided.
+# Put only simple KEY=value pairs here (no JSON).
+# Copy the provided `.env.make.example` to `.env.make` and fill in real values.
 ifneq (,$(wildcard .env.make))
   include .env.make
 endif

--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ deploy-lambda-container:
 		exit 1; \
 	fi
 	@if [ -z "$(LAMBDA_ROLE)" ]; then \
-		echo "Error: LAMBDA_ROLE is required (set in .env)"; \
+		echo "Error: LAMBDA_ROLE is required (set in .env.make)"; \
 		exit 1; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -209,6 +209,10 @@ test-lambda-container:
 
 .PHONY: deploy-lambda-container
 deploy-lambda-container:
+	@if [ -z "$(AWS_ACCOUNT_ID)" ]; then \
+		echo "Error: AWS_ACCOUNT_ID is not set (check .env.make or your environment)"; \
+		exit 1; \
+	fi
 	@if [ "$(ENV)" = "prod" ]; then \
 		echo "******** DEPLOYING TO PRODUCTION ********"; \
 	else \


### PR DESCRIPTION
This pull request introduces environment-specific configurations for deployment and refactors the `Makefile` to support dynamic values based on the selected environment (`dev` or `prod`). The changes improve flexibility and maintainability by reducing hardcoded values and centralizing environment-specific settings.

### Environment-specific configurations:

* Added an `ENV` variable to allow switching between `dev` (default) and `prod` environments, with corresponding settings for `AWS_ACCOUNT_ID`, `REPO_NAME`, and `LAMBDA_FUNCTION`. (`Makefile`, [MakefileR12-R28](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R12-R28))

### Refactoring for dynamic values:

* Updated `deploy-lambda-container` to use the `REPO_NAME` variable for ECR repository creation and image tagging/pushing, replacing hardcoded repository names. (`Makefile`, [MakefileL203-R235](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L203-R235))
* Replaced hardcoded Lambda function names with the `LAMBDA_FUNCTION` variable in `deploy-lambda-container` and `invoke-lambda` targets for both updates and invocations. (`Makefile`, [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L203-R235) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L244-R263)

### Simplification of environment variable checks:

* Removed the check for `AWS_ACCOUNT_ID` in `deploy-lambda-container`, as it is now derived from the environment configuration. (`Makefile`, [MakefileL186-L189](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L186-L189))