### PR TITLE
feat: retry google sheets api calls (#69)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -384,8 +384,8 @@ files = [
 google-auth = ">=2.14.1,<3.0.0"
 googleapis-common-protos = ">=1.56.2,<2.0.0"
 proto-plus = [
-    {version = ">=1.22.3,<2.0.0"},
     {version = ">=1.25.0,<2.0.0", markers = "python_version >= \"3.13\""},
+    {version = ">=1.22.3,<2.0.0", markers = "python_version < \"3.13\""},
 ]
 protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<7.0.0"
 requests = ">=2.18.0,<3.0.0"
@@ -1139,9 +1139,9 @@ files = [
 
 [package.dependencies]
 numpy = [
+    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
     {version = ">=1.22.4", markers = "python_version < \"3.11\""},
     {version = ">=1.23.2", markers = "python_version == \"3.11\""},
-    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -2528,14 +2528,14 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.4.0"
+version = "2.5.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813"},
-    {file = "urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466"},
+    {file = "urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"},
+    {file = "urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760"},
 ]
 
 [package.extras]
@@ -2691,4 +2691,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "8a1194df7bc66246c7eaf22f4d1bde80d36febb7aa0ffae5b1ff8111c1d3063f"
+content-hash = "0ec0853bea5ce94f8ad008aa9b09eae0d25fd72f028fd4efb0f5bee55f0a8899"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ python-dotenv = "^1.1.0"
 pydantic = "^2.11.4"
 pydantic-core = "^2.33.2"
 google-api-python-client = "^2.171.0"
+urllib3 = "^2.5.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.5"

--- a/src/hca_validation/entry_sheet_validator/validate_sheet.py
+++ b/src/hca_validation/entry_sheet_validator/validate_sheet.py
@@ -166,7 +166,7 @@ def create_requests_session(credentials: Credentials) -> requests.Session:
     """
     session = AuthorizedSession(gspread.utils.convert_credentials(credentials))
     retry_cfg = urllib3.Retry(
-        total=4,
+        total=2,
         status_forcelist=(429, 500, 502, 503, 504),
         backoff_factor=10,
         respect_retry_after_header=True
@@ -387,7 +387,7 @@ def read_sheet_with_service_account(sheet_id, sheet_indices=[0]) -> Union[Spread
                 error_message=f"Received error {e.status_code} from Google API: {e.reason}",
                 spreadsheet_metadata=spreadsheet_metadata
             )
-        except urllib3.exceptions.MaxRetryError as e:
+        except requests.exceptions.RetryError as e:
             logger.error(f"Reached maximum configured API retries: {e}")
             return ReadErrorSheetInfo(error_code="max_api_retries", spreadsheet_metadata=spreadsheet_metadata)
             
@@ -741,4 +741,5 @@ if __name__ == "__main__":
         sys.exit(1)
 
     sheet_id = sys.argv[1]
-    validate_google_sheet(sheet_id)
+    r = validate_google_sheet(sheet_id)
+    print(r.error_code)

--- a/src/hca_validation/entry_sheet_validator/validate_sheet.py
+++ b/src/hca_validation/entry_sheet_validator/validate_sheet.py
@@ -169,6 +169,7 @@ def create_requests_session(credentials: Credentials) -> requests.Session:
         total=2,
         status_forcelist=(429, 500, 502, 503, 504),
         backoff_factor=10,
+        backoff_jitter=5,
         respect_retry_after_header=True
     )
     session.mount("https://", requests.adapters.HTTPAdapter(max_retries=retry_cfg))

--- a/src/hca_validation/entry_sheet_validator/validate_sheet.py
+++ b/src/hca_validation/entry_sheet_validator/validate_sheet.py
@@ -742,5 +742,4 @@ if __name__ == "__main__":
         sys.exit(1)
 
     sheet_id = sys.argv[1]
-    r = validate_google_sheet(sheet_id)
-    print(r.error_code)
+    validate_google_sheet(sheet_id)

--- a/src/hca_validation/entry_sheet_validator/validate_sheet.py
+++ b/src/hca_validation/entry_sheet_validator/validate_sheet.py
@@ -16,9 +16,14 @@ from linkml_runtime import SchemaView
 # Import dotenv for loading environment variables
 from dotenv import load_dotenv
 
-# Import gspread for Google Sheets API access
+# Import libraries for Google API access
 import gspread
 from google.oauth2 import service_account
+from google.auth.transport.requests import AuthorizedSession
+from google.auth.credentials import Credentials
+import requests.adapters
+import urllib3
+import requests
 
 @dataclass
 class WorksheetInfo:
@@ -154,6 +159,20 @@ def get_secret_from_extension(secret_name):
     except Exception as e:
         logger.error(f"Error retrieving secret from extension: {e}")
         return None
+
+def create_requests_session(credentials: Credentials) -> requests.Session:
+    """
+    Create a requests session with retry behavior configured
+    """
+    session = AuthorizedSession(gspread.utils.convert_credentials(credentials))
+    retry_cfg = urllib3.Retry(
+        total=4,
+        status_forcelist=(429, 500, 502, 503, 504),
+        backoff_factor=10,
+        respect_retry_after_header=True
+    )
+    session.mount("https://", requests.adapters.HTTPAdapter(max_retries=retry_cfg))
+    return session
 
 def read_worksheet(sheet_id, spreadsheet_metadata, spreadsheet, sheet_index) -> Union[WorksheetInfo, ReadErrorSheetInfo]:
     import logging
@@ -296,7 +315,7 @@ def read_sheet_with_service_account(sheet_id, sheet_indices=[0]) -> Union[Spread
         # Authenticate with gspread
         logger.info("Authorizing with gspread...")
         try:
-            gc = gspread.authorize(credentials)
+            gc = gspread.authorize(credentials, session=create_requests_session(credentials))
             logger.info("Successfully authorized with gspread")
         except Exception as auth_error:
             logger.error(f"Error authorizing with Google Sheets API: {auth_error}")
@@ -368,6 +387,9 @@ def read_sheet_with_service_account(sheet_id, sheet_indices=[0]) -> Union[Spread
                 error_message=f"Received error {e.status_code} from Google API: {e.reason}",
                 spreadsheet_metadata=spreadsheet_metadata
             )
+        except urllib3.exceptions.MaxRetryError as e:
+            logger.error(f"Reached maximum configured API retries: {e}")
+            return ReadErrorSheetInfo(error_code="max_api_retries", spreadsheet_metadata=spreadsheet_metadata)
             
     except json.JSONDecodeError as json_error:
         logger.error(f"Invalid JSON format in service account credentials: {json_error}")

--- a/src/hca_validation/lambda_functions/entry_sheet_validator_lambda/handler.py
+++ b/src/hca_validation/lambda_functions/entry_sheet_validator_lambda/handler.py
@@ -48,6 +48,9 @@ ERROR_TO_STATUS: dict[str, HTTPStatus] = {
     # Resource not found
     "sheet_not_found": HTTPStatus.NOT_FOUND,
     "worksheet_not_found": HTTPStatus.NOT_FOUND,
+
+    # Service unavailable
+    "max_api_retries": HTTPStatus.SERVICE_UNAVAILABLE,
 }
 
 

--- a/tests/test_entry_sheet_validator.py
+++ b/tests/test_entry_sheet_validator.py
@@ -81,9 +81,10 @@ class TestReadSheetWithServiceAccount:
         os.environ.update(original_env)
 
     @patch('googleapiclient.discovery.build')
+    @patch('hca_validation.entry_sheet_validator.validate_sheet.create_requests_session')
     @patch('gspread.authorize')
     @patch('google.oauth2.service_account.Credentials.from_service_account_info')
-    def test_with_service_account_credentials(self, mock_credentials, mock_authorize, mock_build, mock_env_with_credentials):
+    def test_with_service_account_credentials(self, mock_credentials, mock_authorize, mock_create_requests_session, mock_build, mock_env_with_credentials):
         """Test reading a sheet with service account credentials."""
         # Mock the gspread client
         mock_client = MagicMock()
@@ -193,9 +194,10 @@ class TestReadSheetWithServiceAccount:
             os.environ.clear()
             os.environ.update(original_env)
 
+    @patch('hca_validation.entry_sheet_validator.validate_sheet.create_requests_session')
     @patch('gspread.authorize')
     @patch('google.oauth2.service_account.Credentials.from_service_account_info')
-    def test_sheet_not_found(self, mock_credentials, mock_authorize, mock_env_with_credentials):
+    def test_sheet_not_found(self, mock_credentials, mock_authorize, mock_create_requests_session, mock_env_with_credentials):
         """Test handling of sheet not found error."""
         # Mock the gspread client to raise SpreadsheetNotFound
         mock_client = MagicMock()
@@ -213,9 +215,10 @@ class TestReadSheetWithServiceAccount:
         mock_client.open_by_key.assert_called_once_with(NONEXISTENT_SHEET_ID)
 
     @patch('googleapiclient.discovery.build')
+    @patch('hca_validation.entry_sheet_validator.validate_sheet.create_requests_session')
     @patch('gspread.authorize')
     @patch('google.oauth2.service_account.Credentials.from_service_account_info')
-    def test_worksheet_not_found(self, mock_credentials, mock_authorize, mock_build, mock_env_with_credentials):
+    def test_worksheet_not_found(self, mock_credentials, mock_authorize, mock_create_requests_session, mock_build, mock_env_with_credentials):
         """Test handling of worksheet not found error."""
         # Mock the gspread client
         mock_client = MagicMock()
@@ -235,9 +238,10 @@ class TestReadSheetWithServiceAccount:
         mock_client.open_by_key.assert_called_once_with(PUBLIC_SHEET_ID)
         mock_sheet.get_worksheet.assert_called_once_with(0)
 
+    @patch('hca_validation.entry_sheet_validator.validate_sheet.create_requests_session')
     @patch('gspread.authorize')
     @patch('google.oauth2.service_account.Credentials.from_service_account_info')
-    def test_api_error(self, mock_credentials, mock_authorize, mock_env_with_credentials):
+    def test_api_error(self, mock_credentials, mock_authorize, mock_create_requests_session, mock_env_with_credentials):
         """Test handling of API error."""
         # Mock the gspread client
         mock_client = MagicMock()
@@ -256,9 +260,10 @@ class TestReadSheetWithServiceAccount:
         mock_client.open_by_key.assert_called_once_with(PUBLIC_SHEET_ID)
 
     @patch('googleapiclient.discovery.build')
+    @patch('hca_validation.entry_sheet_validator.validate_sheet.create_requests_session')
     @patch('gspread.authorize')
     @patch('google.oauth2.service_account.Credentials.from_service_account_info')
-    def test_generic_exception_with_metadata(self, mock_credentials, mock_authorize, mock_build, mock_env_with_credentials):
+    def test_generic_exception_with_metadata(self, mock_credentials, mock_authorize, mock_create_requests_session, mock_build, mock_env_with_credentials):
         """Test handling of generic exception after spreadsheet metadata is obtained."""
         # Mock the gspread client
         mock_client = MagicMock()


### PR DESCRIPTION
Closes #69

I'm pretty confident that this will **not** solve our issues on its own -- I think the most effective thing after this would probably be to make the Tracker request validations in sequence rather than in parallel as it does now (or maybe do small batches of parallel requests?)

Additionally it might be worth seeing if we can batch the gspread operations