### PR TITLE
fix: update hca-schema-validator dependency to 0.9.x

### DIFF
--- a/services/hca-schema-validator/poetry.lock
+++ b/services/hca-schema-validator/poetry.lock
@@ -509,14 +509,14 @@ numpy = ">=1.21.2"
 
 [[package]]
 name = "hca-schema-validator"
-version = "0.8.1"
+version = "0.9.1"
 description = "HCA schema validation for single-cell datasets"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "hca_schema_validator-0.8.1-py3-none-any.whl", hash = "sha256:69bcd4eb4ff30b60a780d93b98ab1538d3a5c8ffc591a811d6c99ac58d41b79d"},
-    {file = "hca_schema_validator-0.8.1.tar.gz", hash = "sha256:38f1e4d50a842e9fcd10203ec1e8abebe705635d56d855c04e2df26a4de357e7"},
+    {file = "hca_schema_validator-0.9.1-py3-none-any.whl", hash = "sha256:a0a802713b71d944c2daa964777543651482d97c9003e25017a8f7ebce294176"},
+    {file = "hca_schema_validator-0.9.1.tar.gz", hash = "sha256:223d278c0ee70c98d6cb501aeae103858e254b2974d637fdc60cdcb0c49b1c37"},
 ]
 
 [package.dependencies]
@@ -2066,4 +2066,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "~=3.11"
-content-hash = "c03d35d43859e44784741870082e4bac2d59e6bd8373dd3032450c52c1c53da1"
+content-hash = "c6b469d92cfa2a501fec79c2ae5fc73bfced649b303603c97e1d344790f7ef2b"

--- a/services/hca-schema-validator/poetry.lock
+++ b/services/hca-schema-validator/poetry.lock
@@ -2066,4 +2066,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "~=3.11"
-content-hash = "c6b469d92cfa2a501fec79c2ae5fc73bfced649b303603c97e1d344790f7ef2b"
+content-hash = "11327d10353b170e6bdabc1642e5809f83360cd14a4325db4bf9406f01c5e197"

--- a/services/hca-schema-validator/pyproject.toml
+++ b/services/hca-schema-validator/pyproject.toml
@@ -3,7 +3,7 @@ name = "hca-schema-validator-service"
 version = "0.1.0"
 requires-python = "~=3.11"
 dependencies = [
-    "hca-schema-validator (>=0.9.0,<1.0.0)"
+    "hca-schema-validator (>=0.9.0,<0.10.0)"
 ]
 
 [tool.poetry]

--- a/services/hca-schema-validator/pyproject.toml
+++ b/services/hca-schema-validator/pyproject.toml
@@ -3,7 +3,7 @@ name = "hca-schema-validator-service"
 version = "0.1.0"
 requires-python = "~=3.11"
 dependencies = [
-    "hca-schema-validator (>=0.8.0,<0.9.0)"
+    "hca-schema-validator (>=0.9.0,<1.0.0)"
 ]
 
 [tool.poetry]


### PR DESCRIPTION
## Summary
- Bumps `hca-schema-validator` service wrapper dependency from `>=0.8.0,<0.9.0` to `>=0.9.0,<1.0.0` so the batch dataset-validator runs the latest version (0.9.1)
- cap-upload-validator (1.7.0) and cellxgene-schema (7.0.1) are already at latest — no changes needed

## Test plan
- [x] `services/hca-schema-validator` tests pass (4/4)
- [ ] Rebuild batch container and verify hca-schema-validator 0.9.1 is installed
- [ ] Run end-to-end validation on a test dataset

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)