### PR TITLE
feat: build-all make target (#74)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,3 +290,14 @@ invoke-lambda:
 	fi
 	@echo "Response saved to response.json"
 	@cat response.json
+
+# Build and test everything in sequence
+.PHONY: build-all
+build-all:
+	@echo "Running full build & test chain..."
+	@$(MAKE) gen-schema
+	@$(MAKE) validate-schema
+	@$(MAKE) generate-data-dictionary
+	@$(MAKE) build-lambda-container PROFILE=excira
+	@$(MAKE) test-all
+	@echo "✓ All steps succeeded"


### PR DESCRIPTION
This pull request adds a new `build-all` target to the `Makefile` to streamline the process of building and testing the project in sequence.

Key change:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R291-R301): Introduced a `.PHONY` target `build-all` that runs the full build and test chain, including `gen-schema`, `validate-schema`, `generate-data-dictionary`, `build-lambda-container`, and `test-all`. This provides a convenient way to execute all necessary steps with a single command.