### PR TITLE
fix: convert all values to string when reading obs columns (#137)

### DIFF
--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -239,7 +239,7 @@ def get_column_unique_values_if_present(df: pd.DataFrame, name: str, map_value=s
     Args:
         df: Dataframe to get values from
         name: Name of the dataframe column to get values from
-        map_value: Function to apply to each value to get the value to be used in the result
+        map_value: Function to apply to each value to get the value to be used in the result (defaults to `str`)
     
     Returns:
         Unique mapped values from the specified column

--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -233,7 +233,18 @@ def verify_file_integrity(file_path: Path, expected_sha256: str) -> bool:
 
 
 def get_column_unique_values_if_present(df: pd.DataFrame, name: str, map_value=str):
-    return [map_value(v) for v in df[name].unique()] if name in df else []
+    """
+    Get unique values after applying a mapping function to a given column of a dataframe.
+
+    Args:
+        df: Dataframe to get values from
+        name: Name of the dataframe column to get values from
+        map_value: Function to apply to each value to get the value to be used in the result
+    
+    Returns:
+        Unique mapped values from the specified column
+    """
+    return list(df[name].map(map_value).unique()) if name in df else []
 
 
 def read_metadata(file_path: Path) -> MetadataSummary:

--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -232,8 +232,8 @@ def verify_file_integrity(file_path: Path, expected_sha256: str) -> bool:
         return False
 
 
-def get_column_unique_values_if_present(df: pd.DataFrame, name: str):
-    return list(df[name].unique()) if name in df else []
+def get_column_unique_values_if_present(df: pd.DataFrame, name: str, map_value=str):
+    return [map_value(v) for v in df[name].unique()] if name in df else []
 
 
 def read_metadata(file_path: Path) -> MetadataSummary:

--- a/services/dataset-validator/tests/test_dataset_validator.py
+++ b/services/dataset-validator/tests/test_dataset_validator.py
@@ -12,6 +12,7 @@ import boto3
 import pytest
 from moto import mock_s3, mock_sns
 import pandas as pd
+import numpy as np
 from cap_upload_validator.errors import CapException, CapMultiException, AnnDataFileMissingCountMatrix
 
 
@@ -255,6 +256,27 @@ def test_missing_sns_topic_logs_error_and_exits(caplog, env_manager, base_env_va
             "tissue": [],
             "disease": [],
             "cell_count": 0
+        }
+    },
+    {
+        "name": "nan",
+        "description": "Test that NAN is converted to string",
+        "adata": {
+            "obs": {
+                "assay": ["assay-a", "assay-b", np.nan],
+                "suspension_type": ["suspension-type-a", np.nan, "suspension-type-b"],
+                "tissue": [np.nan, "tissue-a", "tissue-a"],
+                "disease": ["disease-a", np.nan, np.nan]
+            },
+            "uns": {"title": "test-dataset-456"}
+        },
+        "expected_result": {
+            "title": "test-dataset-456",
+            "assay": ["assay-a", "assay-b", "nan"],
+            "suspension_type": ["suspension-type-a", "nan", "suspension-type-b"],
+            "tissue": ["nan", "tissue-a"],
+            "disease": ["disease-a", "nan"],
+            "cell_count": 3
         }
     }
 ], ids=lambda x: x["name"])


### PR DESCRIPTION
Closes #137

Theoretically, this doesn't *prevent* a NAN value from ending up in the data that gets passed to `json.dumps`, but as far as I know it covers the places that it's *likely* to occur