### PR TITLE
fix: default ignore_labels=True in HCAValidator

### DIFF
--- a/packages/hca-schema-validator/src/hca_schema_validator/validator.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/validator.py
@@ -22,7 +22,7 @@ class HCAValidator(Validator):
     - organism and organism_ontology_term_id are in obs (not uns)
     """
     
-    def __init__(self, ignore_labels=False):
+    def __init__(self, ignore_labels=True):
         """
         Initialize HCA validator.
 


### PR DESCRIPTION
## Summary

One-line change: default `ignore_labels` from `False` to `True` in `HCAValidator.__init__()`.

## Problem

Users following the README example (`HCAValidator()` with no args) get 16+ reserved column errors on any CXG-downloaded file because label columns already exist.

## Fix

HCA files always have label columns. The CXG add-labels workflow doesn't apply. Default to `True`.

## Test plan

- [x] 39 tests pass (no tests depended on the old default)

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)