### PR TITLE
feat: allow empty manner_of_death for prenatal development stages

### DIFF
--- a/packages/hca-schema-validator/src/hca_schema_validator/schema_definitions/hca_schema_definition.yaml
+++ b/packages/hca-schema-validator/src/hca_schema_validator/schema_definitions/hca_schema_definition.yaml
@@ -869,6 +869,26 @@ components:
           - "4"
           - "unknown"
           - "not applicable"
+        dependencies:
+          - # If development stage is prenatal, also allow empty string
+            rule:
+              column: development_stage_ontology_term_id
+              match_ancestors_inclusive:
+                ancestors:
+                  - HsapDv:0000045
+                  - MmusDv:0000042
+            error_message_suffix: >-
+              When development stage is prenatal, manner_of_death must be '0', '1', '2', '3', '4', 'unknown', 'not applicable', or '' (empty string for embryonic/fetal tissue).
+            type: categorical
+            enum:
+              - "0"
+              - "1"
+              - "2"
+              - "3"
+              - "4"
+              - "unknown"
+              - "not applicable"
+              - ""
       sample_source:
         type: categorical
         enum:

--- a/packages/hca-schema-validator/tests/test_validator.py
+++ b/packages/hca-schema-validator/tests/test_validator.py
@@ -209,6 +209,47 @@ def test_enum_invalid_value():
     assert "manner_of_death" in error_messages
 
 
+def test_manner_of_death_empty_string_allowed_for_prenatal():
+    """Test that manner_of_death='' is allowed when development_stage is prenatal."""
+    import anndata
+    from .fixtures.hca_fixtures import good_obs, good_var, good_uns, good_obsm, non_raw_X, X
+
+    obs = good_obs.copy()
+    # good_obs already uses HsapDv:0000003 (Carnegie stage 01), which is prenatal
+    obs["manner_of_death"] = obs["manner_of_death"].cat.add_categories([""])
+    obs["manner_of_death"] = ""
+    test_adata = anndata.AnnData(X=X.copy(), obs=obs, uns=good_uns.copy(), obsm=good_obsm.copy(), var=good_var.copy())
+    test_adata.raw = test_adata.copy()
+    test_adata.X = non_raw_X
+    test_adata.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+
+    is_valid, validator = _validate_from_fixture(test_adata)
+    assert is_valid is True, f"Validation failed with errors: {validator.errors}"
+
+
+def test_manner_of_death_empty_string_rejected_for_postnatal():
+    """Test that manner_of_death='' is rejected when development_stage is postnatal."""
+    import anndata
+    import numpy
+    from scipy import sparse
+    from .fixtures.hca_fixtures import good_obs, good_var, good_uns, good_obsm
+
+    obs = good_obs.copy()
+    # Change to a postnatal development stage (human adult stage)
+    obs["development_stage_ontology_term_id"] = "HsapDv:0000087"
+    obs["manner_of_death"] = obs["manner_of_death"].cat.add_categories([""])
+    obs["manner_of_death"] = ""
+    X = sparse.csr_matrix((obs.shape[0], good_var.shape[0]), dtype=numpy.float32)
+    test_adata = anndata.AnnData(X=X, obs=obs, uns=good_uns.copy(), obsm=good_obsm.copy(), var=good_var.copy())
+    test_adata.raw = test_adata.copy()
+    test_adata.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+
+    is_valid, validator = _validate_from_fixture(test_adata)
+    assert is_valid is False
+    error_messages = " ".join(validator.errors)
+    assert "manner_of_death" in error_messages
+
+
 def test_pattern_invalid_cell_enrichment():
     """Test that an invalid cell_enrichment value not matching pattern produces an error."""
     import anndata


### PR DESCRIPTION
## Summary
- Adds a dependency rule to `manner_of_death` in the HCA schema definition so that when `development_stage_ontology_term_id` is a prenatal term (descendant of `HsapDv:0000045` for human or `MmusDv:0000042` for mouse), `""` (empty string) is accepted in addition to the standard enum values
- Postnatal subjects continue to require a non-empty `manner_of_death` value
- Adds two tests: one verifying empty string is allowed for prenatal, one verifying it's rejected for postnatal

Closes #102

## Test plan
- [x] `test_manner_of_death_empty_string_allowed_for_prenatal` — prenatal fixture with `manner_of_death=""` passes
- [x] `test_manner_of_death_empty_string_rejected_for_postnatal` — postnatal fixture with `manner_of_death=""` fails
- [x] All 35 existing tests pass (`poetry run pytest tests/test_validator.py -v`)
- [x] Built wheel tests pass (`make test-wheel`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)