### PR TITLE
perf: optimize validate_marker_genes with h5py direct reads

### DIFF
--- a/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
@@ -4,6 +4,7 @@ import gc
 from contextlib import contextmanager
 
 import anndata as ad
+import h5py
 
 
 @contextmanager
@@ -25,3 +26,113 @@ def open_h5ad(path: str, backed: str | None = "r"):
             adata.file.close()
         del adata
         gc.collect()
+
+
+def _decode_bytes(val):
+    """Decode bytes to str, pass through anything else."""
+    if isinstance(val, bytes):
+        return val.decode("utf-8")
+    return val
+
+
+def _strip_ensembl_version(eid: str) -> str:
+    """Strip version suffix from Ensembl ID: ENSG00000173947.7 -> ENSG00000173947."""
+    if eid.startswith("ENSG") and "." in eid:
+        return eid.rsplit(".", 1)[0]
+    return eid
+
+
+def _read_h5_scalar(group: h5py.Group, key: str) -> str | None:
+    """Read a scalar string from an HDF5 group, handling categorical encoding."""
+    if key not in group:
+        return None
+    item = group[key]
+    if isinstance(item, h5py.Dataset):
+        return _decode_bytes(item[()])
+    if isinstance(item, h5py.Group) and "categories" in item:
+        cats = item["categories"][:]
+        return _decode_bytes(cats[0]) if len(cats) > 0 else None
+    return None
+
+
+def read_obs_column_names(path: str) -> list[str]:
+    """Read obs column names from an h5ad file via h5py (no AnnData load)."""
+    with h5py.File(path, "r") as f:
+        return [_decode_bytes(c) for c in f["obs"].attrs["column-order"]]
+
+
+def read_obs_categorical_values(path: str, column: str) -> set[str]:
+    """Read the unique category values for a categorical obs column.
+
+    For categorical columns, HDF5 stores a small 'categories' array
+    separately from the per-cell 'codes' array. This reads only the
+    categories, avoiding the expensive full-column materialization.
+
+    Falls back to reading the full dataset for non-categorical columns.
+    """
+    with h5py.File(path, "r") as f:
+        item = f["obs"][column]
+        if isinstance(item, h5py.Group) and "categories" in item:
+            return {_decode_bytes(v) for v in item["categories"][:]}
+        # Non-categorical: read full dataset
+        return {_decode_bytes(v) for v in item[:]}
+
+
+def read_uns_scalar(path: str, key: str) -> str | None:
+    """Read a scalar string value from uns, or None if absent."""
+    with h5py.File(path, "r") as f:
+        uns = f.get("uns")
+        if uns is None:
+            return None
+        return _read_h5_scalar(uns, key)
+
+
+def read_obs_scalar(path: str, key: str) -> str | None:
+    """Read the first category value from a categorical obs column."""
+    with h5py.File(path, "r") as f:
+        obs = f.get("obs")
+        if obs is None:
+            return None
+        return _read_h5_scalar(obs, key)
+
+
+def read_var_gene_names(path: str) -> tuple[set[str], dict[str, str]]:
+    """Read gene names and Ensembl ID mapping from var via h5py.
+
+    Returns:
+        gene_names: Set of all gene symbols in var
+        eid_to_var_name: Dict mapping Ensembl ID (stripped of version) to gene symbol
+    """
+    with h5py.File(path, "r") as f:
+        var = f["var"]
+        idx_key = _decode_bytes(var.attrs.get("_index", "_index"))
+        raw_index = var[idx_key][:]
+        index = [_decode_bytes(v) for v in raw_index]
+
+        # Find gene name column
+        name_col = None
+        for col in ("feature_name", "gene_name"):
+            if col in var:
+                name_col = col
+                break
+
+        if name_col is None:
+            # Fallback: index IS the gene names
+            return set(index), {}
+
+        item = var[name_col]
+        if isinstance(item, h5py.Group) and "categories" in item:
+            # Categorical: need to decode codes -> categories
+            categories = [_decode_bytes(v) for v in item["categories"][:]]
+            codes = item["codes"][:]
+            names = [categories[c] if c >= 0 else "" for c in codes]
+        else:
+            names = [_decode_bytes(v) for v in item[:]]
+
+        gene_names = set(names)
+
+        eid_to_var_name = {
+            _strip_ensembl_version(eid): name for eid, name in zip(index, names)
+        }
+
+        return gene_names, eid_to_var_name

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
@@ -68,6 +68,10 @@ def read_obs_categorical_values(path: str, column: str) -> set[str]:
     separately from the per-cell 'codes' array. This reads only the
     categories, avoiding the expensive full-column materialization.
 
+    Note: returns all declared categories, which may include unused values
+    if the file was subsetted without removing unused categories. This is
+    acceptable because callers operate on full integrated objects, not subsets.
+
     Falls back to reading the full dataset for non-categorical columns.
     """
     with h5py.File(path, "r") as f:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
@@ -92,7 +92,12 @@ def read_uns_scalar(path: str, key: str) -> str | None:
 
 
 def read_obs_scalar(path: str, key: str) -> str | None:
-    """Read the first category value from a categorical obs column."""
+    """Read the first category value from a categorical obs column.
+
+    For categoricals, returns categories[0] rather than decoding codes to find
+    the actual first observed value. This is correct for our use case
+    (organism_ontology_term_id) where integrated objects have a single category.
+    """
     with h5py.File(path, "r") as f:
         obs = f.get("obs")
         if obs is None:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
@@ -42,19 +42,6 @@ def _strip_ensembl_version(eid: str) -> str:
     return eid
 
 
-def _read_h5_scalar(group: h5py.Group, key: str) -> str | None:
-    """Read a scalar string from an HDF5 group, handling categorical encoding."""
-    if key not in group:
-        return None
-    item = group[key]
-    if isinstance(item, h5py.Dataset):
-        return _decode_bytes(item[()])
-    if isinstance(item, h5py.Group) and "categories" in item:
-        cats = item["categories"][:]
-        return _decode_bytes(cats[0]) if len(cats) > 0 else None
-    return None
-
-
 def read_obs_column_names(path: str) -> list[str]:
     """Read obs column names from an h5ad file via h5py (no AnnData load)."""
     with h5py.File(path, "r") as f:
@@ -80,29 +67,6 @@ def read_obs_categorical_values(path: str, column: str) -> set[str]:
             return {_decode_bytes(v) for v in item["categories"][:]}
         # Non-categorical: read full dataset
         return {_decode_bytes(v) for v in item[:]}
-
-
-def read_uns_scalar(path: str, key: str) -> str | None:
-    """Read a scalar string value from uns, or None if absent."""
-    with h5py.File(path, "r") as f:
-        uns = f.get("uns")
-        if uns is None:
-            return None
-        return _read_h5_scalar(uns, key)
-
-
-def read_obs_scalar(path: str, key: str) -> str | None:
-    """Read the first category value from a categorical obs column.
-
-    For categoricals, returns categories[0] rather than decoding codes to find
-    the actual first observed value. This is correct for our use case
-    (organism_ontology_term_id) where integrated objects have a single category.
-    """
-    with h5py.File(path, "r") as f:
-        obs = f.get("obs")
-        if obs is None:
-            return None
-        return _read_h5_scalar(obs, key)
 
 
 def read_var_gene_names(path: str) -> tuple[set[str], dict[str, str]]:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/marker_genes.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/marker_genes.py
@@ -2,30 +2,27 @@
 
 from __future__ import annotations
 
-import pandas as pd
-
 from ._gencode import load_gencode_reference
-from ._io import open_h5ad
+from ._io import (
+    read_obs_categorical_values,
+    read_obs_column_names,
+    read_obs_scalar,
+    read_uns_scalar,
+    read_var_gene_names,
+)
 from .cap import _find_annotation_sets
 
 _SKIP_VALUES = {"unknown", "", "NA", "na", "none", "None"}
 
 
-def _strip_ensembl_version(eid: str) -> str:
-    """Strip version suffix from Ensembl ID: ENSG00000173947.7 → ENSG00000173947."""
-    if eid.startswith("ENSG") and "." in eid:
-        return eid.rsplit(".", 1)[0]
-    return eid
-
-
-def _extract_marker_genes(series: pd.Series) -> set[str]:
-    """Parse unique gene symbols from a marker_gene_evidence series.
+def _extract_marker_genes_from_categories(categories: set[str]) -> set[str]:
+    """Parse unique gene symbols from a set of category values.
 
     Values are comma-separated gene symbols like "MARCO,CST3,FABP4,INHBA".
     Skips null, empty, and placeholder values.
     """
     genes: set[str] = set()
-    for val in series.dropna().unique():
+    for val in categories:
         val = str(val).strip()
         if val in _SKIP_VALUES:
             continue
@@ -36,28 +33,6 @@ def _extract_marker_genes(series: pd.Series) -> set[str]:
     return genes
 
 
-def _get_gene_names_from_var(var: pd.DataFrame) -> tuple[set[str], dict[str, str]]:
-    """Extract gene symbol set and ensembl_id->symbol map from var.
-
-    Handles both CellxGENE-style (feature_name) and other (gene_name) files.
-
-    Returns:
-        gene_names: Set of all gene symbols in var
-        eid_to_var_name: Dict mapping Ensembl ID (var.index) to gene symbol
-    """
-    for col in ("feature_name", "gene_name"):
-        if col in var.columns:
-            str_values = var[col].astype(str).values
-            gene_names = set(str_values)
-            eid_to_var_name = {
-                _strip_ensembl_version(eid): name
-                for eid, name in zip(var.index, str_values)
-            }
-            return gene_names, eid_to_var_name
-    # Fallback: var.index IS the gene names, no Ensembl ID mapping
-    return set(var.index), {}
-
-
 def _classify_missing(
     gene: str,
     name_to_ids: dict[str, list[str]],
@@ -65,7 +40,7 @@ def _classify_missing(
 ) -> dict:
     """Classify a missing marker gene as a known rename or probable typo."""
     if gene in name_to_ids:
-        # Valid current GENCODE symbol — check if any of its Ensembl IDs
+        # Valid current GENCODE symbol -- check if any of its Ensembl IDs
         # are in var under a different name
         for eid in name_to_ids[gene]:
             if eid in eid_to_var_name:
@@ -77,7 +52,7 @@ def _classify_missing(
                 }
         # Valid GENCODE gene, but not measured in this file
         return {"marker_gene": gene, "type": "missing_from_var"}
-    # Not in GENCODE — probable typo
+    # Not in GENCODE -- probable typo
     return {"marker_gene": gene, "type": "not_in_gencode"}
 
 
@@ -96,111 +71,111 @@ def validate_marker_genes(path: str, annotation_set: str | None = None) -> dict:
         Dict with validation results, or 'error' on failure.
     """
     try:
-        with open_h5ad(path) as adata:
-            # Only human is supported — check organism if available
-            organism = adata.uns.get("organism_ontology_term_id")
-            if organism is None and "organism_ontology_term_id" in adata.obs.columns:
-                organism = adata.obs["organism_ontology_term_id"].iloc[0]
-            if organism is not None and str(organism) != "NCBITaxon:9606":
-                return {"error": f"Only human (NCBITaxon:9606) is supported, found: {organism}"}
+        organism = read_uns_scalar(path, "organism_ontology_term_id")
+        if organism is None:
+            organism = read_obs_scalar(path, "organism_ontology_term_id")
+        if organism is not None and str(organism) != "NCBITaxon:9606":
+            return {"error": f"Only human (NCBITaxon:9606) is supported, found: {organism}"}
 
-            obs_columns = list(adata.obs.columns)
-            all_sets = _find_annotation_sets(obs_columns)
+        obs_columns = read_obs_column_names(path)
+        all_sets = _find_annotation_sets(obs_columns)
 
-            if annotation_set:
-                if annotation_set not in all_sets:
-                    return {
-                        "error": (
-                            f"Annotation set '{annotation_set}' not found. "
-                            f"Available: {all_sets}"
-                        )
-                    }
-                sets_to_check = [annotation_set]
-            else:
-                sets_to_check = all_sets
-
-            # Filter to sets that have marker_gene_evidence
-            sets_with_markers = [
-                s for s in sets_to_check
-                if f"{s}--marker_gene_evidence" in obs_columns
-            ]
-
-            if not sets_with_markers:
+        if annotation_set:
+            if annotation_set not in all_sets:
                 return {
-                    "annotation_sets_with_markers": [],
-                    "total_unique_markers": 0,
-                    "found_in_var": 0,
-                    "missing": 0,
-                    "known_renames": [],
-                    "missing_from_var": [],
-                    "not_in_gencode": [],
-                    "details": {},
+                    "error": (
+                        f"Annotation set '{annotation_set}' not found. "
+                        f"Available: {all_sets}"
+                    )
                 }
+            sets_to_check = [annotation_set]
+        else:
+            sets_to_check = all_sets
 
-            gene_names, eid_to_var_name = _get_gene_names_from_var(adata.var)
-            _, name_to_ids = load_gencode_reference()
+        # Filter to sets that have marker_gene_evidence
+        sets_with_markers = [
+            s for s in sets_to_check
+            if f"{s}--marker_gene_evidence" in obs_columns
+        ]
 
-            all_renames = []
-            all_missing_from_var = []
-            all_not_in_gencode = []
-            all_unique = set()
-            details = {}
-
-            for setname in sets_with_markers:
-                marker_col = f"{setname}--marker_gene_evidence"
-                markers = _extract_marker_genes(adata.obs[marker_col])
-                all_unique.update(markers)
-
-                found = markers & gene_names
-                missing = markers - gene_names
-
-                renames = []
-                missing_from_var = []
-                not_in_gencode = []
-                for gene in sorted(missing):
-                    classification = _classify_missing(gene, name_to_ids, eid_to_var_name)
-                    if classification["type"] == "known_rename":
-                        renames.append(classification)
-                    elif classification["type"] == "missing_from_var":
-                        missing_from_var.append(classification)
-                    else:
-                        not_in_gencode.append(classification)
-
-                all_renames.extend(renames)
-                all_missing_from_var.extend(missing_from_var)
-                all_not_in_gencode.extend(not_in_gencode)
-
-                details[setname] = {
-                    "unique_markers": len(markers),
-                    "found": len(found),
-                    "known_renames": renames,
-                    "missing_from_var": missing_from_var,
-                    "not_in_gencode": not_in_gencode,
-                }
-
-            total_found = len(all_unique & gene_names)
-
-            # Deduplicate top-level lists (same gene can appear in multiple sets)
-            seen = set()
-            def _dedup(items):
-                out = []
-                for item in items:
-                    key = item["marker_gene"]
-                    if key not in seen:
-                        seen.add(key)
-                        out.append(item)
-                return out
-
+        if not sets_with_markers:
             return {
-                "annotation_sets_with_markers": sets_with_markers,
-                "total_unique_markers": len(all_unique),
-                "found_in_var": total_found,
-                "missing": len(all_unique) - total_found,
-                "known_renames": _dedup(all_renames),
-                "missing_from_var": _dedup(all_missing_from_var),
-                "not_in_gencode": _dedup(all_not_in_gencode),
-                "details": details,
+                "annotation_sets_with_markers": [],
+                "total_unique_markers": 0,
+                "found_in_var": 0,
+                "missing": 0,
+                "known_renames": [],
+                "missing_from_var": [],
+                "not_in_gencode": [],
+                "details": {},
             }
+
+        gene_names, eid_to_var_name = read_var_gene_names(path)
+        _, name_to_ids = load_gencode_reference()
+
+        all_renames = []
+        all_missing_from_var = []
+        all_not_in_gencode = []
+        all_unique = set()
+        details = {}
+
+        for setname in sets_with_markers:
+            marker_col = f"{setname}--marker_gene_evidence"
+            # Read only the category values, not the full per-cell column
+            categories = read_obs_categorical_values(path, marker_col)
+            markers = _extract_marker_genes_from_categories(categories)
+            all_unique.update(markers)
+
+            found = markers & gene_names
+            missing = markers - gene_names
+
+            renames = []
+            missing_from_var = []
+            not_in_gencode = []
+            for gene in sorted(missing):
+                classification = _classify_missing(gene, name_to_ids, eid_to_var_name)
+                if classification["type"] == "known_rename":
+                    renames.append(classification)
+                elif classification["type"] == "missing_from_var":
+                    missing_from_var.append(classification)
+                else:
+                    not_in_gencode.append(classification)
+
+            all_renames.extend(renames)
+            all_missing_from_var.extend(missing_from_var)
+            all_not_in_gencode.extend(not_in_gencode)
+
+            details[setname] = {
+                "unique_markers": len(markers),
+                "found": len(found),
+                "known_renames": renames,
+                "missing_from_var": missing_from_var,
+                "not_in_gencode": not_in_gencode,
+            }
+
+        total_found = len(all_unique & gene_names)
+
+        # Deduplicate top-level lists (same gene can appear in multiple sets)
+        seen = set()
+        def _dedup(items):
+            out = []
+            for item in items:
+                key = item["marker_gene"]
+                if key not in seen:
+                    seen.add(key)
+                    out.append(item)
+            return out
+
+        return {
+            "annotation_sets_with_markers": sets_with_markers,
+            "total_unique_markers": len(all_unique),
+            "found_in_var": total_found,
+            "missing": len(all_unique) - total_found,
+            "known_renames": _dedup(all_renames),
+            "missing_from_var": _dedup(all_missing_from_var),
+            "not_in_gencode": _dedup(all_not_in_gencode),
+            "details": details,
+        }
 
     except Exception as e:
         return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/marker_genes.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/marker_genes.py
@@ -70,6 +70,13 @@ def validate_marker_genes(path: str, annotation_set: str | None = None) -> dict:
     """
     try:
         obs_columns = read_obs_column_names(path)
+
+        if "organism_ontology_term_id" not in obs_columns:
+            return {"error": "organism_ontology_term_id not found in obs columns"}
+        organisms = read_obs_categorical_values(path, "organism_ontology_term_id")
+        non_human = organisms - {"NCBITaxon:9606"}
+        if non_human:
+            return {"error": f"Only human (NCBITaxon:9606) is supported, found: {organisms}"}
         all_sets = _find_annotation_sets(obs_columns)
 
         if annotation_set:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/marker_genes.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/marker_genes.py
@@ -57,12 +57,14 @@ def _classify_missing(
 def validate_marker_genes(path: str, annotation_set: str | None = None) -> dict:
     """Validate that CAP marker genes exist in an h5ad file's var.
 
-    Checks each marker gene symbol from CAP annotation obs columns against
-    var['feature_name']. Missing genes are classified as known GENCODE renames
-    or probable typos.
+    Expects an HCA integrated object with organism_ontology_term_id in obs.
+    Rejects non-human organisms. Checks marker gene symbols from CAP
+    annotation obs columns against var gene names (feature_name, gene_name,
+    or var index as fallback). Missing genes are classified as GENCODE
+    renames, unmeasured genes, or probable typos.
 
     Args:
-        path: Absolute path to an .h5ad file.
+        path: Absolute path to an HCA .h5ad file.
         annotation_set: Specific annotation set to validate. If None, validates all.
 
     Returns:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/marker_genes.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/marker_genes.py
@@ -78,7 +78,7 @@ def validate_marker_genes(path: str, annotation_set: str | None = None) -> dict:
         organisms = read_obs_categorical_values(path, "organism_ontology_term_id")
         non_human = organisms - {"NCBITaxon:9606"}
         if non_human:
-            return {"error": f"Only human (NCBITaxon:9606) is supported, found: {organisms}"}
+            return {"error": f"Only human (NCBITaxon:9606) is supported, found non-human: {sorted(non_human)}"}
         all_sets = _find_annotation_sets(obs_columns)
 
         if annotation_set:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/marker_genes.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/marker_genes.py
@@ -6,8 +6,6 @@ from ._gencode import load_gencode_reference
 from ._io import (
     read_obs_categorical_values,
     read_obs_column_names,
-    read_obs_scalar,
-    read_uns_scalar,
     read_var_gene_names,
 )
 from .cap import _find_annotation_sets
@@ -71,12 +69,6 @@ def validate_marker_genes(path: str, annotation_set: str | None = None) -> dict:
         Dict with validation results, or 'error' on failure.
     """
     try:
-        organism = read_uns_scalar(path, "organism_ontology_term_id")
-        if organism is None:
-            organism = read_obs_scalar(path, "organism_ontology_term_id")
-        if organism is not None and str(organism) != "NCBITaxon:9606":
-            return {"error": f"Only human (NCBITaxon:9606) is supported, found: {organism}"}
-
         obs_columns = read_obs_column_names(path)
         all_sets = _find_annotation_sets(obs_columns)
 

--- a/packages/hca-anndata-tools/tests/test_marker_genes.py
+++ b/packages/hca-anndata-tools/tests/test_marker_genes.py
@@ -124,6 +124,7 @@ def marker_h5ad(tmp_path_factory) -> Path:
 
     obs = pd.DataFrame(
         {
+            "organism_ontology_term_id": pd.Categorical(["NCBITaxon:9606"] * n_obs),
             "test_labels": pd.Categorical(rng.choice(["typeA", "typeB", "typeC"], n_obs)),
             "test_labels--marker_gene_evidence": pd.Categorical(
                 rng.choice(["GFAP,AIF1", "RBFOX3", "CIMAP3", "SCL25A5"], n_obs)
@@ -159,6 +160,7 @@ def clean_h5ad(tmp_path_factory) -> Path:
 
     obs = pd.DataFrame(
         {
+            "organism_ontology_term_id": pd.Categorical(["NCBITaxon:9606"] * n_obs),
             "ann": pd.Categorical(rng.choice(["a", "b"], n_obs)),
             "ann--marker_gene_evidence": pd.Categorical(
                 rng.choice(["GFAP", "AIF1,RBFOX3"], n_obs)
@@ -202,10 +204,28 @@ def test_all_markers_found(clean_h5ad):
     assert result["found_in_var"] == result["total_unique_markers"]
 
 
-def test_no_cap_annotations(sample_h5ad):
-    result = validate_marker_genes(str(sample_h5ad))
+def test_no_cap_annotations(tmp_path):
+    """File with organism but no CAP annotation columns."""
+    n_obs = 4
+    X = sp.random(n_obs, 2, density=0.5, format="csr", dtype=np.float32)
+    obs = pd.DataFrame(
+        {"organism_ontology_term_id": pd.Categorical(["NCBITaxon:9606"] * n_obs)},
+        index=[f"c{i}" for i in range(n_obs)],
+    )
+    var = pd.DataFrame({"feature_name": ["A", "B"]}, index=["ENSG1", "ENSG2"])
+    adata = ad.AnnData(X=X, obs=obs, var=var)
+    path = tmp_path / "no_cap.h5ad"
+    adata.write_h5ad(path)
+    result = validate_marker_genes(str(path))
     assert result["annotation_sets_with_markers"] == []
     assert result["total_unique_markers"] == 0
+
+
+def test_missing_organism(sample_h5ad):
+    """CellxGENE file without organism_ontology_term_id in obs is rejected."""
+    result = validate_marker_genes(str(sample_h5ad))
+    assert "error" in result
+    assert "organism_ontology_term_id" in result["error"]
 
 
 def test_specific_annotation_set(marker_h5ad):
@@ -236,6 +256,7 @@ def versioned_h5ad(tmp_path_factory) -> Path:
 
     obs = pd.DataFrame(
         {
+            "organism_ontology_term_id": pd.Categorical(["NCBITaxon:9606"] * n_obs),
             "ann": pd.Categorical(rng.choice(["a", "b"], n_obs)),
             "ann--marker_gene_evidence": pd.Categorical(
                 rng.choice(["GFAP", "CIMAP3"], n_obs)

--- a/packages/hca-anndata-tools/tests/test_marker_genes.py
+++ b/packages/hca-anndata-tools/tests/test_marker_genes.py
@@ -9,9 +9,9 @@ import pytest
 import scipy.sparse as sp
 
 from hca_anndata_tools._gencode import load_gencode_reference
+from hca_anndata_tools._io import read_var_gene_names
 from hca_anndata_tools.marker_genes import (
-    _extract_marker_genes,
-    _get_gene_names_from_var,
+    _extract_marker_genes_from_categories,
     validate_marker_genes,
 )
 
@@ -43,55 +43,66 @@ def test_gencode_duplicate_names():
 
 
 def test_extract_markers_simple():
-    series = pd.Series(["GFAP", "AIF1", "GFAP", "RBFOX3"])
-    assert _extract_marker_genes(series) == {"GFAP", "AIF1", "RBFOX3"}
+    categories = {"GFAP", "AIF1", "RBFOX3"}
+    assert _extract_marker_genes_from_categories(categories) == {"GFAP", "AIF1", "RBFOX3"}
 
 
 def test_extract_markers_comma_separated():
-    series = pd.Series(["GFAP, AIF1", "RBFOX3"])
-    assert _extract_marker_genes(series) == {"GFAP", "AIF1", "RBFOX3"}
+    categories = {"GFAP, AIF1", "RBFOX3"}
+    assert _extract_marker_genes_from_categories(categories) == {"GFAP", "AIF1", "RBFOX3"}
 
 
 def test_extract_markers_skips_unknown():
-    series = pd.Series(["GFAP", "unknown", "", None, "NA", "RBFOX3"])
-    assert _extract_marker_genes(series) == {"GFAP", "RBFOX3"}
+    categories = {"GFAP", "unknown", "", "NA", "RBFOX3"}
+    assert _extract_marker_genes_from_categories(categories) == {"GFAP", "RBFOX3"}
 
 
 def test_extract_markers_strips_whitespace():
-    series = pd.Series(["  GFAP  ", "AIF1 , RBFOX3 "])
-    assert _extract_marker_genes(series) == {"GFAP", "AIF1", "RBFOX3"}
+    categories = {"  GFAP  ", "AIF1 , RBFOX3 "}
+    assert _extract_marker_genes_from_categories(categories) == {"GFAP", "AIF1", "RBFOX3"}
 
 
-def test_extract_markers_empty_series():
-    series = pd.Series([], dtype=object)
-    assert _extract_marker_genes(series) == set()
+def test_extract_markers_empty():
+    assert _extract_marker_genes_from_categories(set()) == set()
 
 
 # -- Var gene name detection tests ---------------------------------------------
 
 
-def test_get_gene_names_feature_name():
+def test_read_var_gene_names_feature_name(tmp_path):
     var = pd.DataFrame(
         {"feature_name": ["GFAP", "AIF1"]},
         index=["ENSG00000131095", "ENSG00000204472"],
     )
-    names, eid_map = _get_gene_names_from_var(var)
+    X = sp.random(2, 2, density=0.5, format="csr", dtype=np.float32)
+    adata = ad.AnnData(X=X, var=var, obs=pd.DataFrame(index=["c0", "c1"]))
+    path = tmp_path / "feat.h5ad"
+    adata.write_h5ad(path)
+    names, eid_map = read_var_gene_names(str(path))
     assert names == {"GFAP", "AIF1"}
     assert eid_map["ENSG00000131095"] == "GFAP"
 
 
-def test_get_gene_names_gene_name_col():
+def test_read_var_gene_names_gene_name_col(tmp_path):
     var = pd.DataFrame(
         {"gene_name": ["GFAP", "AIF1"]},
         index=["ENSG00000131095", "ENSG00000204472"],
     )
-    names, eid_map = _get_gene_names_from_var(var)
+    X = sp.random(2, 2, density=0.5, format="csr", dtype=np.float32)
+    adata = ad.AnnData(X=X, var=var, obs=pd.DataFrame(index=["c0", "c1"]))
+    path = tmp_path / "gene.h5ad"
+    adata.write_h5ad(path)
+    names, eid_map = read_var_gene_names(str(path))
     assert names == {"GFAP", "AIF1"}
 
 
-def test_get_gene_names_fallback():
+def test_read_var_gene_names_fallback(tmp_path):
     var = pd.DataFrame(index=["GFAP", "AIF1"])
-    names, eid_map = _get_gene_names_from_var(var)
+    X = sp.random(2, 2, density=0.5, format="csr", dtype=np.float32)
+    adata = ad.AnnData(X=X, var=var, obs=pd.DataFrame(index=["c0", "c1"]))
+    path = tmp_path / "fallback.h5ad"
+    adata.write_h5ad(path)
+    names, eid_map = read_var_gene_names(str(path))
     assert names == {"GFAP", "AIF1"}
     assert eid_map == {}
 

--- a/packages/hca-anndata-tools/tests/test_marker_genes.py
+++ b/packages/hca-anndata-tools/tests/test_marker_genes.py
@@ -222,7 +222,7 @@ def test_no_cap_annotations(tmp_path):
 
 
 def test_missing_organism(sample_h5ad):
-    """CellxGENE file without organism_ontology_term_id in obs is rejected."""
+    """File without organism_ontology_term_id in obs is rejected."""
     result = validate_marker_genes(str(sample_h5ad))
     assert "error" in result
     assert "organism_ontology_term_id" in result["error"]


### PR DESCRIPTION
## Summary

`validate_marker_genes` was timing out via MCP on large h5ad files because it opened the full AnnData in backed mode, then materialized entire per-cell obs columns just to extract unique marker gene symbols.

### Changes
- **Replace AnnData backed-mode with direct h5py reads** — no AnnData import needed at all
- **Read HDF5 categorical `categories` array directly** (~18 values) instead of materializing the full per-cell `codes` column (~100k+ cells) and calling `.dropna().unique()`
- **Read var gene names via h5py** — decode `feature_name` categories and Ensembl ID index without loading the full var DataFrame
- **Add reusable h5py helpers to `_io.py`**: `read_obs_column_names`, `read_obs_categorical_values`, `read_var_gene_names`
- **Validate organism correctly** — use `read_obs_categorical_values` to check all organism categories in the file; error if `organism_ontology_term_id` is absent from obs or contains non-human organisms
- **Remove unused helpers** — `read_obs_scalar`, `read_uns_scalar`, `_read_h5_scalar` removed (no callers after organism check was rewritten)

### Documented assumptions
- `read_obs_categorical_values` returns all declared categories, which may include unused values on subsetted files. Acceptable because callers operate on full integrated objects, not subsets.

## Test plan
- [x] All 176 tests pass (175 existing + 1 new `test_missing_organism`)
- [x] Validated on real ocular outflow segment files via MCP — results identical to previous implementation
- [x] Benchmarked at ~0.16s on large h5ad files (previously timed out via MCP)

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)