### PR TITLE
fix: prevent columns containing integers and `None` from being cast to float (#106)

### DIFF
--- a/src/hca_validation/entry_sheet_validator/validate_sheet.py
+++ b/src/hca_validation/entry_sheet_validator/validate_sheet.py
@@ -455,7 +455,8 @@ def normalize_dataframe_values(df: pd.DataFrame, schemaview: SchemaView, class_n
             parse_value = lambda v: parse_list(v, parse_item)
 
         # Map over the column, converting whitespace-only value to None and parsing other values where applicable
-        return df[name].map(lambda value: None if value.strip() == "" else parse_value(value))
+        # Use the Series constructor with a list comprehension to ensure that values are put directly into an object series and can't be cast by Pandas
+        return pd.Series([None if value.strip() == "" else parse_value(value) for value in df[name]], dtype="object", index=df.index)
 
     return pd.DataFrame({
         name: map_column(name)


### PR DESCRIPTION
Closes #106

Apparently the output of `Series.map()` is always given a type based on what Pandas infers, and it considers float to be the appropriate type for a series containing only integers and `None`, with the latter being converted to `nan` -- hence the `NaN` in our response when there's an empty cell

There's also the problem of the NaN creating invalid JSON, which I have not made changes to address. Python's built-in JSON module does not ensure spec-compliant JSON by default apparently does not allow automatically casting `nan` to something else (though it can be set to raise an error). There is the package `simplejson` (which apparently the built-in module is based on?) which allows outputting `nan` as `null`, but IDK if we want to bother with that given that we aren't expecting NaN in the first place