### PR TITLE
feat: update spreadsheet validation functions to enable reuse of api objects (#112)

### DIFF
--- a/src/hca_validation/entry_sheet_validator/validate_sheet.py
+++ b/src/hca_validation/entry_sheet_validator/validate_sheet.py
@@ -61,8 +61,8 @@ class SpreadsheetInfo:
     worksheets: List[WorksheetInfo]
 
 @dataclass
-class ReadErrorSheetInfo:
-    """Container for info regarding a failed read of a Google Sheet."""
+class SheetReadError(Exception):
+    """Exception raised when reading a Googe Sheet fails."""
     error_code: str
     error_message: Optional[str] = None
     spreadsheet_metadata: Optional[SpreadsheetMetadata] = None
@@ -183,7 +183,7 @@ def read_worksheets(
     spreadsheet_metadata: SpreadsheetMetadata,
     spreadsheet: gspread.Spreadsheet,
     sheet_indices: List[int]
-) -> Union[List[WorksheetInfo], ReadErrorSheetInfo]:
+) -> List[WorksheetInfo]:
     import logging
     logger = logging.getLogger(__name__)
     
@@ -196,7 +196,7 @@ def read_worksheets(
     for sheet_index in sheet_indices:
         if not sheet_index < len(all_worksheets):
             logger.error(f"Error accessing Google Sheet with service account: Worksheet index {sheet_index} not found in sheet {sheet_id}")
-            return ReadErrorSheetInfo(error_code='worksheet_not_found', spreadsheet_metadata=spreadsheet_metadata)
+            raise SheetReadError(error_code='worksheet_not_found', spreadsheet_metadata=spreadsheet_metadata)
         worksheets.append(all_worksheets[sheet_index])
     
     logger.info(f"Successfully retrieved worksheets")
@@ -227,11 +227,11 @@ def read_worksheets(
             )
         else:
             logger.warning(f"Sheet {sheet_id} (index {sheet_index}) appears to be empty")
-            return ReadErrorSheetInfo(error_code="sheet_data_empty", spreadsheet_metadata=spreadsheet_metadata, worksheet_id=worksheet.id)
+            raise SheetReadError(error_code="sheet_data_empty", spreadsheet_metadata=spreadsheet_metadata, worksheet_id=worksheet.id)
     
     return worksheets_info
 
-def read_sheet_with_service_account(sheet_id, sheet_indices=[0]) -> Union[SpreadsheetInfo, ReadErrorSheetInfo]:
+def read_sheet_with_service_account(sheet_id, sheet_indices=[0]) -> SpreadsheetInfo:
     """
     Read data from a Google Sheet using a service account for authentication.
     
@@ -241,8 +241,10 @@ def read_sheet_with_service_account(sheet_id, sheet_indices=[0]) -> Union[Spread
         
     Returns:
         info: If successful, SpreadsheetInfo object containing list of WorksheetInfo corresponding to
-            the list of sheet indices; otherwise, ReadErrorSheetInfo containing error code and, if available,
-            sheet title and worksheet ID
+            the list of sheet indices
+    
+    Raises:
+        SheetReadError containing error code and, if available, sheet title and worksheet ID
     """
     import os
     import json
@@ -276,7 +278,7 @@ def read_sheet_with_service_account(sheet_id, sheet_indices=[0]) -> Union[Spread
     if not service_account_json:
         error_msg = "No service account credentials found in GOOGLE_SERVICE_ACCOUNT environment variable or Secrets Extension"
         logger.error(error_msg)
-        return ReadErrorSheetInfo(error_code='auth_missing')
+        raise SheetReadError(error_code='auth_missing')
     
     # Log the length and first few characters of the credentials to verify they're present
     logger.info(f"Service account credentials found: Length={len(service_account_json)} chars")
@@ -286,13 +288,13 @@ def read_sheet_with_service_account(sheet_id, sheet_indices=[0]) -> Union[Spread
     if service_account_json.startswith('{{resolve:'):
         logger.error(f"Service account credentials were not resolved from Secrets Manager (CloudFormation syntax): {service_account_json[:50]}...")
         logger.error("Check that the Lambda function has the correct permissions to access the secret and that the secret exists.")
-        return ReadErrorSheetInfo(error_code='auth_unresolved')
+        raise SheetReadError(error_code='auth_unresolved')
     
     # Check for AWS shorthand syntax
     if service_account_json.startswith('aws:secretsmanager:'):
         logger.error(f"Service account credentials were not resolved from Secrets Manager (AWS shorthand syntax): {service_account_json[:50]}...")
         logger.error("Check that the Lambda function has the correct permissions to access the secret and that the secret exists.")
-        return ReadErrorSheetInfo(error_code='auth_unresolved')
+        raise SheetReadError(error_code='auth_unresolved')
     
     # Set up a variable to hold spreadsheet metadata so that it can be referenced if an unexpected type of error occurs after metadata is obtained
     spreadsheet_metadata = None
@@ -314,7 +316,7 @@ def read_sheet_with_service_account(sheet_id, sheet_indices=[0]) -> Union[Spread
             error_msg = f"Service account credentials missing required fields: {missing_fields}"
             logger.error(error_msg)
             logger.error(f"Error: {error_msg}. Check that the service account JSON has the correct format and contains all required fields.")
-            return ReadErrorSheetInfo(error_code='auth_invalid_format')
+            raise SheetReadError(error_code='auth_invalid_format')
         
         logger.info(f"Creating credentials object for service account: {credentials_dict.get('client_email')}")
         
@@ -330,7 +332,7 @@ def read_sheet_with_service_account(sheet_id, sheet_indices=[0]) -> Union[Spread
             logger.info("Successfully created credentials object")
         except Exception as cred_error:
             logger.error(f"Error creating Google credentials object: {cred_error}")
-            return ReadErrorSheetInfo(error_code='auth_error')
+            raise SheetReadError(error_code='auth_error')
         
         # Authenticate with gspread
         logger.info("Authorizing with gspread...")
@@ -339,7 +341,7 @@ def read_sheet_with_service_account(sheet_id, sheet_indices=[0]) -> Union[Spread
             logger.info("Successfully authorized with gspread")
         except Exception as auth_error:
             logger.error(f"Error authorizing with Google Sheets API: {auth_error}")
-            return ReadErrorSheetInfo(error_code='auth_error')
+            raise SheetReadError(error_code='auth_error')
         
         # Authenticate with Drive API
         logger.info("Authorizing with Drive API...")
@@ -348,7 +350,7 @@ def read_sheet_with_service_account(sheet_id, sheet_indices=[0]) -> Union[Spread
             logger.info("Successfully authorized with Drive API")
         except Exception as auth_error:
             logger.error(f"Error authorizing with Google Drive API: {auth_error}")
-            return ReadErrorSheetInfo(error_code='auth_error')
+            raise SheetReadError(error_code='auth_error')
         
         try:
             # Open the spreadsheet and get the worksheets
@@ -380,45 +382,44 @@ def read_sheet_with_service_account(sheet_id, sheet_indices=[0]) -> Union[Spread
             # Get all worksheets
             sheets_info = read_worksheets(sheet_id, spreadsheet_metadata, spreadsheet, sheet_indices)
             
-            if (isinstance(sheets_info, ReadErrorSheetInfo)):
-                return sheets_info
-            
             return SpreadsheetInfo(spreadsheet_metadata, sheets_info)
         
         except gspread.exceptions.SpreadsheetNotFound:
             logger.error(f"Sheet {sheet_id} not found. Check if the sheet ID is correct.")
             logger.error(f"Error accessing Google Sheet with service account: Sheet {sheet_id} not found or not accessible with provided credentials")
-            return ReadErrorSheetInfo(error_code='sheet_not_found', spreadsheet_metadata=spreadsheet_metadata)
+            raise SheetReadError(error_code='sheet_not_found', spreadsheet_metadata=spreadsheet_metadata)
         except PermissionError as e:
             logger.error(f"Permission denied accessing sheet {sheet_id}: {e}")
             logger.error(f"Make sure the service account has access to the sheet.")
-            return ReadErrorSheetInfo(error_code='permission_denied', spreadsheet_metadata=spreadsheet_metadata)
+            raise SheetReadError(error_code='permission_denied', spreadsheet_metadata=spreadsheet_metadata)
         except gspread.exceptions.APIError as e:
             logger.error(f"Google Sheets API error: {e}")
-            return ReadErrorSheetInfo(
+            raise SheetReadError(
                 error_code='api_error',
                 error_message=f"Received error {e.code} from Google Sheets API: {e.error['message']}",
                 spreadsheet_metadata=spreadsheet_metadata
             )
         except GoogleHttpError as e:
             logger.error(f"Google API error: {e}")
-            return ReadErrorSheetInfo(
+            raise SheetReadError(
                 error_code="api_error",
                 error_message=f"Received error {e.status_code} from Google API: {e.reason}",
                 spreadsheet_metadata=spreadsheet_metadata
             )
         except requests.exceptions.RetryError as e:
             logger.error(f"Reached maximum configured API retries: {e}")
-            return ReadErrorSheetInfo(error_code="max_api_retries", spreadsheet_metadata=spreadsheet_metadata)
+            raise SheetReadError(error_code="max_api_retries", spreadsheet_metadata=spreadsheet_metadata)
             
     except json.JSONDecodeError as json_error:
         logger.error(f"Invalid JSON format in service account credentials: {json_error}")
-        return ReadErrorSheetInfo(error_code='auth_invalid_format', spreadsheet_metadata=spreadsheet_metadata)
+        raise SheetReadError(error_code='auth_invalid_format', spreadsheet_metadata=spreadsheet_metadata)
+    except SheetReadError as e:
+        raise e
     except Exception as e:
         logger.error(f"Unexpected error accessing Google Sheet with service account: {e}")
         logger.error(f"Exception type: {type(e).__name__}")
         logger.error(f"Traceback: {traceback.format_exc()}")
-        return ReadErrorSheetInfo(error_code='api_error', spreadsheet_metadata=spreadsheet_metadata)
+        raise SheetReadError(error_code='api_error', spreadsheet_metadata=spreadsheet_metadata)
 
 def normalize_dataframe_values(df: pd.DataFrame, schemaview: SchemaView, class_name: str) -> pd.DataFrame:
     """
@@ -567,26 +568,27 @@ def validate_google_sheet(
     
     logger.info(f"Reading sheet: {sheet_id}")
     
-    # Read the sheet with service account credentials
-    sheet_read_result = read_sheet_with_service_account(sheet_id, [sheet_structure_by_entity_type[t]["sheet_index"] for t in entity_types])
+    try:
+        # Read the sheet with service account credentials
+        sheet_read_result = read_sheet_with_service_account(sheet_id, [sheet_structure_by_entity_type[t]["sheet_index"] for t in entity_types])
     
-    if isinstance(sheet_read_result, ReadErrorSheetInfo):
+    except SheetReadError as read_error:
         error_msg = (
-            sheet_read_result.error_message
-            or f"Could not access or read data from sheet {sheet_id} (Error: {sheet_read_result.error_code})"
+            read_error.error_message
+            or f"Could not access or read data from sheet {sheet_id} (Error: {read_error.error_code})"
         )
-        logger.warning(f"Sheet access failed with error code: {sheet_read_result.error_code}")
+        logger.warning(f"Sheet access failed with error code: {read_error.error_code}")
         
         logger.warning(f"{error_msg}")
         error_info = SheetErrorInfo(
             entity_type=None,
-            worksheet_id=sheet_read_result.worksheet_id,
+            worksheet_id=read_error.worksheet_id,
             message=error_msg
         )
         return SheetValidationResult(
             successful=False,
-            spreadsheet_metadata=sheet_read_result.spreadsheet_metadata,
-            error_code=sheet_read_result.error_code,
+            spreadsheet_metadata=read_error.spreadsheet_metadata,
+            error_code=read_error.error_code,
             summary=make_summary_without_entities(1, entity_types),
             errors=[error_info]
         )

--- a/src/hca_validation/entry_sheet_validator/validate_sheet.py
+++ b/src/hca_validation/entry_sheet_validator/validate_sheet.py
@@ -68,7 +68,7 @@ class SpreadsheetInfo:
 
 @dataclass
 class SheetReadError(Exception):
-    """Exception raised when reading a Googe Sheet fails."""
+    """Exception raised when reading a Google Sheet fails."""
     error_code: str
     error_message: Optional[str] = None
     spreadsheet_metadata: Optional[SpreadsheetMetadata] = None

--- a/tests/test_entry_sheet_validator.py
+++ b/tests/test_entry_sheet_validator.py
@@ -19,7 +19,7 @@ import gspread
 from gspread.exceptions import SpreadsheetNotFound, WorksheetNotFound, APIError
 
 from hca_validation.entry_sheet_validator.validate_sheet import (
-    ReadErrorSheetInfo,
+    SheetReadError,
     SheetErrorInfo,
     SheetValidationResult,
     SpreadsheetInfo,
@@ -264,12 +264,12 @@ class TestReadSheetWithServiceAccount:
         if 'GOOGLE_SERVICE_ACCOUNT' in os.environ:
             del os.environ['GOOGLE_SERVICE_ACCOUNT']
 
-        # The function should return read error containing only 'auth_missing' code when no credentials are available
-        sheet_read_result = read_sheet_with_service_account(PUBLIC_SHEET_ID)
-        assert isinstance(sheet_read_result, ReadErrorSheetInfo)
-        assert sheet_read_result.error_code == 'auth_missing'
-        assert sheet_read_result.spreadsheet_metadata is None
-        assert sheet_read_result.worksheet_id is None
+        # The function should raise a read error containing only 'auth_missing' code when no credentials are available
+        with pytest.raises(SheetReadError) as error_info:
+            read_sheet_with_service_account(PUBLIC_SHEET_ID)
+        assert error_info.value.error_code == 'auth_missing'
+        assert error_info.value.spreadsheet_metadata is None
+        assert error_info.value.worksheet_id is None
         
     def test_with_unresolved_credentials(self):
         """Test reading a sheet with unresolved credentials from Secrets Manager."""
@@ -279,11 +279,11 @@ class TestReadSheetWithServiceAccount:
         
         try:
             # The function should return read error containing only 'auth_unresolved' code when credentials weren't resolved
-            sheet_read_result = read_sheet_with_service_account(PUBLIC_SHEET_ID)
-            assert isinstance(sheet_read_result, ReadErrorSheetInfo)
-            assert sheet_read_result.error_code == 'auth_unresolved'
-            assert sheet_read_result.spreadsheet_metadata is None
-            assert sheet_read_result.worksheet_id is None
+            with pytest.raises(SheetReadError) as error_info:
+                read_sheet_with_service_account(PUBLIC_SHEET_ID)
+            assert error_info.value.error_code == 'auth_unresolved'
+            assert error_info.value.spreadsheet_metadata is None
+            assert error_info.value.worksheet_id is None
         finally:
             # Restore original environment
             os.environ.clear()
@@ -301,11 +301,11 @@ class TestReadSheetWithServiceAccount:
         
         try:
             # The function should return read error containing only 'auth_invalid_format' code when credentials are missing required fields
-            sheet_read_result = read_sheet_with_service_account(PUBLIC_SHEET_ID)
-            assert isinstance(sheet_read_result, ReadErrorSheetInfo)
-            assert sheet_read_result.error_code == 'auth_invalid_format'
-            assert sheet_read_result.spreadsheet_metadata is None
-            assert sheet_read_result.worksheet_id is None
+            with pytest.raises(SheetReadError) as error_info:
+                read_sheet_with_service_account(PUBLIC_SHEET_ID)
+            assert error_info.value.error_code == 'auth_invalid_format'
+            assert error_info.value.spreadsheet_metadata is None
+            assert error_info.value.worksheet_id is None
         finally:
             # Restore original environment
             os.environ.clear()
@@ -322,11 +322,11 @@ class TestReadSheetWithServiceAccount:
         mock_authorize.return_value = mock_client
 
         # The function should return read error containing only 'sheet_not_found' code when the sheet is not found
-        sheet_read_result = read_sheet_with_service_account(NONEXISTENT_SHEET_ID)
-        assert isinstance(sheet_read_result, ReadErrorSheetInfo)
-        assert sheet_read_result.error_code == 'sheet_not_found'
-        assert sheet_read_result.spreadsheet_metadata is None
-        assert sheet_read_result.worksheet_id is None
+        with pytest.raises(SheetReadError) as error_info:
+            read_sheet_with_service_account(NONEXISTENT_SHEET_ID)
+        assert error_info.value.error_code == 'sheet_not_found'
+        assert error_info.value.spreadsheet_metadata is None
+        assert error_info.value.worksheet_id is None
         
         # Verify the mocks were called correctly
         mock_client.open_by_key.assert_called_once_with(NONEXISTENT_SHEET_ID)
@@ -345,11 +345,11 @@ class TestReadSheetWithServiceAccount:
         mock_authorize.return_value = mock_client
 
         # The function should return read error containing 'worksheet_not_found' code and spreadsheet metadata when the worksheet is not found
-        sheet_read_result = read_sheet_with_service_account(PUBLIC_SHEET_ID)
-        assert isinstance(sheet_read_result, ReadErrorSheetInfo)
-        assert sheet_read_result.error_code == 'worksheet_not_found'
-        assert sheet_read_result.spreadsheet_metadata is not None
-        assert sheet_read_result.worksheet_id is None
+        with pytest.raises(SheetReadError) as error_info:
+            read_sheet_with_service_account(PUBLIC_SHEET_ID)
+        assert error_info.value.error_code == 'worksheet_not_found'
+        assert error_info.value.spreadsheet_metadata is not None
+        assert error_info.value.worksheet_id is None
         
         # Verify the mocks were called correctly
         mock_client.open_by_key.assert_called_once_with(PUBLIC_SHEET_ID)
@@ -367,11 +367,11 @@ class TestReadSheetWithServiceAccount:
         mock_authorize.return_value = mock_client
 
         # The function should return read error containing only 'api_error' code when an API error occurs
-        sheet_read_result = read_sheet_with_service_account(PUBLIC_SHEET_ID)
-        assert isinstance(sheet_read_result, ReadErrorSheetInfo)
-        assert sheet_read_result.error_code == 'api_error'
-        assert sheet_read_result.spreadsheet_metadata is None
-        assert sheet_read_result.worksheet_id is None
+        with pytest.raises(SheetReadError) as error_info:
+            read_sheet_with_service_account(PUBLIC_SHEET_ID)
+        assert error_info.value.error_code == 'api_error'
+        assert error_info.value.spreadsheet_metadata is None
+        assert error_info.value.worksheet_id is None
         
         # Verify the mocks were called correctly
         mock_client.open_by_key.assert_called_once_with(PUBLIC_SHEET_ID)
@@ -390,11 +390,11 @@ class TestReadSheetWithServiceAccount:
         mock_authorize.return_value = mock_client
 
         # The function should return read error containing 'api_error' code and spreadsheet metadata
-        sheet_read_result = read_sheet_with_service_account(PUBLIC_SHEET_ID)
-        assert isinstance(sheet_read_result, ReadErrorSheetInfo)
-        assert sheet_read_result.error_code == 'api_error'
-        assert sheet_read_result.spreadsheet_metadata is not None
-        assert sheet_read_result.worksheet_id is None
+        with pytest.raises(SheetReadError) as error_info:
+            read_sheet_with_service_account(PUBLIC_SHEET_ID)
+        assert error_info.value.error_code == 'api_error'
+        assert error_info.value.spreadsheet_metadata is not None
+        assert error_info.value.worksheet_id is None
         
         # Verify the mocks were called correctly
         mock_client.open_by_key.assert_called_once_with(PUBLIC_SHEET_ID)
@@ -500,7 +500,7 @@ class TestValidateGoogleSheet:
     def test_service_account_access_failure(self, mock_read_service_account):
         """Test validation when service account access fails."""
         # Mock service account read failure
-        mock_read_service_account.return_value = ReadErrorSheetInfo(error_code='auth_missing')
+        mock_read_service_account.side_effect = SheetReadError(error_code='auth_missing')
 
         # Run validation
         validation_result = validate_google_sheet(PUBLIC_SHEET_ID)

--- a/tests/test_entry_sheet_validator.py
+++ b/tests/test_entry_sheet_validator.py
@@ -135,15 +135,18 @@ def _test_validation_with_mock_sheets_response(
         )
 
     # Mock successful service account read
-    mock_read_service_account.return_value = SpreadsheetInfo(
-        spreadsheet_metadata=SpreadsheetMetadata(
-            spreadsheet_title="Test Sheet Title",
-            last_updated_date="2025-06-06T22:43:57.554Z",
-            last_updated_by="foo",
-            last_updated_email="foo@example.com",
-            can_edit=False
+    mock_read_service_account.return_value = (
+        SpreadsheetInfo(
+            spreadsheet_metadata=SpreadsheetMetadata(
+                spreadsheet_title="Test Sheet Title",
+                last_updated_date="2025-06-06T22:43:57.554Z",
+                last_updated_by="foo",
+                last_updated_email="foo@example.com",
+                can_edit=False
+            ),
+            worksheets=worksheets
         ),
-        worksheets=worksheets
+        [MagicMock() for _ in worksheets]
     )
 
     # Run validation
@@ -238,7 +241,7 @@ class TestReadSheetWithServiceAccount:
         mock_build.return_value = mock_drive
         
         # Test the function
-        sheet_read_result = read_sheet_with_service_account(PUBLIC_SHEET_ID)
+        sheet_read_result = read_sheet_with_service_account(PUBLIC_SHEET_ID)[0]
         assert isinstance(sheet_read_result, SpreadsheetInfo)
         assert sheet_read_result.spreadsheet_metadata.spreadsheet_title == "Test Sheet Title"
         assert sheet_read_result.spreadsheet_metadata.can_edit is True
@@ -565,7 +568,7 @@ class TestIntegration:
         if not os.environ.get('GOOGLE_SERVICE_ACCOUNT'):
             pytest.skip("No service account credentials available for integration test")
             
-        sheet_read_result = read_sheet_with_service_account(PUBLIC_SHEET_ID)
+        sheet_read_result = read_sheet_with_service_account(PUBLIC_SHEET_ID)[0]
         assert isinstance(sheet_read_result, SpreadsheetInfo)
         assert isinstance(sheet_read_result.spreadsheet_metadata.spreadsheet_title, str)
         assert isinstance(sheet_read_result.spreadsheet_metadata.last_updated_date, str)
@@ -645,7 +648,7 @@ class TestIntegration:
             pytest.skip("Service account credentials not available")
             
         # This test only runs if GOOGLE_SERVICE_ACCOUNT is set
-        sheet_read_result = read_sheet_with_service_account(PRIVATE_SHEET_ID)
+        sheet_read_result = read_sheet_with_service_account(PRIVATE_SHEET_ID)[0]
         assert isinstance(sheet_read_result, SpreadsheetInfo)
         assert sheet_read_result.spreadsheet_metadata is not None
         assert isinstance(sheet_read_result.spreadsheet_metadata.spreadsheet_title, str)

--- a/tests/test_entry_sheet_validator.py
+++ b/tests/test_entry_sheet_validator.py
@@ -153,7 +153,7 @@ def _test_validation_with_mock_sheets_response(
     validation_result = validation_function(PUBLIC_SHEET_ID, bionetwork=bionetwork)
 
     # Verify service account method was used
-    mock_read_service_account.assert_called_once_with(PUBLIC_SHEET_ID, [0, 1, 2])
+    mock_read_service_account.assert_called_once_with(PUBLIC_SHEET_ID, [0, 1, 2], None)
     
     # Verify metadata is returned
     assert validation_result.spreadsheet_metadata
@@ -509,7 +509,7 @@ class TestValidateGoogleSheet:
         validation_result = validate_google_sheet(PUBLIC_SHEET_ID)
 
         # Verify service account method was used
-        mock_read_service_account.assert_called_once_with(PUBLIC_SHEET_ID, [0, 1, 2])
+        mock_read_service_account.assert_called_once_with(PUBLIC_SHEET_ID, [0, 1, 2], None)
         
         # Verify that an error was reported
         assert len(validation_result.errors) > 0


### PR DESCRIPTION
Closes #112

As part of this, I've changed functions to raise `SheetReadError` exceptions rather than returning `ReadErrorSheetInfo` objects; this should make it easier to handle error results when the functions are being used separately