### PR TITLE
feat: add set_uns and list_uns_fields with HCA schema validation

### DIFF
--- a/docs/prd-set-uns.md
+++ b/docs/prd-set-uns.md
@@ -1,0 +1,155 @@
+# PRD: `set_uns` — Schema-Aware Dataset Metadata Editing
+
+**Status:** Draft
+**Date:** 2026-03-28
+**Issue:** #229
+
+## Problem
+
+When preparing h5ad files for HCA submission, wranglers need to set dataset-level metadata in `uns` — things like `title`, `study_pi`, `ambient_count_correction`, etc. Today this requires:
+
+1. Knowing which fields exist and where they go
+2. Looking up valid values (enums, ontology constraints)
+3. Writing Python to set them
+4. Manually checking you didn't typo a field name or use an invalid value
+
+This is error-prone and slow, especially for wranglers who aren't Python-fluent.
+
+## Goals
+
+1. **Schema-aware** — the tool knows the HCA tier 1 uns fields, their types, and valid values
+2. **Validates before writing** — rejects unknown fields, invalid enum values, wrong types
+3. **Cross-validates** — `batch_condition` values must be real obs columns, `default_embedding` must be a real obsm key
+4. **Logged** — every edit tracked via `write_h5ad()` provenance system
+
+## HCA Tier 1 `uns` Fields
+
+Source: `shared/src/hca_validation/schema/slots.yaml`, `shared/src/hca_validation/schema/dataset.yaml`, `data_dictionaries/core_data_dictionary.json`
+
+| Field | Required | Type | Validation |
+|-------|----------|------|------------|
+| `title` | No* | string | Non-empty |
+| `description` | Yes | string | Non-empty |
+| `study_pi` | Yes | list[string] | Non-empty list, each element non-empty |
+| `batch_condition` | No | list[string] | Each value must be a column in `obs` |
+| `default_embedding` | No | string | Must be a key in `obsm` |
+| `comments` | No | string | Free text |
+| `ambient_count_correction` | Yes | string | Free text (common: none, soupx, cellbender) |
+| `doublet_detection` | Yes | string | Free text (common: none, doublet_finder, manual) |
+
+*`title` is required by cellxgene schema but marked optional in the HCA data dictionary.
+
+**Not settable via this tool** (reserved, set by cellxgene post-upload):
+- `schema_version`, `schema_reference`, `citation`
+
+**Not in scope** (not stored in uns):
+- `dataset_id`, `contact_email`, `publication_doi` — these live in the entry sheet / external catalog, not in the h5ad
+
+## API
+
+### `set_uns(path, field, value)`
+
+**Parameters:**
+- `path: str` — path to h5ad file
+- `field: str` — uns field name (must be a known HCA uns field)
+- `value: str | list[str]` — value to set
+
+**Returns:**
+```json
+{
+  "output_path": "/path/to/file-2026-03-28-14-22-11.h5ad",
+  "field": "ambient_count_correction",
+  "old_value": null,
+  "new_value": "cellbender",
+  "changed": true
+}
+```
+
+Or on error:
+```json
+{
+  "error": "Unknown uns field 'titl'. Valid fields: title, description, study_pi, ..."
+}
+```
+
+### Validation rules
+
+1. **Unknown field** → error listing valid field names
+2. **Reserved field** (`schema_version`, etc.) → error explaining it's set by cellxgene
+3. **Type mismatch** — passing a string to a list field or vice versa → error
+4. **`batch_condition`** — each value checked against `adata.obs.columns`; unknown columns → error listing valid columns
+5. **`default_embedding`** — value checked against `adata.obsm.keys()`; unknown key → error listing valid keys
+6. **Empty required field** — setting a required field to empty string/list → warning
+
+### `list_uns_fields(path)`
+
+A companion read-only tool that shows the current state of all HCA uns fields for a file:
+
+```json
+{
+  "fields": [
+    {"field": "title", "required": false, "current_value": "My Dataset", "type": "string"},
+    {"field": "study_pi", "required": true, "current_value": ["Smith,J"], "type": "list[string]"},
+    {"field": "ambient_count_correction", "required": true, "current_value": null, "type": "string"},
+    ...
+  ],
+  "missing_required": ["description", "ambient_count_correction", "doublet_detection"],
+  "obs_columns": ["donor_id", "cell_type", "..."],
+  "obsm_keys": ["X_umap", "X_pca"]
+}
+```
+
+This lets Claude (or the user) see what's set, what's missing, and what the valid cross-reference targets are — before making edits.
+
+## Example Workflow
+
+```
+User: "Set up the dataset metadata for this file"
+
+Claude: [calls list_uns_fields] → sees title is set but study_pi,
+        ambient_count_correction, doublet_detection are missing
+
+Claude: "The file has title='My Dataset' but is missing three required
+        fields: study_pi, ambient_count_correction, doublet_detection.
+        Who are the study PIs?"
+
+User: "Teichmann, Sarah A and Haniffa, Muzlifah"
+
+Claude: [calls set_uns(path, "study_pi", ["Teichmann,Sarah,A", "Haniffa,Muzlifah"])]
+Claude: [calls set_uns(output_path, "ambient_count_correction", "cellbender")]
+Claude: [calls set_uns(output_path, "doublet_detection", "none")]
+```
+
+## Where the Schema Lives
+
+The canonical field definitions live in `shared/`:
+- **LinkML schemas**: `shared/src/hca_validation/schema/` — `dataset.yaml`, `slots.yaml`, etc.
+- **Data dictionary**: `data_dictionaries/core_data_dictionary.json` — generated from LinkML, has `annDataLocation` annotations
+- **Generated Pydantic models**: `shared/src/hca_validation/schema/generated/core.py`
+
+The edit tools should read from these sources, not duplicate them. This means:
+- `hca-anndata-tools` gains a dependency on `shared/` (or on the data dictionary JSON)
+- Edit validation and post-hoc validation agree by construction — same schema, no drift
+- When obs editing comes later (#236), the same schema drives both uns and obs validation
+- These validation functions could also be used in a standalone h5ad validation step, independent of the vendored cellxgene validator
+
+### Dependency approach: bundled generated Pydantic models
+
+Bundle a copy of the generated Pydantic models file (`shared/src/hca_validation/schema/generated/core.py`) into `hca-anndata-tools`. This gives us real Pydantic validation for free — type checking, enum validation, required/optional — without depending on the full `shared/` package (which drags in LinkML, gspread, Google API client, etc.).
+
+- **Self-contained** — publishable to PyPI, only adds `pydantic` as a dep (lightweight)
+- **Real validation** — Pydantic models have typed fields, enums, `extra="forbid"`, `validate_assignment=True`
+- **Kept in sync** — copy step when `make gen-schema` regenerates models from LinkML
+- **Schema-aware introspection** — field metadata includes `annDataLocation` (uns vs obs), examples, descriptions — everything the tool needs to list fields and validate values
+
+The generated `core.py` only imports `pydantic` and stdlib. No LinkML runtime needed.
+
+**Note:** `ambient_count_correction` and `doublet_detection` live on bionetwork subclasses (`AdiposeDataset`, `GutDataset`, `MusculoskeletalDataset`), not base `Dataset`. The tool should collect uns fields from the subclass matching the file's bionetwork, falling back to base `Dataset`.
+
+## Architecture
+
+- **Bundled schema**: `packages/hca-anndata-tools/src/hca_anndata_tools/schema/core.py` — copy of generated Pydantic models from `shared/`
+- **Schema helpers**: `packages/hca-anndata-tools/src/hca_anndata_tools/schema/helpers.py` — introspect models to list uns fields, extract validation rules, check annDataLocation
+- **Edit logic**: `packages/hca-anndata-tools/src/hca_anndata_tools/edit.py` — `set_uns()` and `list_uns_fields()` functions
+- **MCP registration**: `packages/hca-anndata-mcp/src/hca_anndata_mcp/server.py`
+- **Write path**: Uses existing `write_h5ad()` from `write.py`

--- a/docs/prd-set-uns.md
+++ b/docs/prd-set-uns.md
@@ -54,23 +54,7 @@ Source: `shared/src/hca_validation/schema/slots.yaml`, `shared/src/hca_validatio
 - `field: str` — uns field name (must be a known HCA uns field)
 - `value: str | list[str]` — value to set
 
-**Returns:**
-```json
-{
-  "output_path": "/path/to/file-2026-03-28-14-22-11.h5ad",
-  "field": "ambient_count_correction",
-  "old_value": null,
-  "new_value": "cellbender",
-  "changed": true
-}
-```
-
-Or on error:
-```json
-{
-  "error": "Unknown uns field 'titl'. Valid fields: title, description, study_pi, ..."
-}
-```
+**Returns:** Dict with `output_path`, `editing`, `wrote`, `field`, `old_value`, `new_value` on success, or `error` on failure. See implementation for exact shape.
 
 ### Validation rules
 
@@ -79,27 +63,11 @@ Or on error:
 3. **Type mismatch** — passing a string to a list field or vice versa → error
 4. **`batch_condition`** — each value checked against `adata.obs.columns`; unknown columns → error listing valid columns
 5. **`default_embedding`** — value checked against `adata.obsm.keys()`; unknown key → error listing valid keys
-6. **Empty required field** — setting a required field to empty string/list → warning
+6. **Empty required field** — setting a required field to empty string/list → error
 
 ### `list_uns_fields(path)`
 
-A companion read-only tool that shows the current state of all HCA uns fields for a file:
-
-```json
-{
-  "fields": [
-    {"field": "title", "required": false, "current_value": "My Dataset", "type": "string"},
-    {"field": "study_pi", "required": true, "current_value": ["Smith,J"], "type": "list[string]"},
-    {"field": "ambient_count_correction", "required": true, "current_value": null, "type": "string"},
-    ...
-  ],
-  "missing_required": ["description", "ambient_count_correction", "doublet_detection"],
-  "obs_columns": ["donor_id", "cell_type", "..."],
-  "obsm_keys": ["X_umap", "X_pca"]
-}
-```
-
-This lets Claude (or the user) see what's set, what's missing, and what the valid cross-reference targets are — before making edits.
+A companion read-only tool that shows the current state of all HCA uns fields for a file — what's set, what's missing, and cross-reference targets (obs columns, obsm keys). See implementation for exact response shape.
 
 ## Example Workflow
 

--- a/docs/prd-set-uns.md
+++ b/docs/prd-set-uns.md
@@ -59,8 +59,7 @@ Source: `shared/src/hca_validation/schema/slots.yaml`, `shared/src/hca_validatio
 ### Validation rules
 
 1. **Unknown field** → error listing valid field names
-2. **Reserved field** (`schema_version`, etc.) → error explaining it's set by cellxgene
-3. **Type mismatch** — passing a string to a list field or vice versa → error
+2. **Type mismatch** — passing a string to a list field or vice versa → error
 4. **`batch_condition`** — each value checked against `adata.obs.columns`; unknown columns → error listing valid columns
 5. **`default_embedding`** — value checked against `adata.obsm.keys()`; unknown key → error listing valid keys
 6. **Empty required field** — setting a required field to empty string/list → error

--- a/docs/prd-set-uns.md
+++ b/docs/prd-set-uns.md
@@ -111,7 +111,7 @@ Bundle a copy of the generated Pydantic models file (`shared/src/hca_validation/
 
 The generated `core.py` only imports `pydantic` and stdlib. No LinkML runtime needed.
 
-**Note:** `ambient_count_correction` and `doublet_detection` live on bionetwork subclasses (`AdiposeDataset`, `GutDataset`, `MusculoskeletalDataset`), not base `Dataset`. The tool should collect uns fields from the subclass matching the file's bionetwork, falling back to base `Dataset`.
+**Note:** `ambient_count_correction` and `doublet_detection` live on bionetwork subclasses (`AdiposeDataset`, `GutDataset`, `MusculoskeletalDataset`), not base `Dataset`. The tool collects uns fields from base `Dataset` and all bionetwork subclasses, marking subclass-only fields as `bionetwork_only` in the registry.
 
 ## Architecture
 

--- a/packages/hca-anndata-mcp/src/hca_anndata_mcp/server.py
+++ b/packages/hca-anndata-mcp/src/hca_anndata_mcp/server.py
@@ -9,6 +9,8 @@ from hca_anndata_tools import (
     locate_files,
     get_storage_info,
     get_cap_annotations,
+    set_uns,
+    list_uns_fields,
 )
 from hca_anndata_mcp.tools.plot import plot_embedding_mcp
 
@@ -20,7 +22,9 @@ mcp = FastMCP(
         "get_storage_info for HDF5 compression/chunk details, "
         "get_descriptive_stats for distributions, view_data to inspect raw values, "
         "plot_embedding to visualize UMAP/PCA embeddings, "
-        "and get_cap_annotations to inspect CAP cell annotation metadata."
+        "get_cap_annotations to inspect CAP cell annotation metadata, "
+        "list_uns_fields to see HCA dataset metadata and what's missing, "
+        "and set_uns to update HCA dataset metadata fields with schema validation."
     ),
 )
 
@@ -31,3 +35,5 @@ mcp.tool()(view_data)
 mcp.tool()(locate_files)
 mcp.tool()(plot_embedding_mcp)
 mcp.tool()(get_cap_annotations)
+mcp.tool()(list_uns_fields)
+mcp.tool()(set_uns)

--- a/packages/hca-anndata-tools/poetry.lock
+++ b/packages/hca-anndata-tools/poetry.lock
@@ -70,6 +70,18 @@ test = ["aiohttp", "awkward (>=2.3.2)", "boltons", "dask[array] (>=2023.5.1,<202
 test-min = ["awkward (>=2.3.2)", "boltons", "dask[array] (>=2023.5.1,<2024.8.dev0 || >=2024.10.dev0,<2025.2.dev0 || >=2025.9.dev0)", "dask[distributed]", "filelock", "joblib", "loompy (>=3.0.5)", "matplotlib", "openpyxl", "pooch", "pyarrow", "pytest", "pytest-cov", "pytest-memray", "pytest-mock", "pytest-randomly", "pytest-xdist[psutil]", "scanpy (>=1.10)", "scikit-learn"]
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+description = "Reusable constraint types to use with typing.Annotated"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
+    {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
+]
+
+[[package]]
 name = "array-api-compat"
 version = "1.14.0"
 description = "A wrapper around NumPy and other array libraries to make them compatible with the Array API standard"
@@ -1384,6 +1396,162 @@ dev = ["pre-commit", "tox"]
 testing = ["coverage", "pytest", "pytest-benchmark"]
 
 [[package]]
+name = "pydantic"
+version = "2.12.5"
+description = "Data validation using Python type hints"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d"},
+    {file = "pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49"},
+]
+
+[package.dependencies]
+annotated-types = ">=0.6.0"
+pydantic-core = "2.41.5"
+typing-extensions = ">=4.14.1"
+typing-inspection = ">=0.4.2"
+
+[package.extras]
+email = ["email-validator (>=2.0.0)"]
+timezone = ["tzdata ; python_version >= \"3.9\" and platform_system == \"Windows\""]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+description = "Core functionality for Pydantic validation and serialization"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pydantic_core-2.41.5-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:77b63866ca88d804225eaa4af3e664c5faf3568cea95360d21f4725ab6e07146"},
+    {file = "pydantic_core-2.41.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dfa8a0c812ac681395907e71e1274819dec685fec28273a28905df579ef137e2"},
+    {file = "pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5921a4d3ca3aee735d9fd163808f5e8dd6c6972101e4adbda9a4667908849b97"},
+    {file = "pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e25c479382d26a2a41b7ebea1043564a937db462816ea07afa8a44c0866d52f9"},
+    {file = "pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f547144f2966e1e16ae626d8ce72b4cfa0caedc7fa28052001c94fb2fcaa1c52"},
+    {file = "pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6f52298fbd394f9ed112d56f3d11aabd0d5bd27beb3084cc3d8ad069483b8941"},
+    {file = "pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:100baa204bb412b74fe285fb0f3a385256dad1d1879f0a5cb1499ed2e83d132a"},
+    {file = "pydantic_core-2.41.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:05a2c8852530ad2812cb7914dc61a1125dc4e06252ee98e5638a12da6cc6fb6c"},
+    {file = "pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:29452c56df2ed968d18d7e21f4ab0ac55e71dc59524872f6fc57dcf4a3249ed2"},
+    {file = "pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:d5160812ea7a8a2ffbe233d8da666880cad0cbaf5d4de74ae15c313213d62556"},
+    {file = "pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:df3959765b553b9440adfd3c795617c352154e497a4eaf3752555cfb5da8fc49"},
+    {file = "pydantic_core-2.41.5-cp310-cp310-win32.whl", hash = "sha256:1f8d33a7f4d5a7889e60dc39856d76d09333d8a6ed0f5f1190635cbec70ec4ba"},
+    {file = "pydantic_core-2.41.5-cp310-cp310-win_amd64.whl", hash = "sha256:62de39db01b8d593e45871af2af9e497295db8d73b085f6bfd0b18c83c70a8f9"},
+    {file = "pydantic_core-2.41.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a3a52f6156e73e7ccb0f8cced536adccb7042be67cb45f9562e12b319c119da6"},
+    {file = "pydantic_core-2.41.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7f3bf998340c6d4b0c9a2f02d6a400e51f123b59565d74dc60d252ce888c260b"},
+    {file = "pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:378bec5c66998815d224c9ca994f1e14c0c21cb95d2f52b6021cc0b2a58f2a5a"},
+    {file = "pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7b576130c69225432866fe2f4a469a85a54ade141d96fd396dffcf607b558f8"},
+    {file = "pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6cb58b9c66f7e4179a2d5e0f849c48eff5c1fca560994d6eb6543abf955a149e"},
+    {file = "pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:88942d3a3dff3afc8288c21e565e476fc278902ae4d6d134f1eeda118cc830b1"},
+    {file = "pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f31d95a179f8d64d90f6831d71fa93290893a33148d890ba15de25642c5d075b"},
+    {file = "pydantic_core-2.41.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c1df3d34aced70add6f867a8cf413e299177e0c22660cc767218373d0779487b"},
+    {file = "pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4009935984bd36bd2c774e13f9a09563ce8de4abaa7226f5108262fa3e637284"},
+    {file = "pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:34a64bc3441dc1213096a20fe27e8e128bd3ff89921706e83c0b1ac971276594"},
+    {file = "pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:c9e19dd6e28fdcaa5a1de679aec4141f691023916427ef9bae8584f9c2fb3b0e"},
+    {file = "pydantic_core-2.41.5-cp311-cp311-win32.whl", hash = "sha256:2c010c6ded393148374c0f6f0bf89d206bf3217f201faa0635dcd56bd1520f6b"},
+    {file = "pydantic_core-2.41.5-cp311-cp311-win_amd64.whl", hash = "sha256:76ee27c6e9c7f16f47db7a94157112a2f3a00e958bc626e2f4ee8bec5c328fbe"},
+    {file = "pydantic_core-2.41.5-cp311-cp311-win_arm64.whl", hash = "sha256:4bc36bbc0b7584de96561184ad7f012478987882ebf9f9c389b23f432ea3d90f"},
+    {file = "pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7"},
+    {file = "pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0"},
+    {file = "pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69"},
+    {file = "pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75"},
+    {file = "pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05"},
+    {file = "pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc"},
+    {file = "pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c"},
+    {file = "pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5"},
+    {file = "pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c"},
+    {file = "pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294"},
+    {file = "pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1"},
+    {file = "pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d"},
+    {file = "pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815"},
+    {file = "pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3"},
+    {file = "pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9"},
+    {file = "pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34"},
+    {file = "pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0"},
+    {file = "pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33"},
+    {file = "pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e"},
+    {file = "pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2"},
+    {file = "pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586"},
+    {file = "pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d"},
+    {file = "pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740"},
+    {file = "pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e"},
+    {file = "pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858"},
+    {file = "pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36"},
+    {file = "pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11"},
+    {file = "pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd"},
+    {file = "pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a"},
+    {file = "pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14"},
+    {file = "pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1"},
+    {file = "pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66"},
+    {file = "pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869"},
+    {file = "pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2"},
+    {file = "pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375"},
+    {file = "pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553"},
+    {file = "pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90"},
+    {file = "pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07"},
+    {file = "pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb"},
+    {file = "pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23"},
+    {file = "pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf"},
+    {file = "pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0"},
+    {file = "pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a"},
+    {file = "pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3"},
+    {file = "pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c"},
+    {file = "pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612"},
+    {file = "pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d"},
+    {file = "pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9"},
+    {file = "pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660"},
+    {file = "pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9"},
+    {file = "pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3"},
+    {file = "pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf"},
+    {file = "pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470"},
+    {file = "pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa"},
+    {file = "pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c"},
+    {file = "pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008"},
+    {file = "pydantic_core-2.41.5-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:8bfeaf8735be79f225f3fefab7f941c712aaca36f1128c9d7e2352ee1aa87bdf"},
+    {file = "pydantic_core-2.41.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:346285d28e4c8017da95144c7f3acd42740d637ff41946af5ce6e5e420502dd5"},
+    {file = "pydantic_core-2.41.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a75dafbf87d6276ddc5b2bf6fae5254e3d0876b626eb24969a574fff9149ee5d"},
+    {file = "pydantic_core-2.41.5-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7b93a4d08587e2b7e7882de461e82b6ed76d9026ce91ca7915e740ecc7855f60"},
+    {file = "pydantic_core-2.41.5-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e8465ab91a4bd96d36dde3263f06caa6a8a6019e4113f24dc753d79a8b3a3f82"},
+    {file = "pydantic_core-2.41.5-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:299e0a22e7ae2b85c1a57f104538b2656e8ab1873511fd718a1c1c6f149b77b5"},
+    {file = "pydantic_core-2.41.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:707625ef0983fcfb461acfaf14de2067c5942c6bb0f3b4c99158bed6fedd3cf3"},
+    {file = "pydantic_core-2.41.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f41eb9797986d6ebac5e8edff36d5cef9de40def462311b3eb3eeded1431e425"},
+    {file = "pydantic_core-2.41.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0384e2e1021894b1ff5a786dbf94771e2986ebe2869533874d7e43bc79c6f504"},
+    {file = "pydantic_core-2.41.5-cp39-cp39-musllinux_1_1_armv7l.whl", hash = "sha256:f0cd744688278965817fd0839c4a4116add48d23890d468bc436f78beb28abf5"},
+    {file = "pydantic_core-2.41.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:753e230374206729bf0a807954bcc6c150d3743928a73faffee51ac6557a03c3"},
+    {file = "pydantic_core-2.41.5-cp39-cp39-win32.whl", hash = "sha256:873e0d5b4fb9b89ef7c2d2a963ea7d02879d9da0da8d9d4933dee8ee86a8b460"},
+    {file = "pydantic_core-2.41.5-cp39-cp39-win_amd64.whl", hash = "sha256:e4f4a984405e91527a0d62649ee21138f8e3d0ef103be488c1dc11a80d7f184b"},
+    {file = "pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b96d5f26b05d03cc60f11a7761a5ded1741da411e7fe0909e27a5e6a0cb7b034"},
+    {file = "pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:634e8609e89ceecea15e2d61bc9ac3718caaaa71963717bf3c8f38bfde64242c"},
+    {file = "pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93e8740d7503eb008aa2df04d3b9735f845d43ae845e6dcd2be0b55a2da43cd2"},
+    {file = "pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f15489ba13d61f670dcc96772e733aad1a6f9c429cc27574c6cdaed82d0146ad"},
+    {file = "pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd"},
+    {file = "pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc"},
+    {file = "pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56"},
+    {file = "pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b"},
+    {file = "pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b5819cd790dbf0c5eb9f82c73c16b39a65dd6dd4d1439dcdea7816ec9adddab8"},
+    {file = "pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:5a4e67afbc95fa5c34cf27d9089bca7fcab4e51e57278d710320a70b956d1b9a"},
+    {file = "pydantic_core-2.41.5-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ece5c59f0ce7d001e017643d8d24da587ea1f74f6993467d85ae8a5ef9d4f42b"},
+    {file = "pydantic_core-2.41.5-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:16f80f7abe3351f8ea6858914ddc8c77e02578544a0ebc15b4c2e1a0e813b0b2"},
+    {file = "pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:33cb885e759a705b426baada1fe68cbb0a2e68e34c5d0d0289a364cf01709093"},
+    {file = "pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:c8d8b4eb992936023be7dee581270af5c6e0697a8559895f527f5b7105ecd36a"},
+    {file = "pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:242a206cd0318f95cd21bdacff3fcc3aab23e79bba5cac3db5a841c9ef9c6963"},
+    {file = "pydantic_core-2.41.5-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d3a978c4f57a597908b7e697229d996d77a6d3c94901e9edee593adada95ce1a"},
+    {file = "pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b2379fa7ed44ddecb5bfe4e48577d752db9fc10be00a6b7446e9663ba143de26"},
+    {file = "pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:266fb4cbf5e3cbd0b53669a6d1b039c45e3ce651fd5442eff4d07c2cc8d66808"},
+    {file = "pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58133647260ea01e4d0500089a8c4f07bd7aa6ce109682b1426394988d8aaacc"},
+    {file = "pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:287dad91cfb551c363dc62899a80e9e14da1f0e2b6ebde82c806612ca2a13ef1"},
+    {file = "pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:03b77d184b9eb40240ae9fd676ca364ce1085f203e1b1256f8ab9984dca80a84"},
+    {file = "pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770"},
+    {file = "pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f"},
+    {file = "pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51"},
+    {file = "pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e"},
+]
+
+[package.dependencies]
+typing-extensions = ">=4.14.1"
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -2157,6 +2325,21 @@ files = [
 markers = {dev = "python_version == \"3.10\""}
 
 [[package]]
+name = "typing-inspection"
+version = "0.4.2"
+description = "Runtime typing introspection tools"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7"},
+    {file = "typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464"},
+]
+
+[package.dependencies]
+typing-extensions = ">=4.12.0"
+
+[[package]]
 name = "tzdata"
 version = "2025.3"
 description = "Provider of IANA time zone data"
@@ -2224,4 +2407,4 @@ remote = ["fsspec (>=2023.10.0)", "obstore (>=0.5.1)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "289e5c56d122c76043ed7026e807b117df64f6230bce9f570610d1da368077d7"
+content-hash = "c92c6b2c30bb5691936c264e78699f94ccf1e396dbd4af67264d75c044756307"

--- a/packages/hca-anndata-tools/pyproject.toml
+++ b/packages/hca-anndata-tools/pyproject.toml
@@ -16,6 +16,7 @@ numpy = "<3"
 h5py = ">=3.8"
 scanpy = ">=1.10"
 matplotlib = ">=3.7"
+pydantic = ">=2,<3"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0"

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/__init__.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/__init__.py
@@ -14,6 +14,8 @@ __all__ = [
     "strip_timestamp",
     "generate_output_path",
     "EDIT_LOG_KEY",
+    "set_uns",
+    "list_uns_fields",
 ]
 
 _LAZY_IMPORTS = {
@@ -28,6 +30,8 @@ _LAZY_IMPORTS = {
     "strip_timestamp": ".write",
     "generate_output_path": ".write",
     "EDIT_LOG_KEY": ".write",
+    "set_uns": ".edit",
+    "list_uns_fields": ".edit",
 }
 
 

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/_serialize.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/_serialize.py
@@ -1,10 +1,10 @@
-"""Shared serialization utilities for converting numpy/pandas types to JSON-serializable Python types."""
+"""Shared serialization utilities for converting numpy types to JSON-serializable Python types."""
 
 import numpy as np
 
 
 def make_serializable(obj):
-    """Recursively convert numpy/pandas types to JSON-serializable Python types."""
+    """Recursively convert numpy types to JSON-serializable Python types."""
     if isinstance(obj, (np.integer,)):
         return int(obj)
     if isinstance(obj, (np.floating,)):

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/_serialize.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/_serialize.py
@@ -1,0 +1,24 @@
+"""Shared serialization utilities for converting numpy/pandas types to JSON-serializable Python types."""
+
+import numpy as np
+
+
+def make_serializable(obj):
+    """Recursively convert numpy/pandas types to JSON-serializable Python types."""
+    if isinstance(obj, (np.integer,)):
+        return int(obj)
+    if isinstance(obj, (np.floating,)):
+        return float(obj)
+    if isinstance(obj, (np.bool_,)):
+        return bool(obj)
+    if isinstance(obj, (np.str_, np.bytes_)):
+        return str(obj)
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    if isinstance(obj, bytes):
+        return obj.decode("utf-8", errors="replace")
+    if isinstance(obj, dict):
+        return {k: make_serializable(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [make_serializable(v) for v in obj]
+    return obj

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/cap.py
@@ -1,27 +1,7 @@
 """CAP (Cell Annotation Platform) schema inspection for AnnData files."""
 
-import numpy as np
-
 from ._io import open_h5ad
-
-
-def _make_serializable(obj):
-    """Convert numpy/pandas types to JSON-serializable Python types."""
-    if isinstance(obj, (np.integer,)):
-        return int(obj)
-    if isinstance(obj, (np.floating,)):
-        return float(obj)
-    if isinstance(obj, (np.bool_,)):
-        return bool(obj)
-    if isinstance(obj, (np.str_, np.bytes_)):
-        return str(obj)
-    if isinstance(obj, np.ndarray):
-        return obj.tolist()
-    if isinstance(obj, dict):
-        return {k: _make_serializable(v) for k, v in obj.items()}
-    if isinstance(obj, (list, tuple)):
-        return [_make_serializable(v) for v in obj]
-    return obj
+from ._serialize import make_serializable as _make_serializable
 
 # CAP obs column suffixes per the cell-annotation-schema spec
 _REQUIRED_SUFFIXES = [

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
@@ -49,6 +49,7 @@ def list_uns_fields(path: str) -> dict:
         with open_h5ad(path, backed="r") as adata:
             fields = []
             missing_required = []
+            missing_required_bionetwork = []
 
             for name, info in registry.items():
                 current = adata.uns.get(name, None)
@@ -68,7 +69,10 @@ def list_uns_fields(path: str) -> dict:
                 })
 
                 if info.required and not is_set:
-                    missing_required.append(name)
+                    if info.bionetwork_only:
+                        missing_required_bionetwork.append(name)
+                    else:
+                        missing_required.append(name)
 
             # Extra uns keys not in the HCA schema
             schema_keys = set(registry.keys()) | {EDIT_LOG_KEY}
@@ -79,6 +83,7 @@ def list_uns_fields(path: str) -> dict:
                 "fields": fields,
                 "set_count": sum(1 for f in fields if f["is_set"]),
                 "missing_required": missing_required,
+                "missing_required_bionetwork": missing_required_bionetwork,
                 "extra_uns_keys": extra_uns_keys,
                 "obs_columns": list(adata.obs.columns),
                 "obsm_keys": list(adata.obsm.keys()),
@@ -125,6 +130,17 @@ def set_uns(
             validated_value = adapter.validate_python(value)
         except ValidationError as e:
             return {"error": f"Invalid value for '{field}': {e}"}
+
+        # Reject empty values for required fields
+        if info.required:
+            if isinstance(validated_value, str) and not validated_value.strip():
+                return {"error": f"Invalid value for '{field}': must be non-empty"}
+            if isinstance(validated_value, list):
+                if not validated_value:
+                    return {"error": f"Invalid value for '{field}': list must be non-empty"}
+                bad = [v for v in validated_value if isinstance(v, str) and not v.strip()]
+                if bad:
+                    return {"error": f"Invalid value for '{field}': list elements must be non-empty"}
 
         # Open file in memory for editing
         with open_h5ad(path, backed=None) as adata:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
@@ -1,0 +1,188 @@
+"""Schema-aware editing tools for HCA h5ad files."""
+
+from __future__ import annotations
+
+import os
+import types
+import typing
+from datetime import datetime, timezone
+
+from pydantic import TypeAdapter, ValidationError
+
+from ._io import open_h5ad
+from ._serialize import make_serializable
+from .schema.helpers import uns_field_registry
+from .write import EDIT_LOG_KEY, write_h5ad
+from . import __version__
+
+
+def _type_display(annotation) -> str:
+    """Human-readable string for a type annotation."""
+    origin = getattr(annotation, "__origin__", None)
+    args = getattr(annotation, "__args__", ())
+    if origin is list:
+        inner = args[0].__name__ if args else "?"
+        return f"list[{inner}]"
+    # Optional[X] shows as Union[X, None] or X | None (types.UnionType on 3.10+)
+    if (origin is typing.Union or isinstance(annotation, types.UnionType)) and type(None) in args:
+        non_none = [a for a in args if a is not type(None)]
+        if len(non_none) == 1:
+            return _type_display(non_none[0])
+    if hasattr(annotation, "__name__"):
+        return annotation.__name__
+    return str(annotation)
+
+
+def list_uns_fields(path: str) -> dict:
+    """List all HCA uns fields with current values and schema metadata.
+
+    Args:
+        path: Path to an .h5ad file.
+
+    Returns:
+        Dict with 'fields' (list of field info), 'missing_required',
+        'extra_uns_keys', 'obs_columns', 'obsm_keys', or 'error'.
+    """
+    try:
+        registry = uns_field_registry()
+
+        with open_h5ad(path, backed="r") as adata:
+            fields = []
+            missing_required = []
+
+            for name, info in registry.items():
+                current = adata.uns.get(name, None)
+                is_set = name in adata.uns
+                serialized = make_serializable(current) if is_set else None
+
+                fields.append({
+                    "name": name,
+                    "title": info.title,
+                    "description": info.description,
+                    "type": _type_display(info.annotation),
+                    "required": info.required,
+                    "bionetwork_only": info.bionetwork_only,
+                    "current_value": serialized,
+                    "is_set": is_set,
+                    "examples": info.examples,
+                })
+
+                if info.required and not is_set:
+                    missing_required.append(name)
+
+            # Extra uns keys not in the HCA schema
+            schema_keys = set(registry.keys()) | {EDIT_LOG_KEY}
+            extra_uns_keys = sorted(k for k in adata.uns.keys() if k not in schema_keys)
+
+            return {
+                "filename": os.path.basename(path),
+                "fields": fields,
+                "set_count": sum(1 for f in fields if f["is_set"]),
+                "missing_required": missing_required,
+                "extra_uns_keys": extra_uns_keys,
+                "obs_columns": list(adata.obs.columns),
+                "obsm_keys": list(adata.obsm.keys()),
+            }
+
+    except Exception as e:
+        return {"error": str(e)}
+
+
+def set_uns(
+    path: str,
+    field: str,
+    value: str | list[str],
+    output_dir: str | None = None,
+) -> dict:
+    """Set a single HCA uns field with schema validation.
+
+    Validates the field name and value against the HCA schema, then writes
+    the updated file via write_h5ad() with edit log tracking.
+
+    Args:
+        path: Path to an .h5ad file.
+        field: The uns field name (e.g. 'title', 'study_pi').
+        value: The value to set.
+        output_dir: Directory for output file. Defaults to same as source.
+
+    Returns:
+        Dict with 'output_path', 'field', 'old_value', 'new_value' on success,
+        or 'error' on failure.
+    """
+    try:
+        registry = uns_field_registry()
+
+        # Validate field name
+        if field not in registry:
+            valid = sorted(registry.keys())
+            return {"error": f"'{field}' is not a recognized HCA uns field. Valid fields: {valid}"}
+
+        info = registry[field]
+
+        # Validate value type via Pydantic
+        try:
+            adapter = TypeAdapter(info.annotation)
+            validated_value = adapter.validate_python(value)
+        except ValidationError as e:
+            return {"error": f"Invalid value for '{field}': {e}"}
+
+        # Open file in memory for editing
+        with open_h5ad(path, backed=None) as adata:
+            # Cross-validation for specific fields
+            if field == "batch_condition" and validated_value is not None:
+                obs_cols = set(adata.obs.columns)
+                invalid = [v for v in validated_value if v not in obs_cols]
+                if invalid:
+                    return {
+                        "error": (
+                            f"batch_condition values {invalid} are not obs columns. "
+                            f"Valid columns: {sorted(obs_cols)}"
+                        )
+                    }
+
+            if field == "default_embedding" and validated_value is not None:
+                obsm_keys = set(adata.obsm.keys())
+                if validated_value not in obsm_keys:
+                    return {
+                        "error": (
+                            f"default_embedding '{validated_value}' is not an obsm key. "
+                            f"Valid keys: {sorted(obsm_keys)}"
+                        )
+                    }
+
+            # Record previous value
+            old_value = make_serializable(adata.uns.get(field, None))
+
+            # Set the value
+            adata.uns[field] = validated_value
+
+            # Build edit log entry
+            entry = {
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "tool": "hca-anndata-mcp",
+                "tool_version": __version__,
+                "operation": "set_uns",
+                "description": f"Set uns['{field}']",
+                "details": {
+                    "field": field,
+                    "old_value": old_value,
+                    "new_value": make_serializable(validated_value),
+                },
+            }
+
+            result = write_h5ad(adata, path, [entry], output_dir=output_dir)
+
+        if "error" in result:
+            return result
+
+        return {
+            **result,
+            "editing": os.path.basename(path),
+            "wrote": os.path.basename(result["output_path"]),
+            "field": field,
+            "old_value": old_value,
+            "new_value": make_serializable(validated_value),
+        }
+
+    except Exception as e:
+        return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
@@ -115,10 +115,6 @@ def set_uns(
         'new_value' on success, or 'error' on failure.
     """
     try:
-        # Validate path before loading (avoid reading multi-GB file just to fail)
-        if not os.path.isfile(path):
-            return {"error": f"File not found: {path}"}
-
         registry = uns_field_registry()
 
         # Validate field name

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
@@ -175,7 +175,7 @@ def set_uns(
             # Build edit log entry
             entry = {
                 "timestamp": datetime.now(timezone.utc).isoformat(),
-                "tool": "hca-anndata-mcp",
+                "tool": "hca-anndata-tools",
                 "tool_version": __version__,
                 "operation": "set_uns",
                 "description": f"Set uns['{field}']",

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
@@ -40,8 +40,9 @@ def list_uns_fields(path: str) -> dict:
         path: Path to an .h5ad file.
 
     Returns:
-        Dict with 'fields' (list of field info), 'missing_required',
-        'extra_uns_keys', 'obs_columns', 'obsm_keys', or 'error'.
+        Dict with 'filename', 'fields' (list of field info), 'set_count',
+        'missing_required', 'missing_required_bionetwork', 'extra_uns_keys',
+        'obs_columns', 'obsm_keys', or 'error'.
     """
     try:
         registry = uns_field_registry()
@@ -97,24 +98,27 @@ def set_uns(
     path: str,
     field: str,
     value: str | list[str],
-    output_dir: str | None = None,
 ) -> dict:
     """Set a single HCA uns field with schema validation.
 
     Validates the field name and value against the HCA schema, then writes
-    the updated file via write_h5ad() with edit log tracking.
+    the updated file via write_h5ad() with edit log tracking. Output is
+    written to the same directory as the input file.
 
     Args:
         path: Path to an .h5ad file.
         field: The uns field name (e.g. 'title', 'study_pi').
         value: The value to set.
-        output_dir: Directory for output file. Defaults to same as source.
 
     Returns:
-        Dict with 'output_path', 'field', 'old_value', 'new_value' on success,
-        or 'error' on failure.
+        Dict with 'output_path', 'editing', 'wrote', 'field', 'old_value',
+        'new_value' on success, or 'error' on failure.
     """
     try:
+        # Validate path before loading (avoid reading multi-GB file just to fail)
+        if not os.path.isfile(path):
+            return {"error": f"File not found: {path}"}
+
         registry = uns_field_registry()
 
         # Validate field name
@@ -186,7 +190,7 @@ def set_uns(
                 },
             }
 
-            result = write_h5ad(adata, path, [entry], output_dir=output_dir)
+            result = write_h5ad(adata, path, [entry])
 
         if "error" in result:
             return result

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/schema/__init__.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/schema/__init__.py
@@ -1,0 +1,1 @@
+"""HCA schema models bundled for field validation."""

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/schema/core.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/schema/core.py
@@ -1,0 +1,1583 @@
+# Bundled copy of shared/src/hca_validation/schema/generated/core.py
+# Generated from LinkML schemas via `cd shared && make gen-schema`.
+# To refresh: copy the generated file here after regeneration.
+from __future__ import annotations
+
+import re
+import sys
+from datetime import (
+    date,
+    datetime,
+    time
+)
+from decimal import Decimal 
+from enum import Enum 
+from typing import (
+    Any,
+    ClassVar,
+    Literal,
+    Optional,
+    Union
+)
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    RootModel,
+    field_validator
+)
+
+
+metamodel_version = "None"
+version = "0.1.0"
+
+
+class ConfiguredBaseModel(BaseModel):
+    model_config = ConfigDict(
+        validate_assignment = True,
+        validate_default = True,
+        extra = "forbid",
+        arbitrary_types_allowed = True,
+        use_enum_values = True,
+        strict = False,
+    )
+    pass
+
+
+
+
+class LinkMLMeta(RootModel):
+    root: dict[str, Any] = {}
+    model_config = ConfigDict(frozen=True)
+
+    def __getattr__(self, key:str):
+        return getattr(self.root, key)
+
+    def __getitem__(self, key:str):
+        return self.root[key]
+
+    def __setitem__(self, key:str, value):
+        self.root[key] = value
+
+    def __contains__(self, key:str) -> bool:
+        return key in self.root
+
+
+linkml_meta = LinkMLMeta({'default_prefix': 'hca',
+     'default_range': 'string',
+     'description': 'Core schema for validating Human Cell Atlas (HCA) data',
+     'id': 'https://github.com/clevercanary/hca-validation-tools/schema/core',
+     'imports': ['linkml:types',
+                 'dataset',
+                 'bionetwork/adipose',
+                 'bionetwork/gut',
+                 'bionetwork/musculoskeletal',
+                 'donor',
+                 'sample',
+                 'cell'],
+     'license': 'MIT',
+     'name': 'hca-validation-core',
+     'prefixes': {'hca': {'prefix_prefix': 'hca',
+                          'prefix_reference': 'https://github.com/clevercanary/hca-validation-tools/schema/'},
+                  'linkml': {'prefix_prefix': 'linkml',
+                             'prefix_reference': 'https://w3id.org/linkml/'}},
+     'source_file': 'src/hca_validation/schema/core.yaml',
+     'title': 'HCA Validation Core Schema'} )
+
+class ReferenceGenomeEnum(str, Enum):
+    GRCh37 = "GRCh37"
+    """
+    Human reference genome version 37
+    """
+    GRCh38 = "GRCh38"
+    """
+    Human reference genome version 38
+    """
+    GRCm37 = "GRCm37"
+    """
+    Mouse reference genome version 37
+    """
+    GRCm38 = "GRCm38"
+    """
+    Mouse reference genome version 38
+    """
+    GRCm39 = "GRCm39"
+    """
+    Mouse reference genome version 39
+    """
+    not_applicable = "not applicable"
+    """
+    No reference genome was used
+    """
+
+
+class SequencedFragmentEnum(str, Enum):
+    number_3_prime_tag = "3 prime tag"
+    """
+    3' end of the transcript
+    """
+    number_5_prime_tag = "5 prime tag"
+    """
+    5' end of the transcript
+    """
+    full_length = "full length"
+    """
+    Entire transcript
+    """
+    not_applicable = "not applicable"
+    """
+    Not applicable to this dataset
+    """
+    probe_based = "probe-based"
+    """
+    Probe-based sequencing
+    """
+
+
+class YesNoEnum(str, Enum):
+    no = "no"
+    """
+    Negative / false
+    """
+    yes = "yes"
+    """
+    Affirmative / true
+    """
+
+
+class RadialTissueTerm(str, Enum):
+    EPI = "EPI"
+    LP = "LP"
+    MUSC = "MUSC"
+    EPI_LP = "EPI_LP"
+    LP_MUSC = "LP_MUSC"
+    EPI_LP_MUSC = "EPI_LP_MUSC"
+    MLN = "MLN"
+    SUB = "SUB"
+    Peyers_patch = "Peyers patch"
+    Mucosal_ILF = "Mucosal ILF"
+    Submucosal_ILF = "Submucosal ILF"
+    WM = "WM"
+
+
+class SampleCollectionMethod(str, Enum):
+    brush = "brush"
+    scraping = "scraping"
+    biopsy = "biopsy"
+    surgical_resection = "surgical resection"
+    blood_draw = "blood draw"
+    body_fluid = "body fluid"
+    other = "other"
+
+
+class TissueType(str, Enum):
+    tissue = "tissue"
+    organoid = "organoid"
+    cell_culture = "cell culture"
+
+
+class SuspensionType(str, Enum):
+    cell = "cell"
+    nucleus = "nucleus"
+    na = "na"
+
+
+class SampledSiteCondition(str, Enum):
+    healthy = "healthy"
+    diseased = "diseased"
+    adjacent = "adjacent"
+
+
+class SamplePreservationMethod(str, Enum):
+    ambient_temperature = "ambient temperature"
+    cut_slide = "cut slide"
+    fresh = "fresh"
+    frozen_at__70C = "frozen at -70C"
+    frozen_at__80C = "frozen at -80C"
+    frozen_at__150C = "frozen at -150C"
+    frozen_in_liquid_nitrogen = "frozen in liquid nitrogen"
+    frozen_in_vapor_phase = "frozen in vapor phase"
+    paraffin_block = "paraffin block"
+    RNAlater_at_4C = "RNAlater at 4C"
+    RNAlater_at_25C = "RNAlater at 25C"
+    RNAlater_at__20C = "RNAlater at -20C"
+    other = "other"
+
+
+class SampleSource(str, Enum):
+    surgical_donor = "surgical donor"
+    postmortem_donor = "postmortem donor"
+    living_organ_donor = "living organ donor"
+
+
+class MannerOfDeath(str, Enum):
+    number_1 = "1"
+    number_2 = "2"
+    number_3 = "3"
+    number_4 = "4"
+    number_0 = "0"
+    unknown = "unknown"
+    not_applicable = "not applicable"
+
+
+class DevelopmentStage(str, Enum):
+    HsapDvCOLON0000003 = "HsapDv:0000003"
+    HsapDvCOLON0000046 = "HsapDv:0000046"
+    HsapDvCOLON0000264 = "HsapDv:0000264"
+    HsapDvCOLON0000268 = "HsapDv:0000268"
+    HsapDvCOLON0000237 = "HsapDv:0000237"
+    HsapDvCOLON0000238 = "HsapDv:0000238"
+    HsapDvCOLON0000239 = "HsapDv:0000239"
+    HsapDvCOLON0000240 = "HsapDv:0000240"
+    HsapDvCOLON0000241 = "HsapDv:0000241"
+    HsapDvCOLON0000242 = "HsapDv:0000242"
+    HsapDvCOLON0000243 = "HsapDv:0000243"
+    HsapDvCOLON0000244 = "HsapDv:0000244"
+    HsapDvCOLON0000245 = "HsapDv:0000245"
+    MmusDvCOLON0000001 = "MmusDv:0000001"
+    MmusDvCOLON0000002 = "MmusDv:0000002"
+    unknown = "unknown"
+
+
+class Organism(str, Enum):
+    NCBITaxonCOLON9606 = "NCBITaxon:9606"
+    NCBITaxonCOLON10090 = "NCBITaxon:10090"
+
+
+
+class Dataset(ConfiguredBaseModel):
+    """
+    A collection of data from a single experiment or study in the Human Cell Atlas
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/dataset',
+         'slot_usage': {'dataset_id': {'identifier': True,
+                                       'name': 'dataset_id',
+                                       'range': 'string'}}})
+
+    alignment_software: str = Field(default=..., title="Alignment Software", description="""Protocol used for alignment analysis, please specify which version was used e.g. cell ranger 2.0, 2.1.1 etc.""", json_schema_extra = { "linkml_meta": {'alias': 'alignment_software',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'comments': ['Affects which cells are filtered per dataset, and which reads '
+                      '(introns and exons or only exons) are counted as part of the '
+                      'reported transcriptome. This can convey batch effects.'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'cellranger_8.0.0'}]} })
+    assay_ontology_term_id: str = Field(default=..., title="Assay Ontology Term Id", description="""Platform used for single cell library construction.""", json_schema_extra = { "linkml_meta": {'alias': 'assay_ontology_term_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'assay_ontology_term_id'}},
+         'comments': ['Major source of batch effect and dataset filtering criterion'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'EFO:0009922'}],
+         'notes': ['This must be an EFO term and either:\n'
+                   '- "EFO:0002772" for assay by molecule or preferably its most '
+                   'accurate child\n'
+                   '- "EFO:0010183" for single cell library construction or preferably '
+                   'its most accurate child\n'
+                   '- An assay based on 10X Genomics products should either be '
+                   '"EFO:0008995" for 10x technology or preferably its most accurate '
+                   'child.\n'
+                   "- An assay based on SMART (Switching Mechanism at the 5' end of "
+                   'the RNA Template) or SMARTer technology SHOULD either be '
+                   '"EFO:0010184" for Smart-like or preferably its most accurate '
+                   'child.\n'
+                   'Recommended:\n'
+                   '- 10x 3\' v2 "EFO:0009899"\n'
+                   '- 10x 3\' v3 "EFO:0009922"\n'
+                   '- 10x 5\' v1 "EFO:0011025"\n'
+                   '- 10x 5\' v2 "EFO:0009900"\n'
+                   '- Smart-seq2 "EFO:0008931"\n'
+                   '- Visium Spatial Gene Expression "EFO:0010961"\n']} })
+    assay_ontology_term: Optional[str] = Field(default=None, title="Assay Ontology Term", description="""Deprecated placeholder for assay ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'assay_ontology_term',
+         'domain_of': ['Dataset'],
+         'is_a': 'deprecated_slot'} })
+    batch_condition: Optional[list[str]] = Field(default=None, title="Batch Condition", description="""Name of the covariate that confers the dominant batch effect in the data as judged by the data contributor.  The name provided here should be the label by which this covariate is stored in the AnnData object.""", json_schema_extra = { "linkml_meta": {'alias': 'batch_condition',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'},
+                         'cxg': {'tag': 'cxg', 'value': 'batch_condition'}},
+         'domain_of': ['Dataset'],
+         'examples': [{'description': 'Multiple batch conditions as a JSON array',
+                       'value': '["patient", "seqBatch"]'}],
+         'notes': ['Values must refer to cell metadata keys in obs. Together, these '
+                   'keys define the batches that a normalisation or integration '
+                   'algorithm should be aware of. For example if "patient" and '
+                   '"seqBatch" are keys of vectors of cell metadata, either '
+                   '["patient"], ["seqBatch"], or ["patient", "seqBatch"] are valid '
+                   'values.']} })
+    comments: Optional[str] = Field(default=None, title="Comments", description="""Other technical or experimental covariates that could affect the quality or batch of the sample.  Must not contain identifiers. This field is designed to capture potential challenges for data integration not captured elsewhere.
+""", json_schema_extra = { "linkml_meta": {'alias': 'comments',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'domain_of': ['Dataset']} })
+    consortia: Optional[str] = Field(default=None, title="Consortia", description="""Deprecated placeholder for consortia information.""", json_schema_extra = { "linkml_meta": {'alias': 'consortia', 'domain_of': ['Dataset'], 'is_a': 'deprecated_slot'} })
+    contact_email: str = Field(default=..., title="Contact Email", description="""Contact name and email of the submitting person""", json_schema_extra = { "linkml_meta": {'alias': 'contact_email', 'domain_of': ['Dataset']} })
+    default_embedding: Optional[str] = Field(default=None, title="Default Embedding", description="""The value must match a key to an embedding in obsm for the embedding to display by default in CELLxGENE Explorer.""", json_schema_extra = { "linkml_meta": {'alias': 'default_embedding',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'},
+                         'cxg': {'tag': 'cxg', 'value': 'default_embedding'}},
+         'domain_of': ['Dataset']} })
+    description: str = Field(default=..., title="Description", description="""Short description of the dataset""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'domain_of': ['Dataset']} })
+    gene_annotation_version: str = Field(default=..., title="Gene Annotation Version", description="""Ensembl release version accession number. Some common codes include: GRCh38.p12 = GCF_000001405.38 GRCh38.p13 = GCF_000001405.39 GRCh38.p14 = GCF_000001405.40
+""", json_schema_extra = { "linkml_meta": {'alias': 'gene_annotation_version',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'comments': ['Possible source of batch effect and confounder for some '
+                      'biological analysis'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'GCF_000001405.40'}],
+         'notes': ['http://www.ensembl.org/info/website/archives/index.html or '
+                   'NCBI/RefSeq']} })
+    intron_inclusion: Optional[YesNoEnum] = Field(default=None, title="Intron Inclusion", description="""Were introns included during read counting in the alignment process?""", json_schema_extra = { "linkml_meta": {'alias': 'intron_inclusion',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'yes'}, {'value': 'no'}]} })
+    protocol_url: Optional[str] = Field(default=None, title="Protocol URL", description="""The protocols.io URL (if none exists, please use the BioRxiv URL) for the full experimental protocol;  or if multiple protocols exist please list them e.g. sample preparation protocol / sequencing protocol.
+""", json_schema_extra = { "linkml_meta": {'alias': 'protocol_url',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'comments': ['Useful to look up protocol data that can provide insight on '
+                      'batch effects. As protocols can sometimes apply to a subset of '
+                      'the study, we capture this at a sample level. This information '
+                      'may not always be available.'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'https://www.biorxiv.org/content/early/2017/09/24/193219'}]} })
+    publication_doi: Optional[str] = Field(default=None, title="Publication DOI", description="""The publication digital object identifier (doi) for the protocol. If no pre-print nor publication exists, please write 'not applicable'.
+""", json_schema_extra = { "linkml_meta": {'alias': 'publication_doi',
+         'domain_of': ['Dataset'],
+         'examples': [{'value': '10.1016/j.cell.2016.07.054'}]} })
+    reference_genome: ReferenceGenomeEnum = Field(default=..., title="Reference Genome", description="""Reference genome used for alignment.""", json_schema_extra = { "linkml_meta": {'alias': 'reference_genome',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'comments': ['Possible source of batch effect and confounder for some '
+                      'biological analysis'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'GRCm37'}, {'value': 'GRCh37'}]} })
+    sequenced_fragment: SequencedFragmentEnum = Field(default=..., title="Sequenced Fragment", description="""Which part of the RNA transcript was targeted for sequencing.""", json_schema_extra = { "linkml_meta": {'alias': 'sequenced_fragment',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'comments': ['May be a source of batch effect that has to be tested.'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': '3 prime tag'}, {'value': 'full length'}]} })
+    sequencing_platform: Optional[str] = Field(default=None, title="Sequencing Platform", description="""Platform used for sequencing.""", json_schema_extra = { "linkml_meta": {'alias': 'sequencing_platform',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'comments': ['This captures potential strand hopping which may cause data '
+                      'quality issues.'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'EFO:0008563'}],
+         'notes': ['Values should be "subClassOf" ["EFO:0002699"] - '
+                   'https://www.ebi.ac.uk/ols/ontologies/efo/terms?iri=http%3A%2F%2Fwww.ebi.ac.uk%2Fefo%2FEFO_0002699']} })
+    study_pi: list[str] = Field(default=..., title="Study Pi", description="""Principal Investigator(s) leading the study where the data is/was used.""", json_schema_extra = { "linkml_meta": {'alias': 'study_pi',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'domain_of': ['Dataset'],
+         'examples': [{'description': 'Principal Investigator in Last '
+                                      'Name,MiddleInitial, FirstName format',
+                       'value': '["Teichmann,Sarah,A."]'}]} })
+    title: Optional[str] = Field(default=None, title="Title", description="""This text describes and differentiates the dataset from other datasets in the same collection.  It is strongly recommended that each dataset title in a collection is unique and does not depend on other metadata  such as a different assay to disambiguate it from other datasets in the collection.
+""", json_schema_extra = { "linkml_meta": {'alias': 'title',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'},
+                         'cxg': {'tag': 'cxg', 'value': 'title'}},
+         'comments': ['Useful to look up protocol data that can provide insight on '
+                      'batch effects. As protocols can sometimes apply to a subset of '
+                      'the study, we capture this at a sample level. This information '
+                      'may not always be available.'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': "Cells of the adult human heart collection is 'All — "
+                                "Cells of the adult human heart'"}],
+         'is_a': 'deprecated_slot'} })
+    dataset_id: str = Field(default=..., title="Dataset ID", description="""A unique identifier for each dataset in the study. This should be unique to the study.""", json_schema_extra = { "linkml_meta": {'alias': 'dataset_id', 'domain_of': ['Dataset', 'Donor', 'Sample']} })
+
+
+class AdiposeDataset(Dataset):
+    """
+    Dataset with Adipose BioNetwork–specific metadata requirements.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/bionetwork/adipose'})
+
+    ambient_count_correction: str = Field(default=..., title="Ambient Count Correction", description="""Method used to correct ambient RNA contamination in single-cell data.""", json_schema_extra = { "linkml_meta": {'alias': 'ambient_count_correction',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'domain_of': ['AdiposeDataset', 'GutDataset', 'MusculoskeletalDataset'],
+         'examples': [{'value': 'none'}, {'value': 'soupx'}, {'value': 'cellbender'}]} })
+    doublet_detection: str = Field(default=..., title="Doublet Detection", description="""Was doublet detection software used during CELLxGENE processing? If so, which software?""", json_schema_extra = { "linkml_meta": {'alias': 'doublet_detection',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'domain_of': ['AdiposeDataset', 'GutDataset', 'MusculoskeletalDataset'],
+         'examples': [{'value': 'none'},
+                      {'value': 'doublet_finder'},
+                      {'value': 'manual'}]} })
+    alignment_software: str = Field(default=..., title="Alignment Software", description="""Protocol used for alignment analysis, please specify which version was used e.g. cell ranger 2.0, 2.1.1 etc.""", json_schema_extra = { "linkml_meta": {'alias': 'alignment_software',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'comments': ['Affects which cells are filtered per dataset, and which reads '
+                      '(introns and exons or only exons) are counted as part of the '
+                      'reported transcriptome. This can convey batch effects.'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'cellranger_8.0.0'}]} })
+    assay_ontology_term_id: str = Field(default=..., title="Assay Ontology Term Id", description="""Platform used for single cell library construction.""", json_schema_extra = { "linkml_meta": {'alias': 'assay_ontology_term_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'assay_ontology_term_id'}},
+         'comments': ['Major source of batch effect and dataset filtering criterion'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'EFO:0009922'}],
+         'notes': ['This must be an EFO term and either:\n'
+                   '- "EFO:0002772" for assay by molecule or preferably its most '
+                   'accurate child\n'
+                   '- "EFO:0010183" for single cell library construction or preferably '
+                   'its most accurate child\n'
+                   '- An assay based on 10X Genomics products should either be '
+                   '"EFO:0008995" for 10x technology or preferably its most accurate '
+                   'child.\n'
+                   "- An assay based on SMART (Switching Mechanism at the 5' end of "
+                   'the RNA Template) or SMARTer technology SHOULD either be '
+                   '"EFO:0010184" for Smart-like or preferably its most accurate '
+                   'child.\n'
+                   'Recommended:\n'
+                   '- 10x 3\' v2 "EFO:0009899"\n'
+                   '- 10x 3\' v3 "EFO:0009922"\n'
+                   '- 10x 5\' v1 "EFO:0011025"\n'
+                   '- 10x 5\' v2 "EFO:0009900"\n'
+                   '- Smart-seq2 "EFO:0008931"\n'
+                   '- Visium Spatial Gene Expression "EFO:0010961"\n']} })
+    assay_ontology_term: Optional[str] = Field(default=None, title="Assay Ontology Term", description="""Deprecated placeholder for assay ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'assay_ontology_term',
+         'domain_of': ['Dataset'],
+         'is_a': 'deprecated_slot'} })
+    batch_condition: Optional[list[str]] = Field(default=None, title="Batch Condition", description="""Name of the covariate that confers the dominant batch effect in the data as judged by the data contributor.  The name provided here should be the label by which this covariate is stored in the AnnData object.""", json_schema_extra = { "linkml_meta": {'alias': 'batch_condition',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'},
+                         'cxg': {'tag': 'cxg', 'value': 'batch_condition'}},
+         'domain_of': ['Dataset'],
+         'examples': [{'description': 'Multiple batch conditions as a JSON array',
+                       'value': '["patient", "seqBatch"]'}],
+         'notes': ['Values must refer to cell metadata keys in obs. Together, these '
+                   'keys define the batches that a normalisation or integration '
+                   'algorithm should be aware of. For example if "patient" and '
+                   '"seqBatch" are keys of vectors of cell metadata, either '
+                   '["patient"], ["seqBatch"], or ["patient", "seqBatch"] are valid '
+                   'values.']} })
+    comments: Optional[str] = Field(default=None, title="Comments", description="""Other technical or experimental covariates that could affect the quality or batch of the sample.  Must not contain identifiers. This field is designed to capture potential challenges for data integration not captured elsewhere.
+""", json_schema_extra = { "linkml_meta": {'alias': 'comments',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'domain_of': ['Dataset']} })
+    consortia: Optional[str] = Field(default=None, title="Consortia", description="""Deprecated placeholder for consortia information.""", json_schema_extra = { "linkml_meta": {'alias': 'consortia', 'domain_of': ['Dataset'], 'is_a': 'deprecated_slot'} })
+    contact_email: str = Field(default=..., title="Contact Email", description="""Contact name and email of the submitting person""", json_schema_extra = { "linkml_meta": {'alias': 'contact_email', 'domain_of': ['Dataset']} })
+    default_embedding: Optional[str] = Field(default=None, title="Default Embedding", description="""The value must match a key to an embedding in obsm for the embedding to display by default in CELLxGENE Explorer.""", json_schema_extra = { "linkml_meta": {'alias': 'default_embedding',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'},
+                         'cxg': {'tag': 'cxg', 'value': 'default_embedding'}},
+         'domain_of': ['Dataset']} })
+    description: str = Field(default=..., title="Description", description="""Short description of the dataset""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'domain_of': ['Dataset']} })
+    gene_annotation_version: str = Field(default=..., title="Gene Annotation Version", description="""Ensembl release version accession number. Some common codes include: GRCh38.p12 = GCF_000001405.38 GRCh38.p13 = GCF_000001405.39 GRCh38.p14 = GCF_000001405.40
+""", json_schema_extra = { "linkml_meta": {'alias': 'gene_annotation_version',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'comments': ['Possible source of batch effect and confounder for some '
+                      'biological analysis'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'GCF_000001405.40'}],
+         'notes': ['http://www.ensembl.org/info/website/archives/index.html or '
+                   'NCBI/RefSeq']} })
+    intron_inclusion: Optional[YesNoEnum] = Field(default=None, title="Intron Inclusion", description="""Were introns included during read counting in the alignment process?""", json_schema_extra = { "linkml_meta": {'alias': 'intron_inclusion',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'yes'}, {'value': 'no'}]} })
+    protocol_url: Optional[str] = Field(default=None, title="Protocol URL", description="""The protocols.io URL (if none exists, please use the BioRxiv URL) for the full experimental protocol;  or if multiple protocols exist please list them e.g. sample preparation protocol / sequencing protocol.
+""", json_schema_extra = { "linkml_meta": {'alias': 'protocol_url',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'comments': ['Useful to look up protocol data that can provide insight on '
+                      'batch effects. As protocols can sometimes apply to a subset of '
+                      'the study, we capture this at a sample level. This information '
+                      'may not always be available.'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'https://www.biorxiv.org/content/early/2017/09/24/193219'}]} })
+    publication_doi: Optional[str] = Field(default=None, title="Publication DOI", description="""The publication digital object identifier (doi) for the protocol. If no pre-print nor publication exists, please write 'not applicable'.
+""", json_schema_extra = { "linkml_meta": {'alias': 'publication_doi',
+         'domain_of': ['Dataset'],
+         'examples': [{'value': '10.1016/j.cell.2016.07.054'}]} })
+    reference_genome: ReferenceGenomeEnum = Field(default=..., title="Reference Genome", description="""Reference genome used for alignment.""", json_schema_extra = { "linkml_meta": {'alias': 'reference_genome',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'comments': ['Possible source of batch effect and confounder for some '
+                      'biological analysis'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'GRCm37'}, {'value': 'GRCh37'}]} })
+    sequenced_fragment: SequencedFragmentEnum = Field(default=..., title="Sequenced Fragment", description="""Which part of the RNA transcript was targeted for sequencing.""", json_schema_extra = { "linkml_meta": {'alias': 'sequenced_fragment',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'comments': ['May be a source of batch effect that has to be tested.'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': '3 prime tag'}, {'value': 'full length'}]} })
+    sequencing_platform: Optional[str] = Field(default=None, title="Sequencing Platform", description="""Platform used for sequencing.""", json_schema_extra = { "linkml_meta": {'alias': 'sequencing_platform',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'comments': ['This captures potential strand hopping which may cause data '
+                      'quality issues.'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'EFO:0008563'}],
+         'notes': ['Values should be "subClassOf" ["EFO:0002699"] - '
+                   'https://www.ebi.ac.uk/ols/ontologies/efo/terms?iri=http%3A%2F%2Fwww.ebi.ac.uk%2Fefo%2FEFO_0002699']} })
+    study_pi: list[str] = Field(default=..., title="Study Pi", description="""Principal Investigator(s) leading the study where the data is/was used.""", json_schema_extra = { "linkml_meta": {'alias': 'study_pi',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'domain_of': ['Dataset'],
+         'examples': [{'description': 'Principal Investigator in Last '
+                                      'Name,MiddleInitial, FirstName format',
+                       'value': '["Teichmann,Sarah,A."]'}]} })
+    title: Optional[str] = Field(default=None, title="Title", description="""This text describes and differentiates the dataset from other datasets in the same collection.  It is strongly recommended that each dataset title in a collection is unique and does not depend on other metadata  such as a different assay to disambiguate it from other datasets in the collection.
+""", json_schema_extra = { "linkml_meta": {'alias': 'title',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'},
+                         'cxg': {'tag': 'cxg', 'value': 'title'}},
+         'comments': ['Useful to look up protocol data that can provide insight on '
+                      'batch effects. As protocols can sometimes apply to a subset of '
+                      'the study, we capture this at a sample level. This information '
+                      'may not always be available.'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': "Cells of the adult human heart collection is 'All — "
+                                "Cells of the adult human heart'"}],
+         'is_a': 'deprecated_slot'} })
+    dataset_id: str = Field(default=..., title="Dataset ID", description="""A unique identifier for each dataset in the study. This should be unique to the study.""", json_schema_extra = { "linkml_meta": {'alias': 'dataset_id', 'domain_of': ['Dataset', 'Donor', 'Sample']} })
+
+
+class GutDataset(Dataset):
+    """
+    Dataset with Gut BioNetwork–specific metadata requirements.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/bionetwork/gut'})
+
+    ambient_count_correction: str = Field(default=..., title="Ambient Count Correction", description="""Method used to correct ambient RNA contamination in single-cell data.""", json_schema_extra = { "linkml_meta": {'alias': 'ambient_count_correction',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'domain_of': ['AdiposeDataset', 'GutDataset', 'MusculoskeletalDataset'],
+         'examples': [{'value': 'none'}, {'value': 'soupx'}, {'value': 'cellbender'}]} })
+    doublet_detection: str = Field(default=..., title="Doublet Detection", description="""Was doublet detection software used during CELLxGENE processing? If so, which software?""", json_schema_extra = { "linkml_meta": {'alias': 'doublet_detection',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'domain_of': ['AdiposeDataset', 'GutDataset', 'MusculoskeletalDataset'],
+         'examples': [{'value': 'none'},
+                      {'value': 'doublet_finder'},
+                      {'value': 'manual'}]} })
+    alignment_software: str = Field(default=..., title="Alignment Software", description="""Protocol used for alignment analysis, please specify which version was used e.g. cell ranger 2.0, 2.1.1 etc.""", json_schema_extra = { "linkml_meta": {'alias': 'alignment_software',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'comments': ['Affects which cells are filtered per dataset, and which reads '
+                      '(introns and exons or only exons) are counted as part of the '
+                      'reported transcriptome. This can convey batch effects.'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'cellranger_8.0.0'}]} })
+    assay_ontology_term_id: str = Field(default=..., title="Assay Ontology Term Id", description="""Platform used for single cell library construction.""", json_schema_extra = { "linkml_meta": {'alias': 'assay_ontology_term_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'assay_ontology_term_id'}},
+         'comments': ['Major source of batch effect and dataset filtering criterion'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'EFO:0009922'}],
+         'notes': ['This must be an EFO term and either:\n'
+                   '- "EFO:0002772" for assay by molecule or preferably its most '
+                   'accurate child\n'
+                   '- "EFO:0010183" for single cell library construction or preferably '
+                   'its most accurate child\n'
+                   '- An assay based on 10X Genomics products should either be '
+                   '"EFO:0008995" for 10x technology or preferably its most accurate '
+                   'child.\n'
+                   "- An assay based on SMART (Switching Mechanism at the 5' end of "
+                   'the RNA Template) or SMARTer technology SHOULD either be '
+                   '"EFO:0010184" for Smart-like or preferably its most accurate '
+                   'child.\n'
+                   'Recommended:\n'
+                   '- 10x 3\' v2 "EFO:0009899"\n'
+                   '- 10x 3\' v3 "EFO:0009922"\n'
+                   '- 10x 5\' v1 "EFO:0011025"\n'
+                   '- 10x 5\' v2 "EFO:0009900"\n'
+                   '- Smart-seq2 "EFO:0008931"\n'
+                   '- Visium Spatial Gene Expression "EFO:0010961"\n']} })
+    assay_ontology_term: Optional[str] = Field(default=None, title="Assay Ontology Term", description="""Deprecated placeholder for assay ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'assay_ontology_term',
+         'domain_of': ['Dataset'],
+         'is_a': 'deprecated_slot'} })
+    batch_condition: Optional[list[str]] = Field(default=None, title="Batch Condition", description="""Name of the covariate that confers the dominant batch effect in the data as judged by the data contributor.  The name provided here should be the label by which this covariate is stored in the AnnData object.""", json_schema_extra = { "linkml_meta": {'alias': 'batch_condition',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'},
+                         'cxg': {'tag': 'cxg', 'value': 'batch_condition'}},
+         'domain_of': ['Dataset'],
+         'examples': [{'description': 'Multiple batch conditions as a JSON array',
+                       'value': '["patient", "seqBatch"]'}],
+         'notes': ['Values must refer to cell metadata keys in obs. Together, these '
+                   'keys define the batches that a normalisation or integration '
+                   'algorithm should be aware of. For example if "patient" and '
+                   '"seqBatch" are keys of vectors of cell metadata, either '
+                   '["patient"], ["seqBatch"], or ["patient", "seqBatch"] are valid '
+                   'values.']} })
+    comments: Optional[str] = Field(default=None, title="Comments", description="""Other technical or experimental covariates that could affect the quality or batch of the sample.  Must not contain identifiers. This field is designed to capture potential challenges for data integration not captured elsewhere.
+""", json_schema_extra = { "linkml_meta": {'alias': 'comments',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'domain_of': ['Dataset']} })
+    consortia: Optional[str] = Field(default=None, title="Consortia", description="""Deprecated placeholder for consortia information.""", json_schema_extra = { "linkml_meta": {'alias': 'consortia', 'domain_of': ['Dataset'], 'is_a': 'deprecated_slot'} })
+    contact_email: str = Field(default=..., title="Contact Email", description="""Contact name and email of the submitting person""", json_schema_extra = { "linkml_meta": {'alias': 'contact_email', 'domain_of': ['Dataset']} })
+    default_embedding: Optional[str] = Field(default=None, title="Default Embedding", description="""The value must match a key to an embedding in obsm for the embedding to display by default in CELLxGENE Explorer.""", json_schema_extra = { "linkml_meta": {'alias': 'default_embedding',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'},
+                         'cxg': {'tag': 'cxg', 'value': 'default_embedding'}},
+         'domain_of': ['Dataset']} })
+    description: str = Field(default=..., title="Description", description="""Short description of the dataset""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'domain_of': ['Dataset']} })
+    gene_annotation_version: str = Field(default=..., title="Gene Annotation Version", description="""Ensembl release version accession number. Some common codes include: GRCh38.p12 = GCF_000001405.38 GRCh38.p13 = GCF_000001405.39 GRCh38.p14 = GCF_000001405.40
+""", json_schema_extra = { "linkml_meta": {'alias': 'gene_annotation_version',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'comments': ['Possible source of batch effect and confounder for some '
+                      'biological analysis'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'GCF_000001405.40'}],
+         'notes': ['http://www.ensembl.org/info/website/archives/index.html or '
+                   'NCBI/RefSeq']} })
+    intron_inclusion: Optional[YesNoEnum] = Field(default=None, title="Intron Inclusion", description="""Were introns included during read counting in the alignment process?""", json_schema_extra = { "linkml_meta": {'alias': 'intron_inclusion',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'yes'}, {'value': 'no'}]} })
+    protocol_url: Optional[str] = Field(default=None, title="Protocol URL", description="""The protocols.io URL (if none exists, please use the BioRxiv URL) for the full experimental protocol;  or if multiple protocols exist please list them e.g. sample preparation protocol / sequencing protocol.
+""", json_schema_extra = { "linkml_meta": {'alias': 'protocol_url',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'comments': ['Useful to look up protocol data that can provide insight on '
+                      'batch effects. As protocols can sometimes apply to a subset of '
+                      'the study, we capture this at a sample level. This information '
+                      'may not always be available.'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'https://www.biorxiv.org/content/early/2017/09/24/193219'}]} })
+    publication_doi: Optional[str] = Field(default=None, title="Publication DOI", description="""The publication digital object identifier (doi) for the protocol. If no pre-print nor publication exists, please write 'not applicable'.
+""", json_schema_extra = { "linkml_meta": {'alias': 'publication_doi',
+         'domain_of': ['Dataset'],
+         'examples': [{'value': '10.1016/j.cell.2016.07.054'}]} })
+    reference_genome: ReferenceGenomeEnum = Field(default=..., title="Reference Genome", description="""Reference genome used for alignment.""", json_schema_extra = { "linkml_meta": {'alias': 'reference_genome',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'comments': ['Possible source of batch effect and confounder for some '
+                      'biological analysis'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'GRCm37'}, {'value': 'GRCh37'}]} })
+    sequenced_fragment: SequencedFragmentEnum = Field(default=..., title="Sequenced Fragment", description="""Which part of the RNA transcript was targeted for sequencing.""", json_schema_extra = { "linkml_meta": {'alias': 'sequenced_fragment',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'comments': ['May be a source of batch effect that has to be tested.'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': '3 prime tag'}, {'value': 'full length'}]} })
+    sequencing_platform: Optional[str] = Field(default=None, title="Sequencing Platform", description="""Platform used for sequencing.""", json_schema_extra = { "linkml_meta": {'alias': 'sequencing_platform',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'comments': ['This captures potential strand hopping which may cause data '
+                      'quality issues.'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'EFO:0008563'}],
+         'notes': ['Values should be "subClassOf" ["EFO:0002699"] - '
+                   'https://www.ebi.ac.uk/ols/ontologies/efo/terms?iri=http%3A%2F%2Fwww.ebi.ac.uk%2Fefo%2FEFO_0002699']} })
+    study_pi: list[str] = Field(default=..., title="Study Pi", description="""Principal Investigator(s) leading the study where the data is/was used.""", json_schema_extra = { "linkml_meta": {'alias': 'study_pi',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'domain_of': ['Dataset'],
+         'examples': [{'description': 'Principal Investigator in Last '
+                                      'Name,MiddleInitial, FirstName format',
+                       'value': '["Teichmann,Sarah,A."]'}]} })
+    title: Optional[str] = Field(default=None, title="Title", description="""This text describes and differentiates the dataset from other datasets in the same collection.  It is strongly recommended that each dataset title in a collection is unique and does not depend on other metadata  such as a different assay to disambiguate it from other datasets in the collection.
+""", json_schema_extra = { "linkml_meta": {'alias': 'title',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'},
+                         'cxg': {'tag': 'cxg', 'value': 'title'}},
+         'comments': ['Useful to look up protocol data that can provide insight on '
+                      'batch effects. As protocols can sometimes apply to a subset of '
+                      'the study, we capture this at a sample level. This information '
+                      'may not always be available.'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': "Cells of the adult human heart collection is 'All — "
+                                "Cells of the adult human heart'"}],
+         'is_a': 'deprecated_slot'} })
+    dataset_id: str = Field(default=..., title="Dataset ID", description="""A unique identifier for each dataset in the study. This should be unique to the study.""", json_schema_extra = { "linkml_meta": {'alias': 'dataset_id', 'domain_of': ['Dataset', 'Donor', 'Sample']} })
+
+
+class Donor(ConfiguredBaseModel):
+    """
+    An individual organism from which biological samples have been derived
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/donor',
+         'slot_usage': {'donor_id': {'annotations': {'annDataLocation': {'tag': 'annDataLocation',
+                                                                         'value': 'obs'},
+                                                     'cxg': {'tag': 'cxg',
+                                                             'value': 'donor_id'},
+                                                     'tier': {'tag': 'tier',
+                                                              'value': 'Tier 1'}},
+                                     'identifier': True,
+                                     'name': 'donor_id',
+                                     'range': 'string'}}})
+
+    donor_id: str = Field(default=..., title="Donor ID", description="""This must be free-text that identifies a unique individual that data were derived from.""", json_schema_extra = { "linkml_meta": {'alias': 'donor_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'donor_id'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Fundamental unit of biological variation of the data. It is '
+                      'strongly recommended that this identifier be designed so that '
+                      'it is unique to: a given individual within the collection of '
+                      'datasets that includes this dataset, and a given individual '
+                      'across all collections in CELLxGENE Discover. It is strongly '
+                      'recommended that "pooled" be used for observations from a '
+                      'sample of multiple individuals that were not confidently '
+                      'assigned to a single individual through demultiplexing. It is '
+                      'strongly recommended that "unknown" ONLY be used for '
+                      'observations in a dataset when it is not known which '
+                      'observations are from the same individual.'],
+         'domain_of': ['Donor', 'Sample'],
+         'examples': [{'value': 'CR_donor_1; MM_donor_1; LR_donor_2'}]} })
+    organism_ontology_term_id: Organism = Field(default=..., title="Organism Ontology Term ID", description="""The name given to the type of organism, collected in NCBITaxon:0000 format.""", json_schema_extra = { "linkml_meta": {'alias': 'organism_ontology_term_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'organism_ontology_term_id'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Donor'],
+         'notes': ['"NCBITaxon:9606" for Homo sapiens or "NCBITaxon:10090" for Mus '
+                   'musculus.']} })
+    sex_ontology_term_id: str = Field(default=..., title="Sex Ontology Term ID", description="""Reported sex of the donor.""", json_schema_extra = { "linkml_meta": {'alias': 'sex_ontology_term_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'sex_ontology_term_id'}},
+         'domain_of': ['Donor'],
+         'examples': [{'description': 'female', 'value': 'PATO:0000383'},
+                      {'description': 'male', 'value': 'PATO:0000384'}],
+         'notes': ['This must be a child of PATO:0001894 for phenotypic sex or '
+                   '"unknown" if unavailable.\n']} })
+    sex_ontology_term: Optional[str] = Field(default=None, title="Sex Ontology Term", description="""Deprecated placeholder for sex ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'sex_ontology_term',
+         'domain_of': ['Donor'],
+         'is_a': 'deprecated_slot'} })
+    manner_of_death: MannerOfDeath = Field(default=..., title="Manner of Death", description="""Manner of death classification based on the Hardy Scale or \"unknown\" or \"not applicable\":
+* Category 1 = Violent and fast death — deaths due to accident, blunt force trauma or suicide, terminal phase < 10 min.
+* Category 2 = Fast death of natural causes — sudden unexpected deaths of reasonably healthy people, terminal phase < 1 h.
+* Category 3 = Intermediate death — terminal phase 1–24 h, patients ill but death unexpected.
+* Category 4 = Slow death — terminal phase > 1 day (e.g. cancer, chronic pulmonary disease).
+* Category 0 = Ventilator case — on a ventilator immediately before death.
+* Unknown = The cause of death is unknown.
+* Not applicable = Subject is alive.
+[Leave blank for embryonic/fetal tissue.]
+""", json_schema_extra = { "linkml_meta": {'alias': 'manner_of_death',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'domain_of': ['Donor'],
+         'examples': [{'value': '1'}],
+         'notes': ['1; 2; 3; 4; 0; unknown; not applicable']} })
+    dataset_id: str = Field(default=..., title="Dataset ID", description="""A unique identifier for each dataset in the study. This should be unique to the study.""", json_schema_extra = { "linkml_meta": {'alias': 'dataset_id', 'domain_of': ['Dataset', 'Donor', 'Sample']} })
+
+
+class Sample(ConfiguredBaseModel):
+    """
+    A biological sample derived from a donor or another sample
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/sample',
+         'slot_usage': {'sample_id': {'annotations': {'annDataLocation': {'tag': 'annDataLocation',
+                                                                          'value': 'obs'},
+                                                      'tier': {'tag': 'tier',
+                                                               'value': 'Tier 1'}},
+                                      'identifier': True,
+                                      'name': 'sample_id',
+                                      'range': 'string'}}})
+
+    sample_id: str = Field(default=..., title="Sample ID", description="""Identification number of the sample. This is the fundamental unit of sampling the tissue (the specimen taken from the subject), which can be the same as the 'subject_ID', but is often different if multiple samples are taken from the same subject. Note: this is NOT a unit of multiplexing of donor samples, which should be stored in \"library\".""", json_schema_extra = { "linkml_meta": {'alias': 'sample_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'SC24; SC25; SC28'}]} })
+    donor_id: str = Field(default=..., title="Donor ID", description="""This must be free-text that identifies a unique individual that data were derived from.""", json_schema_extra = { "linkml_meta": {'alias': 'donor_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'donor_id'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Fundamental unit of biological variation of the data. It is '
+                      'strongly recommended that this identifier be designed so that '
+                      'it is unique to: a given individual within the collection of '
+                      'datasets that includes this dataset, and a given individual '
+                      'across all collections in CELLxGENE Discover. It is strongly '
+                      'recommended that "pooled" be used for observations from a '
+                      'sample of multiple individuals that were not confidently '
+                      'assigned to a single individual through demultiplexing. It is '
+                      'strongly recommended that "unknown" ONLY be used for '
+                      'observations in a dataset when it is not known which '
+                      'observations are from the same individual.'],
+         'domain_of': ['Donor', 'Sample'],
+         'examples': [{'value': 'CR_donor_1; MM_donor_1; LR_donor_2'}]} })
+    dataset_id: str = Field(default=..., title="Dataset ID", description="""A unique identifier for each dataset in the study. This should be unique to the study.""", json_schema_extra = { "linkml_meta": {'alias': 'dataset_id', 'domain_of': ['Dataset', 'Donor', 'Sample']} })
+    author_batch_notes: Optional[str] = Field(default=None, title="Author Batch Notes", description="""Encoding of author knowledge on any further information related to likely batch effects.""", json_schema_extra = { "linkml_meta": {'alias': 'author_batch_notes',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Space for author intuition of batch effects in their dataset'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'Batch run by different personnel on different days'}]} })
+    age_range: Optional[str] = Field(default=None, title="Age Range", description="""Deprecated placeholder for age range metadata.""", json_schema_extra = { "linkml_meta": {'alias': 'age_range', 'domain_of': ['Sample'], 'is_a': 'deprecated_slot'} })
+    cell_number_loaded: Optional[int] = Field(default=None, title="Cell Number Loaded", description="""Estimated number of cells loaded for library construction.""", json_schema_extra = { "linkml_meta": {'alias': 'cell_number_loaded',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Can explain the number of doublets found in samples'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': '5000; 4000'}]} })
+    cell_viability_percentage: Optional[Union[Decimal, str]] = Field(default=None, title="Cell Viability Percentage", description="""If measured, per sample cell viability before library preparation (as a percentage).""", json_schema_extra = { "linkml_meta": {'alias': 'cell_viability_percentage',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'any_of': [{'range': 'decimal'}, {'range': 'string'}],
+         'comments': ['Is a measure of sample quality that could be used to explain '
+                      'outlier samples'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': '88; 95; 93.5'}, {'value': 'unknown'}]} })
+    cell_enrichment: str = Field(default=..., title="Cell Enrichment", description="""Specifies the cell types targeted for enrichment or depletion beyond the selection of live cells.""", json_schema_extra = { "linkml_meta": {'alias': 'cell_enrichment',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'CL:0000057+'}],
+         'notes': ['This must be a Cell Ontology (CL) term '
+                   '(http://www.ebi.ac.uk/ols4/ontologies/cl). For cells that are '
+                   "enriched, list the CL code followed by a '+'. For cells that were "
+                   "depleted, list the CL code followed by a '-'. If no enrichment or "
+                   "depletion occurred, please use 'na' (not applicable)"]} })
+    development_stage_ontology_term_id: DevelopmentStage = Field(default=..., title="Development Stage Ontology Term ID", description="""Age of the subject.""", json_schema_extra = { "linkml_meta": {'alias': 'development_stage_ontology_term_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg',
+                                 'value': 'development_stage_ontology_term_id'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'HsapDv:0000237'}],
+         'notes': ['If organism_ontolology_term_id is "NCBITaxon:9606" for Homo '
+                   'sapiens, this should be an HsapDv term. If '
+                   'organism_ontolology_term_id is "NCBITaxon:10090" for Mus musculus, '
+                   'this should be an MmusDv term. Refer to broader age bracket terms '
+                   'as needed.']} })
+    disease_ontology_term_id: str = Field(default=..., title="Disease Ontology Term ID", description="""Disease, if expected to impact the sample.""", json_schema_extra = { "linkml_meta": {'alias': 'disease_ontology_term_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'disease_ontology_term_id'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'MONDO:0005385'}, {'value': 'PATO:0000461'}],
+         'notes': ['This must be a MONDO term or "PATO:0000461" for normal or '
+                   'healthy.\n'
+                   '\n'
+                   'Requirements for data contributors adhering to GDPR or like '
+                   'standards: In the case of disease, HCA requests that you submit a '
+                   'higher order ontology term - this is especially important in the '
+                   'case of rare disease.\n']} })
+    disease_ontology_term: Optional[str] = Field(default=None, title="Disease Ontology Term", description="""Deprecated placeholder for disease ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'disease_ontology_term',
+         'domain_of': ['Sample'],
+         'is_a': 'deprecated_slot'} })
+    institute: str = Field(default=..., title="Institute", description="""Institution where the samples were processed.""", json_schema_extra = { "linkml_meta": {'alias': 'institute',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['To be able to link to other studies from the same institution '
+                      'as sometimes samples from different labs in the same institute '
+                      'are processed via similar core facilities. Thus batch effects '
+                      'may be smaller for datasets from the same institute even if '
+                      'other factors differ.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'EMBL-EBI; Genome Institute of Singapore'}]} })
+    is_primary_data: Optional[str] = Field(default=None, title="Is Primary Data", description="""Deprecated placeholder indicating whether sample represents primary data.""", json_schema_extra = { "linkml_meta": {'alias': 'is_primary_data', 'domain_of': ['Sample'], 'is_a': 'deprecated_slot'} })
+    library_id: str = Field(default=..., title="Library ID", description="""The unique ID that is used to track libraries in the investigator's institution (should align with the publication).""", json_schema_extra = { "linkml_meta": {'alias': 'library_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['A way to track the unit of data generation. This should include '
+                      'sample pooling'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'A24; NK_healthy_001'}]} })
+    library_id_repository: Optional[str] = Field(default=None, title="Library ID Repository", description="""The unique ID used to track libraries from one of the following public data repositories: EGAX*, GSM*, SRX*, ERX*, DRX, HRX, CRX.""", json_schema_extra = { "linkml_meta": {'alias': 'library_id_repository',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Links a dataset back to the source from which it was ingested, '
+                      'optional only if this is the same as the library_id.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'GSM1684095'}]} })
+    library_preparation_batch: str = Field(default=..., title="Library Preparation Batch", description="""Indicating which samples' libraries were prepared in the same chip/plate/etc., e.g. batch1, batch2.""", json_schema_extra = { "linkml_meta": {'alias': 'library_preparation_batch',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Sample preparation is a major source of batch effects.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'batch01; batch02'}]} })
+    library_sequencing_run: str = Field(default=..., title="Library Sequencing Run", description="""The identifier (or accession number) that indicates which samples' libraries were sequenced in the same run.""", json_schema_extra = { "linkml_meta": {'alias': 'library_sequencing_run',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Library sequencing is a major source of batch effects'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'run1; NV0087'}]} })
+    sample_collection_method: SampleCollectionMethod = Field(default=..., title="Sample Collection Method", description="""The method the sample was physically obtained from the donor.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_method',
+         'domain_of': ['Sample'],
+         'notes': ['brush; scraping; biopsy; surgical resection; blood draw; body '
+                   'fluid; other']} })
+    sample_collection_year: Optional[str] = Field(default=None, title="Sample Collection Year", description="""Year of sample collection. Should not be detailed further (to exact month and day), to prevent identifiability.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_year',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['May explain whether a dataset was separated into smaller '
+                      'batches.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': '2018'}]} })
+    sample_collection_site: Optional[str] = Field(default=None, title="Sample Collection Site", description="""The pseudonymised name of the site where the sample was collected.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_site',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['To understand whether the collection site contributes to batch '
+                      'effects. It is strongly recommended that this identifier be '
+                      'designed so that it is unique to a given site within the '
+                      'collection of datasets that includes this site (for example, '
+                      "the labels 'site1', 'site2' may appear in other datasets thus "
+                      'rendering them indistinguishable).'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'AIDA_site_1; AIDA_site_2'}]} })
+    sample_collection_relative_time_point: Optional[str] = Field(default=None, title="Sample Collection Relative Time Point", description="""Time point when the sample was collected. This field is only needed if multiple samples from the same subject are available and collected at different time points. Sample collection dates (e.g. 23/09/22) cannot be used due to patient data protection, only relative time points should be used here (e.g. day3).""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_relative_time_point',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Explains variability in the data between samples from the same '
+                      'subject.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'sampleX_day1'}]} })
+    tissue_free_text: Optional[str] = Field(default=None, title="Tissue Free Text", description="""The detailed anatomical location of the sample - this does not have to tie to an ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'tissue_free_text',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['To help the integration team understand the anatomical location '
+                      'of the sample, specifically to solve the problem when the '
+                      'UBERON ontology terms are insufficiently precise.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'terminal ileum'}]} })
+    tissue_type: TissueType = Field(default=..., title="Tissue Type", description="""Whether the tissue is \"tissue\", \"organoid\", or \"cell culture\".""", json_schema_extra = { "linkml_meta": {'alias': 'tissue_type',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'tissue_type'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'tissue'}],
+         'notes': ['tissue; organoid; cell culture']} })
+    tissue_ontology_term_id: str = Field(default=..., title="Tissue Ontology Term ID", description="""The detailed anatomical location of the sample, please provide a specific UBERON term.""", json_schema_extra = { "linkml_meta": {'alias': 'tissue_ontology_term_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'tissue_ontology_term_id'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'UBERON:0001828'}, {'value': 'UBERON:0000966'}],
+         'notes': ['If tissue_type is "tissue" or "organoid", this must be the most '
+                   'accurate child of UBERON:0001062 for anatomical entity. If '
+                   'tissue_type is "cell culture" this must follow the requirements '
+                   'for cell_type_ontology_term_id.\n']} })
+    suspension_type: SuspensionType = Field(default=..., title="Suspension Type", description="""Specifies whether the sample contains single cells or single nuclei data.""", json_schema_extra = { "linkml_meta": {'alias': 'suspension_type',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'suspension_type'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'cell'}],
+         'notes': ['This must be "cell", "nucleus", or "na".\n'
+                   'This must be the correct type for the corresponding assay:\n'
+                   '* 10x transcription profiling [EFO:0030080] and its children = '
+                   '"cell" or "nucleus"\n'
+                   '* ATAC-seq [EFO:0007045] and its children = "nucleus"\n'
+                   '* BD Rhapsody Whole Transcriptome Analysis [EFO:0700003] = "cell"\n'
+                   '* BD Rhapsody Targeted mRNA [EFO:0700004] = "cell"\n'
+                   '* CEL-seq2 [EFO:0010010] = "cell" or "nucleus"\n'
+                   '* CITE-seq [EFO:0009294] and its children = "cell"\n'
+                   '* DroNc-seq [EFO:0008720] = "nucleus"\n'
+                   '* Drop-seq [EFO:0008722] = "cell" or "nucleus"\n'
+                   '* GEXSCOPE technology [EFO:0700011] = "cell" or "nucleus"\n'
+                   '* inDrop [EFO:0008780] = "cell" or "nucleus"\n']} })
+    sampled_site_condition: SampledSiteCondition = Field(default=..., title="Sampled Site Condition", description="""Whether the site is considered healthy, diseased or adjacent to disease.""", json_schema_extra = { "linkml_meta": {'alias': 'sampled_site_condition',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'healthy'}],
+         'notes': ['healthy; diseased; adjacent']} })
+    sample_preservation_method: SamplePreservationMethod = Field(default=..., title="Sample Preservation Method", description="""Indicating if tissue was frozen, or not, at any point before library preparation.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_preservation_method',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'fresh'}],
+         'notes': ['ambient temperature; cut slide; fresh; frozen at -70C; frozen at '
+                   '-80C; frozen at -150C; frozen in liquid nitrogen; frozen in vapor '
+                   'phase; paraffin block; RNAlater at 4C; RNAlater at 25C; RNAlater '
+                   'at -20C; other']} })
+    sample_source: SampleSource = Field(default=..., title="Sample Source", description="""The study subgroup that the participant belongs to, indicating whether the participant was a surgical donor, a postmortem donor, or an organ donor.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_source',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'surgical donor'}],
+         'notes': ['surgical donor; postmortem donor; living organ donor']} })
+    tissue_ontology_term: Optional[str] = Field(default=None, title="Tissue Ontology Term", description="""Deprecated placeholder for tissue ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'tissue_ontology_term',
+         'domain_of': ['Sample'],
+         'is_a': 'deprecated_slot'} })
+
+
+class AdiposeSample(Sample):
+    """
+    Sample with Adipose BioNetwork–specific metadata requirements.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/bionetwork/adipose'})
+
+    dissociation_protocol: str = Field(default=..., title="Dissociation Protocol", description="""Dissociation chemicals used during sample preparation""", json_schema_extra = { "linkml_meta": {'alias': 'dissociation_protocol',
+         'domain_of': ['AdiposeSample', 'GutSample'],
+         'notes': ['trypsin; trypLE; collagenase']} })
+    sample_id: str = Field(default=..., title="Sample ID", description="""Identification number of the sample. This is the fundamental unit of sampling the tissue (the specimen taken from the subject), which can be the same as the 'subject_ID', but is often different if multiple samples are taken from the same subject. Note: this is NOT a unit of multiplexing of donor samples, which should be stored in \"library\".""", json_schema_extra = { "linkml_meta": {'alias': 'sample_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'SC24; SC25; SC28'}]} })
+    donor_id: str = Field(default=..., title="Donor ID", description="""This must be free-text that identifies a unique individual that data were derived from.""", json_schema_extra = { "linkml_meta": {'alias': 'donor_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'donor_id'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Fundamental unit of biological variation of the data. It is '
+                      'strongly recommended that this identifier be designed so that '
+                      'it is unique to: a given individual within the collection of '
+                      'datasets that includes this dataset, and a given individual '
+                      'across all collections in CELLxGENE Discover. It is strongly '
+                      'recommended that "pooled" be used for observations from a '
+                      'sample of multiple individuals that were not confidently '
+                      'assigned to a single individual through demultiplexing. It is '
+                      'strongly recommended that "unknown" ONLY be used for '
+                      'observations in a dataset when it is not known which '
+                      'observations are from the same individual.'],
+         'domain_of': ['Donor', 'Sample'],
+         'examples': [{'value': 'CR_donor_1; MM_donor_1; LR_donor_2'}]} })
+    dataset_id: str = Field(default=..., title="Dataset ID", description="""A unique identifier for each dataset in the study. This should be unique to the study.""", json_schema_extra = { "linkml_meta": {'alias': 'dataset_id', 'domain_of': ['Dataset', 'Donor', 'Sample']} })
+    author_batch_notes: Optional[str] = Field(default=None, title="Author Batch Notes", description="""Encoding of author knowledge on any further information related to likely batch effects.""", json_schema_extra = { "linkml_meta": {'alias': 'author_batch_notes',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Space for author intuition of batch effects in their dataset'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'Batch run by different personnel on different days'}]} })
+    age_range: Optional[str] = Field(default=None, title="Age Range", description="""Deprecated placeholder for age range metadata.""", json_schema_extra = { "linkml_meta": {'alias': 'age_range', 'domain_of': ['Sample'], 'is_a': 'deprecated_slot'} })
+    cell_number_loaded: Optional[int] = Field(default=None, title="Cell Number Loaded", description="""Estimated number of cells loaded for library construction.""", json_schema_extra = { "linkml_meta": {'alias': 'cell_number_loaded',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Can explain the number of doublets found in samples'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': '5000; 4000'}]} })
+    cell_viability_percentage: Optional[Union[Decimal, str]] = Field(default=None, title="Cell Viability Percentage", description="""If measured, per sample cell viability before library preparation (as a percentage).""", json_schema_extra = { "linkml_meta": {'alias': 'cell_viability_percentage',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'any_of': [{'range': 'decimal'}, {'range': 'string'}],
+         'comments': ['Is a measure of sample quality that could be used to explain '
+                      'outlier samples'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': '88; 95; 93.5'}, {'value': 'unknown'}]} })
+    cell_enrichment: str = Field(default=..., title="Cell Enrichment", description="""Specifies the cell types targeted for enrichment or depletion beyond the selection of live cells.""", json_schema_extra = { "linkml_meta": {'alias': 'cell_enrichment',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'CL:0000057+'}],
+         'notes': ['This must be a Cell Ontology (CL) term '
+                   '(http://www.ebi.ac.uk/ols4/ontologies/cl). For cells that are '
+                   "enriched, list the CL code followed by a '+'. For cells that were "
+                   "depleted, list the CL code followed by a '-'. If no enrichment or "
+                   "depletion occurred, please use 'na' (not applicable)"]} })
+    development_stage_ontology_term_id: DevelopmentStage = Field(default=..., title="Development Stage Ontology Term ID", description="""Age of the subject.""", json_schema_extra = { "linkml_meta": {'alias': 'development_stage_ontology_term_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg',
+                                 'value': 'development_stage_ontology_term_id'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'HsapDv:0000237'}],
+         'notes': ['If organism_ontolology_term_id is "NCBITaxon:9606" for Homo '
+                   'sapiens, this should be an HsapDv term. If '
+                   'organism_ontolology_term_id is "NCBITaxon:10090" for Mus musculus, '
+                   'this should be an MmusDv term. Refer to broader age bracket terms '
+                   'as needed.']} })
+    disease_ontology_term_id: str = Field(default=..., title="Disease Ontology Term ID", description="""Disease, if expected to impact the sample.""", json_schema_extra = { "linkml_meta": {'alias': 'disease_ontology_term_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'disease_ontology_term_id'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'MONDO:0005385'}, {'value': 'PATO:0000461'}],
+         'notes': ['This must be a MONDO term or "PATO:0000461" for normal or '
+                   'healthy.\n'
+                   '\n'
+                   'Requirements for data contributors adhering to GDPR or like '
+                   'standards: In the case of disease, HCA requests that you submit a '
+                   'higher order ontology term - this is especially important in the '
+                   'case of rare disease.\n']} })
+    disease_ontology_term: Optional[str] = Field(default=None, title="Disease Ontology Term", description="""Deprecated placeholder for disease ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'disease_ontology_term',
+         'domain_of': ['Sample'],
+         'is_a': 'deprecated_slot'} })
+    institute: str = Field(default=..., title="Institute", description="""Institution where the samples were processed.""", json_schema_extra = { "linkml_meta": {'alias': 'institute',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['To be able to link to other studies from the same institution '
+                      'as sometimes samples from different labs in the same institute '
+                      'are processed via similar core facilities. Thus batch effects '
+                      'may be smaller for datasets from the same institute even if '
+                      'other factors differ.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'EMBL-EBI; Genome Institute of Singapore'}]} })
+    is_primary_data: Optional[str] = Field(default=None, title="Is Primary Data", description="""Deprecated placeholder indicating whether sample represents primary data.""", json_schema_extra = { "linkml_meta": {'alias': 'is_primary_data', 'domain_of': ['Sample'], 'is_a': 'deprecated_slot'} })
+    library_id: str = Field(default=..., title="Library ID", description="""The unique ID that is used to track libraries in the investigator's institution (should align with the publication).""", json_schema_extra = { "linkml_meta": {'alias': 'library_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['A way to track the unit of data generation. This should include '
+                      'sample pooling'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'A24; NK_healthy_001'}]} })
+    library_id_repository: Optional[str] = Field(default=None, title="Library ID Repository", description="""The unique ID used to track libraries from one of the following public data repositories: EGAX*, GSM*, SRX*, ERX*, DRX, HRX, CRX.""", json_schema_extra = { "linkml_meta": {'alias': 'library_id_repository',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Links a dataset back to the source from which it was ingested, '
+                      'optional only if this is the same as the library_id.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'GSM1684095'}]} })
+    library_preparation_batch: str = Field(default=..., title="Library Preparation Batch", description="""Indicating which samples' libraries were prepared in the same chip/plate/etc., e.g. batch1, batch2.""", json_schema_extra = { "linkml_meta": {'alias': 'library_preparation_batch',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Sample preparation is a major source of batch effects.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'batch01; batch02'}]} })
+    library_sequencing_run: str = Field(default=..., title="Library Sequencing Run", description="""The identifier (or accession number) that indicates which samples' libraries were sequenced in the same run.""", json_schema_extra = { "linkml_meta": {'alias': 'library_sequencing_run',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Library sequencing is a major source of batch effects'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'run1; NV0087'}]} })
+    sample_collection_method: SampleCollectionMethod = Field(default=..., title="Sample Collection Method", description="""The method the sample was physically obtained from the donor.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_method',
+         'domain_of': ['Sample'],
+         'notes': ['brush; scraping; biopsy; surgical resection; blood draw; body '
+                   'fluid; other']} })
+    sample_collection_year: Optional[str] = Field(default=None, title="Sample Collection Year", description="""Year of sample collection. Should not be detailed further (to exact month and day), to prevent identifiability.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_year',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['May explain whether a dataset was separated into smaller '
+                      'batches.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': '2018'}]} })
+    sample_collection_site: Optional[str] = Field(default=None, title="Sample Collection Site", description="""The pseudonymised name of the site where the sample was collected.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_site',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['To understand whether the collection site contributes to batch '
+                      'effects. It is strongly recommended that this identifier be '
+                      'designed so that it is unique to a given site within the '
+                      'collection of datasets that includes this site (for example, '
+                      "the labels 'site1', 'site2' may appear in other datasets thus "
+                      'rendering them indistinguishable).'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'AIDA_site_1; AIDA_site_2'}]} })
+    sample_collection_relative_time_point: Optional[str] = Field(default=None, title="Sample Collection Relative Time Point", description="""Time point when the sample was collected. This field is only needed if multiple samples from the same subject are available and collected at different time points. Sample collection dates (e.g. 23/09/22) cannot be used due to patient data protection, only relative time points should be used here (e.g. day3).""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_relative_time_point',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Explains variability in the data between samples from the same '
+                      'subject.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'sampleX_day1'}]} })
+    tissue_free_text: Optional[str] = Field(default=None, title="Tissue Free Text", description="""The detailed anatomical location of the sample - this does not have to tie to an ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'tissue_free_text',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['To help the integration team understand the anatomical location '
+                      'of the sample, specifically to solve the problem when the '
+                      'UBERON ontology terms are insufficiently precise.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'terminal ileum'}]} })
+    tissue_type: TissueType = Field(default=..., title="Tissue Type", description="""Whether the tissue is \"tissue\", \"organoid\", or \"cell culture\".""", json_schema_extra = { "linkml_meta": {'alias': 'tissue_type',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'tissue_type'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'tissue'}],
+         'notes': ['tissue; organoid; cell culture']} })
+    tissue_ontology_term_id: str = Field(default=..., title="Tissue Ontology Term ID", description="""The detailed anatomical location of the sample, please provide a specific UBERON term.""", json_schema_extra = { "linkml_meta": {'alias': 'tissue_ontology_term_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'tissue_ontology_term_id'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'UBERON:0001828'}, {'value': 'UBERON:0000966'}],
+         'notes': ['If tissue_type is "tissue" or "organoid", this must be the most '
+                   'accurate child of UBERON:0001062 for anatomical entity. If '
+                   'tissue_type is "cell culture" this must follow the requirements '
+                   'for cell_type_ontology_term_id.\n']} })
+    suspension_type: SuspensionType = Field(default=..., title="Suspension Type", description="""Specifies whether the sample contains single cells or single nuclei data.""", json_schema_extra = { "linkml_meta": {'alias': 'suspension_type',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'suspension_type'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'cell'}],
+         'notes': ['This must be "cell", "nucleus", or "na".\n'
+                   'This must be the correct type for the corresponding assay:\n'
+                   '* 10x transcription profiling [EFO:0030080] and its children = '
+                   '"cell" or "nucleus"\n'
+                   '* ATAC-seq [EFO:0007045] and its children = "nucleus"\n'
+                   '* BD Rhapsody Whole Transcriptome Analysis [EFO:0700003] = "cell"\n'
+                   '* BD Rhapsody Targeted mRNA [EFO:0700004] = "cell"\n'
+                   '* CEL-seq2 [EFO:0010010] = "cell" or "nucleus"\n'
+                   '* CITE-seq [EFO:0009294] and its children = "cell"\n'
+                   '* DroNc-seq [EFO:0008720] = "nucleus"\n'
+                   '* Drop-seq [EFO:0008722] = "cell" or "nucleus"\n'
+                   '* GEXSCOPE technology [EFO:0700011] = "cell" or "nucleus"\n'
+                   '* inDrop [EFO:0008780] = "cell" or "nucleus"\n']} })
+    sampled_site_condition: SampledSiteCondition = Field(default=..., title="Sampled Site Condition", description="""Whether the site is considered healthy, diseased or adjacent to disease.""", json_schema_extra = { "linkml_meta": {'alias': 'sampled_site_condition',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'healthy'}],
+         'notes': ['healthy; diseased; adjacent']} })
+    sample_preservation_method: SamplePreservationMethod = Field(default=..., title="Sample Preservation Method", description="""Indicating if tissue was frozen, or not, at any point before library preparation.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_preservation_method',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'fresh'}],
+         'notes': ['ambient temperature; cut slide; fresh; frozen at -70C; frozen at '
+                   '-80C; frozen at -150C; frozen in liquid nitrogen; frozen in vapor '
+                   'phase; paraffin block; RNAlater at 4C; RNAlater at 25C; RNAlater '
+                   'at -20C; other']} })
+    sample_source: SampleSource = Field(default=..., title="Sample Source", description="""The study subgroup that the participant belongs to, indicating whether the participant was a surgical donor, a postmortem donor, or an organ donor.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_source',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'surgical donor'}],
+         'notes': ['surgical donor; postmortem donor; living organ donor']} })
+    tissue_ontology_term: Optional[str] = Field(default=None, title="Tissue Ontology Term", description="""Deprecated placeholder for tissue ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'tissue_ontology_term',
+         'domain_of': ['Sample'],
+         'is_a': 'deprecated_slot'} })
+
+
+class GutSample(Sample):
+    """
+    Sample with Gut BioNetwork–specific metadata requirements.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/bionetwork/gut'})
+
+    radial_tissue_term: RadialTissueTerm = Field(default=..., title="Radial Tissue Term", description="""Radial compartment/location of the tissue sample.""", json_schema_extra = { "linkml_meta": {'alias': 'radial_tissue_term', 'domain_of': ['GutSample']} })
+    dissociation_protocol: str = Field(default=..., title="Dissociation Protocol", description="""Dissociation chemicals used during sample preparation""", json_schema_extra = { "linkml_meta": {'alias': 'dissociation_protocol',
+         'domain_of': ['AdiposeSample', 'GutSample'],
+         'notes': ['trypsin; trypLE; collagenase']} })
+    sample_id: str = Field(default=..., title="Sample ID", description="""Identification number of the sample. This is the fundamental unit of sampling the tissue (the specimen taken from the subject), which can be the same as the 'subject_ID', but is often different if multiple samples are taken from the same subject. Note: this is NOT a unit of multiplexing of donor samples, which should be stored in \"library\".""", json_schema_extra = { "linkml_meta": {'alias': 'sample_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'SC24; SC25; SC28'}]} })
+    donor_id: str = Field(default=..., title="Donor ID", description="""This must be free-text that identifies a unique individual that data were derived from.""", json_schema_extra = { "linkml_meta": {'alias': 'donor_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'donor_id'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Fundamental unit of biological variation of the data. It is '
+                      'strongly recommended that this identifier be designed so that '
+                      'it is unique to: a given individual within the collection of '
+                      'datasets that includes this dataset, and a given individual '
+                      'across all collections in CELLxGENE Discover. It is strongly '
+                      'recommended that "pooled" be used for observations from a '
+                      'sample of multiple individuals that were not confidently '
+                      'assigned to a single individual through demultiplexing. It is '
+                      'strongly recommended that "unknown" ONLY be used for '
+                      'observations in a dataset when it is not known which '
+                      'observations are from the same individual.'],
+         'domain_of': ['Donor', 'Sample'],
+         'examples': [{'value': 'CR_donor_1; MM_donor_1; LR_donor_2'}]} })
+    dataset_id: str = Field(default=..., title="Dataset ID", description="""A unique identifier for each dataset in the study. This should be unique to the study.""", json_schema_extra = { "linkml_meta": {'alias': 'dataset_id', 'domain_of': ['Dataset', 'Donor', 'Sample']} })
+    author_batch_notes: Optional[str] = Field(default=None, title="Author Batch Notes", description="""Encoding of author knowledge on any further information related to likely batch effects.""", json_schema_extra = { "linkml_meta": {'alias': 'author_batch_notes',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Space for author intuition of batch effects in their dataset'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'Batch run by different personnel on different days'}]} })
+    age_range: Optional[str] = Field(default=None, title="Age Range", description="""Deprecated placeholder for age range metadata.""", json_schema_extra = { "linkml_meta": {'alias': 'age_range', 'domain_of': ['Sample'], 'is_a': 'deprecated_slot'} })
+    cell_number_loaded: Optional[int] = Field(default=None, title="Cell Number Loaded", description="""Estimated number of cells loaded for library construction.""", json_schema_extra = { "linkml_meta": {'alias': 'cell_number_loaded',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Can explain the number of doublets found in samples'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': '5000; 4000'}]} })
+    cell_viability_percentage: Optional[Union[Decimal, str]] = Field(default=None, title="Cell Viability Percentage", description="""If measured, per sample cell viability before library preparation (as a percentage).""", json_schema_extra = { "linkml_meta": {'alias': 'cell_viability_percentage',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'any_of': [{'range': 'decimal'}, {'range': 'string'}],
+         'comments': ['Is a measure of sample quality that could be used to explain '
+                      'outlier samples'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': '88; 95; 93.5'}, {'value': 'unknown'}]} })
+    cell_enrichment: str = Field(default=..., title="Cell Enrichment", description="""Specifies the cell types targeted for enrichment or depletion beyond the selection of live cells.""", json_schema_extra = { "linkml_meta": {'alias': 'cell_enrichment',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'CL:0000057+'}],
+         'notes': ['This must be a Cell Ontology (CL) term '
+                   '(http://www.ebi.ac.uk/ols4/ontologies/cl). For cells that are '
+                   "enriched, list the CL code followed by a '+'. For cells that were "
+                   "depleted, list the CL code followed by a '-'. If no enrichment or "
+                   "depletion occurred, please use 'na' (not applicable)"]} })
+    development_stage_ontology_term_id: DevelopmentStage = Field(default=..., title="Development Stage Ontology Term ID", description="""Age of the subject.""", json_schema_extra = { "linkml_meta": {'alias': 'development_stage_ontology_term_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg',
+                                 'value': 'development_stage_ontology_term_id'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'HsapDv:0000237'}],
+         'notes': ['If organism_ontolology_term_id is "NCBITaxon:9606" for Homo '
+                   'sapiens, this should be an HsapDv term. If '
+                   'organism_ontolology_term_id is "NCBITaxon:10090" for Mus musculus, '
+                   'this should be an MmusDv term. Refer to broader age bracket terms '
+                   'as needed.']} })
+    disease_ontology_term_id: str = Field(default=..., title="Disease Ontology Term ID", description="""Disease, if expected to impact the sample.""", json_schema_extra = { "linkml_meta": {'alias': 'disease_ontology_term_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'disease_ontology_term_id'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'MONDO:0005385'}, {'value': 'PATO:0000461'}],
+         'notes': ['This must be a MONDO term or "PATO:0000461" for normal or '
+                   'healthy.\n'
+                   '\n'
+                   'Requirements for data contributors adhering to GDPR or like '
+                   'standards: In the case of disease, HCA requests that you submit a '
+                   'higher order ontology term - this is especially important in the '
+                   'case of rare disease.\n']} })
+    disease_ontology_term: Optional[str] = Field(default=None, title="Disease Ontology Term", description="""Deprecated placeholder for disease ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'disease_ontology_term',
+         'domain_of': ['Sample'],
+         'is_a': 'deprecated_slot'} })
+    institute: str = Field(default=..., title="Institute", description="""Institution where the samples were processed.""", json_schema_extra = { "linkml_meta": {'alias': 'institute',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['To be able to link to other studies from the same institution '
+                      'as sometimes samples from different labs in the same institute '
+                      'are processed via similar core facilities. Thus batch effects '
+                      'may be smaller for datasets from the same institute even if '
+                      'other factors differ.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'EMBL-EBI; Genome Institute of Singapore'}]} })
+    is_primary_data: Optional[str] = Field(default=None, title="Is Primary Data", description="""Deprecated placeholder indicating whether sample represents primary data.""", json_schema_extra = { "linkml_meta": {'alias': 'is_primary_data', 'domain_of': ['Sample'], 'is_a': 'deprecated_slot'} })
+    library_id: str = Field(default=..., title="Library ID", description="""The unique ID that is used to track libraries in the investigator's institution (should align with the publication).""", json_schema_extra = { "linkml_meta": {'alias': 'library_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['A way to track the unit of data generation. This should include '
+                      'sample pooling'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'A24; NK_healthy_001'}]} })
+    library_id_repository: Optional[str] = Field(default=None, title="Library ID Repository", description="""The unique ID used to track libraries from one of the following public data repositories: EGAX*, GSM*, SRX*, ERX*, DRX, HRX, CRX.""", json_schema_extra = { "linkml_meta": {'alias': 'library_id_repository',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Links a dataset back to the source from which it was ingested, '
+                      'optional only if this is the same as the library_id.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'GSM1684095'}]} })
+    library_preparation_batch: str = Field(default=..., title="Library Preparation Batch", description="""Indicating which samples' libraries were prepared in the same chip/plate/etc., e.g. batch1, batch2.""", json_schema_extra = { "linkml_meta": {'alias': 'library_preparation_batch',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Sample preparation is a major source of batch effects.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'batch01; batch02'}]} })
+    library_sequencing_run: str = Field(default=..., title="Library Sequencing Run", description="""The identifier (or accession number) that indicates which samples' libraries were sequenced in the same run.""", json_schema_extra = { "linkml_meta": {'alias': 'library_sequencing_run',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Library sequencing is a major source of batch effects'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'run1; NV0087'}]} })
+    sample_collection_method: SampleCollectionMethod = Field(default=..., title="Sample Collection Method", description="""The method the sample was physically obtained from the donor.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_method',
+         'domain_of': ['Sample'],
+         'notes': ['brush; scraping; biopsy; surgical resection; blood draw; body '
+                   'fluid; other']} })
+    sample_collection_year: Optional[str] = Field(default=None, title="Sample Collection Year", description="""Year of sample collection. Should not be detailed further (to exact month and day), to prevent identifiability.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_year',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['May explain whether a dataset was separated into smaller '
+                      'batches.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': '2018'}]} })
+    sample_collection_site: Optional[str] = Field(default=None, title="Sample Collection Site", description="""The pseudonymised name of the site where the sample was collected.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_site',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['To understand whether the collection site contributes to batch '
+                      'effects. It is strongly recommended that this identifier be '
+                      'designed so that it is unique to a given site within the '
+                      'collection of datasets that includes this site (for example, '
+                      "the labels 'site1', 'site2' may appear in other datasets thus "
+                      'rendering them indistinguishable).'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'AIDA_site_1; AIDA_site_2'}]} })
+    sample_collection_relative_time_point: Optional[str] = Field(default=None, title="Sample Collection Relative Time Point", description="""Time point when the sample was collected. This field is only needed if multiple samples from the same subject are available and collected at different time points. Sample collection dates (e.g. 23/09/22) cannot be used due to patient data protection, only relative time points should be used here (e.g. day3).""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_relative_time_point',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Explains variability in the data between samples from the same '
+                      'subject.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'sampleX_day1'}]} })
+    tissue_free_text: Optional[str] = Field(default=None, title="Tissue Free Text", description="""The detailed anatomical location of the sample - this does not have to tie to an ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'tissue_free_text',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['To help the integration team understand the anatomical location '
+                      'of the sample, specifically to solve the problem when the '
+                      'UBERON ontology terms are insufficiently precise.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'terminal ileum'}]} })
+    tissue_type: TissueType = Field(default=..., title="Tissue Type", description="""Whether the tissue is \"tissue\", \"organoid\", or \"cell culture\".""", json_schema_extra = { "linkml_meta": {'alias': 'tissue_type',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'tissue_type'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'tissue'}],
+         'notes': ['tissue; organoid; cell culture']} })
+    tissue_ontology_term_id: str = Field(default=..., title="Tissue Ontology Term ID", description="""The detailed anatomical location of the sample, please provide a specific UBERON term.""", json_schema_extra = { "linkml_meta": {'alias': 'tissue_ontology_term_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'tissue_ontology_term_id'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'UBERON:0001828'}, {'value': 'UBERON:0000966'}],
+         'notes': ['If tissue_type is "tissue" or "organoid", this must be the most '
+                   'accurate child of UBERON:0001062 for anatomical entity. If '
+                   'tissue_type is "cell culture" this must follow the requirements '
+                   'for cell_type_ontology_term_id.\n']} })
+    suspension_type: SuspensionType = Field(default=..., title="Suspension Type", description="""Specifies whether the sample contains single cells or single nuclei data.""", json_schema_extra = { "linkml_meta": {'alias': 'suspension_type',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'suspension_type'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'cell'}],
+         'notes': ['This must be "cell", "nucleus", or "na".\n'
+                   'This must be the correct type for the corresponding assay:\n'
+                   '* 10x transcription profiling [EFO:0030080] and its children = '
+                   '"cell" or "nucleus"\n'
+                   '* ATAC-seq [EFO:0007045] and its children = "nucleus"\n'
+                   '* BD Rhapsody Whole Transcriptome Analysis [EFO:0700003] = "cell"\n'
+                   '* BD Rhapsody Targeted mRNA [EFO:0700004] = "cell"\n'
+                   '* CEL-seq2 [EFO:0010010] = "cell" or "nucleus"\n'
+                   '* CITE-seq [EFO:0009294] and its children = "cell"\n'
+                   '* DroNc-seq [EFO:0008720] = "nucleus"\n'
+                   '* Drop-seq [EFO:0008722] = "cell" or "nucleus"\n'
+                   '* GEXSCOPE technology [EFO:0700011] = "cell" or "nucleus"\n'
+                   '* inDrop [EFO:0008780] = "cell" or "nucleus"\n']} })
+    sampled_site_condition: SampledSiteCondition = Field(default=..., title="Sampled Site Condition", description="""Whether the site is considered healthy, diseased or adjacent to disease.""", json_schema_extra = { "linkml_meta": {'alias': 'sampled_site_condition',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'healthy'}],
+         'notes': ['healthy; diseased; adjacent']} })
+    sample_preservation_method: SamplePreservationMethod = Field(default=..., title="Sample Preservation Method", description="""Indicating if tissue was frozen, or not, at any point before library preparation.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_preservation_method',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'fresh'}],
+         'notes': ['ambient temperature; cut slide; fresh; frozen at -70C; frozen at '
+                   '-80C; frozen at -150C; frozen in liquid nitrogen; frozen in vapor '
+                   'phase; paraffin block; RNAlater at 4C; RNAlater at 25C; RNAlater '
+                   'at -20C; other']} })
+    sample_source: SampleSource = Field(default=..., title="Sample Source", description="""The study subgroup that the participant belongs to, indicating whether the participant was a surgical donor, a postmortem donor, or an organ donor.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_source',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'surgical donor'}],
+         'notes': ['surgical donor; postmortem donor; living organ donor']} })
+    tissue_ontology_term: Optional[str] = Field(default=None, title="Tissue Ontology Term", description="""Deprecated placeholder for tissue ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'tissue_ontology_term',
+         'domain_of': ['Sample'],
+         'is_a': 'deprecated_slot'} })
+
+
+class MusculoskeletalDataset(Dataset):
+    """
+    Dataset with Musculoskeletal BioNetwork–specific metadata requirements.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/bionetwork/musculoskeletal'})
+
+    ambient_count_correction: str = Field(default=..., title="Ambient Count Correction", description="""Method used to correct ambient RNA contamination in single-cell data.""", json_schema_extra = { "linkml_meta": {'alias': 'ambient_count_correction',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'domain_of': ['AdiposeDataset', 'GutDataset', 'MusculoskeletalDataset'],
+         'examples': [{'value': 'none'}, {'value': 'soupx'}, {'value': 'cellbender'}]} })
+    doublet_detection: str = Field(default=..., title="Doublet Detection", description="""Was doublet detection software used during CELLxGENE processing? If so, which software?""", json_schema_extra = { "linkml_meta": {'alias': 'doublet_detection',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'domain_of': ['AdiposeDataset', 'GutDataset', 'MusculoskeletalDataset'],
+         'examples': [{'value': 'none'},
+                      {'value': 'doublet_finder'},
+                      {'value': 'manual'}]} })
+    alignment_software: str = Field(default=..., title="Alignment Software", description="""Protocol used for alignment analysis, please specify which version was used e.g. cell ranger 2.0, 2.1.1 etc.""", json_schema_extra = { "linkml_meta": {'alias': 'alignment_software',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'comments': ['Affects which cells are filtered per dataset, and which reads '
+                      '(introns and exons or only exons) are counted as part of the '
+                      'reported transcriptome. This can convey batch effects.'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'cellranger_8.0.0'}]} })
+    assay_ontology_term_id: str = Field(default=..., title="Assay Ontology Term Id", description="""Platform used for single cell library construction.""", json_schema_extra = { "linkml_meta": {'alias': 'assay_ontology_term_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'assay_ontology_term_id'}},
+         'comments': ['Major source of batch effect and dataset filtering criterion'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'EFO:0009922'}],
+         'notes': ['This must be an EFO term and either:\n'
+                   '- "EFO:0002772" for assay by molecule or preferably its most '
+                   'accurate child\n'
+                   '- "EFO:0010183" for single cell library construction or preferably '
+                   'its most accurate child\n'
+                   '- An assay based on 10X Genomics products should either be '
+                   '"EFO:0008995" for 10x technology or preferably its most accurate '
+                   'child.\n'
+                   "- An assay based on SMART (Switching Mechanism at the 5' end of "
+                   'the RNA Template) or SMARTer technology SHOULD either be '
+                   '"EFO:0010184" for Smart-like or preferably its most accurate '
+                   'child.\n'
+                   'Recommended:\n'
+                   '- 10x 3\' v2 "EFO:0009899"\n'
+                   '- 10x 3\' v3 "EFO:0009922"\n'
+                   '- 10x 5\' v1 "EFO:0011025"\n'
+                   '- 10x 5\' v2 "EFO:0009900"\n'
+                   '- Smart-seq2 "EFO:0008931"\n'
+                   '- Visium Spatial Gene Expression "EFO:0010961"\n']} })
+    assay_ontology_term: Optional[str] = Field(default=None, title="Assay Ontology Term", description="""Deprecated placeholder for assay ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'assay_ontology_term',
+         'domain_of': ['Dataset'],
+         'is_a': 'deprecated_slot'} })
+    batch_condition: Optional[list[str]] = Field(default=None, title="Batch Condition", description="""Name of the covariate that confers the dominant batch effect in the data as judged by the data contributor.  The name provided here should be the label by which this covariate is stored in the AnnData object.""", json_schema_extra = { "linkml_meta": {'alias': 'batch_condition',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'},
+                         'cxg': {'tag': 'cxg', 'value': 'batch_condition'}},
+         'domain_of': ['Dataset'],
+         'examples': [{'description': 'Multiple batch conditions as a JSON array',
+                       'value': '["patient", "seqBatch"]'}],
+         'notes': ['Values must refer to cell metadata keys in obs. Together, these '
+                   'keys define the batches that a normalisation or integration '
+                   'algorithm should be aware of. For example if "patient" and '
+                   '"seqBatch" are keys of vectors of cell metadata, either '
+                   '["patient"], ["seqBatch"], or ["patient", "seqBatch"] are valid '
+                   'values.']} })
+    comments: Optional[str] = Field(default=None, title="Comments", description="""Other technical or experimental covariates that could affect the quality or batch of the sample.  Must not contain identifiers. This field is designed to capture potential challenges for data integration not captured elsewhere.
+""", json_schema_extra = { "linkml_meta": {'alias': 'comments',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'domain_of': ['Dataset']} })
+    consortia: Optional[str] = Field(default=None, title="Consortia", description="""Deprecated placeholder for consortia information.""", json_schema_extra = { "linkml_meta": {'alias': 'consortia', 'domain_of': ['Dataset'], 'is_a': 'deprecated_slot'} })
+    contact_email: str = Field(default=..., title="Contact Email", description="""Contact name and email of the submitting person""", json_schema_extra = { "linkml_meta": {'alias': 'contact_email', 'domain_of': ['Dataset']} })
+    default_embedding: Optional[str] = Field(default=None, title="Default Embedding", description="""The value must match a key to an embedding in obsm for the embedding to display by default in CELLxGENE Explorer.""", json_schema_extra = { "linkml_meta": {'alias': 'default_embedding',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'},
+                         'cxg': {'tag': 'cxg', 'value': 'default_embedding'}},
+         'domain_of': ['Dataset']} })
+    description: str = Field(default=..., title="Description", description="""Short description of the dataset""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'domain_of': ['Dataset']} })
+    gene_annotation_version: str = Field(default=..., title="Gene Annotation Version", description="""Ensembl release version accession number. Some common codes include: GRCh38.p12 = GCF_000001405.38 GRCh38.p13 = GCF_000001405.39 GRCh38.p14 = GCF_000001405.40
+""", json_schema_extra = { "linkml_meta": {'alias': 'gene_annotation_version',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'comments': ['Possible source of batch effect and confounder for some '
+                      'biological analysis'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'GCF_000001405.40'}],
+         'notes': ['http://www.ensembl.org/info/website/archives/index.html or '
+                   'NCBI/RefSeq']} })
+    intron_inclusion: Optional[YesNoEnum] = Field(default=None, title="Intron Inclusion", description="""Were introns included during read counting in the alignment process?""", json_schema_extra = { "linkml_meta": {'alias': 'intron_inclusion',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'yes'}, {'value': 'no'}]} })
+    protocol_url: Optional[str] = Field(default=None, title="Protocol URL", description="""The protocols.io URL (if none exists, please use the BioRxiv URL) for the full experimental protocol;  or if multiple protocols exist please list them e.g. sample preparation protocol / sequencing protocol.
+""", json_schema_extra = { "linkml_meta": {'alias': 'protocol_url',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'comments': ['Useful to look up protocol data that can provide insight on '
+                      'batch effects. As protocols can sometimes apply to a subset of '
+                      'the study, we capture this at a sample level. This information '
+                      'may not always be available.'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'https://www.biorxiv.org/content/early/2017/09/24/193219'}]} })
+    publication_doi: Optional[str] = Field(default=None, title="Publication DOI", description="""The publication digital object identifier (doi) for the protocol. If no pre-print nor publication exists, please write 'not applicable'.
+""", json_schema_extra = { "linkml_meta": {'alias': 'publication_doi',
+         'domain_of': ['Dataset'],
+         'examples': [{'value': '10.1016/j.cell.2016.07.054'}]} })
+    reference_genome: ReferenceGenomeEnum = Field(default=..., title="Reference Genome", description="""Reference genome used for alignment.""", json_schema_extra = { "linkml_meta": {'alias': 'reference_genome',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'comments': ['Possible source of batch effect and confounder for some '
+                      'biological analysis'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'GRCm37'}, {'value': 'GRCh37'}]} })
+    sequenced_fragment: SequencedFragmentEnum = Field(default=..., title="Sequenced Fragment", description="""Which part of the RNA transcript was targeted for sequencing.""", json_schema_extra = { "linkml_meta": {'alias': 'sequenced_fragment',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'comments': ['May be a source of batch effect that has to be tested.'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': '3 prime tag'}, {'value': 'full length'}]} })
+    sequencing_platform: Optional[str] = Field(default=None, title="Sequencing Platform", description="""Platform used for sequencing.""", json_schema_extra = { "linkml_meta": {'alias': 'sequencing_platform',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
+         'comments': ['This captures potential strand hopping which may cause data '
+                      'quality issues.'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': 'EFO:0008563'}],
+         'notes': ['Values should be "subClassOf" ["EFO:0002699"] - '
+                   'https://www.ebi.ac.uk/ols/ontologies/efo/terms?iri=http%3A%2F%2Fwww.ebi.ac.uk%2Fefo%2FEFO_0002699']} })
+    study_pi: list[str] = Field(default=..., title="Study Pi", description="""Principal Investigator(s) leading the study where the data is/was used.""", json_schema_extra = { "linkml_meta": {'alias': 'study_pi',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'domain_of': ['Dataset'],
+         'examples': [{'description': 'Principal Investigator in Last '
+                                      'Name,MiddleInitial, FirstName format',
+                       'value': '["Teichmann,Sarah,A."]'}]} })
+    title: Optional[str] = Field(default=None, title="Title", description="""This text describes and differentiates the dataset from other datasets in the same collection.  It is strongly recommended that each dataset title in a collection is unique and does not depend on other metadata  such as a different assay to disambiguate it from other datasets in the collection.
+""", json_schema_extra = { "linkml_meta": {'alias': 'title',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'},
+                         'cxg': {'tag': 'cxg', 'value': 'title'}},
+         'comments': ['Useful to look up protocol data that can provide insight on '
+                      'batch effects. As protocols can sometimes apply to a subset of '
+                      'the study, we capture this at a sample level. This information '
+                      'may not always be available.'],
+         'domain_of': ['Dataset'],
+         'examples': [{'value': "Cells of the adult human heart collection is 'All — "
+                                "Cells of the adult human heart'"}],
+         'is_a': 'deprecated_slot'} })
+    dataset_id: str = Field(default=..., title="Dataset ID", description="""A unique identifier for each dataset in the study. This should be unique to the study.""", json_schema_extra = { "linkml_meta": {'alias': 'dataset_id', 'domain_of': ['Dataset', 'Donor', 'Sample']} })
+
+
+class Cell(ConfiguredBaseModel):
+    """
+    A single cell derived from a sample
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/cell'})
+
+    pass
+
+
+# Model rebuild
+# see https://pydantic-docs.helpmanual.io/usage/models/#rebuilding-a-model
+Dataset.model_rebuild()
+AdiposeDataset.model_rebuild()
+GutDataset.model_rebuild()
+Donor.model_rebuild()
+Sample.model_rebuild()
+AdiposeSample.model_rebuild()
+GutSample.model_rebuild()
+MusculoskeletalDataset.model_rebuild()
+Cell.model_rebuild()
+

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/schema/helpers.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/schema/helpers.py
@@ -1,0 +1,108 @@
+"""Introspection helpers for extracting uns field metadata from Pydantic models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .core import AdiposeDataset, Dataset, GutDataset, MusculoskeletalDataset
+
+_BIONETWORK_CLASSES = [AdiposeDataset, GutDataset, MusculoskeletalDataset]
+
+
+@dataclass(frozen=True)
+class UnsFieldInfo:
+    """Metadata about a single HCA uns field."""
+
+    name: str
+    annotation: Any
+    required: bool
+    title: str
+    description: str
+    bionetwork_only: bool
+    examples: list[dict] = field(default_factory=list)
+
+
+def _get_linkml_meta(field_info) -> dict | None:
+    """Extract the linkml_meta dict from a Pydantic FieldInfo's json_schema_extra."""
+    extra = getattr(field_info, "json_schema_extra", None)
+    if not extra or not isinstance(extra, dict):
+        return None
+    meta = extra.get("linkml_meta")
+    if not meta or not isinstance(meta, dict):
+        return None
+    return meta
+
+
+def _get_ann_data_location(field_info) -> str | None:
+    """Extract annDataLocation from a Pydantic FieldInfo."""
+    meta = _get_linkml_meta(field_info)
+    if meta is None:
+        return None
+    annotations = meta.get("annotations")
+    if not annotations or not isinstance(annotations, dict):
+        return None
+    location = annotations.get("annDataLocation")
+    if not location or not isinstance(location, dict):
+        return None
+    return location.get("value")
+
+
+def _get_examples(field_info) -> list[dict]:
+    """Extract examples from linkml_meta if present."""
+    meta = _get_linkml_meta(field_info)
+    if meta is None:
+        return []
+    return meta.get("examples", [])
+
+
+def get_uns_field_registry() -> dict[str, UnsFieldInfo]:
+    """Build a registry of all HCA uns fields from the schema models.
+
+    Collects from base Dataset and all bionetwork subclasses.
+    Fields only present on subclasses are marked bionetwork_only=True.
+    """
+    registry: dict[str, UnsFieldInfo] = {}
+
+    # Base Dataset fields
+    for name, fi in Dataset.model_fields.items():
+        if _get_ann_data_location(fi) == "uns":
+            registry[name] = UnsFieldInfo(
+                name=name,
+                annotation=fi.annotation,
+                required=fi.is_required(),
+                title=fi.title or name,
+                description=fi.description or "",
+                bionetwork_only=False,
+                examples=_get_examples(fi),
+            )
+
+    # Bionetwork subclass fields (only add new ones not in base)
+    for cls in _BIONETWORK_CLASSES:
+        for name, fi in cls.model_fields.items():
+            if name in registry:
+                continue
+            if _get_ann_data_location(fi) == "uns":
+                registry[name] = UnsFieldInfo(
+                    name=name,
+                    annotation=fi.annotation,
+                    required=fi.is_required(),
+                    title=fi.title or name,
+                    description=fi.description or "",
+                    bionetwork_only=True,
+                    examples=_get_examples(fi),
+                )
+
+    return registry
+
+
+# Cached at module level — schema is static
+_UNS_REGISTRY: dict[str, UnsFieldInfo] | None = None
+
+
+def uns_field_registry() -> dict[str, UnsFieldInfo]:
+    """Return the cached uns field registry."""
+    global _UNS_REGISTRY
+    if _UNS_REGISTRY is None:
+        _UNS_REGISTRY = get_uns_field_registry()
+    return _UNS_REGISTRY

--- a/packages/hca-anndata-tools/tests/test_edit.py
+++ b/packages/hca-anndata-tools/tests/test_edit.py
@@ -206,3 +206,26 @@ def test_set_uns_list_to_string_field_rejected(sample_h5ad_for_write):
 def test_set_uns_string_to_list_field_rejected(sample_h5ad_for_write):
     result = set_uns(str(sample_h5ad_for_write), "study_pi", "not a list")
     assert "error" in result
+
+
+# --- bionetwork-only fields ---
+
+
+def test_set_uns_ambient_count_correction(sample_h5ad_for_write):
+    result = set_uns(str(sample_h5ad_for_write), "ambient_count_correction", "SoupX")
+    assert "error" not in result
+    written = ad.read_h5ad(result["output_path"])
+    assert written.uns["ambient_count_correction"] == "SoupX"
+
+
+def test_set_uns_doublet_detection(sample_h5ad_for_write):
+    result = set_uns(str(sample_h5ad_for_write), "doublet_detection", "none")
+    assert "error" not in result
+    written = ad.read_h5ad(result["output_path"])
+    assert written.uns["doublet_detection"] == "none"
+
+
+def test_set_uns_bionetwork_empty_rejected(sample_h5ad_for_write):
+    result = set_uns(str(sample_h5ad_for_write), "ambient_count_correction", "")
+    assert "error" in result
+    assert "non-empty" in result["error"]

--- a/packages/hca-anndata-tools/tests/test_edit.py
+++ b/packages/hca-anndata-tools/tests/test_edit.py
@@ -196,3 +196,16 @@ def test_set_uns_list_with_empty_element_rejected(sample_h5ad_for_write):
     result = set_uns(str(sample_h5ad_for_write), "study_pi", ["Smith,John", ""])
     assert "error" in result
     assert "non-empty" in result["error"]
+
+
+# --- type mismatch ---
+
+
+def test_set_uns_list_to_string_field_rejected(sample_h5ad_for_write):
+    result = set_uns(str(sample_h5ad_for_write), "description", ["not", "a", "string"])
+    assert "error" in result
+
+
+def test_set_uns_string_to_list_field_rejected(sample_h5ad_for_write):
+    result = set_uns(str(sample_h5ad_for_write), "study_pi", "not a list")
+    assert "error" in result

--- a/packages/hca-anndata-tools/tests/test_edit.py
+++ b/packages/hca-anndata-tools/tests/test_edit.py
@@ -1,0 +1,168 @@
+"""Tests for set_uns and list_uns_fields."""
+
+import json
+import os
+
+import anndata as ad
+
+from hca_anndata_tools.edit import list_uns_fields, set_uns
+from hca_anndata_tools.write import EDIT_LOG_KEY
+
+
+# --- list_uns_fields ---
+
+
+def test_list_uns_fields_basic(sample_h5ad_for_write):
+    result = list_uns_fields(str(sample_h5ad_for_write))
+    assert "error" not in result
+    assert "fields" in result
+    assert isinstance(result["fields"], list)
+    assert len(result["fields"]) > 0
+
+
+def test_list_uns_fields_shows_current_value(sample_h5ad_for_write):
+    result = list_uns_fields(str(sample_h5ad_for_write))
+    title_field = next(f for f in result["fields"] if f["name"] == "title")
+    assert title_field["is_set"] is True
+    assert title_field["current_value"] == "Test Dataset"
+
+
+def test_list_uns_fields_shows_batch_condition(sample_h5ad_for_write):
+    result = list_uns_fields(str(sample_h5ad_for_write))
+    bc = next(f for f in result["fields"] if f["name"] == "batch_condition")
+    assert bc["is_set"] is True
+    # Stored as numpy array in fixture, should be serialized to list
+    assert bc["current_value"] == ["batch1", "batch2"]
+
+
+def test_list_uns_fields_shows_missing_required(sample_h5ad_for_write):
+    result = list_uns_fields(str(sample_h5ad_for_write))
+    # description and study_pi are required but not in the test fixture
+    assert "description" in result["missing_required"]
+    assert "study_pi" in result["missing_required"]
+
+
+def test_list_uns_fields_shows_bionetwork_fields(sample_h5ad_for_write):
+    result = list_uns_fields(str(sample_h5ad_for_write))
+    field_names = [f["name"] for f in result["fields"]]
+    assert "ambient_count_correction" in field_names
+    assert "doublet_detection" in field_names
+    acc = next(f for f in result["fields"] if f["name"] == "ambient_count_correction")
+    assert acc["bionetwork_only"] is True
+
+
+def test_list_uns_fields_extra_keys(sample_h5ad_for_write):
+    result = list_uns_fields(str(sample_h5ad_for_write))
+    # schema_version is in the fixture uns but not an HCA schema field
+    assert "schema_version" in result["extra_uns_keys"]
+
+
+def test_list_uns_fields_includes_obs_and_obsm(sample_h5ad_for_write):
+    result = list_uns_fields(str(sample_h5ad_for_write))
+    assert "obs_columns" in result
+    assert "obsm_keys" in result
+    assert "sex" in result["obs_columns"]
+    assert "X_umap" in result["obsm_keys"]
+
+
+def test_list_uns_fields_bad_path():
+    result = list_uns_fields("/nonexistent/file.h5ad")
+    assert "error" in result
+
+
+# --- set_uns ---
+
+
+def test_set_uns_string_field(sample_h5ad_for_write):
+    result = set_uns(str(sample_h5ad_for_write), "description", "A test dataset")
+    assert "error" not in result
+    assert "output_path" in result
+
+    written = ad.read_h5ad(result["output_path"])
+    assert written.uns["description"] == "A test dataset"
+
+
+def test_set_uns_list_field(sample_h5ad_for_write):
+    result = set_uns(str(sample_h5ad_for_write), "study_pi", ["Smith,John,A."])
+    assert "error" not in result
+
+    written = ad.read_h5ad(result["output_path"])
+    assert written.uns["study_pi"] == ["Smith,John,A."]
+
+
+def test_set_uns_overwrite(sample_h5ad_for_write):
+    result = set_uns(str(sample_h5ad_for_write), "title", "New Title")
+    assert "error" not in result
+    assert result["old_value"] == "Test Dataset"
+    assert result["new_value"] == "New Title"
+
+    written = ad.read_h5ad(result["output_path"])
+    assert written.uns["title"] == "New Title"
+
+
+def test_set_uns_invalid_field(sample_h5ad_for_write):
+    result = set_uns(str(sample_h5ad_for_write), "not_a_real_field", "value")
+    assert "error" in result
+    assert "not a recognized HCA uns field" in result["error"]
+
+
+def test_set_uns_batch_condition_valid(sample_h5ad_for_write):
+    result = set_uns(str(sample_h5ad_for_write), "batch_condition", ["sex", "tissue"])
+    assert "error" not in result
+
+    written = ad.read_h5ad(result["output_path"])
+    assert list(written.uns["batch_condition"]) == ["sex", "tissue"]
+
+
+def test_set_uns_batch_condition_invalid_column(sample_h5ad_for_write):
+    result = set_uns(str(sample_h5ad_for_write), "batch_condition", ["sex", "nonexistent"])
+    assert "error" in result
+    assert "nonexistent" in result["error"]
+
+
+def test_set_uns_default_embedding_valid(sample_h5ad_for_write):
+    result = set_uns(str(sample_h5ad_for_write), "default_embedding", "X_umap")
+    assert "error" not in result
+
+    written = ad.read_h5ad(result["output_path"])
+    assert written.uns["default_embedding"] == "X_umap"
+
+
+def test_set_uns_default_embedding_invalid(sample_h5ad_for_write):
+    result = set_uns(str(sample_h5ad_for_write), "default_embedding", "X_tsne")
+    assert "error" in result
+    assert "X_tsne" in result["error"]
+
+
+def test_set_uns_edit_log(sample_h5ad_for_write):
+    result = set_uns(str(sample_h5ad_for_write), "description", "Logged edit")
+    assert "error" not in result
+
+    written = ad.read_h5ad(result["output_path"])
+    log = json.loads(written.uns[EDIT_LOG_KEY])
+    assert len(log) == 1
+    assert log[0]["operation"] == "set_uns"
+    assert log[0]["details"]["field"] == "description"
+    assert log[0]["details"]["new_value"] == "Logged edit"
+
+
+def test_set_uns_previous_value_in_details(sample_h5ad_for_write):
+    result = set_uns(str(sample_h5ad_for_write), "title", "Updated")
+    assert "error" not in result
+
+    written = ad.read_h5ad(result["output_path"])
+    log = json.loads(written.uns[EDIT_LOG_KEY])
+    assert log[0]["details"]["old_value"] == "Test Dataset"
+
+
+def test_set_uns_custom_output_dir(sample_h5ad_for_write, tmp_path):
+    out_dir = tmp_path / "custom"
+    out_dir.mkdir()
+    result = set_uns(str(sample_h5ad_for_write), "description", "test", output_dir=str(out_dir))
+    assert "error" not in result
+    assert result["output_path"].startswith(str(out_dir))
+
+
+def test_set_uns_bad_path():
+    result = set_uns("/nonexistent/file.h5ad", "title", "test")
+    assert "error" in result

--- a/packages/hca-anndata-tools/tests/test_edit.py
+++ b/packages/hca-anndata-tools/tests/test_edit.py
@@ -1,7 +1,6 @@
 """Tests for set_uns and list_uns_fields."""
 
 import json
-import os
 
 import anndata as ad
 
@@ -158,12 +157,10 @@ def test_set_uns_previous_value_in_details(sample_h5ad_for_write):
     assert log[0]["details"]["old_value"] == "Test Dataset"
 
 
-def test_set_uns_custom_output_dir(sample_h5ad_for_write, tmp_path):
-    out_dir = tmp_path / "custom"
-    out_dir.mkdir()
-    result = set_uns(str(sample_h5ad_for_write), "description", "test", output_dir=str(out_dir))
+def test_set_uns_output_in_same_dir(sample_h5ad_for_write):
+    result = set_uns(str(sample_h5ad_for_write), "description", "test")
     assert "error" not in result
-    assert result["output_path"].startswith(str(out_dir))
+    assert result["output_path"].startswith(str(sample_h5ad_for_write.parent))
 
 
 def test_set_uns_bad_path():

--- a/packages/hca-anndata-tools/tests/test_edit.py
+++ b/packages/hca-anndata-tools/tests/test_edit.py
@@ -40,6 +40,9 @@ def test_list_uns_fields_shows_missing_required(sample_h5ad_for_write):
     # description and study_pi are required but not in the test fixture
     assert "description" in result["missing_required"]
     assert "study_pi" in result["missing_required"]
+    # bionetwork-only fields are in a separate list
+    assert "ambient_count_correction" not in result["missing_required"]
+    assert "ambient_count_correction" in result["missing_required_bionetwork"]
 
 
 def test_list_uns_fields_shows_bionetwork_fields(sample_h5ad_for_write):
@@ -166,3 +169,30 @@ def test_set_uns_custom_output_dir(sample_h5ad_for_write, tmp_path):
 def test_set_uns_bad_path():
     result = set_uns("/nonexistent/file.h5ad", "title", "test")
     assert "error" in result
+
+
+# --- empty value rejection ---
+
+
+def test_set_uns_empty_string_rejected(sample_h5ad_for_write):
+    result = set_uns(str(sample_h5ad_for_write), "description", "")
+    assert "error" in result
+    assert "non-empty" in result["error"]
+
+
+def test_set_uns_whitespace_string_rejected(sample_h5ad_for_write):
+    result = set_uns(str(sample_h5ad_for_write), "description", "   ")
+    assert "error" in result
+    assert "non-empty" in result["error"]
+
+
+def test_set_uns_empty_list_rejected(sample_h5ad_for_write):
+    result = set_uns(str(sample_h5ad_for_write), "study_pi", [])
+    assert "error" in result
+    assert "non-empty" in result["error"]
+
+
+def test_set_uns_list_with_empty_element_rejected(sample_h5ad_for_write):
+    result = set_uns(str(sample_h5ad_for_write), "study_pi", ["Smith,John", ""])
+    assert "error" in result
+    assert "non-empty" in result["error"]


### PR DESCRIPTION
## Summary

- Adds `set_uns` and `list_uns_fields` MCP tools for schema-aware dataset metadata editing
- Validates field names and values against bundled Pydantic models generated from HCA LinkML schemas
- Cross-validates `batch_condition` against obs columns and `default_embedding` against obsm keys
- Extracts shared `_serialize.py` from `cap.py` for numpy/pandas type serialization
- Bundles `schema/core.py` (generated Pydantic models) — only adds `pydantic` as a dep, no `shared/` dependency

Closes #229

## HCA uns fields supported

| Field | Type | Required | Validation |
|-------|------|----------|------------|
| `title` | string | No | Non-empty |
| `description` | string | Yes | Non-empty |
| `study_pi` | list[string] | Yes | Non-empty list |
| `batch_condition` | list[string] | No | Values must be obs columns |
| `default_embedding` | string | No | Must be obsm key |
| `comments` | string | No | Free text |
| `ambient_count_correction` | string | Yes (bionetwork) | Free text |
| `doublet_detection` | string | Yes (bionetwork) | Free text |

## Test plan

- [x] 20 tests for `set_uns` and `list_uns_fields` (field validation, cross-validation, edit log, error cases)
- [x] Full 104-test suite passes with no regressions
- [x] Tested live via MCP on real gut atlas myeloid file

🤖 Generated with [Claude Code](https://claude.com/claude-code)