### PR TITLE
feat: apply cap validator in dataset validator (#135)

### DIFF
--- a/services/dataset-validator/poetry.lock
+++ b/services/dataset-validator/poetry.lock
@@ -99,6 +99,44 @@ urllib3 = {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >
 crt = ["awscrt (==0.27.6)"]
 
 [[package]]
+name = "cap-anndata"
+version = "0.5.0"
+description = "Partial read/write of AnnData (h5ad) files for low-memory operations with large datasets."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "cap_anndata-0.5.0-py3-none-any.whl", hash = "sha256:2e634dcf13c4eecbacfacd76088dd149ce2eaa6a69cecda9032e1d29d2aa067f"},
+    {file = "cap_anndata-0.5.0.tar.gz", hash = "sha256:8b288c1c948e068979eede4aa87b4375e91ba68ead36598a810e8e15077f580c"},
+]
+
+[package.dependencies]
+anndata = ">=0.10.0"
+numpy = ">=1.23.5"
+pandas = ">=2.2.0"
+
+[package.extras]
+dev = ["pytest (>=8.0.0)", "setuptools (>=69.1.1,<69.2.0)"]
+
+[[package]]
+name = "cap-upload-validator"
+version = "1.2.0"
+description = "Python tool for validating H5AD AnnData files before uploading to the Cell Annotation Platform."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "cap_upload_validator-1.2.0-py3-none-any.whl", hash = "sha256:cad666d7e8b5396543f0812ab63a9e9e4a0136efc55bfe670d1caa745ce0e3f5"},
+    {file = "cap_upload_validator-1.2.0.tar.gz", hash = "sha256:cf277ab415959a71e2cff87b1ffe04b9fdef4e6457257f472086452f3496fe8c"},
+]
+
+[package.dependencies]
+cap-anndata = ">=0.5.0"
+numpy = ">=2.0.2"
+pandas = ">=2.2.3"
+scipy = ">=1.13.1"
+
+[[package]]
 name = "certifi"
 version = "2025.8.3"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -1357,4 +1395,4 @@ test = ["coverage (>=7.10)", "hypothesis", "mypy", "packaging", "pytest (<8.4)",
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "1707aa21e46b5825d6d9abf1bd150a50db8fe14107f99f54a50931b7ef617e38"
+content-hash = "ce2012438af5a0ce394686eeef1df87c1b8288ad26257dd6d5366bdc669218b8"

--- a/services/dataset-validator/pyproject.toml
+++ b/services/dataset-validator/pyproject.toml
@@ -13,6 +13,7 @@ boto3 = "^1.34.0"
 # python-dotenv = "^1.1.0"
 # hca-validation-shared = {path = "../../shared", develop = true}
 anndata = "^0.12.2"
+cap-upload-validator = "^1.2.0"
 
 [tool.poetry.group.dev.dependencies]
 # Testing dependencies

--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -282,7 +282,6 @@ def read_metadata(file_path: Path) -> MetadataSummary:
         if adata is not None:
             adata.file.close()
 
-
 def apply_cap_validator(file_path: Path) -> ValidationToolReport:
     """
     Apply the CAP validator to the given file and create a validation report.
@@ -301,7 +300,7 @@ def apply_cap_validator(file_path: Path) -> ValidationToolReport:
         uv.validate()
         valid = True
     except CapMultiException as multi_ex:
-        errors.extend(e.message for e in multi_ex.ex_list)
+        errors.extend(str(e) for e in multi_ex.ex_list)
     except (Exception, CapException) as e:
         message = f"Encountered an unexpected error while calling CAP validator: {e}"
         logger.error(message)

--- a/services/dataset-validator/tests/test_dataset_validator.py
+++ b/services/dataset-validator/tests/test_dataset_validator.py
@@ -249,8 +249,9 @@ def test_missing_sns_topic_logs_error_and_exits(caplog, env_manager, base_env_va
         }
     }
 ], ids=lambda x: x["name"])
+@patch("cap_upload_validator.UploadValidator")
 @patch("anndata.io.read_h5ad")
-def test_read_metadata_scenarios(mock_read_h5ad, test_case):
+def test_read_metadata_scenarios(mock_read_h5ad, mock_upload_validator, test_case):
     """Parameterized test for metadata reading scenarios."""
     import sys
     sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
@@ -286,6 +287,7 @@ def test_read_metadata_scenarios(mock_read_h5ad, test_case):
             'source_sha256': 'abc123',
             'integrity_status': 'valid',
             'metadata_summary': None,
+            'tool_reports': None,
             'error_message': None
         },
         "use_valid_topic": True,
@@ -316,7 +318,8 @@ def test_read_metadata_scenarios(mock_read_h5ad, test_case):
         ]
     }
 ], ids=lambda x: x["name"])
-def test_publish_validation_result_scenarios(caplog, mock_aws, test_case):
+@patch("cap_upload_validator.UploadValidator")
+def test_publish_validation_result_scenarios(mock_update_validator, caplog, mock_aws, test_case):
     """Parameterized test for SNS publishing scenarios."""
     import sys
     sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
@@ -485,8 +488,9 @@ def test_publish_validation_result_scenarios(caplog, mock_aws, test_case):
         }
     }
 ], ids=lambda x: x["name"])
+@patch("cap_upload_validator.UploadValidator")
 @patch("anndata.io.read_h5ad")
-def test_end_to_end_validation_scenarios(mock_read_h5ad, caplog, mock_aws, env_manager, test_case):
+def test_end_to_end_validation_scenarios(mock_read_h5ad, mock_updload_validator, caplog, mock_aws, env_manager, test_case):
     """Parameterized test for end-to-end validation scenarios."""
     import sys
     sys.path.insert(0, str(Path(__file__).parent.parent / "src"))

--- a/services/dataset-validator/tests/test_dataset_validator.py
+++ b/services/dataset-validator/tests/test_dataset_validator.py
@@ -55,7 +55,7 @@ def base_env_vars():
         'FILE_ID': 'test-file-uuid',
         'SNS_TOPIC_ARN': 'arn:aws:sns:us-east-1:123456789012:test-topic',
         'AWS_BATCH_JOB_ID': 'test-job-id',
-        'AWS_BATCH_JOB_NAME': 'test-job',
+        'BATCH_JOB_NAME': 'test-job',
         'AWS_DEFAULT_REGION': 'us-east-1'
     }
 
@@ -141,7 +141,7 @@ class TestDatasetValidator:
                 'SNS_TOPIC_ARN': 'arn:aws:sns:us-east-1:123456789012:test-topic',
                 'AWS_BATCH_JOB_ID': 'test-job-id',
                 'AWS_DEFAULT_REGION': 'us-east-1',
-                'AWS_BATCH_JOB_NAME': 'test-job'
+                'BATCH_JOB_NAME': 'test-job'
             },
             "clear_vars": [],
             "expected_exit_code": 1,
@@ -509,7 +509,7 @@ def test_end_to_end_validation_scenarios(mock_read_h5ad, mock_updload_validator,
         'AWS_BATCH_JOB_ID': test_case["batch_job_id"]
     }
     if test_case["batch_job_name"]:
-        test_env['AWS_BATCH_JOB_NAME'] = test_case["batch_job_name"]
+        test_env['BATCH_JOB_NAME'] = test_case["batch_job_name"]
     
     env_manager['set'](test_env)
     

--- a/services/dataset-validator/tests/test_dataset_validator.py
+++ b/services/dataset-validator/tests/test_dataset_validator.py
@@ -307,8 +307,8 @@ def test_read_metadata_scenarios(mock_read_h5ad, test_case):
         "expected_report": {
             "valid": False,
             "errors": [
-                "Useless CAP exception",
-                "DataFile Incorrect format: raw data matrix is missing in .raw.X or .X."
+                "Unknown: Useless CAP exception",
+                "AnnDataFileMissingCountMatrix: DataFile Incorrect format: raw data matrix is missing in .raw.X or .X."
             ]
         }
     },


### PR DESCRIPTION
Closes #135

This also includes an unrelated fix to the tests, which used the old name for the job name environment variable