### PR TITLE
fix: dont try to create missing ECR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,9 +233,11 @@ deploy-lambda-container:
 	@echo "Logging in to ECR..."
 	@aws ecr get-login-password --region $(AWS_REGION) | docker login --username AWS --password-stdin $(ECR_REGISTRY)
 
-	@echo "Creating ECR repository if it doesn't exist..."
-	@aws ecr describe-repositories --repository-names $(REPO_NAME) --region $(AWS_REGION) > /dev/null 2>&1 || \
-		aws ecr create-repository --repository-name $(REPO_NAME) --region $(AWS_REGION)
+	@echo "Checking that ECR repository $(REPO_NAME) exists..."
+	@aws ecr describe-repositories --repository-names $(REPO_NAME) --region $(AWS_REGION) > /dev/null 2>&1 || { \
+		echo "Error: ECR repository $(REPO_NAME) not found in account $(AWS_ACCOUNT_ID). Please create it manually before deploying."; \
+		exit 1; \
+	}
 
 	@echo "Tagging and pushing container image to ECR..."
 	@docker tag hca-entry-sheet-validator:latest $(ECR_REPO):latest


### PR DESCRIPTION
This pull request updates the `deploy-lambda-container` target in the `Makefile` to improve the handling of missing ECR repositories during deployment. The key change is replacing the automatic creation of the repository with a manual intervention requirement.

Changes to ECR repository handling:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L236-R240): Modified the `deploy-lambda-container` target to check if the ECR repository exists and provide an error message if it does not, requiring manual creation of the repository instead of automatically creating it.