### PR TITLE
feat: add 10th and 11th decade development stages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,8 @@ cd services/hca-schema-validator && poetry run pytest tests/ -v
 
 ```bash
 # Lambda (Entry Sheet Validator) - ENV=dev by default, use ENV=prod for production
-make build-lambda-container
+# PROFILE=excira is required for build (fetches AWS Lambda Extension layer via AWS API)
+make build-lambda-container PROFILE=excira
 make deploy-lambda-container ENV=dev
 make invoke-lambda SHEET_ID=<google-sheet-id>
 

--- a/data_dictionaries/core_data_dictionary.json
+++ b/data_dictionaries/core_data_dictionary.json
@@ -403,7 +403,7 @@
             "cxg": "development_stage_ontology_term_id",
             "tier": "Tier 1"
           },
-          "values": "HsapDv:0000003; HsapDv:0000046; HsapDv:0000264; HsapDv:0000268; HsapDv:0000237; HsapDv:0000238; HsapDv:0000239; HsapDv:0000240; HsapDv:0000241; HsapDv:0000242; HsapDv:0000243; MmusDv:0000001; MmusDv:0000002; unknown"
+          "values": "HsapDv:0000003; HsapDv:0000046; HsapDv:0000264; HsapDv:0000268; HsapDv:0000237; HsapDv:0000238; HsapDv:0000239; HsapDv:0000240; HsapDv:0000241; HsapDv:0000242; HsapDv:0000243; HsapDv:0000244; HsapDv:0000245; MmusDv:0000001; MmusDv:0000002; unknown"
         },
         {
           "name": "disease_ontology_term",

--- a/shared/src/hca_validation/schema/enums.yaml
+++ b/shared/src/hca_validation/schema/enums.yaml
@@ -111,6 +111,8 @@ enums:
       HsapDv:0000241: {}
       HsapDv:0000242: {}
       HsapDv:0000243: {}
+      HsapDv:0000244: {}
+      HsapDv:0000245: {}
       MmusDv:0000001: {}
       MmusDv:0000002: {}
       unknown: {}

--- a/shared/src/hca_validation/schema/generated/core.py
+++ b/shared/src/hca_validation/schema/generated/core.py
@@ -230,6 +230,8 @@ class DevelopmentStage(str, Enum):
     HsapDvCOLON0000241 = "HsapDv:0000241"
     HsapDvCOLON0000242 = "HsapDv:0000242"
     HsapDvCOLON0000243 = "HsapDv:0000243"
+    HsapDvCOLON0000244 = "HsapDv:0000244"
+    HsapDvCOLON0000245 = "HsapDv:0000245"
     MmusDvCOLON0000001 = "MmusDv:0000001"
     MmusDvCOLON0000002 = "MmusDv:0000002"
     unknown = "unknown"


### PR DESCRIPTION
## Summary
- Add `HsapDv:0000244` (tenth decade, 90-100 years) and `HsapDv:0000245` (eleventh decade, 100-110 years) to the `DevelopmentStage` enum in the spreadsheet/Lambda validator
- Regenerated Pydantic models and data dictionary
- Batch validator (hca-schema-validator) needs no changes — it uses ancestor-based checking against `HsapDv:0000001` and the bundled ontology data already contains both terms

## Test plan
- [x] `shared/` tests pass (33 passed)
- [x] `packages/hca-schema-validator/` tests pass (35 passed)
- [x] Verify in dev environment with a test sheet using the new terms

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)