### PR TITLE
feat: allow multiple semicolon-separated cell_enrichment values

### DIFF
--- a/packages/hca-schema-validator/src/hca_schema_validator/schema_definitions/hca_schema_definition.yaml
+++ b/packages/hca-schema-validator/src/hca_schema_validator/schema_definitions/hca_schema_definition.yaml
@@ -927,8 +927,8 @@ components:
       cell_enrichment:
         type: categorical
         subtype: str
-        pattern: "^(CL:[\\d]{7}(\\+|-)|(na))$"
-        pattern_description: "a Cell Ontology ID followed by '+' or '-' (e.g. 'CL:0000540+'), or 'na'"
+        pattern: "^(CL:[\\d]{7}(\\+|-)(;CL:[\\d]{7}(\\+|-))*|(na))$"
+        pattern_description: "one or more Cell Ontology IDs followed by '+' or '-', separated by semicolons (e.g. 'CL:0000540+', 'CL:0000057+;CL:0000058-'), or 'na'"
       gene_annotation_version:
         type: categorical
         subtype: str

--- a/packages/hca-schema-validator/tests/test_validator.py
+++ b/packages/hca-schema-validator/tests/test_validator.py
@@ -350,6 +350,23 @@ def test_pattern_valid_na_cell_enrichment():
     assert is_valid is True, f"Validation failed with errors: {validator.errors}"
 
 
+def test_pattern_valid_multi_cell_enrichment():
+    """Test that semicolon-separated cell_enrichment values are accepted."""
+    import anndata
+    from .fixtures.hca_fixtures import good_obs, good_var, good_uns, good_obsm, non_raw_X, X
+
+    obs = good_obs.copy()
+    obs["cell_enrichment"] = obs["cell_enrichment"].cat.add_categories(["CL:0000057+;CL:0000058-"])
+    obs["cell_enrichment"] = "CL:0000057+;CL:0000058-"
+    test_adata = anndata.AnnData(X=X.copy(), obs=obs, uns=good_uns.copy(), obsm=good_obsm.copy(), var=good_var.copy())
+    test_adata.raw = test_adata.copy()
+    test_adata.X = non_raw_X
+    test_adata.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+
+    is_valid, validator = _validate_from_fixture(test_adata)
+    assert is_valid is True, f"Validation failed with errors: {validator.errors}"
+
+
 def test_pattern_rejects_cell_enrichment_with_trailing_garbage():
     """Test that cell_enrichment rejects a valid prefix with trailing characters."""
     import anndata


### PR DESCRIPTION
## Summary
- Update `cell_enrichment` regex pattern to accept semicolon-separated CL terms (e.g. `CL:0000057+;CL:0000058-`)
- Add test for multi-value cell_enrichment

Closes #215

## Test plan
- [x] New test `test_pattern_valid_multi_cell_enrichment` passes
- [x] All 38 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)