### PR TITLE
feat: check referential integrity during entry sheet validation (#64)

### DIFF
--- a/src/hca_validation/entry_sheet_validator/validate_sheet.py
+++ b/src/hca_validation/entry_sheet_validator/validate_sheet.py
@@ -649,7 +649,7 @@ def validate_google_sheet(
     if bionetwork is not None and bionetwork not in allowed_bionetwork_names:
         raise ValueError(f"'{bionetwork}' is not a valid bionetwork")
 
-    from hca_validation.validator import validate, validate_id_uniqueness
+    from hca_validation.validator import validate, validate_id_uniqueness, validate_referential_integrity
     from hca_validation.schema_utils import load_schemaview, get_entity_class_name
     import logging
     logger = logging.getLogger()
@@ -773,6 +773,17 @@ def validate_google_sheet(
             all_valid_in_worksheet = False
             handle_validation_error(
                 uniqueness_validation_error,
+                validation_summary=validation_summary,
+                validation_errors_list=validation_errors,
+                entity_type=entity_type,
+                sheet_info=sheet_info
+            )
+        # Validate references and report results
+        references_validation_error = validate_referential_integrity(rows_to_validate_by_entity_type, schemaview, class_name)
+        if references_validation_error:
+            all_valid_in_worksheet = False
+            handle_validation_error(
+                references_validation_error,
                 validation_summary=validation_summary,
                 validation_errors_list=validation_errors,
                 entity_type=entity_type,

--- a/src/hca_validation/entry_sheet_validator/validate_sheet.py
+++ b/src/hca_validation/entry_sheet_validator/validate_sheet.py
@@ -673,8 +673,8 @@ def validate_google_sheet(
         except SheetReadError as read_error:
             return make_read_error_validation_result(sheet_id, entity_types, read_error)
     
-    # Each item is a dataframe of rows to validate, with an index containing the original 1-based indices of the rows
-    rows_to_validate_per_entity_type = []
+    # Mapping from entity type to dataframe of rows to validate, with normalized values, and an index containing the original 1-based indices of the rows
+    rows_to_validate_by_entity_type = {}
 
     for entity_type, sheet_info in zip(entity_types, sheet_read_result.worksheets):
         df = sheet_info.data
@@ -740,12 +740,19 @@ def validate_google_sheet(
         df = df.reset_index(drop=True)
         df.index += 1
 
-        # Save the subset of rows that should be validated
-        rows_to_validate_per_entity_type.append(df.iloc[row_indices])
+        # Get the subset of rows that should be validated
+        source_rows_to_validate = df.iloc[row_indices]
+
+        # Save the dataframe with normalized values
+        rows_to_validate_by_entity_type[entity_type] = normalize_dataframe_values(
+            source_rows_to_validate,
+            schemaview,
+            get_entity_class_name(entity_type, bionetwork)
+        )
     
     # Set up validation summary with entity counts and initial error count
     validation_summary = {
-        **{f"{entity_type}_count": len(rows_df) for entity_type, rows_df in zip(entity_types, rows_to_validate_per_entity_type)},
+        **{f"{entity_type}_count": len(rows_df) for entity_type, rows_df in rows_to_validate_by_entity_type.items()},
         "error_count": 0
     }
 
@@ -754,15 +761,11 @@ def validate_google_sheet(
 
     all_valid = True
 
-    for entity_type, sheet_info, rows_to_validate_source in zip(entity_types, sheet_read_result.worksheets, rows_to_validate_per_entity_type):
+    for entity_type, sheet_info in zip(entity_types, sheet_read_result.worksheets):
         # Determine schema class name to use for validation
         class_name = get_entity_class_name(entity_type, bionetwork)
         # Get normalized dataframe of rows to validate
-        rows_to_validate = normalize_dataframe_values(
-            rows_to_validate_source,
-            schemaview,
-            class_name
-        )
+        rows_to_validate = rows_to_validate_by_entity_type[entity_type]
         all_valid_in_worksheet = True
         # Validate uniqueness and report results
         uniqueness_validation_error = validate_id_uniqueness(rows_to_validate, schemaview, class_name)

--- a/src/hca_validation/schema_utils/__init__.py
+++ b/src/hca_validation/schema_utils/__init__.py
@@ -4,4 +4,4 @@ HCA Validation Tools - Schema Utils Module
 This module provides utilities for interacting with the HCA schema.
 """
 
-from .schema_utils import load_schemaview, get_entity_class_name, get_class_identifier_name
+from .schema_utils import load_schemaview, get_entity_class_name, get_class_entity_type, get_class_identifier_name, get_class_foreign_keys

--- a/src/hca_validation/schema_utils/schema_utils.py
+++ b/src/hca_validation/schema_utils/schema_utils.py
@@ -72,6 +72,6 @@ def get_class_foreign_keys(schemaview: SchemaView, class_name: str):
     foreign_keys = []
     classes = schemaview.all_classes()
     for slot in schemaview.class_induced_slots(class_name):
-        if slot.inlined and slot.range in classes:
+        if slot.inlined is False and slot.range in classes:
             foreign_keys.append((slot.name, slot.range))
     return foreign_keys

--- a/src/hca_validation/schema_utils/schema_utils.py
+++ b/src/hca_validation/schema_utils/schema_utils.py
@@ -1,9 +1,9 @@
 import os
-from typing import Optional
+from typing import List, Optional
 from linkml_runtime import SchemaView
 from linkml_runtime.linkml_model.meta import ClassDefinition
 
-# Map schema types and bionetworks to their corresponding class names
+# Map entity types and bionetworks to their corresponding class names
 schema_classes = {
     "dataset": {
       "DEFAULT": "Dataset",
@@ -22,6 +22,9 @@ schema_classes = {
       "DEFAULT": "Cell"
     }
 }
+
+# Derive mapping from class name to entity type
+entity_types_by_class = dict((class_name, entity_type) for entity_type, network_mapping in schema_classes.items() for _, class_name in network_mapping.items())
 
 
 def load_schemaview():
@@ -42,8 +45,33 @@ def get_entity_class_name(schema_type: str, bionetwork: Optional[str] = None) ->
     return type_classes.get(bionetwork, type_classes["DEFAULT"])
 
 
+def get_class_entity_type(class_name: str) -> str:
+    if class_name not in entity_types_by_class:
+        raise ValueError(f"Unknown schema class: {class_name}")
+    return entity_types_by_class[class_name]
+
+
 def get_class_identifier_name(schemaview: SchemaView, class_name: str) -> str:
     for slot in schemaview.class_induced_slots(class_name):
         if slot.identifier:
             return slot.name
     raise ValueError(f"No identifier slot found for class {class_name}")
+
+
+def get_class_foreign_keys(schemaview: SchemaView, class_name: str):
+    """
+    Get list of (slot name, slot range) tuples for slots of the given class that hold references to other classes.
+
+    Args:
+      schemaview: Schemaview to get class and slot info from
+      class_name: Name of class to get slots for
+    
+    Returns:
+      List of (slot name, slot range) tuples
+    """
+    foreign_keys = []
+    classes = schemaview.all_classes()
+    for slot in schemaview.class_induced_slots(class_name):
+        if slot.inlined and slot.range in classes:
+            foreign_keys.append((slot.name, slot.range))
+    return foreign_keys

--- a/src/hca_validation/validator/__init__.py
+++ b/src/hca_validation/validator/__init__.py
@@ -4,4 +4,4 @@ HCA Validation Tools - Validator Module
 This module provides reusable validation components for HCA data validation.
 """
 
-from .validator import validate, validate_id_uniqueness
+from .validator import validate, validate_id_uniqueness, validate_referential_integrity

--- a/tests/test_entry_sheet_validator.py
+++ b/tests/test_entry_sheet_validator.py
@@ -37,29 +37,52 @@ PRIVATE_SHEET_ID = "1Gp2yocEq9OWECfDgCVbExIgzYfM7s6nJV5ftyn-SMXQ"  # This is a p
 NONEXISTENT_SHEET_ID = "1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"  # This sheet doesn't exist
 
 # Sample data for mocking
+# Generic data
 SAMPLE_SHEET_DATA = pd.DataFrame({
     'column1': ['', '', '', '', 'value1', 'value2'],
     'column2': ['', '', '', '', 'value3', 'value4']
 })
+# Data to test parsing of empty values and lists
 SAMPLE_SHEET_DATA_WITH_CASTS = pd.DataFrame({
     'contact_email': ['', '', '', '', "foo@example.com", '   ', 'bar@example.com'],
     'study_pi': ['', '', '', '', 'Foo', 'Bar; Baz', '']
 })
+# Data to test parsing of integers, including invalid values that will be left as strings
 SAMPLE_SHEET_DATA_WITH_INTEGERS = pd.DataFrame({
     'cell_number_loaded': ['', '', '', '', '1', '-23', '456', '', '7890', '1,234', '-56,789', '123,456', '78,901,234', '56,78', '9,012345'],
     # Required to prevent the empty value above from being treated as the end of the data
     'sample_id': ['', '', '', '', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k']
 })
+# Data to test parsing of integers, with values that can all be represented as optional integers
 SAMPLE_SHEET_DATA_WITH_VALID_AND_MISSING_INTEGERS = pd.DataFrame({
     'cell_number_loaded': ['', '', '', '', '1', '-23', '', '7890'],
     # Required to prevent the empty value above from being treated as the end of the data
     'sample_id': ['', '', '', '', 'a', 'b', 'c', 'd']
 })
+# Data to test validation of ID uniqueness
 SAMPLE_SHEET_DATA_WITH_DUPLICATE_IDS = pd.DataFrame({
     'dataset_id': ['', '', '', '', 'foo', 'bar', 'foo', '', '', 'baz', 'baz', 'baz'],
     # This column is required to prevent the empty IDs from being treated as the end of the data
     'description': ['', '', '', '', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']
 })
+# Data to test validation of referential integrity
+SAMPLE_DATASETS_SHEET_DATA_WITH_REFERENCES = pd.DataFrame({
+    'dataset_id': ['', '', '', '', 'dataset_a', 'dataset_b', 'dataset_c']
+})
+SAMPLE_DONORS_SHEET_DATA_WITH_REFERENCES = pd.DataFrame({
+    # References to datasets, which do have an ID column; contains empty cells and references to missing datasets
+    'dataset_id': ['', '', '', '', 'dataset_b', 'dataset_a', '', 'dataset_missing_a', 'dataset_missing_b', 'dataset_b', '', 'dataset_a', 'dataset_missing_b'],
+    # Prevent the empty IDs from being treated as the end of the data
+    'description': ['', '', '', '', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']
+})
+SAMPLE_SAMPLES_SHEET_DATA_WITH_REFERENCES = pd.DataFrame({
+    # Missing references to datasets
+    # References to donors, which are missing an ID column; contains empty cells
+    'donor_id': ['', '', '', '', 'donor_b', '', 'donor_a', '', '', 'donor_b', 'donor_b'],
+    # Prevent the empty IDs from being treated as the end of the data
+    'description': ['', '', '', '', 'a', 'b', 'c', 'd', 'e', 'f', 'g']
+})
+# Data to test automatic fixes
 SAMPLE_SHEET_DATA_WITH_FIXES = pd.DataFrame({
     'manner_of_death': ['', '', '', '', '1', 'unknown', 'not_applicable', '4', 'not applicable', 'not a manner of death', 'not_applicable'],
 })

--- a/tests/test_entry_sheet_validator.py
+++ b/tests/test_entry_sheet_validator.py
@@ -583,7 +583,7 @@ class TestValidateGoogleSheet:
         assert all(("foo" in error.message or "baz" in error.message) and not ("bar" in error.message or "None" in error.message) for error in duplicate_id_errors)
 
     @patch('hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account')
-    def test_referential_integerity(self, mock_read_service_account):
+    def test_referential_integrity(self, mock_read_service_account):
         """Test validation of referential integrity."""
         result = _test_validation_with_mock_sheets_response(
             validate_google_sheet,


### PR DESCRIPTION
This pull request adds referential integrity validation to the HCA sheet validation pipeline, ensuring that foreign key references between entities (like donors referencing datasets) are checked for missing or invalid references. The implementation includes new utility functions for schema inspection, integrates the new validation step into the main validation flow, and introduces corresponding tests.

**Referential integrity validation:**
* Added `validate_referential_integrity` to check that all foreign key references in entity dataframes correspond to existing rows in the referenced entity's dataframe. Errors are reported for missing references, with details about the row and missing value. (`src/hca_validation/validator/validator.py`, `src/hca_validation/validator/__init__.py`, [[1]](diffhunk://#diff-a9f3167bacac26b6d0eecb3065c07f387e43ef469e99b1717a745bae2fb0ada6R106-R168) [[2]](diffhunk://#diff-f9b4b42ddf3c68a6d1ddb904364a804b57f3bf187a55eeafe69dc88c7fd34b7aL7-R7)
* Integrated referential integrity checks into the main `validate_google_sheet` function, so that each entity type is validated for missing references after uniqueness checks. (`src/hca_validation/entry_sheet_validator/validate_sheet.py`, [[1]](diffhunk://#diff-cc30f5f7239230a3ae0598cabb1fa07ce18c00c3fe2313d708f8ec9fb2cc194bL652-R652) [[2]](diffhunk://#diff-cc30f5f7239230a3ae0598cabb1fa07ce18c00c3fe2313d708f8ec9fb2cc194bL757-R768) [[3]](diffhunk://#diff-cc30f5f7239230a3ae0598cabb1fa07ce18c00c3fe2313d708f8ec9fb2cc194bR781-R791)

**Schema utilities enhancements:**
* Added new functions to `schema_utils` for extracting entity type from class name (`get_class_entity_type`) and for finding foreign key slots (`get_class_foreign_keys`). These are used to generalize foreign key discovery and reference checking. (`src/hca_validation/schema_utils/schema_utils.py`, [[1]](diffhunk://#diff-07634105debe4391c21c8fe083013a6b9a3220576704a28ce63354eea579f74eR26-R28) [[2]](diffhunk://#diff-07634105debe4391c21c8fe083013a6b9a3220576704a28ce63354eea579f74eR48-R77) [[3]](diffhunk://#diff-8e417f1fdd4aaea04b11afb3254995df08bac3263c43b06f1664d193a5170e8fL7-R7)

**Refactoring and data structure improvements:**
* Changed how rows to validate are stored: now uses a mapping from entity type to dataframe (`rows_to_validate_by_entity_type`) instead of a list, simplifying access during cross-entity validation. (`src/hca_validation/entry_sheet_validator/validate_sheet.py`, [[1]](diffhunk://#diff-cc30f5f7239230a3ae0598cabb1fa07ce18c00c3fe2313d708f8ec9fb2cc194bL676-R677) [[2]](diffhunk://#diff-cc30f5f7239230a3ae0598cabb1fa07ce18c00c3fe2313d708f8ec9fb2cc194bL743-R755) [[3]](diffhunk://#diff-cc30f5f7239230a3ae0598cabb1fa07ce18c00c3fe2313d708f8ec9fb2cc194bL757-R768)

**Testing:**
* Added comprehensive tests for referential integrity validation, including cases with missing references and missing ID columns, to ensure correct error reporting. (`tests/test_entry_sheet_validator.py`, [tests/test_entry_sheet_validator.pyR585-R603](diffhunk://#diff-5e23ccbc8b0a0db508f48e029cdce8efc9d51f482a830a87fcbaffa9de14c576R585-R603))
* Expanded test data for various validation scenarios, including new cases for reference checks. (`tests/test_entry_sheet_validator.py`, [tests/test_entry_sheet_validator.pyR40-R85](diffhunk://#diff-5e23ccbc8b0a0db508f48e029cdce8efc9d51f482a830a87fcbaffa9de14c576R40-R85))Closes #64