### PR TITLE
refactor: minimize google sheets api requests (#91)

### DIFF
--- a/src/hca_validation/entry_sheet_validator/validate_sheet.py
+++ b/src/hca_validation/entry_sheet_validator/validate_sheet.py
@@ -207,7 +207,7 @@ def read_worksheets(
     worksheets_info = []
 
     for sheet_index, worksheet, value_range in zip(sheet_indices, worksheets, api_result["valueRanges"]):
-        data = gspread.utils.fill_gaps(value_range["values"])
+        data = gspread.utils.fill_gaps(value_range.get("values", [[]]))
          # Convert to DataFrame
         if len(data) >= 2:
             logger.info(f"Successfully retrieved data from worksheet index {sheet_index}: {len(data)} rows, {len(data[0]) if data[0] else 0} columns")


### PR DESCRIPTION
Closes #91

- Switched from `get_worksheet` to `worksheets` to get full list of worksheets in one call
- Switched from worksheet `get_all_values` to spreadsheet `values_batch_get` to get data from all worksheets in one call