### PR TITLE
feat: return editability in sheet metadata and from api (#111)

### DIFF
--- a/src/hca_validation/entry_sheet_validator/validate_sheet.py
+++ b/src/hca_validation/entry_sheet_validator/validate_sheet.py
@@ -52,6 +52,7 @@ class SpreadsheetMetadata:
     last_updated_date: str
     last_updated_by: str
     last_updated_email: Optional[str]
+    can_edit: bool
 
 @dataclass
 class SpreadsheetInfo:
@@ -360,18 +361,20 @@ def read_sheet_with_service_account(sheet_id, sheet_indices=[0]) -> Union[Spread
 
             # Get the spreadsheet metadata from Drive
             logger.info(f"Attempting to get metadata for spreadsheet with ID: {sheet_id}")
-            file_metadata = drive.files().get(fileId=sheet_id, fields="modifiedTime, lastModifyingUser(displayName, emailAddress)").execute()
+            file_metadata = drive.files().get(fileId=sheet_id, fields="modifiedTime, lastModifyingUser(displayName, emailAddress), capabilities(canModifyContent)").execute()
             last_updated_date = file_metadata["modifiedTime"]
             last_modifying_user = file_metadata.get("lastModifyingUser", {})
             last_updated_by = last_modifying_user.get("displayName", "unknown")
             last_updated_email = last_modifying_user.get("emailAddress") or None
+            can_edit = file_metadata["capabilities"]["canModifyContent"]
             logger.info(f"Successfully got metadata from Drive API")
         
             spreadsheet_metadata = SpreadsheetMetadata(
                 spreadsheet_title=sheet_title,
                 last_updated_date=last_updated_date,
                 last_updated_by=last_updated_by,
-                last_updated_email=last_updated_email
+                last_updated_email=last_updated_email,
+                can_edit=can_edit
             )
 
             # Get all worksheets

--- a/src/hca_validation/lambda_functions/entry_sheet_validator_lambda/handler.py
+++ b/src/hca_validation/lambda_functions/entry_sheet_validator_lambda/handler.py
@@ -212,6 +212,7 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                 "by": spreadsheet_metadata.last_updated_by,
                 "by_email": spreadsheet_metadata.last_updated_email
             },
+            'can_edit': None if spreadsheet_metadata is None else spreadsheet_metadata.can_edit,
             'errors': [asdict(e) for e in validation_result.errors],
             'valid': len(validation_result.errors) == 0,
             'error_code': validation_result.error_code,

--- a/tests/test_entry_sheet_validator.py
+++ b/tests/test_entry_sheet_validator.py
@@ -228,6 +228,9 @@ class TestReadSheetWithServiceAccount:
             "modifiedTime": "2025-06-06T22:43:57.554Z",
             "lastModifyingUser": {
                 "displayName": "foo"
+            },
+            "capabilities": {
+                "canModifyContent": True
             }
         }
         mock_files.get.return_value = mock_get
@@ -238,6 +241,7 @@ class TestReadSheetWithServiceAccount:
         sheet_read_result = read_sheet_with_service_account(PUBLIC_SHEET_ID)
         assert isinstance(sheet_read_result, SpreadsheetInfo)
         assert sheet_read_result.spreadsheet_metadata.spreadsheet_title == "Test Sheet Title"
+        assert sheet_read_result.spreadsheet_metadata.can_edit is True
         sheet_info = sheet_read_result.worksheets[0]
         assert sheet_info.data is not None
         assert isinstance(sheet_info.data, pd.DataFrame)

--- a/tests/test_entry_sheet_validator.py
+++ b/tests/test_entry_sheet_validator.py
@@ -140,7 +140,8 @@ def _test_validation_with_mock_sheets_response(
             spreadsheet_title="Test Sheet Title",
             last_updated_date="2025-06-06T22:43:57.554Z",
             last_updated_by="foo",
-            last_updated_email="foo@example.com"
+            last_updated_email="foo@example.com",
+            can_edit=False
         ),
         worksheets=worksheets
     )


### PR DESCRIPTION
Closes #111

~~A rebase will presumably be required for compatibility with #114, due to the update to the test helper~~ Done!

Added a `can_edit` field to the spreadsheet metadata objects used in the validation process and to the API response body. In the API response, the field is set to `null` if the permission information is unavailable (e.g. if an error occurs in accessing the spreadsheet)