### PR TITLE
feat: add write_h5ad with timestamped naming and edit log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# MCP server config (machine-specific virtualenv paths)
+.mcp.json
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,9 +1,0 @@
-{
-  "mcpServers": {
-    "hca-anndata-mcp": {
-      "command": "poetry",
-      "args": ["run", "hca-anndata-mcp"],
-      "cwd": "packages/hca-anndata-mcp"
-    }
-  }
-}

--- a/docs/prd-h5ad-editing.md
+++ b/docs/prd-h5ad-editing.md
@@ -71,7 +71,7 @@ A list of edit entries stored in `uns['hca_edit_log']`. Each entry is a dict:
 
 - **Append-only log**: Each write appends new entries. Previous entries from the source file are preserved.
 - **Source identity**: Each entry records the source filename and its SHA-256 hash for traceability.
-- **Serialization**: `uns` values must be JSON-serializable for h5ad storage. Lists of dicts work (anndata stores them as JSON strings in HDF5).
+- **Serialization**: The edit log is stored as a JSON string in `uns` because anndata's HDF5 writer cannot reliably round-trip lists of dicts. `write_h5ad()` handles JSON encode/decode transparently.
 - **No external sidecar files**: The log lives in the h5ad so it travels with the file. If someone copies the file, they get the history.
 - **Not a replacement for git**: This tracks data-level edits to the h5ad contents, not code changes.
 - **No rollback**: To undo, re-edit from an earlier timestamped file. Every version is preserved on disk.

--- a/docs/prd-h5ad-editing.md
+++ b/docs/prd-h5ad-editing.md
@@ -1,0 +1,128 @@
+# PRD: H5AD File Editing via MCP Server
+
+**Status:** Draft
+**Date:** 2026-03-27
+
+## Problem
+
+When curating h5ad files for HCA submission, wranglers need to make targeted edits (fix ontology terms, rename columns, drop invalid obs, etc.). Today this means writing ad-hoc Python scripts. We want the MCP server to support editing so Claude can make changes interactively — but we need safe file handling and change tracking.
+
+## Goals
+
+1. **Never modify the original file** — always write to a new timestamped copy
+2. **Track what changed** — store a changelog inside the h5ad so the file is self-documenting
+3. **Simple naming convention** — output filenames make it obvious which file is latest and what the lineage is
+
+## File Naming Convention
+
+**Rule:** Strip any existing timestamp suffix, append current UTC timestamp at write time.
+
+```
+Input:  AlZaim_2024_reprocessed-r1-wip-5.h5ad
+Output: AlZaim_2024_reprocessed-r1-wip-5-2026-03-27-13-54-26.h5ad
+
+Input:  AlZaim_2024_reprocessed-r1-wip-5-2026-03-27-13-54-26.h5ad
+Output: AlZaim_2024_reprocessed-r1-wip-5-2026-03-27-14-22-11.h5ad
+```
+
+- Timestamp is **UTC** (avoids timezone encoding complexity)
+- Format: `YYYY-MM-DD-HH-MM-SS`
+- Regex to strip existing suffix: `-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}(?=\.h5ad$)`
+- Base name is stable across edits — you always know the lineage
+
+## Changelog in `uns`
+
+### Why track changes inside the file?
+
+There is no community standard for changelog/provenance in AnnData (see [scanpy#472](https://github.com/scverse/scanpy/issues/472), open since 2019). Scanpy stores per-function params in `uns` but not a history log. CAP/CAS stores structured annotation provenance. LaminDB tracks lineage externally. We want something lightweight and self-contained.
+
+### Context: what cellxgene already stores in `uns`
+
+Cellxgene schema reserves these `uns` fields (set by the system post-upload, not by submitters):
+- `schema_version`, `schema_reference`, `citation`
+
+User-provided required fields: `title` (both cellxgene and HCA), `study_pi` (HCA only).
+
+Cellxgene does **not** store filename, dataset_id, or file hash in `uns` — those live in their external catalog. Our edit log fills a gap that doesn't conflict with existing conventions.
+
+### Proposed structure: `uns['hca_edit_log']`
+
+A list of edit entries stored in `uns['hca_edit_log']`. Each entry is a dict:
+
+```python
+{
+    "timestamp": "2026-03-27T13:54:26Z",       # UTC ISO 8601
+    "tool": "hca-anndata-mcp",                  # What performed the edit
+    "tool_version": "0.1.0",                    # Version of the tool
+    "operation": "set_obs",                      # Operation type
+    "description": "Fix disease_ontology_term_id for 23 obs from MONDO:0000001 to MONDO:0005015",
+    "details": {                                 # Operation-specific structured data
+        "column": "disease_ontology_term_id",
+        "old_value": "MONDO:0000001",
+        "new_value": "MONDO:0005015",
+        "affected_rows": 23
+    },
+    "source_file": "AlZaim_2024_reprocessed-r1-wip-5.h5ad",
+    "source_sha256": "a1b2c3d4..."               # SHA-256 hash of source file
+}
+```
+
+### Design decisions
+
+- **Append-only log**: Each write appends new entries. Previous entries from the source file are preserved.
+- **Source identity**: Each entry records the source filename and its SHA-256 hash for traceability.
+- **Serialization**: `uns` values must be JSON-serializable for h5ad storage. Lists of dicts work (anndata stores them as JSON strings in HDF5).
+- **No external sidecar files**: The log lives in the h5ad so it travels with the file. If someone copies the file, they get the history.
+- **Not a replacement for git**: This tracks data-level edits to the h5ad contents, not code changes.
+- **No rollback**: To undo, re-edit from an earlier timestamped file. Every version is preserved on disk.
+- **Log size**: Not a concern — even hundreds of entries are tiny compared to expression matrices.
+
+## Architecture
+
+### Write path (single method)
+
+All edit operations flow through one `write_h5ad()` function in `hca-anndata-tools`:
+
+```python
+def write_h5ad(
+    adata: AnnData,
+    source_path: str,
+    edit_entries: list[dict],
+    output_dir: str | None = None,  # defaults to same dir as source
+) -> str:
+    """
+    Write adata to a new timestamped file. Appends edit_entries to uns['hca_edit_log'].
+
+    Returns the output file path.
+    """
+```
+
+1. Compute SHA-256 of source file on disk
+2. Strip existing timestamp suffix from source filename
+3. Generate new UTC timestamp
+4. Populate `source_file` and `source_sha256` on each edit entry
+5. Append `edit_entries` to `adata.uns['hca_edit_log']` (create if missing)
+6. Write to `{base}-{timestamp}.h5ad`
+7. Return the output path
+
+### Edit tools (MCP layer)
+
+Each edit tool in the MCP server:
+1. Opens the file (read into memory — backed mode is read-only)
+2. Performs the edit on the in-memory AnnData
+3. Builds edit log entry(s) describing what changed
+4. Calls `write_h5ad()` to persist
+
+### Initial edit tool: `set_obs`
+
+A single tool to update values in obs columns. Covers the most common curation task (fixing ontology terms, correcting metadata values). Additional edit tools can be added later as needed.
+
+### `view_edit_log` tool
+
+Read and return `uns['hca_edit_log']` for a given file. Useful for inspecting what edits have been applied.
+
+## Tickets
+
+- **write_h5ad**: Core write function with timestamped naming + edit log
+- **set_obs**: MCP tool to update obs column values
+- **view_edit_log**: MCP tool to inspect edit history

--- a/docs/prd-h5ad-editing.md
+++ b/docs/prd-h5ad-editing.md
@@ -89,11 +89,11 @@ def write_h5ad(
     source_path: str,
     edit_entries: list[dict],
     output_dir: str | None = None,  # defaults to same dir as source
-) -> str:
+) -> dict:
     """
     Write adata to a new timestamped file. Appends edit_entries to uns['hca_edit_log'].
 
-    Returns the output file path.
+    Returns dict with 'output_path' on success, or 'error' on failure.
     """
 ```
 

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/__init__.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/__init__.py
@@ -10,6 +10,10 @@ __all__ = [
     "get_storage_info",
     "get_cap_annotations",
     "plot_embedding",
+    "write_h5ad",
+    "strip_timestamp",
+    "generate_output_path",
+    "EDIT_LOG_KEY",
 ]
 
 _LAZY_IMPORTS = {
@@ -20,6 +24,10 @@ _LAZY_IMPORTS = {
     "get_storage_info": ".storage",
     "get_cap_annotations": ".cap",
     "plot_embedding": ".plot",
+    "write_h5ad": ".write",
+    "strip_timestamp": ".write",
+    "generate_output_path": ".write",
+    "EDIT_LOG_KEY": ".write",
 }
 
 

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
@@ -52,16 +52,7 @@ def generate_output_path(source_path: str, output_dir: str | None = None) -> str
     out_filename = f"{stem}-{timestamp}.h5ad"
 
     directory = output_dir if output_dir is not None else os.path.dirname(source_path)
-    output_path = os.path.join(directory, out_filename)
-
-    # On collision (same second), append a numeric suffix
-    counter = 1
-    while os.path.exists(output_path):
-        out_filename = f"{stem}-{timestamp}-{counter}.h5ad"
-        output_path = os.path.join(directory, out_filename)
-        counter += 1
-
-    return output_path
+    return os.path.join(directory, out_filename)
 
 
 def write_h5ad(

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
@@ -1,0 +1,118 @@
+"""Write h5ad files with timestamped naming and edit log tracking."""
+
+import hashlib
+import json
+import os
+import re
+from datetime import datetime, timezone
+
+_TIMESTAMP_PATTERN = re.compile(r"-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}(?=\.h5ad$)")
+_TIMESTAMP_FORMAT = "%Y-%m-%d-%H-%M-%S"
+EDIT_LOG_KEY = "hca_edit_log"
+_HASH_CHUNK_SIZE = 1 << 20  # 1 MB — keeps syscall count low on multi-GB files
+
+
+def _compute_sha256(path: str) -> str:
+    """Compute SHA-256 hex digest of a file."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(_HASH_CHUNK_SIZE), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def strip_timestamp(filename: str) -> str:
+    """Strip an existing UTC timestamp suffix from an h5ad filename.
+
+    Args:
+        filename: A filename (not a full path), e.g. 'foo-2026-03-27-13-54-26.h5ad'.
+
+    Returns:
+        The filename without the timestamp suffix, e.g. 'foo.h5ad'.
+    """
+    return _TIMESTAMP_PATTERN.sub("", filename)
+
+
+def generate_output_path(source_path: str, output_dir: str | None = None) -> str:
+    """Generate a timestamped output path from a source h5ad path.
+
+    Args:
+        source_path: Path to the source .h5ad file.
+        output_dir: Directory for the output file. Defaults to same directory as source_path.
+
+    Returns:
+        Absolute path string like '/dir/base-2026-03-27-13-54-26.h5ad'.
+    """
+    filename = os.path.basename(source_path)
+    base = strip_timestamp(filename)
+    stem = base.removesuffix(".h5ad")
+    timestamp = datetime.now(timezone.utc).strftime(_TIMESTAMP_FORMAT)
+    out_filename = f"{stem}-{timestamp}.h5ad"
+
+    directory = output_dir if output_dir is not None else os.path.dirname(source_path)
+    return os.path.join(directory, out_filename)
+
+
+def write_h5ad(
+    adata: "anndata.AnnData",
+    source_path: str,
+    edit_entries: list[dict],
+    output_dir: str | None = None,
+) -> dict:
+    """Write adata to a new timestamped file with edit log entries.
+
+    Computes SHA-256 of the source file, appends edit_entries to
+    adata.uns['hca_edit_log'], and writes to a new timestamped path.
+    The original source file is never modified.
+
+    Args:
+        adata: An in-memory AnnData object (already modified by the caller).
+        source_path: Path to the original source .h5ad file on disk.
+        edit_entries: List of edit log entry dicts to append. Each should include
+            at minimum: timestamp, tool, tool_version, operation, description.
+            The source_file and source_sha256 fields are set automatically.
+        output_dir: Directory for the output file. Defaults to same directory as source_path.
+
+    Returns:
+        A dict with 'output_path' on success, or 'error' on failure.
+    """
+    try:
+        if not os.path.isfile(source_path):
+            return {"error": f"Source file not found: {source_path}"}
+
+        if not edit_entries:
+            return {"error": "edit_entries must not be empty — every write should document what changed"}
+
+        if output_dir is not None and not os.path.isdir(output_dir):
+            return {"error": f"Output directory not found: {output_dir}"}
+
+        # Compute source identity
+        sha256 = _compute_sha256(source_path)
+        source_filename = os.path.basename(source_path)
+
+        # Build new entries with provenance fields (don't mutate caller's dicts)
+        stamped_entries = [
+            {**entry, "source_file": source_filename, "source_sha256": sha256}
+            for entry in edit_entries
+        ]
+
+        # Append to existing edit log (preserve previous entries).
+        # The log is stored as a JSON string in uns because anndata's HDF5
+        # writer cannot serialize lists of dicts natively.
+        raw_log = adata.uns.get(EDIT_LOG_KEY, "[]")
+        if isinstance(raw_log, str):
+            existing_log = json.loads(raw_log)
+        elif isinstance(raw_log, list):
+            existing_log = raw_log
+        else:
+            existing_log = []
+        adata.uns[EDIT_LOG_KEY] = json.dumps(existing_log + stamped_entries)
+
+        # Write to new timestamped path
+        output_path = generate_output_path(source_path, output_dir)
+        adata.write_h5ad(output_path)
+
+        return {"output_path": output_path}
+
+    except Exception as e:
+        return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
@@ -86,7 +86,7 @@ def write_h5ad(
         A dict with 'output_path' on success, or 'error' on failure.
     """
     try:
-        if not source_path.lower().endswith(".h5ad"):
+        if not source_path.endswith(".h5ad"):
             return {"error": f"Source path must be a .h5ad file, got: {source_path}"}
 
         if not os.path.isfile(source_path):

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
@@ -10,6 +10,7 @@ _TIMESTAMP_PATTERN = re.compile(r"-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}(?=\.h5ad$
 _TIMESTAMP_FORMAT = "%Y-%m-%d-%H-%M-%S"
 EDIT_LOG_KEY = "hca_edit_log"
 _HASH_CHUNK_SIZE = 1 << 20  # 1 MB — keeps syscall count low on multi-GB files
+_REQUIRED_ENTRY_KEYS = {"timestamp", "tool", "tool_version", "operation", "description"}
 
 
 def _compute_sha256(path: str) -> str:
@@ -51,7 +52,16 @@ def generate_output_path(source_path: str, output_dir: str | None = None) -> str
     out_filename = f"{stem}-{timestamp}.h5ad"
 
     directory = output_dir if output_dir is not None else os.path.dirname(source_path)
-    return os.path.join(directory, out_filename)
+    output_path = os.path.join(directory, out_filename)
+
+    # On collision (same second), append a numeric suffix
+    counter = 1
+    while os.path.exists(output_path):
+        out_filename = f"{stem}-{timestamp}-{counter}.h5ad"
+        output_path = os.path.join(directory, out_filename)
+        counter += 1
+
+    return output_path
 
 
 def write_h5ad(
@@ -87,6 +97,12 @@ def write_h5ad(
         if output_dir is not None and not os.path.isdir(output_dir):
             return {"error": f"Output directory not found: {output_dir}"}
 
+        # Validate edit entries have required fields
+        for i, entry in enumerate(edit_entries):
+            missing = _REQUIRED_ENTRY_KEYS - entry.keys()
+            if missing:
+                return {"error": f"edit_entries[{i}] missing required keys: {sorted(missing)}"}
+
         # Compute source identity
         sha256 = _compute_sha256(source_path)
         source_filename = os.path.basename(source_path)
@@ -102,7 +118,12 @@ def write_h5ad(
         # writer cannot serialize lists of dicts natively.
         raw_log = adata.uns.get(EDIT_LOG_KEY, "[]")
         if isinstance(raw_log, str):
-            existing_log = json.loads(raw_log)
+            try:
+                existing_log = json.loads(raw_log)
+            except json.JSONDecodeError:
+                return {"error": f"Existing {EDIT_LOG_KEY} contains invalid JSON"}
+            if not isinstance(existing_log, list):
+                return {"error": f"Existing {EDIT_LOG_KEY} decoded to {type(existing_log).__name__}, expected list"}
         elif isinstance(raw_log, list):
             existing_log = raw_log
         else:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
@@ -1,10 +1,16 @@
 """Write h5ad files with timestamped naming and edit log tracking."""
 
+from __future__ import annotations
+
 import hashlib
 import json
 import os
 import re
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from anndata import AnnData
 
 _TIMESTAMP_PATTERN = re.compile(r"-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}(?=\.h5ad$)")
 _TIMESTAMP_FORMAT = "%Y-%m-%d-%H-%M-%S"
@@ -56,7 +62,7 @@ def generate_output_path(source_path: str, output_dir: str | None = None) -> str
 
 
 def write_h5ad(
-    adata: "anndata.AnnData",
+    adata: AnnData,
     source_path: str,
     edit_entries: list[dict],
     output_dir: str | None = None,
@@ -80,6 +86,9 @@ def write_h5ad(
         A dict with 'output_path' on success, or 'error' on failure.
     """
     try:
+        if not source_path.lower().endswith(".h5ad"):
+            return {"error": f"Source path must be a .h5ad file, got: {source_path}"}
+
         if not os.path.isfile(source_path):
             return {"error": f"Source file not found: {source_path}"}
 

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
@@ -41,7 +41,8 @@ def generate_output_path(source_path: str, output_dir: str | None = None) -> str
         output_dir: Directory for the output file. Defaults to same directory as source_path.
 
     Returns:
-        Absolute path string like '/dir/base-2026-03-27-13-54-26.h5ad'.
+        Path string like '/dir/base-2026-03-27-13-54-26.h5ad'. Inherits
+        absoluteness from source_path/output_dir.
     """
     filename = os.path.basename(source_path)
     base = strip_timestamp(filename)
@@ -105,7 +106,12 @@ def write_h5ad(
         elif isinstance(raw_log, list):
             existing_log = raw_log
         else:
-            existing_log = []
+            return {
+                "error": (
+                    f"Existing {EDIT_LOG_KEY} has unsupported type "
+                    f"{type(raw_log).__name__}; refusing to overwrite edit log"
+                )
+            }
         adata.uns[EDIT_LOG_KEY] = json.dumps(existing_log + stamped_entries)
 
         # Write to new timestamped path

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
@@ -70,8 +70,9 @@ def write_h5ad(
     Args:
         adata: An in-memory AnnData object (already modified by the caller).
         source_path: Path to the original source .h5ad file on disk.
-        edit_entries: List of edit log entry dicts to append. Each should include
-            at minimum: timestamp, tool, tool_version, operation, description.
+        edit_entries: List of edit log entry dicts to append. Required keys:
+            timestamp, tool, tool_version, operation, description. Optional:
+            details (dict of operation-specific structured data).
             The source_file and source_sha256 fields are set automatically.
         output_dir: Directory for the output file. Defaults to same directory as source_path.
 

--- a/packages/hca-anndata-tools/tests/conftest.py
+++ b/packages/hca-anndata-tools/tests/conftest.py
@@ -18,3 +18,10 @@ def sample_h5ad(tmp_path_factory) -> Path:
 def sample_dir(sample_h5ad) -> Path:
     """Return the directory containing the sample h5ad file."""
     return sample_h5ad.parent
+
+
+@pytest.fixture
+def sample_h5ad_for_write(tmp_path) -> Path:
+    """Create a sample h5ad file in a writable tmp dir (function-scoped)."""
+    path = tmp_path / "test-dataset.h5ad"
+    return create_sample_h5ad(path)

--- a/packages/hca-anndata-tools/tests/test_write.py
+++ b/packages/hca-anndata-tools/tests/test_write.py
@@ -155,7 +155,7 @@ def test_write_h5ad_source_file_is_basename(sample_h5ad_for_write):
     written = ad.read_h5ad(result["output_path"])
     log = json.loads(written.uns[EDIT_LOG_KEY])
     source_file = log[0]["source_file"]
-    assert "/" not in source_file
+    assert source_file == os.path.basename(source_file)
     assert source_file == "test-dataset.h5ad"
 
 

--- a/packages/hca-anndata-tools/tests/test_write.py
+++ b/packages/hca-anndata-tools/tests/test_write.py
@@ -75,8 +75,9 @@ def test_generate_output_path_strips_existing_timestamp(tmp_path):
     # Should have base "data" with a NEW timestamp, not double-stamped
     basename = os.path.basename(result)
     assert basename.startswith("data-")
-    # Exactly one timestamp suffix (no double-stamping)
-    assert len(re.findall(TIMESTAMP_RE, basename)) == 1
+    # Exactly one timestamp (no double-stamping) — use unanchored pattern
+    ts_pattern = r"\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}"
+    assert len(re.findall(ts_pattern, basename)) == 1
 
 
 def test_generate_output_path_format(sample_h5ad_for_write):

--- a/packages/hca-anndata-tools/tests/test_write.py
+++ b/packages/hca-anndata-tools/tests/test_write.py
@@ -75,7 +75,8 @@ def test_generate_output_path_strips_existing_timestamp(tmp_path):
     # Should have base "data" with a NEW timestamp, not double-stamped
     basename = os.path.basename(result)
     assert basename.startswith("data-")
-    assert basename.count("-20") == 1  # only one timestamp
+    # Exactly one timestamp suffix (no double-stamping)
+    assert len(re.findall(TIMESTAMP_RE, basename)) == 1
 
 
 def test_generate_output_path_format(sample_h5ad_for_write):

--- a/packages/hca-anndata-tools/tests/test_write.py
+++ b/packages/hca-anndata-tools/tests/test_write.py
@@ -1,0 +1,223 @@
+"""Tests for write_h5ad, strip_timestamp, and generate_output_path."""
+
+import hashlib
+import json
+import os
+import re
+
+import anndata as ad
+
+from hca_anndata_tools.write import (
+    EDIT_LOG_KEY,
+    generate_output_path,
+    strip_timestamp,
+    write_h5ad,
+)
+
+TIMESTAMP_RE = re.compile(r"-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}\.h5ad$")
+
+
+def _make_entry(**overrides):
+    """Build a minimal edit log entry for testing."""
+    entry = {
+        "timestamp": "2026-03-27T13:54:26Z",
+        "tool": "test",
+        "tool_version": "0.0.1",
+        "operation": "test_op",
+        "description": "test edit",
+    }
+    entry.update(overrides)
+    return entry
+
+
+# --- strip_timestamp ---
+
+
+def test_strip_timestamp_removes_suffix():
+    assert strip_timestamp("foo-2026-03-27-13-54-26.h5ad") == "foo.h5ad"
+
+
+def test_strip_timestamp_no_suffix():
+    assert strip_timestamp("foo.h5ad") == "foo.h5ad"
+
+
+def test_strip_timestamp_preserves_complex_basename():
+    result = strip_timestamp("AlZaim_2024_reprocessed-r1-wip-5-2026-03-27-13-54-26.h5ad")
+    assert result == "AlZaim_2024_reprocessed-r1-wip-5.h5ad"
+
+
+def test_strip_timestamp_ignores_non_h5ad():
+    name = "foo-2026-03-27-13-54-26.csv"
+    assert strip_timestamp(name) == name
+
+
+# --- generate_output_path ---
+
+
+def test_generate_output_path_default_dir(sample_h5ad_for_write):
+    result = generate_output_path(str(sample_h5ad_for_write))
+    assert result.startswith(str(sample_h5ad_for_write.parent))
+    assert TIMESTAMP_RE.search(result)
+
+
+def test_generate_output_path_custom_dir(sample_h5ad_for_write, tmp_path):
+    out_dir = str(tmp_path / "output")
+    os.makedirs(out_dir)
+    result = generate_output_path(str(sample_h5ad_for_write), output_dir=out_dir)
+    assert result.startswith(out_dir)
+
+
+def test_generate_output_path_strips_existing_timestamp(tmp_path):
+    # Simulate a file with an existing timestamp in the name
+    source = tmp_path / "data-2026-03-27-13-54-26.h5ad"
+    source.touch()
+    result = generate_output_path(str(source))
+    # Should have base "data" with a NEW timestamp, not double-stamped
+    basename = result.split("/")[-1]
+    assert basename.startswith("data-")
+    assert basename.count("-20") == 1  # only one timestamp
+
+
+def test_generate_output_path_format(sample_h5ad_for_write):
+    result = generate_output_path(str(sample_h5ad_for_write))
+    basename = result.split("/")[-1]
+    assert TIMESTAMP_RE.search(basename)
+    assert basename.startswith("test-dataset-")
+
+
+# --- write_h5ad ---
+
+
+def test_write_h5ad_basic(sample_h5ad_for_write):
+    adata = ad.read_h5ad(str(sample_h5ad_for_write))
+    result = write_h5ad(adata, str(sample_h5ad_for_write), [_make_entry()])
+
+    assert "error" not in result
+    assert "output_path" in result
+
+    assert os.path.isfile(result["output_path"])
+    assert TIMESTAMP_RE.search(result["output_path"])
+
+
+def test_write_h5ad_edit_log_populated(sample_h5ad_for_write):
+    adata = ad.read_h5ad(str(sample_h5ad_for_write))
+    entry = _make_entry(operation="update_obs_column", description="fix tissue values")
+    result = write_h5ad(adata, str(sample_h5ad_for_write), [entry])
+
+    written = ad.read_h5ad(result["output_path"])
+    log = json.loads(written.uns[EDIT_LOG_KEY])
+    assert isinstance(log, list)
+    assert len(log) == 1
+    assert log[0]["operation"] == "update_obs_column"
+    assert log[0]["description"] == "fix tissue values"
+    assert "source_file" in log[0]
+    assert "source_sha256" in log[0]
+
+
+def test_write_h5ad_preserves_existing_log(sample_h5ad_for_write):
+    # First write
+    adata = ad.read_h5ad(str(sample_h5ad_for_write))
+    result1 = write_h5ad(adata, str(sample_h5ad_for_write), [_make_entry(description="edit 1")])
+
+    # Second write from the first output
+    adata2 = ad.read_h5ad(result1["output_path"])
+    result2 = write_h5ad(adata2, result1["output_path"], [_make_entry(description="edit 2")])
+
+    written = ad.read_h5ad(result2["output_path"])
+    log = json.loads(written.uns[EDIT_LOG_KEY])
+    assert len(log) == 2
+    assert log[0]["description"] == "edit 1"
+    assert log[1]["description"] == "edit 2"
+
+
+def test_write_h5ad_sha256_correct(sample_h5ad_for_write):
+    # Compute expected hash independently
+    h = hashlib.sha256()
+    with open(sample_h5ad_for_write, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    expected_sha = h.hexdigest()
+
+    adata = ad.read_h5ad(str(sample_h5ad_for_write))
+    result = write_h5ad(adata, str(sample_h5ad_for_write), [_make_entry()])
+
+    written = ad.read_h5ad(result["output_path"])
+    log = json.loads(written.uns[EDIT_LOG_KEY])
+    assert log[0]["source_sha256"] == expected_sha
+
+
+def test_write_h5ad_source_file_is_basename(sample_h5ad_for_write):
+    adata = ad.read_h5ad(str(sample_h5ad_for_write))
+    result = write_h5ad(adata, str(sample_h5ad_for_write), [_make_entry()])
+
+    written = ad.read_h5ad(result["output_path"])
+    log = json.loads(written.uns[EDIT_LOG_KEY])
+    source_file = log[0]["source_file"]
+    assert "/" not in source_file
+    assert source_file == "test-dataset.h5ad"
+
+
+def test_write_h5ad_custom_output_dir(sample_h5ad_for_write, tmp_path):
+    out_dir = tmp_path / "custom_output"
+    out_dir.mkdir()
+
+    adata = ad.read_h5ad(str(sample_h5ad_for_write))
+    result = write_h5ad(adata, str(sample_h5ad_for_write), [_make_entry()], output_dir=str(out_dir))
+
+    assert "error" not in result
+    assert result["output_path"].startswith(str(out_dir))
+
+
+def test_write_h5ad_missing_source(sample_h5ad_for_write):
+    adata = ad.read_h5ad(str(sample_h5ad_for_write))
+    result = write_h5ad(adata, "/nonexistent/file.h5ad", [_make_entry()])
+
+    assert "error" in result
+    assert "not found" in result["error"].lower()
+
+
+def test_write_h5ad_empty_entries(sample_h5ad_for_write):
+    adata = ad.read_h5ad(str(sample_h5ad_for_write))
+    result = write_h5ad(adata, str(sample_h5ad_for_write), [])
+
+    assert "error" in result
+
+
+def test_write_h5ad_data_integrity(sample_h5ad_for_write):
+    adata = ad.read_h5ad(str(sample_h5ad_for_write))
+    original_shape = adata.X.shape
+    original_obs_cols = list(adata.obs.columns)
+    original_var_cols = list(adata.var.columns)
+
+    result = write_h5ad(adata, str(sample_h5ad_for_write), [_make_entry()])
+
+    written = ad.read_h5ad(result["output_path"])
+    assert written.X.shape == original_shape
+    assert list(written.obs.columns) == original_obs_cols
+    assert list(written.var.columns) == original_var_cols
+    assert written.n_obs == 50
+    assert written.n_vars == 20
+
+
+def test_write_h5ad_roundtrip_edit_log(sample_h5ad_for_write):
+    """Write -> read -> write -> read, verify full log chain."""
+    # First write
+    adata1 = ad.read_h5ad(str(sample_h5ad_for_write))
+    r1 = write_h5ad(adata1, str(sample_h5ad_for_write), [_make_entry(description="first")])
+    assert "error" not in r1
+
+    # Second write from first output
+    adata2 = ad.read_h5ad(r1["output_path"])
+    r2 = write_h5ad(adata2, r1["output_path"], [_make_entry(description="second")])
+    assert "error" not in r2
+
+    # Third write from second output
+    adata3 = ad.read_h5ad(r2["output_path"])
+    r3 = write_h5ad(adata3, r2["output_path"], [_make_entry(description="third")])
+    assert "error" not in r3
+
+    # Verify full chain
+    final = ad.read_h5ad(r3["output_path"])
+    log = json.loads(final.uns[EDIT_LOG_KEY])
+    assert len(log) == 3
+    assert [e["description"] for e in log] == ["first", "second", "third"]

--- a/packages/hca-anndata-tools/tests/test_write.py
+++ b/packages/hca-anndata-tools/tests/test_write.py
@@ -222,3 +222,42 @@ def test_write_h5ad_roundtrip_edit_log(sample_h5ad_for_write):
     log = json.loads(final.uns[EDIT_LOG_KEY])
     assert len(log) == 3
     assert [e["description"] for e in log] == ["first", "second", "third"]
+
+
+# --- validation edge cases ---
+
+
+def test_write_h5ad_missing_required_keys(sample_h5ad_for_write):
+    adata = ad.read_h5ad(str(sample_h5ad_for_write))
+    bad_entry = {"timestamp": "2026-03-27T00:00:00Z", "tool": "test"}
+    result = write_h5ad(adata, str(sample_h5ad_for_write), [bad_entry])
+
+    assert "error" in result
+    assert "missing required keys" in result["error"]
+
+
+def test_write_h5ad_corrupt_json_log(sample_h5ad_for_write):
+    adata = ad.read_h5ad(str(sample_h5ad_for_write))
+    adata.uns[EDIT_LOG_KEY] = "not valid json {{"
+    result = write_h5ad(adata, str(sample_h5ad_for_write), [_make_entry()])
+
+    assert "error" in result
+    assert "invalid JSON" in result["error"]
+
+
+def test_write_h5ad_non_list_json_log(sample_h5ad_for_write):
+    adata = ad.read_h5ad(str(sample_h5ad_for_write))
+    adata.uns[EDIT_LOG_KEY] = json.dumps({"not": "a list"})
+    result = write_h5ad(adata, str(sample_h5ad_for_write), [_make_entry()])
+
+    assert "error" in result
+    assert "expected list" in result["error"]
+
+
+def test_write_h5ad_unsupported_log_type(sample_h5ad_for_write):
+    adata = ad.read_h5ad(str(sample_h5ad_for_write))
+    adata.uns[EDIT_LOG_KEY] = 42
+    result = write_h5ad(adata, str(sample_h5ad_for_write), [_make_entry()])
+
+    assert "error" in result
+    assert "unsupported type" in result["error"]

--- a/packages/hca-anndata-tools/tests/test_write.py
+++ b/packages/hca-anndata-tools/tests/test_write.py
@@ -73,14 +73,14 @@ def test_generate_output_path_strips_existing_timestamp(tmp_path):
     source.touch()
     result = generate_output_path(str(source))
     # Should have base "data" with a NEW timestamp, not double-stamped
-    basename = result.split("/")[-1]
+    basename = os.path.basename(result)
     assert basename.startswith("data-")
     assert basename.count("-20") == 1  # only one timestamp
 
 
 def test_generate_output_path_format(sample_h5ad_for_write):
     result = generate_output_path(str(sample_h5ad_for_write))
-    basename = result.split("/")[-1]
+    basename = os.path.basename(result)
     assert TIMESTAMP_RE.search(basename)
     assert basename.startswith("test-dataset-")
 


### PR DESCRIPTION
## Summary

- Adds `write_h5ad()` to `hca-anndata-tools` — the single write path for all future h5ad editing operations
- Writes to a new timestamped file (never modifies the original), with an append-only edit log in `uns['hca_edit_log']`
- Exports `strip_timestamp()`, `generate_output_path()`, and `EDIT_LOG_KEY` as public utilities
- Includes PRD for the broader h5ad editing feature set (`docs/prd-h5ad-editing.md`)

Closes #228

## Key design decisions

- Edit log stored as **JSON string** in `uns` (anndata's HDF5 writer can't serialize lists of dicts natively)
- Each log entry records **source filename + SHA-256 hash** for provenance
- Function takes an already-loaded `adata` object (caller handles read + edit, `write_h5ad` handles persist)
- 1 MB hash buffer for efficient SHA-256 on multi-GB files
- Copies edit entry dicts instead of mutating caller's data

## Test plan

- [x] 18 tests covering `strip_timestamp`, `generate_output_path`, and `write_h5ad`
- [x] Full 80-test suite passes with no regressions
- [x] Roundtrip test: write → read → write → read verifies log chain integrity

🤖 Generated with [Claude Code](https://claude.com/claude-code)