### PR TITLE
feat: allow empty string for manner_of_death regardless of development stage

### DIFF
--- a/packages/hca-schema-validator/src/hca_schema_validator/schema_definitions/hca_schema_definition.yaml
+++ b/packages/hca-schema-validator/src/hca_schema_validator/schema_definitions/hca_schema_definition.yaml
@@ -869,26 +869,7 @@ components:
           - "4"
           - "unknown"
           - "not applicable"
-        dependencies:
-          - # If development stage is prenatal, also allow empty string
-            rule:
-              column: development_stage_ontology_term_id
-              match_ancestors_inclusive:
-                ancestors:
-                  - HsapDv:0000045
-                  - MmusDv:0000042
-            error_message_suffix: >-
-              When development stage is prenatal, manner_of_death must be '0', '1', '2', '3', '4', 'unknown', 'not applicable', or '' (empty string for embryonic/fetal tissue).
-            type: categorical
-            enum:
-              - "0"
-              - "1"
-              - "2"
-              - "3"
-              - "4"
-              - "unknown"
-              - "not applicable"
-              - ""
+          - ""
       sample_source:
         type: categorical
         enum:

--- a/packages/hca-schema-validator/tests/test_validator.py
+++ b/packages/hca-schema-validator/tests/test_validator.py
@@ -227,21 +227,36 @@ def test_manner_of_death_empty_string_allowed_for_prenatal():
     assert is_valid is True, f"Validation failed with errors: {validator.errors}"
 
 
-def test_manner_of_death_empty_string_rejected_for_postnatal():
-    """Test that manner_of_death='' is rejected when development_stage is postnatal."""
+def test_manner_of_death_empty_string_allowed_for_postnatal():
+    """Test that manner_of_death='' is allowed even when development_stage is postnatal."""
     import anndata
-    import numpy
-    from scipy import sparse
-    from .fixtures.hca_fixtures import good_obs, good_var, good_uns, good_obsm
+    from .fixtures.hca_fixtures import good_obs, good_var, good_uns, good_obsm, non_raw_X, X
 
     obs = good_obs.copy()
-    # Change to a postnatal development stage (human adult stage)
-    obs["development_stage_ontology_term_id"] = "HsapDv:0000087"
+    # Change to a postnatal development stage (2-year-old stage)
+    obs["development_stage_ontology_term_id"] = "HsapDv:0000096"
     obs["manner_of_death"] = obs["manner_of_death"].cat.add_categories([""])
     obs["manner_of_death"] = ""
-    X = sparse.csr_matrix((obs.shape[0], good_var.shape[0]), dtype=numpy.float32)
-    test_adata = anndata.AnnData(X=X, obs=obs, uns=good_uns.copy(), obsm=good_obsm.copy(), var=good_var.copy())
+    test_adata = anndata.AnnData(X=X.copy(), obs=obs, uns=good_uns.copy(), obsm=good_obsm.copy(), var=good_var.copy())
     test_adata.raw = test_adata.copy()
+    test_adata.X = non_raw_X
+    test_adata.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+
+    is_valid, validator = _validate_from_fixture(test_adata)
+    assert is_valid is True, f"Validation failed with errors: {validator.errors}"
+
+
+def test_manner_of_death_invalid_value_rejected():
+    """Test that an invalid manner_of_death value is rejected."""
+    import anndata
+    from .fixtures.hca_fixtures import good_obs, good_var, good_uns, good_obsm, non_raw_X, X
+
+    obs = good_obs.copy()
+    obs["manner_of_death"] = obs["manner_of_death"].cat.add_categories(["banana"])
+    obs["manner_of_death"] = "banana"
+    test_adata = anndata.AnnData(X=X.copy(), obs=obs, uns=good_uns.copy(), obsm=good_obsm.copy(), var=good_var.copy())
+    test_adata.raw = test_adata.copy()
+    test_adata.X = non_raw_X
     test_adata.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
 
     is_valid, validator = _validate_from_fixture(test_adata)


### PR DESCRIPTION
## Summary
- Allow empty string (`""`) as a valid value for `manner_of_death` unconditionally, not just when the development stage is prenatal
- Remove the prenatal-only dependency rule from the schema definition
- Update existing test and add new test for invalid manner_of_death values

Closes #205

## Test plan
- [x] `test_manner_of_death_empty_string_allowed_for_prenatal` — still passes
- [x] `test_manner_of_death_empty_string_allowed_for_postnatal` — now expects success
- [x] `test_manner_of_death_invalid_value_rejected` — new test, confirms bad values still rejected
- [x] Full test suite (36 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)