### PR TITLE
feat: add copy_cap_annotations tool

### DIFF
--- a/packages/hca-anndata-mcp/src/hca_anndata_mcp/server.py
+++ b/packages/hca-anndata-mcp/src/hca_anndata_mcp/server.py
@@ -13,6 +13,7 @@ from hca_anndata_tools import (
     list_uns_fields,
     convert_cellxgene_to_hca,
     validate_marker_genes,
+    copy_cap_annotations,
 )
 from hca_anndata_mcp.tools.plot import plot_embedding_mcp
 
@@ -28,7 +29,8 @@ mcp = FastMCP(
         "list_uns_fields to see HCA dataset metadata and what's missing, "
         "set_uns to update HCA dataset metadata fields with schema validation, "
         "convert_cellxgene_to_hca to convert CellxGENE files to HCA format, "
-        "and validate_marker_genes to check CAP marker genes against var."
+        "validate_marker_genes to check CAP marker genes against var, "
+        "and copy_cap_annotations to copy CAP annotations from a source into an HCA target file."
     ),
 )
 
@@ -43,3 +45,4 @@ mcp.tool()(list_uns_fields)
 mcp.tool()(set_uns)
 mcp.tool()(convert_cellxgene_to_hca)
 mcp.tool()(validate_marker_genes)
+mcp.tool()(copy_cap_annotations)

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/__init__.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/__init__.py
@@ -20,6 +20,7 @@ __all__ = [
     "list_uns_fields",
     "convert_cellxgene_to_hca",
     "validate_marker_genes",
+    "copy_cap_annotations",
 ]
 
 _LAZY_IMPORTS = {
@@ -40,6 +41,7 @@ _LAZY_IMPORTS = {
     "list_uns_fields": ".edit",
     "convert_cellxgene_to_hca": ".convert",
     "validate_marker_genes": ".marker_genes",
+    "copy_cap_annotations": ".copy_cap",
 }
 
 

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -165,17 +165,6 @@ def copy_cap_annotations(
                     )
                 }
 
-            # --- Validation 4: Base label columns exist in target ---
-            target_obs_columns = list(target.obs.columns)
-            for setname in annotation_sets:
-                if setname not in target_obs_columns:
-                    return {
-                        "error": (
-                            f"Target is missing base label column '{setname}' "
-                            f"in obs. Cannot copy annotation set."
-                        )
-                    }
-
             # --- Copy obs columns (aligned by index) ---
             aligned = source_obs_subset.loc[target.obs.index]
             for col in obs_cols_to_copy:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -102,32 +102,31 @@ def copy_cap_annotations(
 
         # --- Validation 1: Source has CAP ---
         with open_h5ad(source_path) as source:
-            source_uns_keys = list(source.uns.keys())
-            if "cellannotation_metadata" not in source_uns_keys:
+            if "cellannotation_metadata" not in source.uns:
                 return {"error": "Source has no cellannotation_metadata in uns"}
-            if "cellannotation_schema_version" not in source_uns_keys:
+            if "cellannotation_schema_version" not in source.uns:
                 return {"error": "Source has no cellannotation_schema_version in uns"}
 
-            source_obs_columns = list(source.obs.columns)
             annotation_sets = _get_real_annotation_sets(source.uns)
             if not annotation_sets:
                 return {"error": "Source has no annotation sets in cellannotation_metadata"}
+
+            if not source.obs.index.is_unique:
+                dupes = source.obs.index[source.obs.index.duplicated()].unique()[:5].tolist()
+                return {"error": f"Source has duplicate cell IDs (first 5): {dupes}"}
 
             # Snapshot source data we need (before closing backed file)
             cap_schema_version = str(source.uns["cellannotation_schema_version"])
             all_uns_keys = _UNS_COPY_TOPLEVEL + _UNS_CAP_METADATA
             source_uns = {k: make_serializable(source.uns[k]) for k in all_uns_keys if k in source.uns}
 
+            source_obs_columns = list(source.obs.columns)
             obs_cols_to_copy = _get_obs_columns_to_copy(annotation_sets, source_obs_columns)
             if not obs_cols_to_copy:
                 return {"error": "No CAP obs columns found to copy"}
 
             source_obs_subset = source.obs[obs_cols_to_copy].copy()
             source_n_obs = source.n_obs
-            if not source.obs.index.is_unique:
-                dupes = source.obs.index[source.obs.index.duplicated()].unique().tolist()
-                shown = dupes[:5]
-                return {"error": f"Source has {len(dupes)} duplicate cell IDs (first 5): {shown}"}
             source_index = set(source.obs.index)
 
         # --- Validation 2: Target clean ---

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -64,7 +64,9 @@ def _get_obs_columns_to_copy(
 
     for setname in annotation_sets:
         for suffix in all_suffixes:
-            col = f"{setname}{suffix}" if suffix else setname
+            if not suffix:
+                continue
+            col = f"{setname}{suffix}"
             if col in source_obs_columns:
                 columns.append(col)
 

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import os
 from datetime import datetime, timezone
 
@@ -10,7 +9,7 @@ from ._io import open_h5ad
 from ._serialize import make_serializable
 from .cap import _REQUIRED_SUFFIXES, _OPTIONAL_SUFFIXES
 from .marker_genes import validate_marker_genes
-from .write import write_h5ad, resolve_latest
+from .write import write_h5ad, resolve_latest, _compute_sha256
 from . import __version__
 
 # uns keys copied as-is (already namespaced or CAP-specific)
@@ -196,9 +195,7 @@ def copy_cap_annotations(
 
             # --- Edit log ---
             source_basename = os.path.basename(source_path)
-            source_sha256 = hashlib.sha256(
-                open(source_path, "rb").read()
-            ).hexdigest()
+            source_sha256 = _compute_sha256(source_path)
             entry = {
                 "timestamp": datetime.now(timezone.utc).isoformat(),
                 "tool": "hca-anndata-tools",

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -124,6 +124,10 @@ def copy_cap_annotations(
 
             source_obs_subset = source.obs[obs_cols_to_copy].copy()
             source_n_obs = source.n_obs
+            if not source.obs.index.is_unique:
+                dupes = source.obs.index[source.obs.index.duplicated()].unique().tolist()
+                shown = dupes[:5]
+                return {"error": f"Source has {len(dupes)} duplicate cell IDs (first 5): {shown}"}
             source_index = set(source.obs.index)
 
         # --- Validation 2: Target clean ---

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -12,14 +12,19 @@ from .marker_genes import validate_marker_genes
 from .write import write_h5ad, resolve_latest, _compute_sha256
 from . import __version__
 
-# CAP uns keys to copy (all copied as-is, no renaming)
-_UNS_COPY = [
+# CAP uns keys copied top-level (already namespaced)
+_UNS_COPY_TOPLEVEL = [
     "cellannotation_schema_version",
     "cellannotation_metadata",
     "cap_dataset_url",
     "cap_publication_title",
     "cap_publication_description",
     "cap_publication_url",
+]
+
+# CAP uns keys collected into uns["cap_metadata"] container
+# (generic names that could collide with HCA/CXG fields)
+_UNS_CAP_METADATA = [
     "authors_list",
     "hierarchy",
     "description",
@@ -38,7 +43,7 @@ _CELL_TYPE_ENRICHMENT = [
 ]
 
 # CAP uns keys to remove on overwrite
-_CAP_UNS_KEYS = set(_UNS_COPY)
+_CAP_UNS_KEYS = set(_UNS_COPY_TOPLEVEL) | {"cap_metadata"}
 
 
 def _get_real_annotation_sets(source_uns: dict) -> list[str]:
@@ -59,9 +64,7 @@ def _get_obs_columns_to_copy(
 
     for setname in annotation_sets:
         for suffix in all_suffixes:
-            if not suffix:
-                continue
-            col = f"{setname}{suffix}"
+            col = f"{setname}{suffix}" if suffix else setname
             if col in source_obs_columns:
                 columns.append(col)
 
@@ -110,7 +113,8 @@ def copy_cap_annotations(
 
             # Snapshot source data we need (before closing backed file)
             cap_schema_version = str(source.uns["cellannotation_schema_version"])
-            source_uns = {k: make_serializable(source.uns[k]) for k in _UNS_COPY if k in source.uns}
+            all_uns_keys = _UNS_COPY_TOPLEVEL + _UNS_CAP_METADATA
+            source_uns = {k: make_serializable(source.uns[k]) for k in all_uns_keys if k in source.uns}
 
             obs_cols_to_copy = _get_obs_columns_to_copy(annotation_sets, source_obs_columns)
             if not obs_cols_to_copy:
@@ -167,10 +171,16 @@ def copy_cap_annotations(
 
             # --- Copy uns metadata ---
             uns_keys_added = []
-            for key in _UNS_COPY:
+            for key in _UNS_COPY_TOPLEVEL:
                 if key in source_uns:
                     target.uns[key] = source_uns[key]
                     uns_keys_added.append(key)
+
+            # Collect generic CAP keys into a container
+            cap_metadata = {k: source_uns[k] for k in _UNS_CAP_METADATA if k in source_uns}
+            if cap_metadata:
+                target.uns["cap_metadata"] = cap_metadata
+                uns_keys_added.append("cap_metadata")
 
             # --- Edit log ---
             source_basename = os.path.basename(source_path)

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -1,0 +1,215 @@
+"""Copy CAP cell annotations from a source h5ad into an HCA target h5ad."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+
+from ._io import open_h5ad
+from ._serialize import make_serializable
+from .cap import _REQUIRED_SUFFIXES, _OPTIONAL_SUFFIXES
+from .write import write_h5ad, resolve_latest
+from . import __version__
+
+# uns keys copied as-is (already namespaced or CAP-specific)
+_UNS_COPY_DIRECT = [
+    "cellannotation_schema_version",
+    "cellannotation_metadata",
+    "cap_dataset_url",
+    "cap_publication_title",
+    "cap_publication_description",
+    "cap_publication_url",
+]
+
+# uns keys renamed on copy to avoid collisions with HCA/CXG fields
+_UNS_COPY_RENAMED = {
+    "authors_list": "cap_authors_list",
+    "hierarchy": "cap_hierarchy",
+    "description": "cap_description",
+    "publication_timestamp": "cap_publication_timestamp",
+    "publication_version": "cap_publication_version",
+}
+
+# Demographic annotation sets — not real CAP annotations, just renamed CXG columns
+_SKIP_SETS = {"sex", "development_stage", "self_reported_ethnicity"}
+
+# cell_type enrichment columns to copy (but NOT cell_type--cell_ontology_term_id)
+_CELL_TYPE_ENRICHMENT = [
+    "cell_type--cell_fullname",
+    "cell_type--cell_ontology_exists",
+    "cell_type--cell_ontology_term",
+]
+
+# CAP uns keys to remove on overwrite
+_CAP_UNS_KEYS = set(_UNS_COPY_DIRECT) | set(_UNS_COPY_RENAMED.values())
+
+
+def _get_real_annotation_sets(source_uns: dict) -> list[str]:
+    """Get annotation sets defined in cellannotation_metadata (the real CAP sets)."""
+    meta = source_uns.get("cellannotation_metadata", {})
+    if isinstance(meta, dict):
+        return [s for s in meta.keys() if s not in _SKIP_SETS]
+    return []
+
+
+def _get_obs_columns_to_copy(
+    annotation_sets: list[str],
+    source_obs_columns: list[str],
+) -> list[str]:
+    """Build list of obs columns to copy from source."""
+    columns = []
+    all_suffixes = _REQUIRED_SUFFIXES + _OPTIONAL_SUFFIXES
+
+    for setname in annotation_sets:
+        for suffix in all_suffixes:
+            if not suffix:
+                continue
+            col = f"{setname}{suffix}"
+            if col in source_obs_columns:
+                columns.append(col)
+
+    # cell_type enrichment columns (but not cell_type--cell_ontology_term_id)
+    for col in _CELL_TYPE_ENRICHMENT:
+        if col in source_obs_columns:
+            columns.append(col)
+
+    return columns
+
+
+def copy_cap_annotations(
+    source_path: str,
+    target_path: str,
+    overwrite: bool = False,
+) -> dict:
+    """Copy CAP cell annotations from source to target h5ad file.
+
+    Validates prerequisites, copies annotation obs columns and uns metadata,
+    then writes the target with an edit log entry.
+
+    Args:
+        source_path: Path to source h5ad with CAP annotations.
+        target_path: Path to target HCA h5ad to receive annotations.
+        overwrite: If True, replace existing CAP data in target.
+
+    Returns:
+        Dict with output_path, copied columns/keys, and warnings,
+        or 'error' on failure.
+    """
+    try:
+        target_path = resolve_latest(target_path)
+
+        # --- Validation 1: Source has CAP ---
+        with open_h5ad(source_path) as source:
+            source_uns_keys = list(source.uns.keys())
+            if "cellannotation_metadata" not in source_uns_keys:
+                return {"error": "Source has no cellannotation_metadata in uns"}
+            if "cellannotation_schema_version" not in source_uns_keys:
+                return {"error": "Source has no cellannotation_schema_version in uns"}
+
+            source_obs_columns = list(source.obs.columns)
+            annotation_sets = _get_real_annotation_sets(source.uns)
+            if not annotation_sets:
+                return {"error": "Source has no annotation sets in cellannotation_metadata"}
+
+            # Snapshot source data we need (before closing backed file)
+            cap_schema_version = str(source.uns["cellannotation_schema_version"])
+            keys_to_copy = list(_UNS_COPY_DIRECT) + list(_UNS_COPY_RENAMED.keys())
+            source_uns = {k: make_serializable(source.uns[k]) for k in keys_to_copy if k in source.uns}
+
+            obs_cols_to_copy = _get_obs_columns_to_copy(annotation_sets, source_obs_columns)
+            if not obs_cols_to_copy:
+                return {"error": "No CAP obs columns found to copy"}
+
+            source_obs_subset = source.obs[obs_cols_to_copy].copy()
+            source_n_obs = source.n_obs
+            source_index = set(source.obs.index)
+
+        # --- Validation 2: Target clean ---
+        with open_h5ad(target_path, backed=None) as target:
+            target_obs_columns = list(target.obs.columns)
+            existing_cap_cols = [c for c in target_obs_columns if "--" in c]
+
+            if existing_cap_cols and not overwrite:
+                return {
+                    "error": (
+                        f"Target already has {len(existing_cap_cols)} CAP columns "
+                        f"(e.g., {existing_cap_cols[0]}). Use overwrite=True to replace."
+                    )
+                }
+
+            if existing_cap_cols and overwrite:
+                target.obs.drop(columns=existing_cap_cols, inplace=True)
+                for key in list(target.uns.keys()):
+                    if key in _CAP_UNS_KEYS:
+                        del target.uns[key]
+
+            # --- Validation 3: Cell identity match ---
+            if target.n_obs != source_n_obs:
+                return {
+                    "error": (
+                        f"Cell count mismatch: source has {source_n_obs}, "
+                        f"target has {target.n_obs}"
+                    )
+                }
+
+            target_index = set(target.obs.index)
+            if source_index != target_index:
+                missing_in_target = source_index - target_index
+                missing_in_source = target_index - source_index
+                return {
+                    "error": (
+                        f"Cell ID mismatch: {len(missing_in_target)} IDs in source "
+                        f"not in target, {len(missing_in_source)} IDs in target not "
+                        f"in source"
+                    )
+                }
+
+            # --- Copy obs columns (aligned by index) ---
+            aligned = source_obs_subset.loc[target.obs.index]
+            for col in obs_cols_to_copy:
+                target.obs[col] = aligned[col].values
+
+            # --- Copy uns metadata ---
+            uns_keys_added = []
+            for key in _UNS_COPY_DIRECT:
+                if key in source_uns:
+                    target.uns[key] = source_uns[key]
+                    uns_keys_added.append(key)
+
+            for src_key, tgt_key in _UNS_COPY_RENAMED.items():
+                if src_key in source_uns:
+                    target.uns[tgt_key] = source_uns[src_key]
+                    uns_keys_added.append(tgt_key)
+
+            # --- Edit log ---
+            source_basename = os.path.basename(source_path)
+            entry = {
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "tool": "hca-anndata-tools",
+                "tool_version": __version__,
+                "operation": "import_cap_annotations",
+                "description": f"Copied CAP annotations from {source_basename}",
+                "details": {
+                    "cap_schema_version": cap_schema_version,
+                    "annotation_sets": annotation_sets,
+                    "obs_columns_added": obs_cols_to_copy,
+                    "uns_keys_added": uns_keys_added,
+                },
+            }
+
+            # --- Write ---
+            result = write_h5ad(target, target_path, [entry])
+
+        if "error" in result:
+            return result
+
+        return {
+            **result,
+            "source": source_basename,
+            "annotation_sets": annotation_sets,
+            "obs_columns_added": obs_cols_to_copy,
+            "uns_keys_added": uns_keys_added,
+        }
+
+    except Exception as e:
+        return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from ._io import open_h5ad
 from ._serialize import make_serializable
 from .cap import _REQUIRED_SUFFIXES, _OPTIONAL_SUFFIXES
+from .marker_genes import validate_marker_genes
 from .write import write_h5ad, resolve_latest
 from . import __version__
 
@@ -203,12 +204,16 @@ def copy_cap_annotations(
         if "error" in result:
             return result
 
+        # --- Post-copy: validate marker genes ---
+        marker_validation = validate_marker_genes(result["output_path"])
+
         return {
             **result,
             "source": source_basename,
             "annotation_sets": annotation_sets,
             "obs_columns_added": obs_cols_to_copy,
             "uns_keys_added": uns_keys_added,
+            "marker_gene_validation": marker_validation,
         }
 
     except Exception as e:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -12,24 +12,20 @@ from .marker_genes import validate_marker_genes
 from .write import write_h5ad, resolve_latest, _compute_sha256
 from . import __version__
 
-# uns keys copied as-is (already namespaced or CAP-specific)
-_UNS_COPY_DIRECT = [
+# CAP uns keys to copy (all copied as-is, no renaming)
+_UNS_COPY = [
     "cellannotation_schema_version",
     "cellannotation_metadata",
     "cap_dataset_url",
     "cap_publication_title",
     "cap_publication_description",
     "cap_publication_url",
+    "authors_list",
+    "hierarchy",
+    "description",
+    "publication_timestamp",
+    "publication_version",
 ]
-
-# uns keys renamed on copy to avoid collisions with HCA/CXG fields
-_UNS_COPY_RENAMED = {
-    "authors_list": "cap_authors_list",
-    "hierarchy": "cap_hierarchy",
-    "description": "cap_description",
-    "publication_timestamp": "cap_publication_timestamp",
-    "publication_version": "cap_publication_version",
-}
 
 # Demographic annotation sets — not real CAP annotations, just renamed CXG columns
 _SKIP_SETS = {"sex", "development_stage", "self_reported_ethnicity"}
@@ -42,7 +38,7 @@ _CELL_TYPE_ENRICHMENT = [
 ]
 
 # CAP uns keys to remove on overwrite
-_CAP_UNS_KEYS = set(_UNS_COPY_DIRECT) | set(_UNS_COPY_RENAMED.values())
+_CAP_UNS_KEYS = set(_UNS_COPY)
 
 
 def _get_real_annotation_sets(source_uns: dict) -> list[str]:
@@ -114,8 +110,7 @@ def copy_cap_annotations(
 
             # Snapshot source data we need (before closing backed file)
             cap_schema_version = str(source.uns["cellannotation_schema_version"])
-            keys_to_copy = list(_UNS_COPY_DIRECT) + list(_UNS_COPY_RENAMED.keys())
-            source_uns = {k: make_serializable(source.uns[k]) for k in keys_to_copy if k in source.uns}
+            source_uns = {k: make_serializable(source.uns[k]) for k in _UNS_COPY if k in source.uns}
 
             obs_cols_to_copy = _get_obs_columns_to_copy(annotation_sets, source_obs_columns)
             if not obs_cols_to_copy:
@@ -172,15 +167,10 @@ def copy_cap_annotations(
 
             # --- Copy uns metadata ---
             uns_keys_added = []
-            for key in _UNS_COPY_DIRECT:
+            for key in _UNS_COPY:
                 if key in source_uns:
                     target.uns[key] = source_uns[key]
                     uns_keys_added.append(key)
-
-            for src_key, tgt_key in _UNS_COPY_RENAMED.items():
-                if src_key in source_uns:
-                    target.uns[tgt_key] = source_uns[src_key]
-                    uns_keys_added.append(tgt_key)
 
             # --- Edit log ---
             source_basename = os.path.basename(source_path)

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
 from datetime import datetime, timezone
 
@@ -93,8 +94,8 @@ def copy_cap_annotations(
         overwrite: If True, replace existing CAP data in target.
 
     Returns:
-        Dict with output_path, copied columns/keys, and warnings,
-        or 'error' on failure.
+        Dict with output_path, copied columns/keys, and marker gene
+        validation results, or 'error' on failure.
     """
     try:
         target_path = resolve_latest(target_path)
@@ -165,6 +166,17 @@ def copy_cap_annotations(
                     )
                 }
 
+            # --- Validation 4: Base label columns exist in target ---
+            target_obs_columns = list(target.obs.columns)
+            for setname in annotation_sets:
+                if setname not in target_obs_columns:
+                    return {
+                        "error": (
+                            f"Target is missing base label column '{setname}' "
+                            f"in obs. Cannot copy annotation set."
+                        )
+                    }
+
             # --- Copy obs columns (aligned by index) ---
             aligned = source_obs_subset.loc[target.obs.index]
             for col in obs_cols_to_copy:
@@ -184,6 +196,9 @@ def copy_cap_annotations(
 
             # --- Edit log ---
             source_basename = os.path.basename(source_path)
+            source_sha256 = hashlib.sha256(
+                open(source_path, "rb").read()
+            ).hexdigest()
             entry = {
                 "timestamp": datetime.now(timezone.utc).isoformat(),
                 "tool": "hca-anndata-tools",
@@ -191,6 +206,8 @@ def copy_cap_annotations(
                 "operation": "import_cap_annotations",
                 "description": f"Copied CAP annotations from {source_basename}",
                 "details": {
+                    "source_file": source_basename,
+                    "source_sha256": source_sha256,
                     "cap_schema_version": cap_schema_version,
                     "annotation_sets": annotation_sets,
                     "obs_columns_added": obs_cols_to_copy,

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -163,7 +163,7 @@ def copy_cap_annotations(
             # --- Copy obs columns (aligned by index) ---
             aligned = source_obs_subset.loc[target.obs.index]
             for col in obs_cols_to_copy:
-                target.obs[col] = aligned[col].values
+                target.obs[col] = aligned[col]
 
             # --- Copy uns metadata ---
             uns_keys_added = []
@@ -182,8 +182,8 @@ def copy_cap_annotations(
                 "operation": "import_cap_annotations",
                 "description": f"Copied CAP annotations from {source_basename}",
                 "details": {
-                    "source_file": source_basename,
-                    "source_sha256": source_sha256,
+                    "cap_source_file": source_basename,
+                    "cap_source_sha256": source_sha256,
                     "cap_schema_version": cap_schema_version,
                     "annotation_sets": annotation_sets,
                     "obs_columns_added": obs_cols_to_copy,

--- a/packages/hca-anndata-tools/tests/test_copy_cap.py
+++ b/packages/hca-anndata-tools/tests/test_copy_cap.py
@@ -1,0 +1,278 @@
+"""Tests for copy_cap_annotations."""
+
+import json
+from pathlib import Path
+
+import anndata as ad
+import numpy as np
+import pandas as pd
+import pytest
+import scipy.sparse as sp
+
+from hca_anndata_tools.copy_cap import copy_cap_annotations
+from hca_anndata_tools.write import EDIT_LOG_KEY
+
+
+# --- Fixtures ---
+
+
+def _make_cap_source(path: Path, cell_ids: list[str]) -> Path:
+    """Create an h5ad with CAP annotations."""
+    n = len(cell_ids)
+    rng = np.random.default_rng(42)
+
+    X = sp.random(n, 5, density=0.3, format="csr", dtype=np.float32, random_state=rng)
+
+    labels = rng.choice(["typeA", "typeB"], n)
+    obs = pd.DataFrame(
+        {
+            "author_cell_type": pd.Categorical(labels),
+            "author_cell_type--cell_fullname": [f"{l} cell" for l in labels],
+            "author_cell_type--cell_ontology_exists": [True] * n,
+            "author_cell_type--cell_ontology_term_id": pd.Categorical(
+                rng.choice(["CL:0000540", "CL:0000127"], n)
+            ),
+            "author_cell_type--cell_ontology_term": pd.Categorical(
+                rng.choice(["neuron", "astrocyte"], n)
+            ),
+            "author_cell_type--rationale": ["morphology"] * n,
+            "author_cell_type--marker_gene_evidence": pd.Categorical(
+                rng.choice(["GFAP", "AIF1"], n)
+            ),
+            "author_cell_type--canonical_marker_genes": ["unknown"] * n,
+            "author_cell_type--synonyms": ["unknown"] * n,
+            "author_cell_type--category_fullname": ["neural cell"] * n,
+            "author_cell_type--category_cell_ontology_term_id": ["CL:0002319"] * n,
+            "author_cell_type--category_cell_ontology_term": ["neural cell"] * n,
+            # cell_type enrichment columns
+            "cell_type--cell_fullname": ["neuron"] * n,
+            "cell_type--cell_ontology_exists": [True] * n,
+            "cell_type--cell_ontology_term": ["neuron"] * n,
+            # Demographic columns (should NOT be copied)
+            "sex--cell_ontology_term_id": ["PATO:0000384"] * n,
+            "development_stage--cell_ontology_term_id": ["HsapDv:0000087"] * n,
+            "self_reported_ethnicity--cell_ontology_term_id": ["HANCESTRO:0005"] * n,
+            "cell_type--cell_ontology_term_id": ["CL:0000540"] * n,
+        },
+        index=cell_ids,
+    )
+
+    var = pd.DataFrame(index=[f"GENE{i}" for i in range(5)])
+    adata = ad.AnnData(X=X, obs=obs, var=var)
+
+    adata.uns["title"] = "CAP Test Dataset"
+    adata.uns["cellannotation_schema_version"] = "1.0.2"
+    adata.uns["cellannotation_metadata"] = {
+        "author_cell_type": {
+            "algorithm_name": "NA",
+            "algorithm_version": "NA",
+            "algorithm_repo_url": "NA",
+            "annotation_method": "manual",
+            "description": "Test annotation set",
+        }
+    }
+    adata.uns["authors_list"] = "Test Author"
+    adata.uns["hierarchy"] = {"author_cell_type": 1}
+    adata.uns["description"] = "A test CAP dataset"
+    adata.uns["cap_dataset_url"] = "https://celltype.info/test"
+    adata.uns["publication_timestamp"] = "2026-01-01"
+    adata.uns["publication_version"] = "1.0"
+
+    adata.write_h5ad(path)
+    return path
+
+
+def _make_hca_target(path: Path, cell_ids: list[str]) -> Path:
+    """Create a minimal HCA-converted h5ad with same cells, no CAP columns."""
+    n = len(cell_ids)
+    rng = np.random.default_rng(7)
+
+    X = sp.random(n, 5, density=0.3, format="csr", dtype=np.float32, random_state=rng)
+
+    obs = pd.DataFrame(
+        {
+            "author_cell_type": pd.Categorical(rng.choice(["typeA", "typeB"], n)),
+            "cell_type": pd.Categorical(rng.choice(["neuron", "astrocyte"], n)),
+            "organism_ontology_term_id": pd.Categorical(["NCBITaxon:9606"] * n),
+        },
+        index=cell_ids,
+    )
+
+    var = pd.DataFrame(index=[f"GENE{i}" for i in range(5)])
+    adata = ad.AnnData(X=X, obs=obs, var=var)
+    adata.uns["title"] = "HCA Test Dataset"
+
+    adata.write_h5ad(path)
+    return path
+
+
+CELL_IDS = [f"cell_{i}" for i in range(10)]
+
+
+@pytest.fixture
+def cap_source(tmp_path) -> Path:
+    return _make_cap_source(tmp_path / "cap_source.h5ad", CELL_IDS)
+
+
+@pytest.fixture
+def hca_target(tmp_path) -> Path:
+    return _make_hca_target(tmp_path / "hca-target.h5ad", CELL_IDS)
+
+
+@pytest.fixture
+def hca_target_with_cap(tmp_path) -> Path:
+    """Target that already has CAP columns."""
+    target = _make_hca_target(tmp_path / "hca-target-cap.h5ad", CELL_IDS)
+    adata = ad.read_h5ad(target)
+    adata.obs["existing--cell_ontology_term_id"] = "CL:0000000"
+    adata.write_h5ad(target)
+    return target
+
+
+# --- Basic copy tests ---
+
+
+def test_copy_basic(cap_source, hca_target):
+    result = copy_cap_annotations(str(cap_source), str(hca_target))
+    assert "error" not in result
+    assert "output_path" in result
+    assert "author_cell_type" in result["annotation_sets"]
+
+
+def test_copy_obs_columns_present(cap_source, hca_target):
+    result = copy_cap_annotations(str(cap_source), str(hca_target))
+    written = ad.read_h5ad(result["output_path"])
+    assert "author_cell_type--cell_ontology_term_id" in written.obs.columns
+    assert "author_cell_type--marker_gene_evidence" in written.obs.columns
+    assert "author_cell_type--rationale" in written.obs.columns
+    assert "author_cell_type--category_fullname" in written.obs.columns
+
+
+def test_copy_cell_type_enrichment(cap_source, hca_target):
+    result = copy_cap_annotations(str(cap_source), str(hca_target))
+    written = ad.read_h5ad(result["output_path"])
+    assert "cell_type--cell_fullname" in written.obs.columns
+    assert "cell_type--cell_ontology_exists" in written.obs.columns
+    assert "cell_type--cell_ontology_term" in written.obs.columns
+
+
+def test_copy_uns_direct(cap_source, hca_target):
+    result = copy_cap_annotations(str(cap_source), str(hca_target))
+    written = ad.read_h5ad(result["output_path"])
+    assert "cellannotation_schema_version" in written.uns
+    assert "cellannotation_metadata" in written.uns
+    assert "cap_dataset_url" in written.uns
+
+
+def test_copy_uns_renamed(cap_source, hca_target):
+    result = copy_cap_annotations(str(cap_source), str(hca_target))
+    written = ad.read_h5ad(result["output_path"])
+    # Renamed keys present
+    assert "cap_authors_list" in written.uns
+    assert "cap_hierarchy" in written.uns
+    assert "cap_description" in written.uns
+    assert "cap_publication_timestamp" in written.uns
+    assert "cap_publication_version" in written.uns
+    # Original keys NOT present
+    assert "authors_list" not in written.uns
+    assert "hierarchy" not in written.uns
+
+
+# --- Skip demographic columns ---
+
+
+def test_copy_skips_demographic_columns(cap_source, hca_target):
+    result = copy_cap_annotations(str(cap_source), str(hca_target))
+    written = ad.read_h5ad(result["output_path"])
+    assert "sex--cell_ontology_term_id" not in written.obs.columns
+    assert "development_stage--cell_ontology_term_id" not in written.obs.columns
+    assert "self_reported_ethnicity--cell_ontology_term_id" not in written.obs.columns
+
+
+def test_copy_skips_cell_type_ontology_id(cap_source, hca_target):
+    result = copy_cap_annotations(str(cap_source), str(hca_target))
+    written = ad.read_h5ad(result["output_path"])
+    assert "cell_type--cell_ontology_term_id" not in written.obs.columns
+
+
+# --- Edit log ---
+
+
+def test_copy_edit_log(cap_source, hca_target):
+    result = copy_cap_annotations(str(cap_source), str(hca_target))
+    written = ad.read_h5ad(result["output_path"])
+    assert EDIT_LOG_KEY in written.uns
+    log = json.loads(written.uns[EDIT_LOG_KEY])
+    assert len(log) >= 1
+    entry = log[-1]
+    assert entry["operation"] == "import_cap_annotations"
+    assert "author_cell_type" in entry["details"]["annotation_sets"]
+
+
+# --- Failure cases ---
+
+
+def test_copy_cell_mismatch_fails(cap_source, tmp_path):
+    different_cells = _make_hca_target(
+        tmp_path / "different.h5ad", [f"other_{i}" for i in range(10)]
+    )
+    result = copy_cap_annotations(str(cap_source), str(different_cells))
+    assert "error" in result
+    assert "mismatch" in result["error"].lower()
+
+
+def test_copy_cell_count_mismatch_fails(cap_source, tmp_path):
+    fewer_cells = _make_hca_target(
+        tmp_path / "fewer.h5ad", [f"cell_{i}" for i in range(5)]
+    )
+    result = copy_cap_annotations(str(cap_source), str(fewer_cells))
+    assert "error" in result
+    assert "mismatch" in result["error"].lower()
+
+
+def test_copy_no_cap_source_fails(hca_target, tmp_path):
+    no_cap = _make_hca_target(tmp_path / "no_cap.h5ad", CELL_IDS)
+    result = copy_cap_annotations(str(no_cap), str(hca_target))
+    assert "error" in result
+    assert "cellannotation_metadata" in result["error"]
+
+
+def test_copy_target_has_cap_fails(cap_source, hca_target_with_cap):
+    result = copy_cap_annotations(str(cap_source), str(hca_target_with_cap))
+    assert "error" in result
+    assert "overwrite" in result["error"].lower()
+
+
+# --- Overwrite ---
+
+
+def test_copy_overwrite(cap_source, hca_target_with_cap):
+    result = copy_cap_annotations(
+        str(cap_source), str(hca_target_with_cap), overwrite=True
+    )
+    assert "error" not in result
+    written = ad.read_h5ad(result["output_path"])
+    # Old CAP column removed
+    assert "existing--cell_ontology_term_id" not in written.obs.columns
+    # New CAP columns present
+    assert "author_cell_type--cell_ontology_term_id" in written.obs.columns
+
+
+# --- Index ordering ---
+
+
+def test_copy_obs_index_reordered(cap_source, tmp_path):
+    """Source and target have same cells in different order."""
+    reversed_ids = list(reversed(CELL_IDS))
+    target = _make_hca_target(tmp_path / "reversed.h5ad", reversed_ids)
+    result = copy_cap_annotations(str(cap_source), str(target))
+    assert "error" not in result
+
+    written = ad.read_h5ad(result["output_path"])
+    # Verify obs index is still in the target's order
+    assert list(written.obs.index) == reversed_ids
+
+
+def test_missing_file():
+    result = copy_cap_annotations("/nonexistent/source.h5ad", "/nonexistent/target.h5ad")
+    assert "error" in result

--- a/packages/hca-anndata-tools/tests/test_copy_cap.py
+++ b/packages/hca-anndata-tools/tests/test_copy_cap.py
@@ -148,6 +148,14 @@ def test_copy_obs_columns_present(cap_source, hca_target):
     assert "author_cell_type--category_fullname" in written.obs.columns
 
 
+def test_copy_marker_gene_validation(cap_source, hca_target):
+    result = copy_cap_annotations(str(cap_source), str(hca_target))
+    assert "marker_gene_validation" in result
+    mv = result["marker_gene_validation"]
+    assert "total_unique_markers" in mv
+    assert "found_in_var" in mv
+
+
 def test_copy_cell_type_enrichment(cap_source, hca_target):
     result = copy_cap_annotations(str(cap_source), str(hca_target))
     written = ad.read_h5ad(result["output_path"])

--- a/packages/hca-anndata-tools/tests/test_copy_cap.py
+++ b/packages/hca-anndata-tools/tests/test_copy_cap.py
@@ -272,15 +272,21 @@ def test_copy_overwrite(cap_source, hca_target_with_cap):
 
 
 def test_copy_obs_index_reordered(cap_source, tmp_path):
-    """Source and target have same cells in different order."""
+    """Source and target have same cells in different order — values align correctly."""
     reversed_ids = list(reversed(CELL_IDS))
     target = _make_hca_target(tmp_path / "reversed.h5ad", reversed_ids)
     result = copy_cap_annotations(str(cap_source), str(target))
     assert "error" not in result
 
     written = ad.read_h5ad(result["output_path"])
-    # Verify obs index is still in the target's order
     assert list(written.obs.index) == reversed_ids
+
+    # Verify annotation values align with cell IDs, not positional order
+    source = ad.read_h5ad(str(cap_source))
+    for cell_id in reversed_ids[:3]:
+        src_val = source.obs.loc[cell_id, "author_cell_type--cell_ontology_term_id"]
+        tgt_val = written.obs.loc[cell_id, "author_cell_type--cell_ontology_term_id"]
+        assert str(src_val) == str(tgt_val), f"Mismatch at {cell_id}"
 
 
 def test_missing_file():

--- a/packages/hca-anndata-tools/tests/test_copy_cap.py
+++ b/packages/hca-anndata-tools/tests/test_copy_cap.py
@@ -156,28 +156,6 @@ def test_copy_marker_gene_validation(cap_source, hca_target):
     assert "found_in_var" in mv
 
 
-def test_copy_base_label_column(cap_source, tmp_path):
-    """Base label column (e.g., author_cell_type) is copied from source."""
-    # Target WITHOUT author_cell_type
-    n = len(CELL_IDS)
-    rng = np.random.default_rng(99)
-    X = sp.random(n, 5, density=0.3, format="csr", dtype=np.float32, random_state=rng)
-    obs = pd.DataFrame(
-        {"cell_type": pd.Categorical(rng.choice(["neuron", "astrocyte"], n))},
-        index=CELL_IDS,
-    )
-    var = pd.DataFrame(index=[f"GENE{i}" for i in range(5)])
-    adata = ad.AnnData(X=X, obs=obs, var=var)
-    adata.uns["title"] = "No base label"
-    path = tmp_path / "no-base.h5ad"
-    adata.write_h5ad(path)
-
-    result = copy_cap_annotations(str(cap_source), str(path))
-    assert "error" not in result
-    written = ad.read_h5ad(result["output_path"])
-    assert "author_cell_type" in written.obs.columns
-
-
 def test_copy_cell_type_enrichment(cap_source, hca_target):
     result = copy_cap_annotations(str(cap_source), str(hca_target))
     written = ad.read_h5ad(result["output_path"])

--- a/packages/hca-anndata-tools/tests/test_copy_cap.py
+++ b/packages/hca-anndata-tools/tests/test_copy_cap.py
@@ -281,29 +281,6 @@ def test_copy_obs_index_reordered(cap_source, tmp_path):
     assert list(written.obs.index) == reversed_ids
 
 
-def test_copy_target_missing_base_label(cap_source, tmp_path):
-    """Target without the base annotation label column should fail."""
-    n = len(CELL_IDS)
-    rng = np.random.default_rng(99)
-    X = sp.random(n, 5, density=0.3, format="csr", dtype=np.float32, random_state=rng)
-    obs = pd.DataFrame(
-        {
-            "cell_type": pd.Categorical(rng.choice(["neuron", "astrocyte"], n)),
-            # Note: no 'author_cell_type' column
-        },
-        index=CELL_IDS,
-    )
-    var = pd.DataFrame(index=[f"GENE{i}" for i in range(5)])
-    adata = ad.AnnData(X=X, obs=obs, var=var)
-    adata.uns["title"] = "No base label"
-    path = tmp_path / "no-base-label.h5ad"
-    adata.write_h5ad(path)
-
-    result = copy_cap_annotations(str(cap_source), str(path))
-    assert "error" in result
-    assert "author_cell_type" in result["error"]
-
-
 def test_missing_file():
     result = copy_cap_annotations("/nonexistent/source.h5ad", "/nonexistent/target.h5ad")
     assert "error" in result

--- a/packages/hca-anndata-tools/tests/test_copy_cap.py
+++ b/packages/hca-anndata-tools/tests/test_copy_cap.py
@@ -156,6 +156,28 @@ def test_copy_marker_gene_validation(cap_source, hca_target):
     assert "found_in_var" in mv
 
 
+def test_copy_base_label_column(cap_source, tmp_path):
+    """Base label column (e.g., author_cell_type) is copied from source."""
+    # Target WITHOUT author_cell_type
+    n = len(CELL_IDS)
+    rng = np.random.default_rng(99)
+    X = sp.random(n, 5, density=0.3, format="csr", dtype=np.float32, random_state=rng)
+    obs = pd.DataFrame(
+        {"cell_type": pd.Categorical(rng.choice(["neuron", "astrocyte"], n))},
+        index=CELL_IDS,
+    )
+    var = pd.DataFrame(index=[f"GENE{i}" for i in range(5)])
+    adata = ad.AnnData(X=X, obs=obs, var=var)
+    adata.uns["title"] = "No base label"
+    path = tmp_path / "no-base.h5ad"
+    adata.write_h5ad(path)
+
+    result = copy_cap_annotations(str(cap_source), str(path))
+    assert "error" not in result
+    written = ad.read_h5ad(result["output_path"])
+    assert "author_cell_type" in written.obs.columns
+
+
 def test_copy_cell_type_enrichment(cap_source, hca_target):
     result = copy_cap_annotations(str(cap_source), str(hca_target))
     written = ad.read_h5ad(result["output_path"])
@@ -172,14 +194,20 @@ def test_copy_uns_direct(cap_source, hca_target):
     assert "cap_dataset_url" in written.uns
 
 
-def test_copy_uns_cap_keys(cap_source, hca_target):
+def test_copy_uns_cap_metadata_container(cap_source, hca_target):
     result = copy_cap_annotations(str(cap_source), str(hca_target))
     written = ad.read_h5ad(result["output_path"])
-    assert "authors_list" in written.uns
-    assert "hierarchy" in written.uns
-    assert "description" in written.uns
-    assert "publication_timestamp" in written.uns
-    assert "publication_version" in written.uns
+    # Generic CAP keys go into cap_metadata container, not top-level
+    assert "cap_metadata" in written.uns
+    meta = written.uns["cap_metadata"]
+    assert meta["authors_list"] == "Test Author"
+    assert meta["description"] == "A test CAP dataset"
+    assert meta["publication_timestamp"] == "2026-01-01"
+    assert meta["publication_version"] == "1.0"
+    # NOT top-level
+    assert "authors_list" not in written.uns
+    assert "hierarchy" not in written.uns
+    assert "description" not in written.uns
 
 
 # --- Skip demographic columns ---

--- a/packages/hca-anndata-tools/tests/test_copy_cap.py
+++ b/packages/hca-anndata-tools/tests/test_copy_cap.py
@@ -281,6 +281,29 @@ def test_copy_obs_index_reordered(cap_source, tmp_path):
     assert list(written.obs.index) == reversed_ids
 
 
+def test_copy_target_missing_base_label(cap_source, tmp_path):
+    """Target without the base annotation label column should fail."""
+    n = len(CELL_IDS)
+    rng = np.random.default_rng(99)
+    X = sp.random(n, 5, density=0.3, format="csr", dtype=np.float32, random_state=rng)
+    obs = pd.DataFrame(
+        {
+            "cell_type": pd.Categorical(rng.choice(["neuron", "astrocyte"], n)),
+            # Note: no 'author_cell_type' column
+        },
+        index=CELL_IDS,
+    )
+    var = pd.DataFrame(index=[f"GENE{i}" for i in range(5)])
+    adata = ad.AnnData(X=X, obs=obs, var=var)
+    adata.uns["title"] = "No base label"
+    path = tmp_path / "no-base-label.h5ad"
+    adata.write_h5ad(path)
+
+    result = copy_cap_annotations(str(cap_source), str(path))
+    assert "error" in result
+    assert "author_cell_type" in result["error"]
+
+
 def test_missing_file():
     result = copy_cap_annotations("/nonexistent/source.h5ad", "/nonexistent/target.h5ad")
     assert "error" in result

--- a/packages/hca-anndata-tools/tests/test_copy_cap.py
+++ b/packages/hca-anndata-tools/tests/test_copy_cap.py
@@ -172,18 +172,14 @@ def test_copy_uns_direct(cap_source, hca_target):
     assert "cap_dataset_url" in written.uns
 
 
-def test_copy_uns_renamed(cap_source, hca_target):
+def test_copy_uns_cap_keys(cap_source, hca_target):
     result = copy_cap_annotations(str(cap_source), str(hca_target))
     written = ad.read_h5ad(result["output_path"])
-    # Renamed keys present
-    assert "cap_authors_list" in written.uns
-    assert "cap_hierarchy" in written.uns
-    assert "cap_description" in written.uns
-    assert "cap_publication_timestamp" in written.uns
-    assert "cap_publication_version" in written.uns
-    # Original keys NOT present
-    assert "authors_list" not in written.uns
-    assert "hierarchy" not in written.uns
+    assert "authors_list" in written.uns
+    assert "hierarchy" in written.uns
+    assert "description" in written.uns
+    assert "publication_timestamp" in written.uns
+    assert "publication_version" in written.uns
 
 
 # --- Skip demographic columns ---


### PR DESCRIPTION
## Summary

- Add `copy_cap_annotations()` to hca-anndata-tools that copies CAP cell annotation metadata from a source h5ad into an HCA-converted target
- Register as MCP tool for interactive use

## What it does

1. **Validates** — source has CAP, target is clean (or overwrite), cell IDs match (unique, same set)
2. **Copies obs columns** — annotation set `--` columns matched by obs index (preserves Categorical dtype)
3. **Copies uns metadata** — already-namespaced keys (`cellannotation_*`, `cap_*`) top-level; generic keys (`authors_list`, `hierarchy`, `description`, `publication_timestamp`, `publication_version`) into `uns["cap_metadata"]` container
4. **Validates marker genes** — post-copy `validate_marker_genes` on output file
5. **Logs** — `import_cap_annotations` entry in `hca_edit_log` with CAP source provenance

## What it skips

- Base label column (e.g., `author_cell_type`) — comes from CXG, not CAP
- Demographic columns (`sex--*`, `development_stage--*`, `self_reported_ethnicity--*`)
- `cell_type--cell_ontology_term_id` — CXG rename, already in target
- `user_provided` layer
- CXG uns keys (`citation`, `schema_version`, `schema_reference`, `title`)

## Verified on real data

- Ocular: CXG → HCA convert → CAP copy (with overwrite). 332,995 cells, 14 obs columns, 7 uns keys. 58/58 marker genes found.
- Lung: Same workflow. 584,944 cells, 15 obs columns, 7 uns keys. 160/161 marker genes found (1 not in GENCODE).

## Test plan

- [x] 16 unit tests: basic copy, uns container, demographic skip, edit log, cell mismatch, overwrite, index reorder, marker validation
- [x] All tests pass
- [x] End-to-end on real lung and ocular files

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)