### PR TITLE
feat: add -edit- prefix to timestamped output filenames

### DIFF
--- a/docs/prd-h5ad-editing.md
+++ b/docs/prd-h5ad-editing.md
@@ -19,15 +19,15 @@ When curating h5ad files for HCA submission, wranglers need to make targeted edi
 
 ```
 Input:  AlZaim_2024_reprocessed-r1-wip-5.h5ad
-Output: AlZaim_2024_reprocessed-r1-wip-5-2026-03-27-13-54-26.h5ad
+Output: AlZaim_2024_reprocessed-r1-wip-5-edit-2026-03-27-13-54-26.h5ad
 
-Input:  AlZaim_2024_reprocessed-r1-wip-5-2026-03-27-13-54-26.h5ad
-Output: AlZaim_2024_reprocessed-r1-wip-5-2026-03-27-14-22-11.h5ad
+Input:  AlZaim_2024_reprocessed-r1-wip-5-edit-2026-03-27-13-54-26.h5ad
+Output: AlZaim_2024_reprocessed-r1-wip-5-edit-2026-03-27-14-22-11.h5ad
 ```
 
 - Timestamp is **UTC** (avoids timezone encoding complexity)
-- Format: `YYYY-MM-DD-HH-MM-SS`
-- Regex to strip existing suffix: `-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}(?=\.h5ad$)`
+- Format: `-edit-YYYY-MM-DD-HH-MM-SS`
+- Regex to strip existing suffix: `-edit-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}(?=\.h5ad$)`
 - Base name is stable across edits — you always know the lineage
 
 ## Changelog in `uns`
@@ -102,7 +102,7 @@ def write_h5ad(
 3. Generate new UTC timestamp
 4. Populate `source_file` and `source_sha256` on each edit entry
 5. Append `edit_entries` to `adata.uns['hca_edit_log']` (create if missing)
-6. Write to `{base}-{timestamp}.h5ad`
+6. Write to `{base}-edit-{timestamp}.h5ad`
 7. Return the output path
 
 ### Edit tools (MCP layer)

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/convert.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/convert.py
@@ -101,7 +101,7 @@ def convert_cellxgene_to_hca(
             # --- 3. Build output path from title slug ---
             slug = _slugify(title)
             timestamp = generate_timestamp()
-            out_filename = f"{slug}-{timestamp}.h5ad"
+            out_filename = f"{slug}-edit-{timestamp}.h5ad"
             directory = output_dir if output_dir is not None else os.path.dirname(path)
             output_path = os.path.join(directory, out_filename)
 

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
@@ -33,7 +33,7 @@ def strip_timestamp(filename: str) -> str:
     """Strip an existing UTC timestamp suffix from an h5ad filename.
 
     Args:
-        filename: A filename (not a full path), e.g. 'foo-2026-03-27-13-54-26.h5ad'.
+        filename: A filename (not a full path), e.g. 'foo-edit-2026-03-27-13-54-26.h5ad'.
 
     Returns:
         The filename without the timestamp suffix, e.g. 'foo.h5ad'.

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from anndata import AnnData
 
-_TIMESTAMP_PATTERN = re.compile(r"-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}(?=\.h5ad$)")
+_TIMESTAMP_PATTERN = re.compile(r"-edit-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}(?=\.h5ad$)")
 _TIMESTAMP_FORMAT = "%Y-%m-%d-%H-%M-%S"
 EDIT_LOG_KEY = "hca_edit_log"
 _HASH_CHUNK_SIZE = 1 << 20  # 1 MB — keeps syscall count low on multi-GB files
@@ -61,7 +61,7 @@ def generate_output_path(source_path: str) -> str:
         Path string in the same directory as source_path.
     """
     stem = _base_stem(source_path)
-    return os.path.join(os.path.dirname(source_path), f"{stem}-{generate_timestamp()}.h5ad")
+    return os.path.join(os.path.dirname(source_path), f"{stem}-edit-{generate_timestamp()}.h5ad")
 
 
 def resolve_latest(path: str) -> str:
@@ -81,8 +81,8 @@ def resolve_latest(path: str) -> str:
     stem = _base_stem(path)
 
     # Glob for timestamped variants, then strict regex filter on full basename
-    pattern = os.path.join(directory, f"{glob.escape(stem)}-*-*-*-*-*-*.h5ad")
-    full_re = re.compile(rf"^{re.escape(stem)}-\d{{4}}-\d{{2}}-\d{{2}}-\d{{2}}-\d{{2}}-\d{{2}}\.h5ad$")
+    pattern = os.path.join(directory, f"{glob.escape(stem)}-edit-*-*-*-*-*-*.h5ad")
+    full_re = re.compile(rf"^{re.escape(stem)}-edit-\d{{4}}-\d{{2}}-\d{{2}}-\d{{2}}-\d{{2}}-\d{{2}}\.h5ad$")
     candidates = [
         f for f in glob.glob(pattern)
         if full_re.match(os.path.basename(f))

--- a/packages/hca-anndata-tools/tests/test_convert.py
+++ b/packages/hca-anndata-tools/tests/test_convert.py
@@ -98,7 +98,7 @@ def test_convert_output_named_from_title(cellxgene_h5ad):
     result = convert_cellxgene_to_hca(str(cellxgene_h5ad))
     basename = os.path.basename(result["output_path"])
 
-    assert basename.startswith("snrna-seq-of-human-retina-test-subset-")
+    assert basename.startswith("snrna-seq-of-human-retina-test-subset-edit-")
     assert re.search(r"\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}\.h5ad$", basename)
 
 

--- a/packages/hca-anndata-tools/tests/test_write.py
+++ b/packages/hca-anndata-tools/tests/test_write.py
@@ -15,7 +15,7 @@ from hca_anndata_tools.write import (
     write_h5ad,
 )
 
-TIMESTAMP_RE = re.compile(r"-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}\.h5ad$")
+TIMESTAMP_RE = re.compile(r"-edit-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}\.h5ad$")
 
 
 def _make_entry(**overrides):
@@ -35,7 +35,7 @@ def _make_entry(**overrides):
 
 
 def test_strip_timestamp_removes_suffix():
-    assert strip_timestamp("foo-2026-03-27-13-54-26.h5ad") == "foo.h5ad"
+    assert strip_timestamp("foo-edit-2026-03-27-13-54-26.h5ad") == "foo.h5ad"
 
 
 def test_strip_timestamp_no_suffix():
@@ -43,12 +43,12 @@ def test_strip_timestamp_no_suffix():
 
 
 def test_strip_timestamp_preserves_complex_basename():
-    result = strip_timestamp("AlZaim_2024_reprocessed-r1-wip-5-2026-03-27-13-54-26.h5ad")
+    result = strip_timestamp("AlZaim_2024_reprocessed-r1-wip-5-edit-2026-03-27-13-54-26.h5ad")
     assert result == "AlZaim_2024_reprocessed-r1-wip-5.h5ad"
 
 
 def test_strip_timestamp_ignores_non_h5ad():
-    name = "foo-2026-03-27-13-54-26.csv"
+    name = "foo-edit-2026-03-27-13-54-26.csv"
     assert strip_timestamp(name) == name
 
 
@@ -63,7 +63,7 @@ def test_generate_output_path_default_dir(sample_h5ad_for_write):
 
 def test_generate_output_path_strips_existing_timestamp(tmp_path):
     # Simulate a file with an existing timestamp in the name
-    source = tmp_path / "data-2026-03-27-13-54-26.h5ad"
+    source = tmp_path / "data-edit-2026-03-27-13-54-26.h5ad"
     source.touch()
     result = generate_output_path(str(source))
     # Should have base "data" with a NEW timestamp, not double-stamped
@@ -252,7 +252,7 @@ def test_write_h5ad_unsupported_log_type(sample_h5ad_for_write):
 
 def test_write_h5ad_custom_output_path(sample_h5ad_for_write, tmp_path):
     adata = ad.read_h5ad(str(sample_h5ad_for_write))
-    custom = str(tmp_path / "custom-name-2026-03-29-00-00-00.h5ad")
+    custom = str(tmp_path / "custom-name-edit-2026-03-29-00-00-00.h5ad")
     result = write_h5ad(adata, str(sample_h5ad_for_write), [_make_entry()], output_path=custom)
 
     assert "error" not in result
@@ -274,25 +274,25 @@ def test_resolve_latest_finds_newest(sample_h5ad_for_write):
     d = sample_h5ad_for_write.parent
     stem = sample_h5ad_for_write.stem  # "test-dataset"
     # Create fake timestamped files
-    (d / f"{stem}-2026-03-27-10-00-00.h5ad").touch()
-    (d / f"{stem}-2026-03-28-15-30-00.h5ad").touch()
-    (d / f"{stem}-2026-03-27-12-00-00.h5ad").touch()
+    (d / f"{stem}-edit-2026-03-27-10-00-00.h5ad").touch()
+    (d / f"{stem}-edit-2026-03-28-15-30-00.h5ad").touch()
+    (d / f"{stem}-edit-2026-03-27-12-00-00.h5ad").touch()
 
     result = resolve_latest(str(sample_h5ad_for_write))
-    assert result.endswith(f"{stem}-2026-03-28-15-30-00.h5ad")
+    assert result.endswith(f"{stem}-edit-2026-03-28-15-30-00.h5ad")
 
 
 def test_resolve_latest_from_timestamped_path(sample_h5ad_for_write):
     """Given a timestamped path, still finds the latest (not self)."""
     d = sample_h5ad_for_write.parent
     stem = sample_h5ad_for_write.stem
-    old = d / f"{stem}-2026-03-27-10-00-00.h5ad"
-    new = d / f"{stem}-2026-03-28-15-30-00.h5ad"
+    old = d / f"{stem}-edit-2026-03-27-10-00-00.h5ad"
+    new = d / f"{stem}-edit-2026-03-28-15-30-00.h5ad"
     old.touch()
     new.touch()
 
     result = resolve_latest(str(old))
-    assert result.endswith(f"{stem}-2026-03-28-15-30-00.h5ad")
+    assert result.endswith(f"{stem}-edit-2026-03-28-15-30-00.h5ad")
 
 
 # --- write_h5ad overwrite ---


### PR DESCRIPTION
## Summary

Changes output filenames from `foo-2026-03-30-08-00-00.h5ad` to `foo-edit-2026-03-30-08-00-00.h5ad`. Makes it visually obvious which files are edits vs originals.

Closes #245

## Changes

Pure string substitution across 4 files — no logic changes:
- `write.py`: regex pattern, `generate_output_path`, `resolve_latest` glob
- `convert.py`: output filename format
- `test_write.py` + `test_convert.py`: updated fixtures

## Test plan

- [x] 138 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)