### PR TITLE
fix: retry raw validation when skipped due to unrelated errors

### DIFF
--- a/packages/hca-schema-validator/src/hca_schema_validator/validator.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/validator.py
@@ -52,6 +52,28 @@ class HCAValidator(Validator):
             with open(schema_path) as fp:
                 self.schema_def = yaml.safe_load(fp)
 
+    def _deep_check(self):
+        """
+        The base class skips raw validation when *any* errors exist, but raw
+        validation only depends on assay_ontology_term_id. We retry it here
+        so raw-layer errors are reported in the same pass.
+        """
+        super()._deep_check()
+
+        # Match by substring to avoid brittle coupling to exact upstream wording
+        raw_skip_warnings = [
+            w for w in self.warnings
+            if "Validation of raw layer was not performed" in w
+        ]
+        if (
+            raw_skip_warnings
+            and "raw" in self.schema_def
+            and "assay_ontology_term_id" in self.adata.obs.columns
+        ):
+            for w in raw_skip_warnings:
+                self.warnings.remove(w)
+            self._validate_raw()
+
     def _validate_list(self, list_name, current_list, element_type):
         """
         Extends base list validation with support for element_type: string.

--- a/packages/hca-schema-validator/tests/test_validator.py
+++ b/packages/hca-schema-validator/tests/test_validator.py
@@ -536,6 +536,33 @@ class TestValidateColumn:
         assert "xyz" in pattern_errors[0]
 
 
+def test_raw_validation_runs_despite_unrelated_errors():
+    """Raw validation should run even when unrelated HCA fields are missing.
+
+    Regression test for #243: the base class skips raw validation if any
+    errors exist, but our override retries it when assay_ontology_term_id
+    is present.
+    """
+    from .fixtures.hca_fixtures import adata
+
+    # Remove an HCA-specific field to create an unrelated error
+    modified = adata.copy()
+    del modified.uns["study_pi"]
+
+    is_valid, validator = _validate_from_fixture(modified)
+    assert is_valid is False
+
+    # The "raw layer was not performed" warning should be absent
+    raw_skip_warnings = [
+        w for w in validator.warnings
+        if "Validation of raw layer was not performed" in w
+    ]
+    assert len(raw_skip_warnings) == 0, (
+        f"Raw validation was skipped despite assay_ontology_term_id being present. "
+        f"Warnings: {validator.warnings}"
+    )
+
+
 class TestCLOntologyOverlay:
     """Tests that the CL ontology overlay includes newer salivary gland cell types."""
 


### PR DESCRIPTION
## Summary

The vendored cellxgene validator skips raw layer validation if **any** errors exist (`if not self.errors`). This means unrelated errors like missing HCA-specific fields (`library_preparation_batch`, `manner_of_death`, etc.) block raw validation even though it only depends on `assay_ontology_term_id` in obs.

This override in `HCAValidator._deep_check()` retries raw validation when:
- The skip warning was emitted
- `assay_ontology_term_id` exists in obs
- The schema defines a raw layer

No vendored code modified — uses method override. Substring match on warning text avoids brittle coupling to exact upstream wording.

Closes #243

## Before/After

**Before:** 7 errors + 1 warning ("raw layer was not performed")
**After:** 7 errors + 0 warnings (raw validation runs, passes)

## Test plan

- [x] 38 existing hca-schema-validator tests pass
- [x] Tested on real converted cellxgene file — raw validation now runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)