### PR TITLE
feat: add available fixes to error info objects (#110)

### DIFF
--- a/src/hca_validation/entry_sheet_validator/common.py
+++ b/src/hca_validation/entry_sheet_validator/common.py
@@ -1,0 +1,2 @@
+# Default list of entity types to process
+default_entity_types = ["dataset", "donor", "sample"]

--- a/src/hca_validation/entry_sheet_validator/find_fixes.py
+++ b/src/hca_validation/entry_sheet_validator/find_fixes.py
@@ -1,4 +1,3 @@
-import copy
 import dataclasses
 from typing import List, Optional
 from linkml_runtime import SchemaView

--- a/src/hca_validation/entry_sheet_validator/find_fixes.py
+++ b/src/hca_validation/entry_sheet_validator/find_fixes.py
@@ -1,0 +1,57 @@
+import copy
+import dataclasses
+from typing import List, Optional
+from linkml_runtime import SchemaView
+from linkml_runtime.linkml_model.meta import ClassDefinition
+
+from hca_validation.schema_utils import load_schemaview, get_entity_class_name
+from .validate_sheet import SheetErrorInfo
+
+
+# Spreadsheet values to identify possible fixes for
+# Mapping tuple of entity type, slot, and input value to corrected value
+sheet_value_fix_map = {
+    ("donor", "manner_of_death", "not_applicable"): "not applicable",
+    ("sample", "sample_source", "surgical_donor"): "surgical donor",
+    ("sample", "sample_source", "postmortem_donor"): "postmortem donor",
+    ("sample", "sample_source", "living_organ_donor"): "living organ donor",
+    ("sample", "sample_collection_method", "surgical_resection"): "surgical resection",
+    ("sample", "sample_collection_method", "blood_draw"): "blood draw",
+    ("sample", "sample_collection_method", "body_fluid"): "body fluid",
+}
+
+
+def get_fixed_value(entity_type: str, entity_induced_class: ClassDefinition, slot_name: str, value: str) -> Optional[str]:
+    # We only need to check `attributes`, since an induced class has nothing in `slots`
+    if slot_name not in entity_induced_class.attributes:
+        return None
+    return sheet_value_fix_map.get((entity_type, slot_name, value))
+
+
+def add_fix_to_error_if_available(error: SheetErrorInfo, bionetwork: Optional[str], schemaview: SchemaView) -> SheetErrorInfo:
+    # If the error doesn't have the required values, return it unchanged
+    # Require string input value to avoid values that consist of the entire input row
+    if error.entity_type is None or error.column is None or not isinstance(error.input, str):
+        return error
+    
+    entity_induced_class = schemaview.induced_class(get_entity_class_name(error.entity_type, bionetwork))
+    input_fix = get_fixed_value(error.entity_type, entity_induced_class, error.column, error.input)
+
+    return dataclasses.replace(error, input_fix=input_fix)
+
+
+def add_fixes_to_errors(errors: List[SheetErrorInfo], bionetwork: Optional[str]) -> List[SheetErrorInfo]:
+    """
+    Identify fixes for the given errors where possible, and return copies of the error objects with fixed values specified.
+
+    Args:
+        errors: List of error info objects
+        bionetwork: Bionetwork associated with the data the errors come from
+    
+    Returns:
+        List of errors with fixes added where possible
+    """
+
+    schemaview = load_schemaview()
+
+    return [add_fix_to_error_if_available(error, bionetwork, schemaview) for error in errors]

--- a/src/hca_validation/entry_sheet_validator/process_sheet.py
+++ b/src/hca_validation/entry_sheet_validator/process_sheet.py
@@ -1,0 +1,32 @@
+import dataclasses
+from typing import List, Optional
+
+from .validate_sheet import SheetValidationResult, validate_google_sheet
+from .find_fixes import add_fixes_to_errors
+from .common import default_entity_types
+
+def process_google_sheet(
+    sheet_id: str,
+    *,
+    entity_types: List[str] = default_entity_types,
+    bionetwork: Optional[str] = None,
+) -> SheetValidationResult:
+    """
+    Process a Google Sheet by:
+    - Validating it according to the HCA schema
+    - Identifying fixes where possible for any resulting validation errors
+
+    Args:
+        sheet_id: The ID of the Google Sheet (required)
+        entity_types: List of entity types to validate. Determines which worksheets are read and which schema is used for each.
+        bionetwork: Optional string identifying the biological network context.
+        
+    Returns:
+        SheetValidationResult object
+    """
+
+    # Get validation result
+    validation_result = validate_google_sheet(sheet_id, entity_types=entity_types, bionetwork=bionetwork)
+
+    # Return with available fixes added to errors
+    return dataclasses.replace(validation_result, errors=add_fixes_to_errors(validation_result.errors, bionetwork))

--- a/src/hca_validation/entry_sheet_validator/validate_sheet.py
+++ b/src/hca_validation/entry_sheet_validator/validate_sheet.py
@@ -10,7 +10,6 @@ import os
 import json
 from pathlib import Path
 from typing import Any, Mapping, Optional, List, Union, Callable
-from collections.abc import Hashable
 from dataclasses import dataclass
 from pydantic import ValidationError
 from linkml_runtime import SchemaView
@@ -485,7 +484,7 @@ def make_summary_without_entities(error_count: int, entity_types: List[str] = de
         "error_count": error_count
     }
 
-def get_fixed_value(entity_type: str, entity_induced_class: ClassDefinition, slot_name: str, value: Hashable) -> Optional[str]:
+def get_fixed_value(entity_type: str, entity_induced_class: ClassDefinition, slot_name: str, value: str) -> Optional[str]:
     # We only need to check `attributes`, since an induced class has nothing in `slots`
     if slot_name not in entity_induced_class.attributes:
         return None

--- a/src/hca_validation/entry_sheet_validator/validate_sheet.py
+++ b/src/hca_validation/entry_sheet_validator/validate_sheet.py
@@ -569,7 +569,8 @@ def validate_google_sheet(
     if bionetwork is not None and bionetwork not in allowed_bionetwork_names:
         raise ValueError(f"'{bionetwork}' is not a valid bionetwork")
 
-    from hca_validation.validator import get_entity_class_name, validate, validate_id_uniqueness
+    from hca_validation.validator import validate, validate_id_uniqueness
+    from hca_validation.schema_utils import get_entity_class_name
     import logging
     logger = logging.getLogger()
 

--- a/src/hca_validation/lambda_functions/entry_sheet_validator_lambda/handler.py
+++ b/src/hca_validation/lambda_functions/entry_sheet_validator_lambda/handler.py
@@ -23,8 +23,8 @@ from hca_validation.entry_sheet_validator.validate_sheet import (
     SheetErrorInfo,
     SheetValidationResult,
     make_summary_without_entities,
-    validate_google_sheet,
 )
+from hca_validation.entry_sheet_validator.process_sheet import process_google_sheet
 
 # Configure logging
 logger = logging.getLogger()
@@ -69,8 +69,8 @@ def extract_validation_errors(sheet_id: str, bionetwork: Optional[str] = None) -
     
     # Run the validation with our custom handler
     try:
-        # Call the validate_google_sheet function
-        validation_result = validate_google_sheet(
+        # Call the process_google_sheet function to perform validation and check for fixes
+        validation_result = process_google_sheet(
             sheet_id,
             bionetwork=bionetwork,
         )

--- a/src/hca_validation/schema_utils/__init__.py
+++ b/src/hca_validation/schema_utils/__init__.py
@@ -4,4 +4,4 @@ HCA Validation Tools - Schema Utils Module
 This module provides utilities for interacting with the HCA schema.
 """
 
-from .schema_utils import get_entity_class_name, get_class_identifier_name
+from .schema_utils import load_schemaview, get_entity_class_name, get_class_identifier_name

--- a/src/hca_validation/schema_utils/__init__.py
+++ b/src/hca_validation/schema_utils/__init__.py
@@ -1,0 +1,7 @@
+"""
+HCA Validation Tools - Schema Utils Module
+
+This module provides utilities for interacting with the HCA schema.
+"""
+
+from .schema_utils import get_entity_class_name, get_class_identifier_name

--- a/src/hca_validation/schema_utils/schema_utils.py
+++ b/src/hca_validation/schema_utils/schema_utils.py
@@ -1,0 +1,41 @@
+from typing import Optional
+from linkml_runtime import SchemaView
+
+import hca_validation.schema.generated.core as schema
+
+# Map schema types and bionetworks to their corresponding class names
+schema_classes = {
+    "dataset": {
+      "DEFAULT": "Dataset",
+      "adipose": "AdiposeDataset",
+      "gut": "GutDataset"
+    },
+    "donor": {
+      "DEFAULT": "Donor"
+    },
+    "sample": {
+      "DEFAULT": "Sample",
+      "adipose": "AdiposeSample",
+      "gut": "GutSample"
+    },
+    "cell": {
+      "DEFAULT": "Cell"
+    }
+}
+
+
+def get_entity_class_name(schema_type: str, bionetwork: Optional[str] = None) -> str:
+    # Validate schema type
+    if schema_type not in schema_classes:
+        raise ValueError(f"Unsupported schema type: {schema_type}. "
+                       f"Supported types are: {', '.join(schema_classes.keys())}")
+    
+    type_classes = schema_classes[schema_type]
+    return type_classes.get(bionetwork, type_classes["DEFAULT"])
+
+
+def get_class_identifier_name(schemaview: SchemaView, class_name: str) -> str:
+    for slot in schemaview.class_induced_slots(class_name):
+        if slot.identifier:
+            return slot.name
+    raise ValueError(f"No identifier slot found for class {class_name}")

--- a/src/hca_validation/schema_utils/schema_utils.py
+++ b/src/hca_validation/schema_utils/schema_utils.py
@@ -1,7 +1,7 @@
+import os
 from typing import Optional
 from linkml_runtime import SchemaView
-
-import hca_validation.schema.generated.core as schema
+from linkml_runtime.linkml_model.meta import ClassDefinition
 
 # Map schema types and bionetworks to their corresponding class names
 schema_classes = {
@@ -22,6 +22,14 @@ schema_classes = {
       "DEFAULT": "Cell"
     }
 }
+
+
+def load_schemaview():
+    # Get the schema path
+    module_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    schema_path = os.path.join(module_dir, "schema/core.yaml")
+    # Create a schemaview
+    return SchemaView(schema_path)
 
 
 def get_entity_class_name(schema_type: str, bionetwork: Optional[str] = None) -> str:

--- a/src/hca_validation/validator/__init__.py
+++ b/src/hca_validation/validator/__init__.py
@@ -4,4 +4,4 @@ HCA Validation Tools - Validator Module
 This module provides reusable validation components for HCA data validation.
 """
 
-from .validator import get_entity_class_name, validate, validate_id_uniqueness
+from .validator import validate, validate_id_uniqueness

--- a/src/hca_validation/validator/validator.py
+++ b/src/hca_validation/validator/validator.py
@@ -10,6 +10,7 @@ import pandas as pd
 from pydantic_core import InitErrorDetails, PydanticCustomError
 
 import hca_validation.schema.generated.core as schema
+from hca_validation.schema_utils import get_class_identifier_name
 
 # Map schema types and bionetworks to their corresponding class names
 schema_classes = {
@@ -30,16 +31,6 @@ schema_classes = {
       "DEFAULT": "Cell"
     }
 }
-
-
-def get_entity_class_name(schema_type: str, bionetwork: Optional[str] = None) -> str:
-    # Validate schema type
-    if schema_type not in schema_classes:
-        raise ValueError(f"Unsupported schema type: {schema_type}. "
-                       f"Supported types are: {', '.join(schema_classes.keys())}")
-    
-    type_classes = schema_classes[schema_type]
-    return type_classes.get(bionetwork, type_classes["DEFAULT"])
 
 
 def validate(data: Dict[str, Any], *, class_name: str) -> Optional[ValidationError]:
@@ -65,13 +56,6 @@ def validate(data: Dict[str, Any], *, class_name: str) -> Optional[ValidationErr
     except ValidationError as e:
         # Return validation error
         return e
-
-
-def get_class_identifier_name(schemaview: SchemaView, class_name: str) -> str:
-    for slot in schemaview.class_induced_slots(class_name):
-        if slot.identifier:
-            return slot.name
-    raise ValueError(f"No identifier slot found for class {class_name}")
 
 
 def validate_id_uniqueness(data: pd.DataFrame, schemaview: SchemaView, class_name: str) -> Optional[ValidationError]:

--- a/tests/test_entry_sheet_validator.py
+++ b/tests/test_entry_sheet_validator.py
@@ -28,6 +28,7 @@ from hca_validation.entry_sheet_validator.validate_sheet import (
     read_sheet_with_service_account,
     validate_google_sheet
 )
+from hca_validation.entry_sheet_validator.process_sheet import process_google_sheet
 
 # Test sheet IDs
 PUBLIC_SHEET_ID = "1oPFb6qb0Y2HeoQqjSGRe_TlsZPRLwq-HUlVF0iqtVlY"  # This is a public sheet
@@ -87,6 +88,79 @@ SAMPLE_SHEET_DATA_WITH_VALID_AND_MISSING_INTEGERS_EXPECTED_NORMALIZATION = [
     {"sample_id": "c", "cell_number_loaded": None},
     {"sample_id": "d", "cell_number_loaded": 7890},
 ]
+
+
+def _test_validation_with_mock_sheets_response(
+    validation_function,
+    mock_read_service_account,
+    *,
+    bionetwork=None,
+    sheet_data=None,
+    datasets_sheet_data=None,
+    donors_sheet_data=None,
+    samples_sheet_data=None
+) -> SheetValidationResult:
+    """Helper function for testing validation with service account access, for a validation function with a call signature like validate_google_sheet."""
+
+    if datasets_sheet_data is None:
+        datasets_sheet_data = SAMPLE_SHEET_DATA if sheet_data is None else sheet_data
+    if samples_sheet_data is not None and donors_sheet_data is None:
+        donors_sheet_data = SAMPLE_SHEET_DATA
+    
+    worksheets = [
+        WorksheetInfo(
+            data=datasets_sheet_data,
+            worksheet_id=123,
+            source_columns=list(datasets_sheet_data.columns),
+            source_rows_start_index=1
+        )
+    ]
+    if donors_sheet_data is not None:
+        worksheets.append(
+            WorksheetInfo(
+                data=donors_sheet_data,
+                worksheet_id=456,
+                source_columns=list(donors_sheet_data.columns),
+                source_rows_start_index=1
+            )
+        )
+    if samples_sheet_data is not None:
+        worksheets.append(
+            WorksheetInfo(
+                data=samples_sheet_data,
+                worksheet_id=789,
+                source_columns=list(samples_sheet_data.columns),
+                source_rows_start_index=1
+            )
+        )
+
+    # Mock successful service account read
+    mock_read_service_account.return_value = SpreadsheetInfo(
+        spreadsheet_metadata=SpreadsheetMetadata(
+            spreadsheet_title="Test Sheet Title",
+            last_updated_date="2025-06-06T22:43:57.554Z",
+            last_updated_by="foo",
+            last_updated_email="foo@example.com"
+        ),
+        worksheets=worksheets
+    )
+
+    # Run validation
+    validation_result = validation_function(PUBLIC_SHEET_ID, bionetwork=bionetwork)
+
+    # Verify service account method was used
+    mock_read_service_account.assert_called_once_with(PUBLIC_SHEET_ID, [0, 1, 2])
+    
+    # Verify metadata is returned
+    assert validation_result.spreadsheet_metadata
+    assert validation_result.spreadsheet_metadata.spreadsheet_title == "Test Sheet Title"
+    assert validation_result.spreadsheet_metadata.last_updated_date == "2025-06-06T22:43:57.554Z"
+    assert validation_result.spreadsheet_metadata.last_updated_by == "foo"
+    assert validation_result.spreadsheet_metadata.last_updated_email == "foo@example.com"
+    # The mock data is in the format necessary to be parsed, but does not contain actual dataset fields, so we expect the 'validation_error' code
+    assert validation_result.error_code == 'validation_error'
+    
+    return validation_result
 
 
 class TestReadSheetWithServiceAccount:
@@ -325,87 +399,15 @@ class TestReadSheetWithServiceAccount:
 class TestValidateGoogleSheet:
     """Tests for the validate_google_sheet function."""
 
-    def _test_service_account_access_helper(
-        self,
-        mock_read_service_account,
-        *,
-        bionetwork=None,
-        sheet_data=None,
-        datasets_sheet_data=None,
-        donors_sheet_data=None,
-        samples_sheet_data=None
-    ) -> SheetValidationResult:
-        """Helper method for testing validation with service account access."""
-
-        if datasets_sheet_data is None:
-            datasets_sheet_data = SAMPLE_SHEET_DATA if sheet_data is None else sheet_data
-        if samples_sheet_data is not None and donors_sheet_data is None:
-            donors_sheet_data = SAMPLE_SHEET_DATA
-        
-        worksheets = [
-            WorksheetInfo(
-                data=datasets_sheet_data,
-                worksheet_id=123,
-                source_columns=list(datasets_sheet_data.columns),
-                source_rows_start_index=1
-            )
-        ]
-        if donors_sheet_data is not None:
-            worksheets.append(
-                WorksheetInfo(
-                    data=donors_sheet_data,
-                    worksheet_id=456,
-                    source_columns=list(donors_sheet_data.columns),
-                    source_rows_start_index=1
-                )
-            )
-        if samples_sheet_data is not None:
-            worksheets.append(
-                WorksheetInfo(
-                    data=samples_sheet_data,
-                    worksheet_id=789,
-                    source_columns=list(samples_sheet_data.columns),
-                    source_rows_start_index=1
-                )
-            )
-
-        # Mock successful service account read
-        mock_read_service_account.return_value = SpreadsheetInfo(
-            spreadsheet_metadata=SpreadsheetMetadata(
-                spreadsheet_title="Test Sheet Title",
-                last_updated_date="2025-06-06T22:43:57.554Z",
-                last_updated_by="foo",
-                last_updated_email="foo@example.com"
-            ),
-            worksheets=worksheets
-        )
-
-        # Run validation
-        validation_result = validate_google_sheet(PUBLIC_SHEET_ID, bionetwork=bionetwork)
-
-        # Verify service account method was used
-        mock_read_service_account.assert_called_once_with(PUBLIC_SHEET_ID, [0, 1, 2])
-        
-        # Verify metadata is returned
-        assert validation_result.spreadsheet_metadata
-        assert validation_result.spreadsheet_metadata.spreadsheet_title == "Test Sheet Title"
-        assert validation_result.spreadsheet_metadata.last_updated_date == "2025-06-06T22:43:57.554Z"
-        assert validation_result.spreadsheet_metadata.last_updated_by == "foo"
-        assert validation_result.spreadsheet_metadata.last_updated_email == "foo@example.com"
-        # The mock data is in the format necessary to be parsed, but does not contain actual dataset fields, so we expect the 'validation_error' code
-        assert validation_result.error_code == 'validation_error'
-        
-        return validation_result
-
     @patch('hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account')
     def test_service_account_access(self, mock_read_service_account):
         """Test validation with service account access."""
-        self._test_service_account_access_helper(mock_read_service_account)
+        _test_validation_with_mock_sheets_response(validate_google_sheet, mock_read_service_account)
 
     @patch('hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account')
     def test_service_account_access_with_bionetwork(self, mock_read_service_account):
         """Test validation using network-specific model."""
-        result = self._test_service_account_access_helper(mock_read_service_account, bionetwork="gut")
+        result = _test_validation_with_mock_sheets_response(validate_google_sheet, mock_read_service_account, bionetwork="gut")
         # We expect there to be an error referencing `doublet_detection`, a field required by the Gut Network model but not by the default model
         assert any(error.column == "doublet_detection" for error in result.errors)
 
@@ -420,7 +422,7 @@ class TestValidateGoogleSheet:
             return DEFAULT
         mock_validate.side_effect = save_data
         # Validate the mock sheet
-        self._test_service_account_access_helper(mock_read_service_account, sheet_data=SAMPLE_SHEET_DATA_WITH_CASTS)
+        _test_validation_with_mock_sheets_response(validate_google_sheet, mock_read_service_account, sheet_data=SAMPLE_SHEET_DATA_WITH_CASTS)
         # Confirm that values were converted as expected
         assert validated_dicts == SAMPLE_SHEET_DATA_WITH_CASTS_EXPECTED_NORMALIZATION
 
@@ -435,7 +437,7 @@ class TestValidateGoogleSheet:
             return DEFAULT
         mock_validate.side_effect = save_data
         # Validate the mock sheet
-        self._test_service_account_access_helper(mock_read_service_account, samples_sheet_data=SAMPLE_SHEET_DATA_WITH_INTEGERS)
+        _test_validation_with_mock_sheets_response(validate_google_sheet, mock_read_service_account, samples_sheet_data=SAMPLE_SHEET_DATA_WITH_INTEGERS)
         # Confirm that values were converted as expected
         assert validated_dicts == SAMPLE_SHEET_DATA_WITH_INTEGERS_EXPECTED_NORMALIZATION
 
@@ -450,7 +452,7 @@ class TestValidateGoogleSheet:
             return DEFAULT
         mock_validate.side_effect = save_data
         # Validate the mock sheet
-        self._test_service_account_access_helper(mock_read_service_account, samples_sheet_data=SAMPLE_SHEET_DATA_WITH_VALID_AND_MISSING_INTEGERS)
+        _test_validation_with_mock_sheets_response(validate_google_sheet, mock_read_service_account, samples_sheet_data=SAMPLE_SHEET_DATA_WITH_VALID_AND_MISSING_INTEGERS)
         # Confirm that values were converted as expected
         assert validated_dicts == SAMPLE_SHEET_DATA_WITH_VALID_AND_MISSING_INTEGERS_EXPECTED_NORMALIZATION
 
@@ -465,19 +467,19 @@ class TestValidateGoogleSheet:
             return DEFAULT
         mock_validate.side_effect = save_class_name
         # Validate the mock sheet with default dataset model
-        self._test_service_account_access_helper(mock_read_service_account)
+        _test_validation_with_mock_sheets_response(validate_google_sheet, mock_read_service_account)
         # Confirm that correct class was used
         assert last_class_name_info["value"] == "Dataset"
         mock_read_service_account.reset_mock()
         # Validate the mock sheet with Gut Network dataset model
-        self._test_service_account_access_helper(mock_read_service_account, bionetwork="gut")
+        _test_validation_with_mock_sheets_response(validate_google_sheet, mock_read_service_account, bionetwork="gut")
         # Confirm that correct class was used
         assert last_class_name_info["value"] == "GutDataset"
 
     @patch('hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account')
     def test_duplicate_ids(self, mock_read_service_account):
         """Test validation of duplicate IDs."""
-        result = self._test_service_account_access_helper(mock_read_service_account, sheet_data=SAMPLE_SHEET_DATA_WITH_DUPLICATE_IDS)
+        result = _test_validation_with_mock_sheets_response(validate_google_sheet, mock_read_service_account, sheet_data=SAMPLE_SHEET_DATA_WITH_DUPLICATE_IDS)
         # Based on the mock data, expect five duplicate ID errors, for IDs "foo" and "baz" but not "bar" (which is not duplicated) or None (which is not an ID)
         duplicate_id_errors = [error for error in result.errors if error.message.startswith("Duplicate identifier ")]
         assert len(duplicate_id_errors) == 5
@@ -485,17 +487,9 @@ class TestValidateGoogleSheet:
 
     @patch('hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account')
     def test_available_fixes(self, mock_read_service_account):
-        """Test that available fixes are present in error info."""
-        result = self._test_service_account_access_helper(mock_read_service_account, donors_sheet_data=SAMPLE_SHEET_DATA_WITH_FIXES)
-        # Based on the mock data, expect three errors in the manner_of_death column, with appropriate input values and fixed values (or lack thereof)
-        mod_errors = [error for error in result.errors if error.column == "manner_of_death"]
-        assert len(mod_errors) == 3
-        assert mod_errors[0].input == "not_applicable"
-        assert mod_errors[0].input_fix == "not applicable"
-        assert mod_errors[1].input == "not a manner of death"
-        assert mod_errors[1].input_fix is None
-        assert mod_errors[2].input == "not_applicable"
-        assert mod_errors[2].input_fix == "not applicable"
+        """Test that validate_google_sheet does not provide fixes on its own."""
+        result = _test_validation_with_mock_sheets_response(validate_google_sheet, mock_read_service_account, donors_sheet_data=SAMPLE_SHEET_DATA_WITH_FIXES)
+        assert all(error.input_fix is None for error in result.errors)
 
     @patch('hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account')
     def test_service_account_access_failure(self, mock_read_service_account):
@@ -525,6 +519,24 @@ class TestValidateGoogleSheet:
         # Run validation
         with pytest.raises(ValueError, match="'not-a-bionetwork' is not a valid bionetwork"):
             validate_google_sheet(PUBLIC_SHEET_ID, bionetwork="not-a-bionetwork")
+
+
+class TestProcessGoogleSheet:
+    """Tests for the process_google_sheet function."""
+
+    @patch('hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account')
+    def test_available_fixes(self, mock_read_service_account):
+        """Test that available fixes are present in error info."""
+        result = _test_validation_with_mock_sheets_response(process_google_sheet, mock_read_service_account, donors_sheet_data=SAMPLE_SHEET_DATA_WITH_FIXES)
+        # Based on the mock data, expect three errors in the manner_of_death column, with appropriate input values and fixed values (or lack thereof)
+        mod_errors = [error for error in result.errors if error.column == "manner_of_death"]
+        assert len(mod_errors) == 3
+        assert mod_errors[0].input == "not_applicable"
+        assert mod_errors[0].input_fix == "not applicable"
+        assert mod_errors[1].input == "not a manner of death"
+        assert mod_errors[1].input_fix is None
+        assert mod_errors[2].input == "not_applicable"
+        assert mod_errors[2].input_fix == "not applicable"
 
 
 # Integration tests that use actual Google Sheets


### PR DESCRIPTION
Closes #110

The addition of the field to error info objects automatically means that the possible fixes are returned by the API