### PR TITLE
feat: bump hca-schema-validator to 0.7.0 in batch validator

### DIFF
--- a/services/hca-schema-validator/poetry.lock
+++ b/services/hca-schema-validator/poetry.lock
@@ -509,14 +509,14 @@ numpy = ">=1.21.2"
 
 [[package]]
 name = "hca-schema-validator"
-version = "0.6.0"
+version = "0.7.0"
 description = "HCA schema validation for single-cell datasets"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "hca_schema_validator-0.6.0-py3-none-any.whl", hash = "sha256:ca9122d2a97989878f8ed1cae3e9f280f59fc7888182d8a51376f1e9051d1f94"},
-    {file = "hca_schema_validator-0.6.0.tar.gz", hash = "sha256:52700ccef627a9ba30f1ad17b2eafd0b9a2dbbcb31f9c2fae208fbf4b6b326da"},
+    {file = "hca_schema_validator-0.7.0-py3-none-any.whl", hash = "sha256:a75b603fc6317bbe9366f26b6f574fb2d9f37b98f2936052376dd5d70aa9b3a4"},
+    {file = "hca_schema_validator-0.7.0.tar.gz", hash = "sha256:35f3d6a281ea6e7701ca133d129d06e6c0942e986092f87d31025825bb5e2714"},
 ]
 
 [package.dependencies]
@@ -2066,4 +2066,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "~=3.11"
-content-hash = "593bd585c4d16bcd6b1837ebfe00fa2c8839151d7e7f02e27e407c4c6fa95440"
+content-hash = "bdbd3b2a2d8e9529efbecb81198a1ae2acfbf047d4fa50fc66cf85335bf258e4"

--- a/services/hca-schema-validator/pyproject.toml
+++ b/services/hca-schema-validator/pyproject.toml
@@ -3,7 +3,7 @@ name = "hca-schema-validator-service"
 version = "0.1.0"
 requires-python = "~=3.11"
 dependencies = [
-    "hca-schema-validator (>=0.6.0,<0.7.0)"
+    "hca-schema-validator (>=0.7.0,<0.8.0)"
 ]
 
 [tool.poetry]


### PR DESCRIPTION
## Summary
- Bumps hca-schema-validator from 0.6.0 to 0.7.0 in the batch validator service
- Updates poetry.lock

## Test plan
- [x] All 4 hca-schema-validator service tests pass

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)