### PR TITLE
fix: ensure publish job runs on workflow_dispatch

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,7 +21,9 @@ jobs:
 
   publish-hca-schema-validator:
     needs: release-please
-    if: needs.release-please.outputs.release_created == 'true' || (github.event_name == 'workflow_dispatch')
+    if: |
+      !failure() && !cancelled() &&
+      (needs.release-please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Closes #181

## Summary

- Follow-up to #182 — the publish job was being skipped on manual `workflow_dispatch` because GitHub Actions doesn't evaluate the `if` condition on dependent jobs when the `needs` job's outputs are empty
- Uses `!failure() && !cancelled()` to force evaluation of the full condition while still skipping if release-please actually errors out

## Test plan

- [ ] Manually trigger the workflow via `workflow_dispatch` and verify the publish job runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)