### PR TITLE
chore: update hca-schema-validator dependency to 0.10.x

### DIFF
--- a/services/hca-schema-validator/pyproject.toml
+++ b/services/hca-schema-validator/pyproject.toml
@@ -3,7 +3,7 @@ name = "hca-schema-validator-service"
 version = "0.1.0"
 requires-python = "~=3.11"
 dependencies = [
-    "hca-schema-validator (>=0.9.0,<0.10.0)"
+    "hca-schema-validator (>=0.10.0,<0.11.0)"
 ]
 
 [tool.poetry]


### PR DESCRIPTION
## Summary

Bump hca-schema-validator-service dependency from `>=0.9.0,<0.10.0` to `>=0.10.0,<0.11.0`.

## What's in 0.10.0

- `ignore_labels=True` default — no reserved column errors on CXG files
- `requirement_level: strongly_recommended` for library fields
- Placeholder blocklist (unknown, na, none, etc.)
- Separator check for single-value fields
- Improved gene ID warnings with GENCODE version

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)