### PR TITLE
feat: bump cap-upload-validator to 1.7.0

### DIFF
--- a/services/dataset-validator/poetry.lock
+++ b/services/dataset-validator/poetry.lock
@@ -120,14 +120,14 @@ dev = ["pytest (>=8.0.0)", "setuptools (>=69.1.1,<69.2.0)"]
 
 [[package]]
 name = "cap-upload-validator"
-version = "1.5.2"
+version = "1.7.0"
 description = "Python tool for validating H5AD AnnData files before uploading to the Cell Annotation Platform."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "cap_upload_validator-1.5.2-py3-none-any.whl", hash = "sha256:2c6ceb6b00714a51827d2363216f4844e44039accf0333d20354c4d0c93f370f"},
-    {file = "cap_upload_validator-1.5.2.tar.gz", hash = "sha256:a08fafe14e448b794c7ed8b2c0de7239b7895a3401d7cf623b5d0c1e4e8d088d"},
+    {file = "cap_upload_validator-1.7.0-py3-none-any.whl", hash = "sha256:c49ad0882fd5568a8d93c0ffc024edcc6e82fc2f564551e381592f1a5ffcc31e"},
+    {file = "cap_upload_validator-1.7.0.tar.gz", hash = "sha256:cdc9da65e84deecd4833e472bb126d0deed7521a34406b7c46c468a488bf9b1a"},
 ]
 
 [package.dependencies]

--- a/services/dataset-validator/tests/test_dataset_validator.py
+++ b/services/dataset-validator/tests/test_dataset_validator.py
@@ -370,9 +370,9 @@ def _build_cap_multi_exception(exceptions):
     {
         "name": "cap_exception",
         "description": "Test cap_validator_script with CapException",
-        "exception": "AnnDataFileMissingCountMatrix",
+        "exception": "AnnDataMissingCountMatrix",
         "expected_valid": False,
-        "expected_errors_contain": "AnnDataFileMissingCountMatrix"
+        "expected_errors_contain": "AnnDataMissingCountMatrix"
     },
     {
         "name": "cap_multi_exception",
@@ -392,17 +392,17 @@ def _build_cap_multi_exception(exceptions):
 @patch("dataset_validator.cap_validator_script.UploadValidator")
 def test_cap_validator_script_scenarios(mock_upload_validator, test_case):
     """Unit tests for cap_validator_script.py exception handling."""
-    from cap_upload_validator.errors import CapException, CapMultiException, AnnDataFileMissingCountMatrix
+    from cap_upload_validator.errors import CapException, CapMultiException, AnnDataMissingCountMatrix
     from dataset_validator.cap_validator_script import main
 
     mock_instance = MagicMock()
     mock_upload_validator.return_value = mock_instance
 
-    if test_case["exception"] == "AnnDataFileMissingCountMatrix":
-        mock_instance.validate.side_effect = AnnDataFileMissingCountMatrix()
+    if test_case["exception"] == "AnnDataMissingCountMatrix":
+        mock_instance.validate.side_effect = AnnDataMissingCountMatrix()
     elif test_case["exception"] == "CapMultiException":
         mock_instance.validate.side_effect = _build_cap_multi_exception([
-            CapException(), AnnDataFileMissingCountMatrix()
+            CapException(), AnnDataMissingCountMatrix()
         ])
     elif test_case["exception"] == "Exception":
         mock_instance.validate.side_effect = Exception("something broke")


### PR DESCRIPTION
## Summary
- Bump `cap-upload-validator` from 1.5.2 to 1.7.0 in the dataset (batch) validator
- Fix test imports: `AnnDataFileMissingCountMatrix` renamed to `AnnDataMissingCountMatrix` in 1.7.0
- Production code unaffected — only imports `CapException` and `CapMultiException`

## Test plan
- [x] All 38 dataset-validator tests pass
- [ ] Run a batch validation job against a real H5AD file on dev to verify end-to-end

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)