### PR TITLE
feat: make ensembl id mismatches warnings instead of errors (#167)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,6 @@ deployment/layers/
 deployment/test-lambda-env/
 deployment/entry-sheet-validator/output/
 response.json
+
+# macOS
+.DS_Store

--- a/packages/hca-schema-validator/src/hca_schema_validator/_vendored/cellxgene_schema/validate.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/_vendored/cellxgene_schema/validate.py
@@ -461,7 +461,7 @@ class Validator:
             dataset_organism = self.adata.uns.get("organism_ontology_term_id", None)
 
             if not organism:
-                self.errors.append(
+                self.warnings.append(
                     f"Could not infer organism from feature ID '{feature_id}' in '{df_name}', "
                     f"make sure it is a valid ID."
                 )
@@ -472,7 +472,7 @@ class Validator:
             valid_gene_id = get_gene_checker(organism).is_valid_id(feature_id)
 
             if not valid_gene_id:
-                self.errors.append(f"'{feature_id}' is not a valid feature ID in '{df_name}'.")
+                self.warnings.append(f"'{feature_id}' is not a valid feature ID in '{df_name}'.")
 
             if dataset_organism is not None and organism_ontology_id is not None and valid_gene_id:
                 # If the gene id is valid, check if that organism matches the dataset's organism
@@ -482,7 +482,7 @@ class Validator:
 
         invalid_gene_organisms = list(set(invalid_gene_organisms))
         if len(invalid_gene_organisms) > 0:
-            self.errors.append(
+            self.warnings.append(
                 f"uns['organism_ontology_term_id'] is '{dataset_organism}' but feature_ids are from {invalid_gene_organisms}."
             )
 


### PR DESCRIPTION
This pull request changes how validation issues are reported when checking feature IDs in the `cellxgene_schema` validator. Specifically, issues that were previously classified as errors are now reported as warnings, making the validation less strict and more informative rather than blocking.

Validation reporting changes:

* Changed messages about inability to infer organism from a feature ID from being appended to `self.errors` to `self.warnings`, so they're now warnings instead of errors.
* Changed invalid feature ID messages from errors to warnings, so invalid IDs no longer fail validation but instead generate a warning.
* Changed organism mismatch messages from errors to warnings, so mismatches between the dataset organism and feature ID organisms are now warnings.