### PR TITLE
ci: add PyPI publishing for hca-anndata-tools and hca-anndata-mcp

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,9 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     outputs:
-      release_created: ${{ steps.release.outputs['packages/hca-schema-validator--release_created'] }}
+      hca-schema-validator-release: ${{ steps.release.outputs['packages/hca-schema-validator--release_created'] }}
+      hca-anndata-tools-release: ${{ steps.release.outputs['packages/hca-anndata-tools--release_created'] }}
+      hca-anndata-mcp-release: ${{ steps.release.outputs['packages/hca-anndata-mcp--release_created'] }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -23,11 +25,11 @@ jobs:
     needs: release-please
     if: |
       !failure() && !cancelled() &&
-      (needs.release-please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch')
+      (needs.release-please.outputs.hca-schema-validator-release == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write  # Required for PyPI trusted publishing
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -51,3 +53,74 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: packages/hca-schema-validator/dist/
+
+  publish-hca-anndata-tools:
+    needs: release-please
+    if: |
+      !failure() && !cancelled() &&
+      (needs.release-please.outputs.hca-anndata-tools-release == 'true' || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Build package
+        run: |
+          cd packages/hca-anndata-tools
+          poetry build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: packages/hca-anndata-tools/dist/
+
+  publish-hca-anndata-mcp:
+    needs: release-please
+    if: |
+      !failure() && !cancelled() &&
+      (needs.release-please.outputs.hca-anndata-mcp-release == 'true' || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Swap path dep to version pin for PyPI
+        run: |
+          cd packages/hca-anndata-mcp
+          sed -i 's|hca-anndata-tools = {path = "../hca-anndata-tools", develop = true}|hca-anndata-tools = ">=0.1.0,<1"|' pyproject.toml
+
+      - name: Build package
+        run: |
+          cd packages/hca-anndata-mcp
+          poetry build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: packages/hca-anndata-mcp/dist/

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,9 +14,9 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     outputs:
-      hca-schema-validator-release: ${{ steps.release.outputs['packages/hca-schema-validator--release_created'] }}
-      hca-anndata-tools-release: ${{ steps.release.outputs['packages/hca-anndata-tools--release_created'] }}
-      hca-anndata-mcp-release: ${{ steps.release.outputs['packages/hca-anndata-mcp--release_created'] }}
+      hca_schema_validator_release: ${{ steps.release.outputs['packages/hca-schema-validator--release_created'] }}
+      hca_anndata_tools_release: ${{ steps.release.outputs['packages/hca-anndata-tools--release_created'] }}
+      hca_anndata_mcp_release: ${{ steps.release.outputs['packages/hca-anndata-mcp--release_created'] }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -25,7 +25,7 @@ jobs:
     needs: release-please
     if: |
       !failure() && !cancelled() &&
-      (needs.release-please.outputs.hca-schema-validator-release == 'true' || github.event_name == 'workflow_dispatch')
+      (needs.release-please.outputs.hca_schema_validator_release == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -58,7 +58,7 @@ jobs:
     needs: release-please
     if: |
       !failure() && !cancelled() &&
-      (needs.release-please.outputs.hca-anndata-tools-release == 'true' || github.event_name == 'workflow_dispatch')
+      (needs.release-please.outputs.hca_anndata_tools_release == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -88,10 +88,10 @@ jobs:
           packages-dir: packages/hca-anndata-tools/dist/
 
   publish-hca-anndata-mcp:
-    needs: release-please
+    needs: [release-please, publish-hca-anndata-tools]
     if: |
       !failure() && !cancelled() &&
-      (needs.release-please.outputs.hca-anndata-mcp-release == 'true' || github.event_name == 'workflow_dispatch')
+      (needs.release-please.outputs.hca_anndata_mcp_release == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -114,6 +114,11 @@ jobs:
         run: |
           cd packages/hca-anndata-mcp
           sed -i 's|hca-anndata-tools = {path = "../hca-anndata-tools", develop = true}|hca-anndata-tools = ">=0.1.0,<1"|' pyproject.toml
+          if grep -q 'path = "../hca-anndata-tools"' pyproject.toml; then
+            echo "ERROR: path dependency still present after sed replacement"
+            cat pyproject.toml
+            exit 1
+          fi
 
       - name: Build package
         run: |

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,5 @@
 {
   "packages/hca-schema-validator": "0.9.0",
-  "packages/hca-anndata-tools": "0.1.0"
+  "packages/hca-anndata-tools": "0.1.0",
+  "packages/hca-anndata-mcp": "0.1.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -15,6 +15,14 @@
       "extra-files": [
         "packages/hca-anndata-tools/src/hca_anndata_tools/__init__.py"
       ]
+    },
+    "packages/hca-anndata-mcp": {
+      "release-type": "python",
+      "package-name": "hca-anndata-mcp",
+      "changelog-path": "packages/hca-anndata-mcp/CHANGELOG.md",
+      "extra-files": [
+        "packages/hca-anndata-mcp/src/hca_anndata_mcp/__init__.py"
+      ]
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
## Summary

Sets up automated PyPI publishing for both new packages via the existing release-please + GitHub Actions infrastructure.

Closes #235

## Changes

- Added `hca-anndata-mcp` to `release-please-config.json` and `.release-please-manifest.json`
- Added publish jobs for `hca-anndata-tools` and `hca-anndata-mcp` in the release-please workflow
- `hca-anndata-mcp` path dependency on `hca-anndata-tools` is swapped to a version pin (`>=0.1.0,<1`) at build time via `sed`
- Updated workflow outputs to expose release_created for all three packages

## Pre-requisite (manual, one-time)

Before merging, configure **trusted publishing** on pypi.org for each new package:
1. Go to pypi.org → "Your projects" → "Publishing"
2. Add "GitHub Actions" trusted publisher for `hca-anndata-tools`:
   - Owner: `clevercanary`, Repo: `hca-validation-tools`, Workflow: `release-please.yml`
3. Same for `hca-anndata-mcp`

## How it works

1. Conventional commits on main → release-please creates release PRs
2. Merge release PR → publish jobs trigger for changed packages
3. `workflow_dispatch` also works for manual publishing

## Test plan

- [x] YAML validates
- [x] JSON configs validate
- [ ] Trusted publishing configured on pypi.org (manual)
- [ ] First release triggered and packages appear on pypi.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)