### PR TITLE
feat: apply available fixes if spreadsheet is editable (#113)

### DIFF
--- a/src/hca_validation/entry_sheet_validator/apply_fixes.py
+++ b/src/hca_validation/entry_sheet_validator/apply_fixes.py
@@ -27,6 +27,8 @@ def get_fix_value_range(a1: str, value: str):
 def get_fix_value_ranges_by_entity_type(errors: List[SheetErrorInfo], entity_types: List[str]):
   """
   Create value range dicts to be passed to gspread in order to fix the given errors, organized by entity type
+
+  If multiple errors for the same cell specify fixes, only the first is included in the returned list
   
   Args:
     errors:
@@ -65,6 +67,10 @@ def apply_fixes(validation_result: SheetValidationResult, entity_types: List[str
   Returns:
     bool:
       True if any fixes were applied to any worksheet, False if no fixes were applied
+
+  Raises:
+    gspread.exceptions.APIError:
+      May be raised if a gspread operation fails
   """
   worksheets_by_entity_type = dict(zip(entity_types, worksheets))
 

--- a/src/hca_validation/entry_sheet_validator/apply_fixes.py
+++ b/src/hca_validation/entry_sheet_validator/apply_fixes.py
@@ -42,7 +42,8 @@ def get_fix_value_ranges_by_entity_type(errors: List[SheetErrorInfo], entity_typ
   value_ranges = {entity_type: [] for entity_type in entity_types}
 
   for error in errors:
-    if error.input_fix is not None and error.entity_type is not None and error.cell is not None and (error.entity_type, error.cell) not in cells_with_fixes:
+    has_fields_for_fix = error.input_fix is not None and error.entity_type is not None and error.cell is not None
+    if has_fields_for_fix and (error.entity_type, error.cell) not in cells_with_fixes:
       value_ranges[error.entity_type].append(get_fix_value_range(error.cell, error.input_fix))
       cells_with_fixes.add((error.entity_type, error.cell))
   

--- a/src/hca_validation/entry_sheet_validator/apply_fixes.py
+++ b/src/hca_validation/entry_sheet_validator/apply_fixes.py
@@ -1,0 +1,40 @@
+from typing import List
+import gspread
+
+from hca_validation.entry_sheet_validator.validate_sheet import SheetErrorInfo, SheetValidationResult
+
+
+def get_fix_value_range(a1: str, value: str):
+  return {
+    "range": a1,
+    "values": [[value]]
+  }
+
+
+def get_fix_value_ranges_by_entity_type(errors: List[SheetErrorInfo], entity_types: List[str]):
+  cells_with_fixes = set()
+  value_ranges = {entity_type: [] for entity_type in entity_types}
+
+  for error in errors:
+    if error.input_fix is not None and error.entity_type is not None and error.cell is not None and (error.entity_type, error.cell) not in cells_with_fixes:
+      value_ranges[error.entity_type].append(get_fix_value_range(error.cell, error.input_fix))
+      cells_with_fixes.add((error.entity_type, error.cell))
+  
+  return value_ranges
+
+
+def apply_fixes(validation_result: SheetValidationResult, entity_types: List[str], worksheets: List[gspread.Worksheet]) -> bool:
+  worksheets_by_entity_type = dict(zip(entity_types, worksheets))
+
+  value_ranges_by_entity_type = get_fix_value_ranges_by_entity_type(validation_result.errors, entity_types)
+
+  made_fixes = False
+
+  for entity_type, value_ranges in value_ranges_by_entity_type.items():
+    if not value_ranges:
+      continue
+    worksheet = worksheets_by_entity_type[entity_type]
+    worksheet.batch_update(value_ranges)
+    made_fixes = True
+  
+  return made_fixes

--- a/src/hca_validation/entry_sheet_validator/apply_fixes.py
+++ b/src/hca_validation/entry_sheet_validator/apply_fixes.py
@@ -5,6 +5,19 @@ from hca_validation.entry_sheet_validator.validate_sheet import SheetErrorInfo, 
 
 
 def get_fix_value_range(a1: str, value: str):
+  """
+  Create a value range dict to be passed to gspread in order to set the specified cell to the given raw value
+  
+  Args:
+    a1:
+      The A1 notation of the cell to set the value of
+    value:
+      The value to be written to the cell
+    
+  Returns:
+    dict:
+      A value range dictionary without a specified worksheet
+  """
   return {
     "range": a1,
     "values": [[value]]
@@ -12,6 +25,19 @@ def get_fix_value_range(a1: str, value: str):
 
 
 def get_fix_value_ranges_by_entity_type(errors: List[SheetErrorInfo], entity_types: List[str]):
+  """
+  Create value range dicts to be passed to gspread in order to fix the given errors, organized by entity type
+  
+  Args:
+    errors:
+      List of validation errors that may have fixes specified
+    entity_types:
+      List of entity types that the errors may apply to
+    
+  Returns:
+    dict:
+      Dictionary mapping entity types to lists of value range dicts.
+  """
   cells_with_fixes = set()
   value_ranges = {entity_type: [] for entity_type in entity_types}
 
@@ -24,6 +50,21 @@ def get_fix_value_ranges_by_entity_type(errors: List[SheetErrorInfo], entity_typ
 
 
 def apply_fixes(validation_result: SheetValidationResult, entity_types: List[str], worksheets: List[gspread.Worksheet]) -> bool:
+  """
+  Apply available fixes from the given validation result to the given gspread worksheets
+  
+  Args:
+    validation_result:
+      SheetValidationResult containing validation errors that may have fixes specified
+    entity_types:
+      List of entity types being processed
+    worksheets:
+      List of gspread worksheets, corresponding element-wise to entity_types
+    
+  Returns:
+    bool:
+      True if any fixes were applied to any worksheet, False if no fixes were applied
+  """
   worksheets_by_entity_type = dict(zip(entity_types, worksheets))
 
   value_ranges_by_entity_type = get_fix_value_ranges_by_entity_type(validation_result.errors, entity_types)

--- a/src/hca_validation/entry_sheet_validator/process_sheet.py
+++ b/src/hca_validation/entry_sheet_validator/process_sheet.py
@@ -49,11 +49,15 @@ def process_google_sheet(
 
         # If the spreadsheet is editable, apply any available fixes
         if validation_result.spreadsheet_metadata is not None and validation_result.spreadsheet_metadata.can_edit:
-            made_changes = apply_fixes(validation_result, entity_types, gspread_worksheets)
+            made_changes = apply_fixes(validation_result, entity_types, gspread_worksheets, sheet_id)
 
             # If the spreadsheet was updated, re-validate
             if made_changes:
                 validation_result = validate_google_sheet(sheet_id, entity_types=entity_types, bionetwork=bionetwork, apis=apis)
+                # Verify that fixes are no longer available, and log an error otherwise
+                errors_with_fix_info = add_fixes_to_errors(validation_result.errors, bionetwork)
+                if any(error.input_fix is not None for error in errors_with_fix_info):
+                    logger.error(f"Sheet {sheet_id} still has fixes available after fixes were applied")
         
         # Return validation result
         return validation_result

--- a/src/hca_validation/entry_sheet_validator/process_sheet.py
+++ b/src/hca_validation/entry_sheet_validator/process_sheet.py
@@ -1,7 +1,8 @@
 import dataclasses
 from typing import List, Optional
+import gspread
 
-from .validate_sheet import SheetValidationResult, init_apis, read_sheet_with_service_account, validate_google_sheet
+from .validate_sheet import SheetReadError, SheetValidationResult, init_apis, make_read_error_validation_result, make_validation_result_for_whole_sheet_error, read_sheet_with_service_account, validate_google_sheet
 from .find_fixes import add_fixes_to_errors
 from .apply_fixes import apply_fixes
 from .common import default_entity_types
@@ -26,25 +27,44 @@ def process_google_sheet(
         SheetValidationResult object
     """
 
-    # Initialize APIs
-    apis = init_apis()
+    import logging
+    logger = logging.getLogger(__name__)
 
-    # Read spreadsheet
-    sheet_data, gspread_worksheets = read_sheet_with_service_account(sheet_id, entity_types, apis)
+    # Initialize sheet_data variable so it can be referenced during exception handling
+    sheet_data = None
 
-    # Get validation result
-    validation_result = validate_google_sheet(sheet_id, entity_types=entity_types, bionetwork=bionetwork, sheet_read_result=sheet_data)
+    try:
+        # Initialize APIs
+        apis = init_apis()
 
-    # Add available fixes to errors
-    validation_result = dataclasses.replace(validation_result, errors=add_fixes_to_errors(validation_result.errors, bionetwork))
+        # Read spreadsheet
+        sheet_data, gspread_worksheets = read_sheet_with_service_account(sheet_id, entity_types, apis)
 
-    # If the spreadsheet is editable, apply any available fixes
-    if validation_result.spreadsheet_metadata is not None and validation_result.spreadsheet_metadata.can_edit:
-        made_changes = apply_fixes(validation_result, entity_types, gspread_worksheets)
+        # Get validation result
+        validation_result = validate_google_sheet(sheet_id, entity_types=entity_types, bionetwork=bionetwork, sheet_read_result=sheet_data)
 
-        # If the spreadsheet was updated, re-validate
-        if made_changes:
-            validation_result = validate_google_sheet(sheet_id, entity_types=entity_types, bionetwork=bionetwork, apis=apis)
+        # Add available fixes to errors
+        validation_result = dataclasses.replace(validation_result, errors=add_fixes_to_errors(validation_result.errors, bionetwork))
+
+        # If the spreadsheet is editable, apply any available fixes
+        if validation_result.spreadsheet_metadata is not None and validation_result.spreadsheet_metadata.can_edit:
+            made_changes = apply_fixes(validation_result, entity_types, gspread_worksheets)
+
+            # If the spreadsheet was updated, re-validate
+            if made_changes:
+                validation_result = validate_google_sheet(sheet_id, entity_types=entity_types, bionetwork=bionetwork, apis=apis)
+        
+        # Return validation result
+        return validation_result
     
-    # Return validation result
-    return validation_result
+    except gspread.exceptions.APIError as e:
+        logger.error(f"Google Sheets API error: {e}")
+        return make_validation_result_for_whole_sheet_error(
+            sheet_id=sheet_id,
+            entity_types=entity_types,
+            error_code="api_error",
+            error_message=f"Received error {e.code} from Google Sheets API: {e.error['message']}",
+            spreadsheet_metadata=None if sheet_data is None else sheet_data.spreadsheet_metadata
+        )
+    except SheetReadError as read_error:
+        return make_read_error_validation_result(sheet_id, entity_types, read_error)

--- a/src/hca_validation/entry_sheet_validator/process_sheet.py
+++ b/src/hca_validation/entry_sheet_validator/process_sheet.py
@@ -17,6 +17,7 @@ def process_google_sheet(
     Process a Google Sheet by:
     - Validating it according to the HCA schema
     - Identifying fixes where possible for any resulting validation errors
+    - If the spreadsheet is editable, applying the fixes and revalidating
 
     Args:
         sheet_id: The ID of the Google Sheet (required)

--- a/src/hca_validation/entry_sheet_validator/process_sheet.py
+++ b/src/hca_validation/entry_sheet_validator/process_sheet.py
@@ -29,7 +29,7 @@ def process_google_sheet(
     # Initialize APIs
     apis = init_apis()
 
-    # Read spreadsheet=
+    # Read spreadsheet
     sheet_data, gspread_worksheets = read_sheet_with_service_account(sheet_id, entity_types, apis)
 
     # Get validation result
@@ -38,7 +38,7 @@ def process_google_sheet(
     # Add available fixes to errors
     validation_result = dataclasses.replace(validation_result, errors=add_fixes_to_errors(validation_result.errors, bionetwork))
 
-    # If the the spreadsheet is editable, apply any available fixes
+    # If the spreadsheet is editable, apply any available fixes
     if validation_result.spreadsheet_metadata is not None and validation_result.spreadsheet_metadata.can_edit:
         made_changes = apply_fixes(validation_result, entity_types, gspread_worksheets)
 

--- a/src/hca_validation/entry_sheet_validator/validate_sheet.py
+++ b/src/hca_validation/entry_sheet_validator/validate_sheet.py
@@ -276,7 +276,7 @@ def init_apis() -> ApiInstances:
             credentials = service_account.Credentials.from_service_account_info(
                 credentials_dict,
                 scopes=[
-                    'https://www.googleapis.com/auth/spreadsheets.readonly',
+                    'https://www.googleapis.com/auth/spreadsheets',
                     'https://www.googleapis.com/auth/drive.metadata.readonly'
                 ]
             )

--- a/tests/test_entry_sheet_validator.py
+++ b/tests/test_entry_sheet_validator.py
@@ -174,7 +174,7 @@ def _test_validation_with_mock_sheets_response(
 
     if expect_read_call:
         # If expected, verify service account method was used
-        mock_read_service_account.assert_called_once_with(PUBLIC_SHEET_ID, [0, 1, 2], expected_apis_parameter)
+        mock_read_service_account.assert_called_once_with(PUBLIC_SHEET_ID, ["dataset", "donor", "sample"], expected_apis_parameter)
     else:
         # Otherwise, verify sheet data was not read
         mock_read_service_account.assert_not_called()
@@ -592,7 +592,7 @@ class TestValidateGoogleSheet:
         validation_result = validate_google_sheet(PUBLIC_SHEET_ID)
 
         # Verify service account method was used
-        mock_read_service_account.assert_called_once_with(PUBLIC_SHEET_ID, [0, 1, 2], None)
+        mock_read_service_account.assert_called_once_with(PUBLIC_SHEET_ID, ["dataset", "donor", "sample"], None)
         
         # Verify that an error was reported
         assert len(validation_result.errors) > 0

--- a/tests/test_entry_sheet_validator.py
+++ b/tests/test_entry_sheet_validator.py
@@ -615,10 +615,18 @@ class TestValidateGoogleSheet:
 class TestProcessGoogleSheet:
     """Tests for the process_google_sheet function."""
 
-    @patch('hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account')
-    def test_available_fixes(self, mock_read_service_account):
+    @patch('hca_validation.entry_sheet_validator.process_sheet.init_apis')
+    @patch('hca_validation.entry_sheet_validator.process_sheet.read_sheet_with_service_account')
+    def test_available_fixes(self, mock_read_service_account, mock_init_apis):
         """Test that available fixes are present in error info."""
-        result = _test_validation_with_mock_sheets_response(process_google_sheet, mock_read_service_account, donors_sheet_data=SAMPLE_SHEET_DATA_WITH_FIXES)
+        mock_apis = MagicMock()
+        mock_init_apis.return_value = mock_apis
+        result = _test_validation_with_mock_sheets_response(
+            process_google_sheet,
+            mock_read_service_account,
+            donors_sheet_data=SAMPLE_SHEET_DATA_WITH_FIXES,
+            expected_apis_parameter=mock_apis
+        )
         # Based on the mock data, expect three errors in the manner_of_death column, with appropriate input values and fixed values (or lack thereof)
         mod_errors = [error for error in result.errors if error.column == "manner_of_death"]
         assert len(mod_errors) == 3


### PR DESCRIPTION
Closes #113 

I think we had a ChatGPT response somewhere that claimed that only 100 updates should be done per request, but I wasn't able to find any mention of an upper limit when googling it, so I've just made it so each worksheet has all its updates done in one request