### PR TITLE
feat: prioritize errors over warnings in SNS message truncation

### DIFF
--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -27,6 +27,9 @@ import pandas as pd
 
 MAX_SNS_MESSAGE_LENGTH = 250_000 # Somewhat less than the actual value of 256KiB, to make room for small unforseen deviations
 TRUNCATED_MESSAGES_MESSAGE = "Messages truncated"
+# When truncating to fit SNS limits, error lists from higher-priority tools are preserved longer.
+# Unknown tools default to priority 0 (truncated first among errors).
+TOOL_ERROR_PRIORITY = {"cellxgene": 0, "cap": 1, "hcaSchema": 2}
 
 
 # Environment variable constants
@@ -141,8 +144,11 @@ class ValidationMessage:
         
         # Create a list of message arrays from tool_reports, represented as (key in tool_reports, attribute in tool report object) pairs
         list_paths = [(key, message_type) for key in self.tool_reports.keys() for message_type in ["errors", "warnings"]]
-        # Sort from longest to shortest list so that we won't remove shorter lists entirely before getting to a disproportionally long list that has to be truncated
-        list_paths.sort(key=lambda p: self._json_length_of_report_list(*p), reverse=True)
+        # Truncation priority: warnings first, then cellxgene errors, then cap errors, then hcaSchema errors (preserved longest)
+        list_paths.sort(key=lambda p: (
+            0 if p[1] == "warnings" else 1 + TOOL_ERROR_PRIORITY.get(p[0], 0),
+            -self._json_length_of_report_list(*p),
+        ))
 
         # Create a copy of the validation message to truncate lists in
         truncated_message = copy.deepcopy(self)

--- a/services/dataset-validator/tests/test_validation_message.py
+++ b/services/dataset-validator/tests/test_validation_message.py
@@ -1,10 +1,11 @@
+import json
 import sys
 from pathlib import Path
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
-from dataset_validator.main import ValidationToolReport, ValidationMessage
+from dataset_validator.main import ValidationToolReport, ValidationMessage, TRUNCATED_MESSAGES_MESSAGE
 
 @pytest.mark.parametrize("test_case", [
     {
@@ -27,15 +28,15 @@ from dataset_validator.main import ValidationToolReport, ValidationMessage
     },
     {
         "name": "one_truncated",
-        "description": "Test JSON with one message list requiring truncation",
+        "description": "Test JSON with one warning list requiring truncation",
         "message_length": 100,
         "message_counts": {
           "cap": {
             "errors": 5,
-            "warnings": 10
+            "warnings": 2500
           },
           "cellxgene": {
-            "errors": 2500,
+            "errors": 10,
             "warnings": 20
           }
         },
@@ -59,7 +60,48 @@ from dataset_validator.main import ValidationToolReport, ValidationMessage
         },
         "expected_min_length": 249800,
         "expected_max_length": 250000,
-        "expected_truncated_count": 2
+        "expected_truncated_count": 4
+    },
+    {
+        "name": "errors_prioritized_over_warnings",
+        "description": "Small warnings truncated before large errors, proving priority over length",
+        "message_length": 100,
+        "message_counts": {
+          "cap": {
+            "errors": 1200,
+            "warnings": 50
+          },
+          "cellxgene": {
+            "errors": 1200,
+            "warnings": 50
+          }
+        },
+        "expected_min_length": 249800,
+        "expected_max_length": 250000,
+        "expected_truncated_count": 2,
+        "expect_errors_preserved": True
+    },
+    {
+        "name": "hca_errors_prioritized_over_cellxgene_errors",
+        "description": "Small cellxgene errors truncated before large cap/hcaSchema errors, proving tool priority over length",
+        "message_length": 100,
+        "message_counts": {
+          "cap": {
+            "errors": 1200,
+            "warnings": 5
+          },
+          "cellxgene": {
+            "errors": 50,
+            "warnings": 5
+          },
+          "hcaSchema": {
+            "errors": 1200,
+            "warnings": 5
+          }
+        },
+        "expected_min_length": 249800,
+        "expected_max_length": 250000,
+        "expect_tool_errors_preserved": ["hcaSchema", "cap"]
     },
 ], ids=lambda x: x["name"])
 def test_length_limited_json_scenarios(test_case):
@@ -86,4 +128,12 @@ def test_length_limited_json_scenarios(test_case):
   message_json = message.to_length_limited_json()
   assert test_case["expected_min_length"] <= len(message_json)
   assert len(message_json) <= test_case["expected_max_length"]
-  assert message_json.count('"Messages truncated"') == test_case["expected_truncated_count"]
+  if "expected_truncated_count" in test_case:
+    assert message_json.count(f'"{TRUNCATED_MESSAGES_MESSAGE}"') == test_case["expected_truncated_count"]
+  parsed = json.loads(message_json)
+  if test_case.get("expect_errors_preserved"):
+    for tool_report in parsed["tool_reports"].values():
+      assert TRUNCATED_MESSAGES_MESSAGE not in tool_report["errors"], "Errors should not be truncated when warnings can be truncated instead"
+  if test_case.get("expect_tool_errors_preserved"):
+    for tool_key in test_case["expect_tool_errors_preserved"]:
+      assert TRUNCATED_MESSAGES_MESSAGE not in parsed["tool_reports"][tool_key]["errors"], f"{tool_key} errors should not be truncated"


### PR DESCRIPTION
## Summary
- Truncation now follows a priority order when the SNS message exceeds the ~250KB size limit:
  1. All warnings (any tool) — truncated first
  2. cellxgene errors — truncated next
  3. cap errors — truncated next
  4. hcaSchema errors — preserved longest (most important)
- This ensures important HCA schema and CAP errors are never lost when verbose cellxgene errors dominate the message (e.g. 37K "Could not infer organism" errors)

## Test plan
- [x] All 34 dataset-validator unit tests pass (including 2 new prioritization test cases)
- [x] All 4 Docker smoke tests pass
- [x] Ran full validator in Docker against `Kretzschmar-unpublished.h5ad` — all three tool validators executed successfully
- [ ] Verify in dev environment with a large validation result

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)