### PR TITLE
fix: use cellannotation_metadata for annotation set detection

### DIFF
--- a/packages/hca-anndata-tools/src/hca_anndata_tools/cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/cap.py
@@ -75,14 +75,17 @@ def get_cap_annotations(path: str, annotation_set: str | None = None) -> dict:
     try:
         with open_h5ad(path) as adata:
             obs_columns = list(adata.obs.columns)
-            annotation_sets = _find_annotation_sets(obs_columns)
+
+            # Annotation sets are defined in cellannotation_metadata
+            meta = adata.uns.get("cellannotation_metadata", {})
+            annotation_sets = sorted(meta.keys()) if isinstance(meta, dict) else []
 
             uns_keys = list(adata.uns.keys())
             uns_present = [k for k in _UNS_REQUIRED_KEYS if k in uns_keys]
             uns_missing = [k for k in _UNS_REQUIRED_KEYS if k not in uns_keys]
             uns_optional_present = [k for k in _UNS_OPTIONAL_KEYS if k in uns_keys]
 
-            has_cap = len(annotation_sets) > 0 or "cellannotation_metadata" in uns_keys
+            has_cap = "cellannotation_metadata" in uns_keys and len(annotation_sets) > 0
 
             result = {
                 "has_cap_annotations": has_cap,
@@ -109,7 +112,7 @@ def get_cap_annotations(path: str, annotation_set: str | None = None) -> dict:
                     sets_to_inspect = [annotation_set]
                 else:
                     return {"error": f"Annotation set '{annotation_set}' not found. Available: {annotation_sets}"}
-            elif len(annotation_sets) <= 3:
+            else:
                 sets_to_inspect = annotation_sets
 
             set_details = {}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -46,8 +46,8 @@ _CELL_TYPE_ENRICHMENT = [
 _CAP_UNS_KEYS = set(_UNS_COPY_TOPLEVEL) | {"cap_metadata"}
 
 
-def _get_real_annotation_sets(source_uns: dict) -> list[str]:
-    """Get annotation sets defined in cellannotation_metadata (the real CAP sets)."""
+def _get_annotation_sets(source_uns: dict) -> list[str]:
+    """Get annotation sets defined in cellannotation_metadata."""
     meta = source_uns.get("cellannotation_metadata", {})
     if isinstance(meta, dict):
         return [s for s in meta.keys() if s not in _SKIP_SETS]
@@ -107,7 +107,7 @@ def copy_cap_annotations(
             if "cellannotation_schema_version" not in source.uns:
                 return {"error": "Source has no cellannotation_schema_version in uns"}
 
-            annotation_sets = _get_real_annotation_sets(source.uns)
+            annotation_sets = _get_annotation_sets(source.uns)
             if not annotation_sets:
                 return {"error": "Source has no annotation sets in cellannotation_metadata"}
 

--- a/packages/hca-anndata-tools/tests/test_cap.py
+++ b/packages/hca-anndata-tools/tests/test_cap.py
@@ -127,8 +127,12 @@ def cap_h5ad(tmp_path_factory) -> Path:
     adata.uns["title"] = "CAP Test"
     adata.uns["cellannotation_schema_version"] = "0.2.0"
     adata.uns["cellannotation_metadata"] = {
-        "author": "test",
-        "count": np.int64(42),
+        "my_labels": {
+            "annotation_method": "manual",
+            "description": "Test annotations",
+            "author": "test",
+            "count": np.int64(42),
+        },
     }
 
     path = tmp_path_factory.mktemp("cap") / "cap_test.h5ad"
@@ -171,7 +175,7 @@ def test_cap_reports_marker_genes(cap_h5ad):
 
 def test_cap_serializes_uns_metadata(cap_h5ad):
     result = get_cap_annotations(str(cap_h5ad))
-    meta = result["cellannotation_metadata"]
+    meta = result["cellannotation_metadata"]["my_labels"]
     assert meta["author"] == "test"
     # np.int64 should have been serialized to int
     assert meta["count"] == 42


### PR DESCRIPTION
## Summary

`get_cap_annotations` now uses `cellannotation_metadata` keys to identify annotation sets instead of scanning obs columns for `--`.

## Problem

Previously, any obs column with `--` was treated as an annotation set. This meant `cell_type`, `sex`, `development_stage`, `self_reported_ethnicity` all appeared as annotation sets with missing required columns flagged — confusing and misleading.

## Fix

- Annotation sets come from `cellannotation_metadata` keys only
- Required/optional column checks only apply to those sets
- Renamed `_get_real_annotation_sets` to `_get_annotation_sets` in copy_cap

## Test plan

- [x] 175 tests pass
- [x] Updated fixture to use proper `cellannotation_metadata` structure

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)