### PR TITLE
feat: return entity counts even when some sheets have no rows to validate (#83)

### DIFF
--- a/services/entry-sheet-validator/src/entry_sheet_validator_lambda/handler.py
+++ b/services/entry-sheet-validator/src/entry_sheet_validator_lambda/handler.py
@@ -267,7 +267,7 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
 if __name__ == "__main__":
     # Test with a sample event
     test_event = {
-        'sheet_id': '1dGR-CP8XQEWtUtSbaVaa28wZ204P1U83EJ03ZEtdPZA'
+        'sheet_id': '1oPFb6qb0Y2HeoQqjSGRe_TlsZPRLwq-HUlVF0iqtVlY'
     }
     
     result = handler(test_event, None)

--- a/services/entry-sheet-validator/src/entry_sheet_validator_lambda/handler.py
+++ b/services/entry-sheet-validator/src/entry_sheet_validator_lambda/handler.py
@@ -267,7 +267,7 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
 if __name__ == "__main__":
     # Test with a sample event
     test_event = {
-        'sheet_id': '1oPFb6qb0Y2HeoQqjSGRe_TlsZPRLwq-HUlVF0iqtVlY'
+        'sheet_id': '1dGR-CP8XQEWtUtSbaVaa28wZ204P1U83EJ03ZEtdPZA'
     }
     
     result = handler(test_event, None)

--- a/shared/src/hca_validation/entry_sheet_validator/validate_sheet.py
+++ b/shared/src/hca_validation/entry_sheet_validator/validate_sheet.py
@@ -367,7 +367,7 @@ def read_worksheets(
     for sheet_index, worksheet, value_range in zip(sheet_indices, worksheets, api_result["valueRanges"]):
         data = gspread.utils.fill_gaps(value_range.get("values", [[]]))
          # Convert to DataFrame
-        if len(data) >= 2:
+        if len(data) >= 1:
             logger.info(f"Successfully retrieved data from worksheet index {sheet_index}: {len(data)} rows, {len(data[0]) if data[0] else 0} columns")
             source_columns = data[0]
             source_rows_start_index = 1


### PR DESCRIPTION
Closes #83

There were some tests that used the full default entity type list, despite only mocking sheet data for a subset of the entity types; these started failing due to the inconsistency becoming relevant when looking up counts in the summary dict, so I updated the tests to use only the entity types associated with the mock data