### PR TITLE
fix: initialize error state in HCAValidator.__init__

### DIFF
--- a/packages/hca-schema-validator/src/hca_schema_validator/validator.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/validator.py
@@ -30,11 +30,9 @@ class HCAValidator(Validator):
             ignore_labels: If True, skip label validation
         """
         super().__init__(ignore_labels=ignore_labels)
-        # Initialize error/warning state so the exception handler in
-        # validate_adata() works even if reset() hasn't run yet.
-        self.errors = []
-        self.warnings = []
-        self.is_valid = False
+        # Initialize all validator state so the exception handler in
+        # validate_adata() works even if reset() hasn't been called yet.
+        self.reset()
     
     def _set_schema_def(self):
         """

--- a/packages/hca-schema-validator/src/hca_schema_validator/validator.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/validator.py
@@ -25,11 +25,16 @@ class HCAValidator(Validator):
     def __init__(self, ignore_labels=False):
         """
         Initialize HCA validator.
-        
+
         Args:
             ignore_labels: If True, skip label validation
         """
         super().__init__(ignore_labels=ignore_labels)
+        # Initialize error/warning state so the exception handler in
+        # validate_adata() works even if reset() hasn't run yet.
+        self.errors = []
+        self.warnings = []
+        self.is_valid = False
     
     def _set_schema_def(self):
         """

--- a/packages/hca-schema-validator/tests/test_validator.py
+++ b/packages/hca-schema-validator/tests/test_validator.py
@@ -22,6 +22,28 @@ def _validate_from_fixture(adata):
         return is_valid, validator
 
 
+def test_error_handling_before_reset(monkeypatch):
+    """Test that exceptions before reset() don't cause AttributeError.
+
+    Regression test for #210: self.errors was not initialized in __init__,
+    so an exception raised before reset() in validate_adata caused
+    AttributeError when the handler tried to append to self.errors.
+    """
+    from hca_schema_validator._vendored.cellxgene_schema import validate as validate_mod
+
+    def fake_read_h5ad(path):
+        raise RuntimeError("simulated read failure")
+
+    monkeypatch.setattr(validate_mod, "read_h5ad", fake_read_h5ad)
+
+    validator = HCAValidator()
+    is_valid = validator.validate_adata("dummy.h5ad")
+
+    assert is_valid is False
+    assert len(validator.errors) > 0
+    assert any("simulated read failure" in e for e in validator.errors)
+
+
 def test_import():
     """Test that HCAValidator can be imported."""
     assert HCAValidator is not None


### PR DESCRIPTION
## Summary
- Initialize `self.errors`, `self.warnings`, and `self.is_valid` in `HCAValidator.__init__()` so the exception handler in `validate_adata()` works even when `read_h5ad()` throws before `reset()` runs
- Add regression test that monkeypatches `read_h5ad` to simulate the failure scenario

Closes #210

## Test plan
- [x] New test `test_error_handling_before_reset` passes
- [x] All 37 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)