### PR TITLE
feat: add HCA tier-1 validation fields

### DIFF
--- a/packages/hca-schema-validator/PRD-add-hca-tier-1-validation.md
+++ b/packages/hca-schema-validator/PRD-add-hca-tier-1-validation.md
@@ -1,0 +1,64 @@
+# PRD: HCA Schema Validator — HCA-Specific Field Validation
+
+## Goal
+
+Extend the HCA schema validator to enforce HCA-specific required fields, enum constraints, and regex pattern constraints on `.h5ad` uns and obs, beyond what the base cellxgene schema validates.
+
+## Fields
+
+### uns — required presence + list type
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `study_pi` | `list` of strings | Yes | "Last, First" format. At least one entry. |
+
+### obs — required presence (free-text string, no enum/pattern)
+
+| Field | Type | Required |
+|-------|------|----------|
+| `sample_id` | string | Yes |
+| `library_id` | string | Yes |
+| `institute` | string | Yes |
+| `library_preparation_batch` | string | Yes |
+| `library_sequencing_run` | string | Yes |
+| `alignment_software` | string | Yes |
+
+### obs — required enum
+
+| Field | Allowed Values |
+|-------|---------------|
+| `manner_of_death` | `0`, `1`, `2`, `3`, `4`, `unknown`, `not applicable` |
+| `sample_source` | `surgical donor`, `postmortem donor`, `living organ donor` |
+| `sample_collection_method` | `brush`, `scraping`, `biopsy`, `surgical resection`, `blood draw`, `body fluid`, `other` |
+| `sampled_site_condition` | `healthy`, `diseased`, `adjacent` |
+| `sample_preservation_method` | `fresh`, `ambient temperature`, `cut slide`, `paraffin block`, `frozen at -70C`, `frozen at -80C`, `frozen at -150C`, `frozen in liquid nitrogen`, `frozen in vapor phase`, `RNAlater at 4C`, `RNAlater at 25C`, `RNAlater at -20C`, `other` |
+| `sequenced_fragment` | `3 prime tag`, `5 prime tag`, `full length`, `probe-based` |
+| `reference_genome` | `GRCh38`, `GRCh37`, `GRCm39`, `GRCm38`, `GRCm37`, `not applicable` |
+
+### obs — required pattern (regex)
+
+| Field | Pattern | Examples |
+|-------|---------|----------|
+| `cell_enrichment` | `^(CL:[\d]{7}(\+\|-))\|(na)` | `CL:0000540+`, `CL:0000236-`, `na` |
+| `gene_annotation_version` | `^v(7[5-9]\|[8-9][0-9]\|10[0-9]\|11[01])\|GCF_000001405\.(2[5-9]\|3[0-9]\|40)` | `v75`, `v111`, `GCF_000001405.40` |
+
+## Implementation Gap Analysis
+
+What the existing schema YAML + vendored validator already supports vs what needs code changes:
+
+| Capability | Schema YAML support | Vendored Python support | Gap? |
+|---|---|---|---|
+| obs required string column | Yes (`type: string`, `required: True`) | Yes (`_validate_dataframe`) | None |
+| obs enum column | Yes (`enum: [...]`) | Yes (line 745-751) | None |
+| obs regex pattern column | **No** — no `pattern` key in schema YAML | **No** — no generic regex validation for obs columns | **New feature needed** |
+| uns `type: list` with `element_type: string` | Partially — `type: list` exists but only `element_type: match_obs_columns` | `_validate_list()` only handles `match_obs_columns` (line 921) | **Code change needed** — add `element_type: string` handling |
+
+## Changes Required
+
+1. **`hca_schema_definition.yaml`** — Add all fields to the `uns.keys` and `obs.columns` sections using existing schema patterns where possible (string, enum). Use new `pattern` key for regex fields.
+
+2. **`validate.py` `_validate_list()`** (~line 909) — Add `element_type: string` branch that validates each element is a non-empty string.
+
+3. **`validate.py` `_validate_column()`** (~line 682) — Add handling for a `pattern` key in column definitions: run `re.match(pattern, value)` against all unique values in the column and report invalids.
+
+4. **Tests** — Add test cases for each new field covering valid data, missing columns, invalid enum values, and regex mismatches.

--- a/packages/hca-schema-validator/PRD-add-hca-tier-1-validation.md
+++ b/packages/hca-schema-validator/PRD-add-hca-tier-1-validation.md
@@ -39,8 +39,8 @@ Extend the HCA schema validator to enforce HCA-specific required fields, enum co
 
 | Field | Pattern | Examples |
 |-------|---------|----------|
-| `cell_enrichment` | `^(CL:[\d]{7}(\+\|-))\|(na)` | `CL:0000540+`, `CL:0000236-`, `na` |
-| `gene_annotation_version` | `^v(7[5-9]\|[8-9][0-9]\|10[0-9]\|11[01])\|GCF_000001405\.(2[5-9]\|3[0-9]\|40)` | `v75`, `v111`, `GCF_000001405.40` |
+| `cell_enrichment` | `^(CL:\d{7}(\+\|-)|(na))$` | `CL:0000540+`, `CL:0000236-`, `na` |
+| `gene_annotation_version` | `^(v(7[5-9]\|[8-9][0-9]\|10[0-9]\|11[01])\|GCF_000001405\.(2[5-9]\|3[0-9]\|40))$` | `v75`, `v111`, `GCF_000001405.40` |
 
 ## Implementation Gap Analysis
 
@@ -57,8 +57,8 @@ What the existing schema YAML + vendored validator already supports vs what need
 
 1. **`hca_schema_definition.yaml`** — Add all fields to the `uns.keys` and `obs.columns` sections using existing schema patterns where possible (string, enum). Use new `pattern` key for regex fields.
 
-2. **`validate.py` `_validate_list()`** (~line 909) — Add `element_type: string` branch that validates each element is a non-empty string.
+2. **`HCAValidator` in `src/hca_schema_validator/validator.py`** — Override `_validate_list()` to add an `element_type: string` branch that validates each element is a non-empty string.
 
-3. **`validate.py` `_validate_column()`** (~line 682) — Add handling for a `pattern` key in column definitions: run `re.match(pattern, value)` against all unique values in the column and report invalids.
+3. **`HCAValidator` in `src/hca_schema_validator/validator.py`** — Override `_validate_column()` to add handling for a `pattern` key in column definitions: run `re.fullmatch(pattern, value)` against all unique values in the column and report invalids.
 
 4. **Tests** — Add test cases for each new field covering valid data, missing columns, invalid enum values, and regex mismatches.

--- a/packages/hca-schema-validator/src/hca_schema_validator/schema_definitions/hca_schema_definition.yaml
+++ b/packages/hca-schema-validator/src/hca_schema_validator/schema_definitions/hca_schema_definition.yaml
@@ -50,6 +50,10 @@ components:
         enum:
           - count
           - normal
+      study_pi:
+        type: list
+        required: True
+        element_type: string
   var:
     type: dataframe
     required: True
@@ -837,3 +841,93 @@ components:
         add_labels:
           - type: curie
             to_column: organism
+      sample_id:
+        type: categorical
+        subtype: str
+      library_id:
+        type: categorical
+        subtype: str
+      institute:
+        type: categorical
+        subtype: str
+      library_preparation_batch:
+        type: categorical
+        subtype: str
+      library_sequencing_run:
+        type: categorical
+        subtype: str
+      alignment_software:
+        type: categorical
+        subtype: str
+      manner_of_death:
+        type: categorical
+        enum:
+          - "0"
+          - "1"
+          - "2"
+          - "3"
+          - "4"
+          - "unknown"
+          - "not applicable"
+      sample_source:
+        type: categorical
+        enum:
+          - "surgical donor"
+          - "postmortem donor"
+          - "living organ donor"
+      sample_collection_method:
+        type: categorical
+        enum:
+          - "brush"
+          - "scraping"
+          - "biopsy"
+          - "surgical resection"
+          - "blood draw"
+          - "body fluid"
+          - "other"
+      sampled_site_condition:
+        type: categorical
+        enum:
+          - "healthy"
+          - "diseased"
+          - "adjacent"
+      sample_preservation_method:
+        type: categorical
+        enum:
+          - "fresh"
+          - "ambient temperature"
+          - "cut slide"
+          - "paraffin block"
+          - "frozen at -70C"
+          - "frozen at -80C"
+          - "frozen at -150C"
+          - "frozen in liquid nitrogen"
+          - "frozen in vapor phase"
+          - "RNAlater at 4C"
+          - "RNAlater at 25C"
+          - "RNAlater at -20C"
+          - "other"
+      sequenced_fragment:
+        type: categorical
+        enum:
+          - "3 prime tag"
+          - "5 prime tag"
+          - "full length"
+          - "probe-based"
+      reference_genome:
+        type: categorical
+        enum:
+          - "GRCh38"
+          - "GRCh37"
+          - "GRCm39"
+          - "GRCm38"
+          - "GRCm37"
+          - "not applicable"
+      cell_enrichment:
+        type: categorical
+        subtype: str
+        pattern: "^(CL:[\\d]{7}(\\+|-)|(na))$"
+      gene_annotation_version:
+        type: categorical
+        subtype: str
+        pattern: "^(v(7[5-9]|[8-9][0-9]|10[0-9]|11[01])|GCF_000001405\\.(2[5-9]|3[0-9]|40))$"

--- a/packages/hca-schema-validator/src/hca_schema_validator/validator.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/validator.py
@@ -1,6 +1,9 @@
 """HCA Validator - extends cellxgene Validator with HCA-specific rules."""
 
+import re
 from pathlib import Path
+
+import pandas as pd
 import yaml
 
 from hca_schema_validator._vendored.cellxgene_schema.validate import Validator
@@ -45,3 +48,40 @@ class HCAValidator(Validator):
             
             with open(schema_path) as fp:
                 self.schema_def = yaml.safe_load(fp)
+
+    def _validate_list(self, list_name, current_list, element_type):
+        """
+        Extends base list validation with support for element_type: string.
+
+        Validates that all elements are non-empty strings when element_type is "string".
+        """
+        super()._validate_list(list_name, current_list, element_type)
+        if element_type == "string":
+            for i in current_list:
+                if not isinstance(i, str):
+                    self.errors.append(
+                        f"Value '{i}' in list '{list_name}' is not valid, it must be a string."
+                    )
+                elif len(i.strip()) == 0:
+                    self.errors.append(
+                        f"Value in list '{list_name}' must not be empty or whitespace-only."
+                    )
+
+    def _validate_column(self, column, column_name, df_name, column_def, default_error_message_suffix=None):
+        """
+        Extends base column validation with support for regex pattern matching.
+
+        When a column_def contains a "pattern" key, validates that all non-NaN values
+        match the specified regex pattern.
+        """
+        super()._validate_column(column, column_name, df_name, column_def, default_error_message_suffix)
+        if "pattern" in column_def:
+            pattern = column_def["pattern"]
+            for value in column.drop_duplicates():
+                if pd.isna(value):
+                    continue
+                if not re.match(pattern, str(value)):
+                    self.errors.append(
+                        f"Column '{column_name}' in dataframe '{df_name}' contains a value "
+                        f"'{value}' that does not match the required pattern '{pattern}'."
+                    )

--- a/packages/hca-schema-validator/src/hca_schema_validator/validator.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/validator.py
@@ -76,12 +76,12 @@ class HCAValidator(Validator):
         """
         super()._validate_column(column, column_name, df_name, column_def, default_error_message_suffix)
         if "pattern" in column_def:
-            pattern = column_def["pattern"]
+            compiled_pattern = re.compile(column_def["pattern"])
             for value in column.drop_duplicates():
                 if pd.isna(value):
                     continue
-                if not re.match(pattern, str(value)):
+                if not compiled_pattern.fullmatch(str(value)):
                     self.errors.append(
                         f"Column '{column_name}' in dataframe '{df_name}' contains a value "
-                        f"'{value}' that does not match the required pattern '{pattern}'."
+                        f"'{value}' that does not match the required pattern '{column_def['pattern']}'."
                     )

--- a/packages/hca-schema-validator/tests/fixtures/hca_fixtures.py
+++ b/packages/hca-schema-validator/tests/fixtures/hca_fixtures.py
@@ -49,6 +49,21 @@ good_obs = pd.DataFrame(
             "donor_1",
             "nucleus",
             "NCBITaxon:9606",  # HCA: organism in obs
+            "sample_001",
+            "lib_001",
+            "Broad Institute",
+            "batch_001",
+            "run_001",
+            "STAR 2.7.10a",
+            "0",
+            "surgical donor",
+            "biopsy",
+            "healthy",
+            "fresh",
+            "3 prime tag",
+            "GRCh38",
+            "CL:0000066+",
+            "v101",
         ],
         [
             "CL:0000066",
@@ -63,6 +78,21 @@ good_obs = pd.DataFrame(
             "donor_1",
             "nucleus",
             "NCBITaxon:9606",  # HCA: organism in obs
+            "sample_001",
+            "lib_001",
+            "Broad Institute",
+            "batch_001",
+            "run_001",
+            "STAR 2.7.10a",
+            "0",
+            "surgical donor",
+            "biopsy",
+            "healthy",
+            "fresh",
+            "3 prime tag",
+            "GRCh38",
+            "CL:0000066+",
+            "v101",
         ],
     ],
     index=["X", "Y"],
@@ -79,6 +109,21 @@ good_obs = pd.DataFrame(
         "donor_id",
         "suspension_type",
         "organism_ontology_term_id",  # HCA: organism in obs
+        "sample_id",
+        "library_id",
+        "institute",
+        "library_preparation_batch",
+        "library_sequencing_run",
+        "alignment_software",
+        "manner_of_death",
+        "sample_source",
+        "sample_collection_method",
+        "sampled_site_condition",
+        "sample_preservation_method",
+        "sequenced_fragment",
+        "reference_genome",
+        "cell_enrichment",
+        "gene_annotation_version",
     ],
 )
 
@@ -86,6 +131,14 @@ good_obs["donor_id"] = good_obs["donor_id"].astype("category")
 good_obs["suspension_type"] = good_obs["suspension_type"].astype("category")
 good_obs["tissue_type"] = good_obs["tissue_type"].astype("category")
 good_obs["tissue_type"] = good_obs["tissue_type"].cat.add_categories(["primary cell culture", "organoid", "cell line"])
+for _col in [
+    "sample_id", "library_id", "institute", "library_preparation_batch",
+    "library_sequencing_run", "alignment_software", "manner_of_death",
+    "sample_source", "sample_collection_method", "sampled_site_condition",
+    "sample_preservation_method", "sequenced_fragment", "reference_genome",
+    "cell_enrichment", "gene_annotation_version",
+]:
+    good_obs[_col] = good_obs[_col].astype("category")
 
 # Expected obs, this is what the obs above should look like after adding the necessary columns with the validator,
 # these columns are defined in the schema
@@ -142,6 +195,21 @@ good_obs_visium = pd.DataFrame(
             "donor_1",
             "na",
             0,
+            "sample_001",
+            "lib_001",
+            "Broad Institute",
+            "batch_001",
+            "run_001",
+            "STAR 2.7.10a",
+            "0",
+            "surgical donor",
+            "biopsy",
+            "healthy",
+            "fresh",
+            "3 prime tag",
+            "GRCh38",
+            "CL:0000066+",
+            "v101",
         ],
         [
             1,
@@ -158,6 +226,21 @@ good_obs_visium = pd.DataFrame(
             "donor_1",
             "na",
             1,
+            "sample_001",
+            "lib_001",
+            "Broad Institute",
+            "batch_001",
+            "run_001",
+            "STAR 2.7.10a",
+            "0",
+            "surgical donor",
+            "biopsy",
+            "healthy",
+            "fresh",
+            "3 prime tag",
+            "GRCh38",
+            "CL:0000066+",
+            "v101",
         ],
     ],
     index=["X", "Y"],
@@ -176,6 +259,21 @@ good_obs_visium = pd.DataFrame(
         "donor_id",
         "suspension_type",
         "in_tissue",
+        "sample_id",
+        "library_id",
+        "institute",
+        "library_preparation_batch",
+        "library_sequencing_run",
+        "alignment_software",
+        "manner_of_death",
+        "sample_source",
+        "sample_collection_method",
+        "sampled_site_condition",
+        "sample_preservation_method",
+        "sequenced_fragment",
+        "reference_genome",
+        "cell_enrichment",
+        "gene_annotation_version",
     ],
 )
 
@@ -185,6 +283,14 @@ good_obs_visium["tissue_type"] = good_obs_visium["tissue_type"].astype("category
 good_obs_visium["tissue_type"] = good_obs_visium["tissue_type"].cat.add_categories(
     ["primary cell culture", "organoid", "cell line"]
 )
+for _col in [
+    "sample_id", "library_id", "institute", "library_preparation_batch",
+    "library_sequencing_run", "alignment_software", "manner_of_death",
+    "sample_source", "sample_collection_method", "sampled_site_condition",
+    "sample_preservation_method", "sequenced_fragment", "reference_genome",
+    "cell_enrichment", "gene_annotation_version",
+]:
+    good_obs_visium[_col] = good_obs_visium[_col].astype("category")
 
 # Valid spatial obs per schema
 good_obs_slide_seqv2 = pd.DataFrame(
@@ -201,6 +307,21 @@ good_obs_slide_seqv2 = pd.DataFrame(
             "HsapDv:0000003",
             "donor_1",
             "na",
+            "sample_001",
+            "lib_001",
+            "Broad Institute",
+            "batch_001",
+            "run_001",
+            "STAR 2.7.10a",
+            "0",
+            "surgical donor",
+            "biopsy",
+            "healthy",
+            "fresh",
+            "3 prime tag",
+            "GRCh38",
+            "CL:0000066+",
+            "v101",
         ],
         [
             "CL:0000066",
@@ -214,6 +335,21 @@ good_obs_slide_seqv2 = pd.DataFrame(
             "HsapDv:0000003",
             "donor_1",
             "na",
+            "sample_001",
+            "lib_001",
+            "Broad Institute",
+            "batch_001",
+            "run_001",
+            "STAR 2.7.10a",
+            "0",
+            "surgical donor",
+            "biopsy",
+            "healthy",
+            "fresh",
+            "3 prime tag",
+            "GRCh38",
+            "CL:0000066+",
+            "v101",
         ],
     ],
     index=["X", "Y"],
@@ -229,6 +365,21 @@ good_obs_slide_seqv2 = pd.DataFrame(
         "development_stage_ontology_term_id",
         "donor_id",
         "suspension_type",
+        "sample_id",
+        "library_id",
+        "institute",
+        "library_preparation_batch",
+        "library_sequencing_run",
+        "alignment_software",
+        "manner_of_death",
+        "sample_source",
+        "sample_collection_method",
+        "sampled_site_condition",
+        "sample_preservation_method",
+        "sequenced_fragment",
+        "reference_genome",
+        "cell_enrichment",
+        "gene_annotation_version",
     ],
 )
 
@@ -238,6 +389,14 @@ good_obs_slide_seqv2["tissue_type"] = good_obs_slide_seqv2["tissue_type"].astype
 good_obs_slide_seqv2["tissue_type"] = good_obs_slide_seqv2["tissue_type"].cat.add_categories(
     ["primary cell culture", "organoid", "cell line"]
 )
+for _col in [
+    "sample_id", "library_id", "institute", "library_preparation_batch",
+    "library_sequencing_run", "alignment_software", "manner_of_death",
+    "sample_source", "sample_collection_method", "sampled_site_condition",
+    "sample_preservation_method", "sequenced_fragment", "reference_genome",
+    "cell_enrichment", "gene_annotation_version",
+]:
+    good_obs_slide_seqv2[_col] = good_obs_slide_seqv2[_col].astype("category")
 
 good_obs_visium_is_single_false = pd.DataFrame(
     [
@@ -253,6 +412,21 @@ good_obs_visium_is_single_false = pd.DataFrame(
             "HsapDv:0000003",
             "donor_1",
             "na",
+            "sample_001",
+            "lib_001",
+            "Broad Institute",
+            "batch_001",
+            "run_001",
+            "STAR 2.7.10a",
+            "0",
+            "surgical donor",
+            "biopsy",
+            "healthy",
+            "fresh",
+            "3 prime tag",
+            "GRCh38",
+            "CL:0000066+",
+            "v101",
         ],
         [
             "CL:0000066",
@@ -266,6 +440,21 @@ good_obs_visium_is_single_false = pd.DataFrame(
             "HsapDv:0000003",
             "donor_1",
             "na",
+            "sample_001",
+            "lib_001",
+            "Broad Institute",
+            "batch_001",
+            "run_001",
+            "STAR 2.7.10a",
+            "0",
+            "surgical donor",
+            "biopsy",
+            "healthy",
+            "fresh",
+            "3 prime tag",
+            "GRCh38",
+            "CL:0000066+",
+            "v101",
         ],
     ],
     index=["X", "Y"],
@@ -281,6 +470,21 @@ good_obs_visium_is_single_false = pd.DataFrame(
         "development_stage_ontology_term_id",
         "donor_id",
         "suspension_type",
+        "sample_id",
+        "library_id",
+        "institute",
+        "library_preparation_batch",
+        "library_sequencing_run",
+        "alignment_software",
+        "manner_of_death",
+        "sample_source",
+        "sample_collection_method",
+        "sampled_site_condition",
+        "sample_preservation_method",
+        "sequenced_fragment",
+        "reference_genome",
+        "cell_enrichment",
+        "gene_annotation_version",
     ],
 )
 
@@ -292,6 +496,14 @@ good_obs_visium_is_single_false["tissue_type"] = good_obs_visium_is_single_false
 good_obs_visium_is_single_false["tissue_type"] = good_obs_visium_is_single_false["tissue_type"].cat.add_categories(
     ["primary cell culture", "organoid", "cell line"]
 )
+for _col in [
+    "sample_id", "library_id", "institute", "library_preparation_batch",
+    "library_sequencing_run", "alignment_software", "manner_of_death",
+    "sample_source", "sample_collection_method", "sampled_site_condition",
+    "sample_preservation_method", "sequenced_fragment", "reference_genome",
+    "cell_enrichment", "gene_annotation_version",
+]:
+    good_obs_visium_is_single_false[_col] = good_obs_visium_is_single_false[_col].astype("category")
 
 good_obs_mouse = pd.DataFrame(
     [
@@ -308,6 +520,21 @@ good_obs_mouse = pd.DataFrame(
             "donor_2",
             "na",
             "NCBITaxon:10090",  # HCA: organism in obs
+            "sample_001",
+            "lib_001",
+            "Broad Institute",
+            "batch_001",
+            "run_001",
+            "STAR 2.7.10a",
+            "0",
+            "surgical donor",
+            "biopsy",
+            "healthy",
+            "fresh",
+            "3 prime tag",
+            "GRCm39",
+            "CL:0000066+",
+            "v101",
         ],
         [
             "CL:0000192",
@@ -322,6 +549,21 @@ good_obs_mouse = pd.DataFrame(
             "donor_2",
             "na",
             "NCBITaxon:10090",  # HCA: organism in obs
+            "sample_001",
+            "lib_001",
+            "Broad Institute",
+            "batch_001",
+            "run_001",
+            "STAR 2.7.10a",
+            "0",
+            "surgical donor",
+            "biopsy",
+            "healthy",
+            "fresh",
+            "3 prime tag",
+            "GRCm39",
+            "CL:0000066+",
+            "v101",
         ],
     ],
     index=["X", "Y"],
@@ -338,6 +580,21 @@ good_obs_mouse = pd.DataFrame(
         "donor_id",
         "suspension_type",
         "organism_ontology_term_id",  # HCA: organism in obs
+        "sample_id",
+        "library_id",
+        "institute",
+        "library_preparation_batch",
+        "library_sequencing_run",
+        "alignment_software",
+        "manner_of_death",
+        "sample_source",
+        "sample_collection_method",
+        "sampled_site_condition",
+        "sample_preservation_method",
+        "sequenced_fragment",
+        "reference_genome",
+        "cell_enrichment",
+        "gene_annotation_version",
     ],
 )
 
@@ -345,6 +602,14 @@ good_obs_mouse["donor_id"] = good_obs_mouse["donor_id"].astype("category")
 good_obs_mouse["suspension_type"] = good_obs_mouse["suspension_type"].astype("category")
 good_obs_mouse["tissue_type"] = good_obs_mouse["tissue_type"].astype("category")
 good_obs_mouse["tissue_type"] = good_obs_mouse["tissue_type"].cat.add_categories(["tissue", "organoid", "cell line"])
+for _col in [
+    "sample_id", "library_id", "institute", "library_preparation_batch",
+    "library_sequencing_run", "alignment_software", "manner_of_death",
+    "sample_source", "sample_collection_method", "sampled_site_condition",
+    "sample_preservation_method", "sequenced_fragment", "reference_genome",
+    "cell_enrichment", "gene_annotation_version",
+]:
+    good_obs_mouse[_col] = good_obs_mouse[_col].astype("category")
 
 # Creating a cell line obs by copying good_obs and changing the necessary fields
 good_obs_cell_line = good_obs.copy()
@@ -428,6 +693,7 @@ good_uns = {
     "default_embedding": "X_umap",
     "X_approximate_distribution": "normal",
     "batch_condition": ["is_primary_data"],
+    "study_pi": ["Smith, Jane"],
 }
 
 # HCA: organism_ontology_term_id NOT in uns (it's in obs)
@@ -436,6 +702,7 @@ good_uns_mouse = {
     "default_embedding": "X_umap",
     "X_approximate_distribution": "normal",
     "batch_condition": ["is_primary_data"],
+    "study_pi": ["Smith, Jane"],
 }
 
 good_uns_with_labels = {
@@ -448,6 +715,7 @@ good_uns_with_labels = {
     "default_embedding": "X_umap",
     "X_approximate_distribution": "normal",
     "batch_condition": ["is_primary_data"],
+    "study_pi": ["Smith, Jane"],
 }
 
 good_uns_with_colors = {
@@ -455,6 +723,7 @@ good_uns_with_colors = {
     "default_embedding": "X_umap",
     "X_approximate_distribution": "normal",
     "batch_condition": ["is_primary_data"],
+    "study_pi": ["Smith, Jane"],
     "suspension_type_colors": numpy.array(["red", "blue"]),
     "donor_id_colors": numpy.array(["#000000", "#ffffff"]),
     "tissue_type_colors": numpy.array(["black", "pink"]),
@@ -467,6 +736,7 @@ good_uns_with_visium_spatial = {
     "default_embedding": "X_umap",
     "X_approximate_distribution": "normal",
     "batch_condition": ["is_primary_data"],
+    "study_pi": ["Smith, Jane"],
     "spatial": {
         "is_single": numpy.bool_(True),
         visium_library_id: {
@@ -487,6 +757,7 @@ good_uns_with_is_single_false = {
     "default_embedding": "X_umap",
     "X_approximate_distribution": "normal",
     "batch_condition": ["is_primary_data"],
+    "study_pi": ["Smith, Jane"],
     "spatial": {"is_single": False},
 }
 
@@ -495,6 +766,7 @@ good_uns_with_slide_seqV2_spatial = {
     "default_embedding": "X_umap",
     "X_approximate_distribution": "normal",
     "batch_condition": ["is_primary_data"],
+    "study_pi": ["Smith, Jane"],
     "spatial": {"is_single": True},
 }
 

--- a/packages/hca-schema-validator/tests/test_validator.py
+++ b/packages/hca-schema-validator/tests/test_validator.py
@@ -1,13 +1,26 @@
 """Tests for HCA Validator."""
 
+import copy
 import tempfile
 from pathlib import Path
 
+import numpy as np
+import pandas as pd
 import pytest
 from hca_schema_validator import HCAValidator
 
 # Test fixtures directory
 FIXTURES_DIR = Path(__file__).parent / "fixtures" / "h5ads"
+
+
+def _validate_from_fixture(adata):
+    """Write adata to a temp file and validate it, returning (is_valid, validator)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir) / "test.h5ad"
+        adata.write_h5ad(str(tmp_path))
+        validator = HCAValidator()
+        is_valid = validator.validate_adata(str(tmp_path))
+        return is_valid, validator
 
 
 def test_import():
@@ -85,24 +98,318 @@ def test_validate_invalid_h5ad():
 def test_organism_in_obs():
     """
     Test that HCA schema accepts organism_ontology_term_id in obs.
-    
+
     This is the HCA requirement - organism fields should be in obs, not uns
     (reverting the CELLxGENE v6 change that moved them to uns).
     """
     from .fixtures.hca_fixtures import adata
-    
+
     # Use TemporaryDirectory for automatic cleanup
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp_path = Path(tmpdir) / "test.h5ad"
         adata.write_h5ad(str(tmp_path))
-        
+
         validator = HCAValidator()
         is_valid = validator.validate_adata(str(tmp_path))
-        
+
         # HCA requirement: Should accept organism_ontology_term_id in obs
         assert is_valid is True, f"Validation failed with errors: {validator.errors}"
-        
+
         # Should not have errors about organism being deprecated in obs
         for error in validator.errors:
             assert not ("organism" in error.lower() and "deprecated" in error.lower()), \
                 "organism_ontology_term_id should not be deprecated in obs for HCA schema"
+
+
+def test_valid_adata_passes():
+    """Test that the full valid adata fixture (with all new fields) passes validation."""
+    from .fixtures.hca_fixtures import adata
+
+    is_valid, validator = _validate_from_fixture(adata)
+    assert is_valid is True, f"Validation failed with errors: {validator.errors}"
+
+
+def test_study_pi_missing():
+    """Test that removing study_pi from uns produces an error."""
+    import anndata
+    from .fixtures.hca_fixtures import adata
+
+    modified = adata.copy()
+    del modified.uns["study_pi"]
+    is_valid, validator = _validate_from_fixture(modified)
+    assert is_valid is False
+    error_messages = " ".join(validator.errors)
+    assert "study_pi" in error_messages
+
+
+def test_study_pi_empty_list():
+    """Test that an empty study_pi list produces an error."""
+    import anndata
+    from .fixtures.hca_fixtures import adata
+
+    modified = adata.copy()
+    modified.uns["study_pi"] = []
+    is_valid, validator = _validate_from_fixture(modified)
+    assert is_valid is False
+    error_messages = " ".join(validator.errors)
+    assert "study_pi" in error_messages
+
+
+def test_study_pi_non_string_element():
+    """Test that a non-string element in study_pi produces an error."""
+    import anndata
+    from .fixtures.hca_fixtures import adata
+
+    modified = adata.copy()
+    modified.uns["study_pi"] = [123]
+    is_valid, validator = _validate_from_fixture(modified)
+    assert is_valid is False
+    error_messages = " ".join(validator.errors)
+    assert "study_pi" in error_messages
+    assert "string" in error_messages.lower()
+
+
+def test_missing_required_obs_column():
+    """Test that dropping a required new obs column produces an error."""
+    import anndata
+    import numpy
+    from scipy import sparse
+    from .fixtures.hca_fixtures import good_obs, good_var, good_uns, good_obsm
+
+    obs = good_obs.copy()
+    obs = obs.drop(columns=["sample_id"])
+    X = sparse.csr_matrix((obs.shape[0], good_var.shape[0]), dtype=numpy.float32)
+    test_adata = anndata.AnnData(X=X, obs=obs, uns=good_uns.copy(), obsm=good_obsm.copy(), var=good_var.copy())
+    test_adata.raw = test_adata.copy()
+    test_adata.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+
+    is_valid, validator = _validate_from_fixture(test_adata)
+    assert is_valid is False
+    error_messages = " ".join(validator.errors)
+    assert "sample_id" in error_messages
+
+
+def test_enum_invalid_value():
+    """Test that an invalid enum value for manner_of_death produces an error."""
+    import anndata
+    import numpy
+    from scipy import sparse
+    from .fixtures.hca_fixtures import good_obs, good_var, good_uns, good_obsm
+
+    obs = good_obs.copy()
+    obs["manner_of_death"] = obs["manner_of_death"].cat.add_categories(["invalid_value"])
+    obs["manner_of_death"] = "invalid_value"
+    X = sparse.csr_matrix((obs.shape[0], good_var.shape[0]), dtype=numpy.float32)
+    test_adata = anndata.AnnData(X=X, obs=obs, uns=good_uns.copy(), obsm=good_obsm.copy(), var=good_var.copy())
+    test_adata.raw = test_adata.copy()
+    test_adata.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+
+    is_valid, validator = _validate_from_fixture(test_adata)
+    assert is_valid is False
+    error_messages = " ".join(validator.errors)
+    assert "manner_of_death" in error_messages
+
+
+def test_pattern_invalid_cell_enrichment():
+    """Test that an invalid cell_enrichment value not matching pattern produces an error."""
+    import anndata
+    import numpy
+    from scipy import sparse
+    from .fixtures.hca_fixtures import good_obs, good_var, good_uns, good_obsm
+
+    obs = good_obs.copy()
+    obs["cell_enrichment"] = obs["cell_enrichment"].cat.add_categories(["INVALID"])
+    obs["cell_enrichment"] = "INVALID"
+    X = sparse.csr_matrix((obs.shape[0], good_var.shape[0]), dtype=numpy.float32)
+    test_adata = anndata.AnnData(X=X, obs=obs, uns=good_uns.copy(), obsm=good_obsm.copy(), var=good_var.copy())
+    test_adata.raw = test_adata.copy()
+    test_adata.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+
+    is_valid, validator = _validate_from_fixture(test_adata)
+    assert is_valid is False
+    error_messages = " ".join(validator.errors)
+    assert "cell_enrichment" in error_messages
+    assert "pattern" in error_messages.lower()
+
+
+def test_pattern_invalid_gene_annotation_version():
+    """Test that gene_annotation_version 'v50' does not match the version pattern."""
+    import anndata
+    import numpy
+    from scipy import sparse
+    from .fixtures.hca_fixtures import good_obs, good_var, good_uns, good_obsm
+
+    obs = good_obs.copy()
+    obs["gene_annotation_version"] = obs["gene_annotation_version"].cat.add_categories(["v50"])
+    obs["gene_annotation_version"] = "v50"
+    X = sparse.csr_matrix((obs.shape[0], good_var.shape[0]), dtype=numpy.float32)
+    test_adata = anndata.AnnData(X=X, obs=obs, uns=good_uns.copy(), obsm=good_obsm.copy(), var=good_var.copy())
+    test_adata.raw = test_adata.copy()
+    test_adata.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+
+    is_valid, validator = _validate_from_fixture(test_adata)
+    assert is_valid is False
+    error_messages = " ".join(validator.errors)
+    assert "gene_annotation_version" in error_messages
+    assert "pattern" in error_messages.lower()
+
+
+def test_pattern_valid_na_cell_enrichment():
+    """Test that 'na' is a valid value for cell_enrichment (matches pattern)."""
+    import anndata
+    import numpy
+    from scipy import sparse
+    from dask.array import from_array
+    from .fixtures.hca_fixtures import good_obs, good_var, good_uns, good_obsm, non_raw_X, X
+
+    obs = good_obs.copy()
+    obs["cell_enrichment"] = obs["cell_enrichment"].cat.add_categories(["na"])
+    obs["cell_enrichment"] = "na"
+    test_adata = anndata.AnnData(X=X.copy(), obs=obs, uns=good_uns.copy(), obsm=good_obsm.copy(), var=good_var.copy())
+    test_adata.raw = test_adata.copy()
+    test_adata.X = non_raw_X
+    test_adata.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+
+    is_valid, validator = _validate_from_fixture(test_adata)
+    assert is_valid is True, f"Validation failed with errors: {validator.errors}"
+
+
+def test_pattern_rejects_cell_enrichment_with_trailing_garbage():
+    """Test that cell_enrichment rejects a valid prefix with trailing characters."""
+    import anndata
+    import numpy
+    from scipy import sparse
+    from .fixtures.hca_fixtures import good_obs, good_var, good_uns, good_obsm
+
+    obs = good_obs.copy()
+    obs["cell_enrichment"] = obs["cell_enrichment"].cat.add_categories(["CL:0000066+garbage"])
+    obs["cell_enrichment"] = "CL:0000066+garbage"
+    X = sparse.csr_matrix((obs.shape[0], good_var.shape[0]), dtype=numpy.float32)
+    test_adata = anndata.AnnData(X=X, obs=obs, uns=good_uns.copy(), obsm=good_obsm.copy(), var=good_var.copy())
+    test_adata.raw = test_adata.copy()
+    test_adata.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+
+    is_valid, validator = _validate_from_fixture(test_adata)
+    assert is_valid is False
+    error_messages = " ".join(validator.errors)
+    assert "cell_enrichment" in error_messages
+    assert "pattern" in error_messages.lower()
+
+
+def test_pattern_rejects_gene_annotation_version_with_trailing_garbage():
+    """Test that gene_annotation_version rejects a valid prefix with trailing characters."""
+    import anndata
+    import numpy
+    from scipy import sparse
+    from .fixtures.hca_fixtures import good_obs, good_var, good_uns, good_obsm
+
+    obs = good_obs.copy()
+    obs["gene_annotation_version"] = obs["gene_annotation_version"].cat.add_categories(["v101xyz"])
+    obs["gene_annotation_version"] = "v101xyz"
+    X = sparse.csr_matrix((obs.shape[0], good_var.shape[0]), dtype=numpy.float32)
+    test_adata = anndata.AnnData(X=X, obs=obs, uns=good_uns.copy(), obsm=good_obsm.copy(), var=good_var.copy())
+    test_adata.raw = test_adata.copy()
+    test_adata.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+
+    is_valid, validator = _validate_from_fixture(test_adata)
+    assert is_valid is False
+    error_messages = " ".join(validator.errors)
+    assert "gene_annotation_version" in error_messages
+    assert "pattern" in error_messages.lower()
+
+
+# ---------------------------------------------------------------------------
+# Direct unit tests for _validate_list and _validate_column overrides
+# ---------------------------------------------------------------------------
+
+class TestValidateList:
+    """Direct unit tests for HCAValidator._validate_list with element_type 'string'."""
+
+    def _make_validator(self):
+        validator = HCAValidator()
+        validator.errors = []
+        return validator
+
+    def test_valid_strings_no_errors(self):
+        v = self._make_validator()
+        v._validate_list("study_pi", ["Smith, Jane", "Doe, John"], "string")
+        assert v.errors == []
+
+    def test_non_string_element_produces_error(self):
+        v = self._make_validator()
+        v._validate_list("study_pi", [123], "string")
+        assert len(v.errors) == 1
+        assert "123" in v.errors[0]
+        assert "string" in v.errors[0].lower()
+
+    def test_empty_string_element_produces_error(self):
+        v = self._make_validator()
+        v._validate_list("study_pi", [""], "string")
+        assert len(v.errors) == 1
+        assert "empty" in v.errors[0].lower() or "whitespace" in v.errors[0].lower()
+
+    def test_whitespace_only_element_produces_error(self):
+        v = self._make_validator()
+        v._validate_list("study_pi", ["   "], "string")
+        assert len(v.errors) == 1
+        assert "whitespace" in v.errors[0].lower()
+
+    def test_multiple_bad_elements_produce_multiple_errors(self):
+        v = self._make_validator()
+        v._validate_list("study_pi", [42, "", "  "], "string")
+        assert len(v.errors) == 3
+
+    def test_non_string_element_type_ignored(self):
+        """element_type values other than 'string' should not trigger string checks."""
+        v = self._make_validator()
+        # Use an unknown element_type that won't trigger the base class adata access
+        v._validate_list("some_list", [123], "other_type")
+        string_errors = [e for e in v.errors if "must be a string" in e]
+        assert string_errors == []
+
+
+class TestValidateColumn:
+    """Direct unit tests for HCAValidator._validate_column with pattern support."""
+
+    def _make_validator(self):
+        validator = HCAValidator()
+        validator.errors = []
+        return validator
+
+    def test_matching_values_no_errors(self):
+        v = self._make_validator()
+        col = pd.Series(["abc", "abc"], dtype="category")
+        v._validate_column(col, "test_col", "obs", {"pattern": "^abc$"})
+        assert v.errors == []
+
+    def test_non_matching_value_produces_error(self):
+        v = self._make_validator()
+        col = pd.Series(["xyz", "xyz"], dtype="category")
+        v._validate_column(col, "test_col", "obs", {"pattern": "^abc$"})
+        pattern_errors = [e for e in v.errors if "pattern" in e.lower()]
+        assert len(pattern_errors) == 1
+        assert "test_col" in pattern_errors[0]
+        assert "xyz" in pattern_errors[0]
+
+    def test_nan_values_skipped(self):
+        v = self._make_validator()
+        col = pd.Series([np.nan, "abc"], dtype="object")
+        v._validate_column(col, "test_col", "obs", {"pattern": "^abc$"})
+        pattern_errors = [e for e in v.errors if "pattern" in e.lower()]
+        assert pattern_errors == []
+
+    def test_column_def_without_pattern_no_pattern_errors(self):
+        """A column_def with no 'pattern' key should not trigger pattern checks."""
+        v = self._make_validator()
+        col = pd.Series(["anything", "anything"], dtype="category")
+        v._validate_column(col, "test_col", "obs", {"type": "categorical"})
+        pattern_errors = [e for e in v.errors if "pattern" in e.lower()]
+        assert pattern_errors == []
+
+    def test_mixed_valid_and_invalid_values(self):
+        v = self._make_validator()
+        col = pd.Series(["abc", "xyz", "abc"], dtype="category")
+        v._validate_column(col, "test_col", "obs", {"pattern": "^abc$"})
+        pattern_errors = [e for e in v.errors if "pattern" in e.lower()]
+        assert len(pattern_errors) == 1
+        assert "xyz" in pattern_errors[0]

--- a/packages/hca-schema-validator/tests/test_validator.py
+++ b/packages/hca-schema-validator/tests/test_validator.py
@@ -1,6 +1,5 @@
 """Tests for HCA Validator."""
 
-import copy
 import tempfile
 from pathlib import Path
 
@@ -257,9 +256,6 @@ def test_pattern_invalid_gene_annotation_version():
 def test_pattern_valid_na_cell_enrichment():
     """Test that 'na' is a valid value for cell_enrichment (matches pattern)."""
     import anndata
-    import numpy
-    from scipy import sparse
-    from dask.array import from_array
     from .fixtures.hca_fixtures import good_obs, good_var, good_uns, good_obsm, non_raw_X, X
 
     obs = good_obs.copy()


### PR DESCRIPTION
## Summary

- Add 17 new validated fields to the HCA schema validator (1 uns, 16 obs)
- Implement `_validate_list` override supporting `element_type: string` for list-of-strings validation (used by `study_pi`)
- Implement `_validate_column` override supporting `pattern` key for regex validation (used by `cell_enrichment`, `gene_annotation_version`)
- No vendored cellxgene code modified — all new behavior via method overrides in `HCAValidator`

### New fields

| Location | Fields |
|----------|--------|
| **uns** | `study_pi` (required list of strings) |
| **obs** (free-text) | `sample_id`, `library_id`, `institute`, `library_preparation_batch`, `library_sequencing_run`, `alignment_software` |
| **obs** (enum) | `manner_of_death`, `sample_source`, `sample_collection_method`, `sampled_site_condition`, `sample_preservation_method`, `sequenced_fragment`, `reference_genome` |
| **obs** (regex pattern) | `cell_enrichment`, `gene_annotation_version` |

## Test plan

- [x] All 29 tests pass (`poetry run pytest tests/ -v` in `packages/hca-schema-validator`)
- [x] Existing tests unaffected (organism_in_obs, valid/invalid h5ad fixtures)
- [x] New integration tests: study_pi missing/empty/non-string, missing obs column, invalid enum, invalid pattern, valid `na` pattern
- [x] New unit tests: direct `_validate_list` and `_validate_column` edge cases (whitespace, NaN skip, mixed valid/invalid, element_type passthrough)
- [x] Regex anchor bug caught and fixed — patterns use `^(...)$` grouping to prevent partial matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)