### PR TITLE
feat: human-readable pattern validation errors

### DIFF
--- a/packages/hca-schema-validator/src/hca_schema_validator/schema_definitions/hca_schema_definition.yaml
+++ b/packages/hca-schema-validator/src/hca_schema_validator/schema_definitions/hca_schema_definition.yaml
@@ -927,7 +927,9 @@ components:
         type: categorical
         subtype: str
         pattern: "^(CL:[\\d]{7}(\\+|-)|(na))$"
+        pattern_description: "a Cell Ontology ID followed by '+' or '-' (e.g. 'CL:0000540+'), or 'na'"
       gene_annotation_version:
         type: categorical
         subtype: str
         pattern: "^(v(7[5-9]|[8-9][0-9]|10[0-9]|11[01])|GCF_000001405\\.(2[5-9]|3[0-9]|40))$"
+        pattern_description: "a GENCODE version between v75 and v111 (e.g. 'v101'), or a RefSeq assembly like 'GCF_000001405.40'"

--- a/packages/hca-schema-validator/src/hca_schema_validator/validator.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/validator.py
@@ -77,11 +77,18 @@ class HCAValidator(Validator):
         super()._validate_column(column, column_name, df_name, column_def, default_error_message_suffix)
         if "pattern" in column_def:
             compiled_pattern = re.compile(column_def["pattern"])
+            description = column_def.get("pattern_description")
             for value in column.drop_duplicates():
                 if pd.isna(value):
                     continue
                 if not compiled_pattern.fullmatch(str(value)):
-                    self.errors.append(
-                        f"Column '{column_name}' in dataframe '{df_name}' contains a value "
-                        f"'{value}' that does not match the required pattern '{column_def['pattern']}'."
-                    )
+                    if description:
+                        self.errors.append(
+                            f"Column '{column_name}' in dataframe '{df_name}' contains a value "
+                            f"'{value}' which is not valid. Expected {description}."
+                        )
+                    else:
+                        self.errors.append(
+                            f"Column '{column_name}' in dataframe '{df_name}' contains a value "
+                            f"'{value}' that does not match the required pattern '{column_def['pattern']}'."
+                        )

--- a/packages/hca-schema-validator/tests/test_validator.py
+++ b/packages/hca-schema-validator/tests/test_validator.py
@@ -228,7 +228,8 @@ def test_pattern_invalid_cell_enrichment():
     assert is_valid is False
     error_messages = " ".join(validator.errors)
     assert "cell_enrichment" in error_messages
-    assert "pattern" in error_messages.lower()
+    assert "not valid" in error_messages.lower()
+    assert "cell ontology" in error_messages.lower()
 
 
 def test_pattern_invalid_gene_annotation_version():
@@ -250,7 +251,8 @@ def test_pattern_invalid_gene_annotation_version():
     assert is_valid is False
     error_messages = " ".join(validator.errors)
     assert "gene_annotation_version" in error_messages
-    assert "pattern" in error_messages.lower()
+    assert "not valid" in error_messages.lower()
+    assert "gencode" in error_messages.lower()
 
 
 def test_pattern_valid_na_cell_enrichment():
@@ -289,7 +291,7 @@ def test_pattern_rejects_cell_enrichment_with_trailing_garbage():
     assert is_valid is False
     error_messages = " ".join(validator.errors)
     assert "cell_enrichment" in error_messages
-    assert "pattern" in error_messages.lower()
+    assert "not valid" in error_messages.lower()
 
 
 def test_pattern_rejects_gene_annotation_version_with_trailing_garbage():
@@ -311,7 +313,7 @@ def test_pattern_rejects_gene_annotation_version_with_trailing_garbage():
     assert is_valid is False
     error_messages = " ".join(validator.errors)
     assert "gene_annotation_version" in error_messages
-    assert "pattern" in error_messages.lower()
+    assert "not valid" in error_messages.lower()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `pattern_description` key to schema YAML for `cell_enrichment` and `gene_annotation_version`
- When present, pattern validation errors show a clear description instead of the raw regex
- Falls back to showing the regex pattern when no description is defined

### Before
```
Column 'cell_enrichment' in dataframe 'obs' contains a value 'FACS-sorted'
that does not match the required pattern '^(CL:[\d]{7}(\+|-)|(na))$'.
```

### After
```
Column 'cell_enrichment' in dataframe 'obs' contains a value 'FACS-sorted'
which is not valid. Expected a Cell Ontology ID followed by '+' or '-'
(e.g. 'CL:0000540+'), or 'na'.
```

Closes #179

## Test plan

- [x] All 29 tests pass
- [x] Integration tests verify human-readable text appears in error messages
- [x] Unit tests still verify fallback to raw pattern when no description is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)