### PR TITLE
perf: optimize copy_cap_annotations with copy-then-patch

### DIFF
--- a/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
@@ -42,6 +42,13 @@ def _strip_ensembl_version(eid: str) -> str:
     return eid
 
 
+def read_obs_index(path: str) -> list[str]:
+    """Read the obs index (cell IDs) from an h5ad file via h5py."""
+    with h5py.File(path, "r") as f:
+        idx_key = _decode_bytes(f["obs"].attrs.get("_index", "_index"))
+        return [_decode_bytes(v) for v in f["obs"][idx_key][:]]
+
+
 def read_obs_column_names(path: str) -> list[str]:
     """Read obs column names from an h5ad file via h5py (no AnnData load)."""
     with h5py.File(path, "r") as f:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -236,6 +236,7 @@ def copy_cap_annotations(
 
         # --- Step 3: Build aligned temp AnnData ---
         aligned_obs = source_obs_subset.loc[target_index]
+        del source_obs_subset
 
         temp_uns = {}
         uns_keys_added = []
@@ -332,57 +333,25 @@ def copy_cap_annotations(
                 if EDIT_LOG_KEY in f_temp["uns"]:
                     f_temp.copy(f"uns/{EDIT_LOG_KEY}", f_out["uns"])
 
-        # --- Step 5: Verify transplant correctness ---
-        # Spot-check a few cells to catch alignment or encoding errors.
-        check_positions = [0, len(target_index) // 2, len(target_index) - 1]
-        check_cell_ids = [target_index[i] for i in check_positions]
+            # --- Step 5: Verify transplant — full column comparison ---
+            # Compare raw HDF5 data in temp vs output for every copied column.
+            with h5py.File(temp_path, "r") as f_temp, \
+                 h5py.File(output_path, "r") as f_out:
+                for col in obs_cols_to_copy:
+                    temp_item = f_temp["obs"][col]
+                    out_item = f_out["obs"][col]
 
-        def _normalize(val):
-            if val is None:
-                return None
-            try:
-                if pd.isna(val):
-                    return None
-            except (TypeError, ValueError):
-                pass
-            return str(val)
-
-        verification_error = None
-        with h5py.File(output_path, "r") as f_out:
-            for col in obs_cols_to_copy:
-                if verification_error:
-                    break
-                item = f_out["obs"][col]
-                if isinstance(item, h5py.Group) and "categories" in item:
-                    cats = [_decode_bytes(v) for v in item["categories"][:]]
-                    codes = item["codes"]
-                    for pos, cell_id in zip(check_positions, check_cell_ids):
-                        output_val = _normalize(cats[codes[pos]] if codes[pos] >= 0 else None)
-                        expected_val = _normalize(source_obs_subset.at[cell_id, col])
-                        if output_val != expected_val:
-                            verification_error = (
-                                f"Verification failed: column '{col}', "
-                                f"cell '{cell_id}' (pos {pos}): "
-                                f"expected '{expected_val}', got '{output_val}'"
-                            )
-                            break
-                else:
-                    for pos, cell_id in zip(check_positions, check_cell_ids):
-                        output_val = _normalize(_decode_bytes(item[pos]))
-                        expected_val = _normalize(source_obs_subset.at[cell_id, col])
-                        if output_val != expected_val:
-                            verification_error = (
-                                f"Verification failed: column '{col}', "
-                                f"cell '{cell_id}' (pos {pos}): "
-                                f"expected '{expected_val}', got '{output_val}'"
-                            )
-                            break
-
-        del source_obs_subset
-
-        if verification_error:
-            os.remove(output_path)
-            return {"error": verification_error}
+                    if isinstance(temp_item, h5py.Group) and "categories" in temp_item:
+                        if not np.array_equal(temp_item["categories"][:], out_item["categories"][:]):
+                            os.remove(output_path)
+                            return {"error": f"Verification failed: categories mismatch for column '{col}'"}
+                        if not np.array_equal(temp_item["codes"][:], out_item["codes"][:]):
+                            os.remove(output_path)
+                            return {"error": f"Verification failed: codes mismatch for column '{col}'"}
+                    else:
+                        if not np.array_equal(temp_item[:], out_item[:]):
+                            os.remove(output_path)
+                            return {"error": f"Verification failed: data mismatch for column '{col}'"}
 
         # --- Step 6: Cleanup + validate marker genes ---
         cleanup_previous_version(target_path, output_path)

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -320,10 +320,9 @@ def copy_cap_annotations(
         check_positions = [0, len(target_index) // 2, len(target_index) - 1]
         check_cell_ids = [target_index[i] for i in check_positions]
 
-        def _to_str(val) -> str:
-            """Normalize a value to string for comparison."""
+        def _normalize(val):
             if val is None or (isinstance(val, float) and pd.isna(val)):
-                return "<NA>"
+                return None
             return str(val)
 
         verification_error = None
@@ -336,8 +335,8 @@ def copy_cap_annotations(
                     cats = [_decode_bytes(v) for v in item["categories"][:]]
                     codes = item["codes"]
                     for pos, cell_id in zip(check_positions, check_cell_ids):
-                        output_val = _to_str(cats[codes[pos]] if codes[pos] >= 0 else None)
-                        expected_val = _to_str(source_obs_subset.at[cell_id, col])
+                        output_val = _normalize(cats[codes[pos]] if codes[pos] >= 0 else None)
+                        expected_val = _normalize(source_obs_subset.at[cell_id, col])
                         if output_val != expected_val:
                             verification_error = (
                                 f"Verification failed: column '{col}', "
@@ -347,8 +346,8 @@ def copy_cap_annotations(
                             break
                 else:
                     for pos, cell_id in zip(check_positions, check_cell_ids):
-                        output_val = _to_str(_decode_bytes(item[pos]))
-                        expected_val = _to_str(source_obs_subset.at[cell_id, col])
+                        output_val = _normalize(_decode_bytes(item[pos]))
+                        expected_val = _normalize(source_obs_subset.at[cell_id, col])
                         if output_val != expected_val:
                             verification_error = (
                                 f"Verification failed: column '{col}', "

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -181,21 +181,38 @@ def copy_cap_annotations(
             target_index = [_decode_bytes(v) for v in obs_group[idx_key][:]]
 
             uns = f.get("uns")
+            target_uns_keys = set(uns.keys()) if uns else set()
             if uns and EDIT_LOG_KEY in uns:
                 raw_log = _decode_bytes(uns[EDIT_LOG_KEY][()])
             else:
                 raw_log = "[]"
 
+        target_n_obs = len(target_index)
+        target_index_set = set(target_index)
+        if len(target_index_set) != target_n_obs:
+            seen, dupes = set(), []
+            for x in target_index:
+                if x in seen and x not in dupes:
+                    dupes.append(x)
+                    if len(dupes) >= 5:
+                        break
+                seen.add(x)
+            return {"error": f"Target has duplicate cell IDs (first 5): {dupes}"}
+
+        # Detect existing CAP obs columns: any column with "--" separator
         existing_cap_cols = [c for c in target_obs_columns if "--" in c]
 
-        if existing_cap_cols and not overwrite:
+        existing_cap_uns = [k for k in _CAP_UNS_KEYS if k in target_uns_keys]
+
+        if (existing_cap_cols or existing_cap_uns) and not overwrite:
             return {
                 "error": (
-                    f"Target already has {len(existing_cap_cols)} CAP columns "
-                    f"(e.g., {existing_cap_cols[0]}). Use overwrite=True to replace."
+                    f"Target already has CAP data "
+                    f"({len(existing_cap_cols)} obs columns, "
+                    f"{len(existing_cap_uns)} uns keys). "
+                    f"Use overwrite=True to replace."
                 )
             }
-        target_n_obs = len(target_index)
 
         if target_n_obs != source_n_obs:
             return {
@@ -205,7 +222,6 @@ def copy_cap_annotations(
                 )
             }
 
-        target_index_set = set(target_index)
         if source_index != target_index_set:
             missing_in_target = source_index - target_index_set
             missing_in_source = target_index_set - source_index
@@ -280,9 +296,10 @@ def copy_cap_annotations(
             with h5py.File(temp_path, "r") as f_temp, \
                  h5py.File(output_path, "a") as f_out:
 
-                # Overwrite: delete existing CAP columns and uns keys
+                f_out.require_group("uns")
+
                 deleted_cols = set()
-                if existing_cap_cols and overwrite:
+                if (existing_cap_cols or existing_cap_uns) and overwrite:
                     for col in existing_cap_cols:
                         if col in f_out["obs"]:
                             del f_out["obs"][col]
@@ -320,8 +337,13 @@ def copy_cap_annotations(
         check_cell_ids = [target_index[i] for i in check_positions]
 
         def _normalize(val):
-            if val is None or (isinstance(val, float) and pd.isna(val)):
+            if val is None:
                 return None
+            try:
+                if pd.isna(val):
+                    return None
+            except (TypeError, ValueError):
+                pass
             return str(val)
 
         verification_error = None

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -115,6 +115,7 @@ def copy_cap_annotations(
         Dict with output_path, copied columns/keys, and marker gene
         validation results, or 'error' on failure.
     """
+    output_path = None
     try:
         target_path = resolve_latest(target_path)
 
@@ -398,4 +399,9 @@ def copy_cap_annotations(
         }
 
     except Exception as e:
+        if output_path and os.path.isfile(output_path):
+            try:
+                os.remove(output_path)
+            except OSError:
+                pass
         return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -316,8 +316,11 @@ def copy_cap_annotations(
         check_positions = [0, len(target_index) // 2, len(target_index) - 1]
         check_cell_ids = [target_index[i] for i in check_positions]
 
+        verification_error = None
         with h5py.File(output_path, "r") as f_out:
             for col in obs_cols_to_copy:
+                if verification_error:
+                    break
                 item = f_out["obs"][col]
                 if isinstance(item, h5py.Group) and "categories" in item:
                     cats = [_decode_bytes(v) for v in item["categories"][:]]
@@ -327,29 +330,29 @@ def copy_cap_annotations(
                         expected = source_obs_subset.at[cell_id, col]
                         expected_str = str(expected) if not pd.isna(expected) else None
                         if str(output_val) != str(expected_str):
-                            os.remove(output_path)
-                            return {
-                                "error": (
-                                    f"Verification failed: column '{col}', "
-                                    f"cell '{cell_id}' (pos {pos}): "
-                                    f"expected '{expected_str}', got '{output_val}'"
-                                )
-                            }
+                            verification_error = (
+                                f"Verification failed: column '{col}', "
+                                f"cell '{cell_id}' (pos {pos}): "
+                                f"expected '{expected_str}', got '{output_val}'"
+                            )
+                            break
                 else:
                     for pos, cell_id in zip(check_positions, check_cell_ids):
                         output_val = str(_decode_bytes(item[pos]))
                         expected = str(source_obs_subset.at[cell_id, col])
                         if output_val != expected:
-                            os.remove(output_path)
-                            return {
-                                "error": (
-                                    f"Verification failed: column '{col}', "
-                                    f"cell '{cell_id}' (pos {pos}): "
-                                    f"expected '{expected}', got '{output_val}'"
-                                )
-                            }
+                            verification_error = (
+                                f"Verification failed: column '{col}', "
+                                f"cell '{cell_id}' (pos {pos}): "
+                                f"expected '{expected}', got '{output_val}'"
+                            )
+                            break
 
         del source_obs_subset
+
+        if verification_error:
+            os.remove(output_path)
+            return {"error": verification_error}
 
         # --- Step 6: Cleanup + validate marker genes ---
         cleanup_previous_version(target_path, output_path)

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -60,6 +60,20 @@ _CELL_TYPE_ENRICHMENT = [
 _CAP_UNS_KEYS = set(_UNS_COPY_TOPLEVEL) | {"cap_metadata"}
 
 
+def _check_duplicate_ids(index: list[str], label: str) -> str | None:
+    """Return an error message if index has duplicates, else None."""
+    if len(set(index)) == len(index):
+        return None
+    seen, dupes = set(), []
+    for x in index:
+        if x in seen and x not in dupes:
+            dupes.append(x)
+            if len(dupes) >= 5:
+                break
+        seen.add(x)
+    return f"{label} has duplicate cell IDs (first 5): {dupes}"
+
+
 def _get_annotation_sets(source_uns: dict) -> list[str]:
     """Get annotation sets defined in cellannotation_metadata."""
     meta = source_uns.get("cellannotation_metadata", {})
@@ -162,15 +176,9 @@ def copy_cap_annotations(
 
         source_n_obs = len(source_index_list)
         source_index = set(source_index_list)
-        if len(source_index) != source_n_obs:
-            seen, dupes = set(), []
-            for x in source_index_list:
-                if x in seen and x not in dupes:
-                    dupes.append(x)
-                    if len(dupes) >= 5:
-                        break
-                seen.add(x)
-            return {"error": f"Source has duplicate cell IDs (first 5): {dupes}"}
+        dupe_err = _check_duplicate_ids(source_index_list, "Source")
+        if dupe_err:
+            return {"error": dupe_err}
 
         source_obs_subset = pd.DataFrame(source_obs_data, index=source_index_list)
 
@@ -190,15 +198,9 @@ def copy_cap_annotations(
 
         target_n_obs = len(target_index)
         target_index_set = set(target_index)
-        if len(target_index_set) != target_n_obs:
-            seen, dupes = set(), []
-            for x in target_index:
-                if x in seen and x not in dupes:
-                    dupes.append(x)
-                    if len(dupes) >= 5:
-                        break
-                seen.add(x)
-            return {"error": f"Target has duplicate cell IDs (first 5): {dupes}"}
+        dupe_err = _check_duplicate_ids(target_index, "Target")
+        if dupe_err:
+            return {"error": dupe_err}
 
         # Detect existing CAP obs columns: any column with "--" separator
         existing_cap_cols = [c for c in target_obs_columns if "--" in c]

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -3,13 +3,28 @@
 from __future__ import annotations
 
 import os
+import shutil
+import tempfile
 from datetime import datetime, timezone
 
-from ._io import open_h5ad
+import anndata as ad
+import h5py
+import numpy as np
+import pandas as pd
+import scipy.sparse as sp
+
+from ._io import open_h5ad, read_obs_column_names, read_obs_index, _decode_bytes
 from ._serialize import make_serializable
 from .cap import _REQUIRED_SUFFIXES, _OPTIONAL_SUFFIXES
 from .marker_genes import validate_marker_genes
-from .write import write_h5ad, resolve_latest, _compute_sha256
+from .write import (
+    EDIT_LOG_KEY,
+    build_edit_log,
+    cleanup_previous_version,
+    generate_output_path,
+    resolve_latest,
+    _compute_sha256,
+)
 from . import __version__
 
 # CAP uns keys copied top-level (already namespaced)
@@ -85,8 +100,12 @@ def copy_cap_annotations(
 ) -> dict:
     """Copy CAP cell annotations from source to target h5ad file.
 
-    Validates prerequisites, copies annotation obs columns and uns metadata,
-    then writes the target with an edit log entry.
+    Uses a hybrid anndata + h5py approach: reads source uns via AnnData
+    (backed mode, fast for metadata), reads source obs columns via h5py
+    (avoids slow backed-mode column access), writes a temp file via
+    anndata for correct encoding, then copies the target and transplants
+    new data via h5py.copy(). Avoids loading either file's expression
+    matrix into memory.
 
     Args:
         source_path: Path to source h5ad with CAP annotations.
@@ -100,7 +119,11 @@ def copy_cap_annotations(
     try:
         target_path = resolve_latest(target_path)
 
-        # --- Validation 1: Source has CAP ---
+        # --- Step 1: Read source data via h5py (no full AnnData load) ---
+
+        # Read source uns via backed mode (fast — uns is small metadata).
+        # We use anndata here because uns contains nested dicts with
+        # anndata-specific encoding that's complex to parse via raw h5py.
         with open_h5ad(source_path) as source:
             if "cellannotation_metadata" not in source.uns:
                 return {"error": "Source has no cellannotation_metadata in uns"}
@@ -111,112 +134,230 @@ def copy_cap_annotations(
             if not annotation_sets:
                 return {"error": "Source has no annotation sets in cellannotation_metadata"}
 
-            if not source.obs.index.is_unique:
-                dupes = source.obs.index[source.obs.index.duplicated()].unique()[:5].tolist()
-                return {"error": f"Source has duplicate cell IDs (first 5): {dupes}"}
-
-            # Snapshot source data we need (before closing backed file)
             cap_schema_version = str(source.uns["cellannotation_schema_version"])
             all_uns_keys = _UNS_COPY_TOPLEVEL + _UNS_CAP_METADATA
             source_uns = {k: make_serializable(source.uns[k]) for k in all_uns_keys if k in source.uns}
 
-            source_obs_columns = list(source.obs.columns)
-            obs_cols_to_copy = _get_obs_columns_to_copy(annotation_sets, source_obs_columns)
-            if not obs_cols_to_copy:
-                return {"error": "No CAP obs columns found to copy"}
+        # Read source obs via h5py (avoids slow backed-mode column access)
+        source_obs_columns = read_obs_column_names(source_path)
+        obs_cols_to_copy = _get_obs_columns_to_copy(annotation_sets, source_obs_columns)
+        if not obs_cols_to_copy:
+            return {"error": "No CAP obs columns found to copy"}
 
-            source_obs_subset = source.obs[obs_cols_to_copy].copy()
-            source_n_obs = source.n_obs
-            source_index = set(source.obs.index)
+        source_index_list = read_obs_index(source_path)
+        source_n_obs = len(source_index_list)
+        source_index = set(source_index_list)
+        if len(source_index) != source_n_obs:
+            seen, dupes = set(), []
+            for x in source_index_list:
+                if x in seen and x not in dupes:
+                    dupes.append(x)
+                    if len(dupes) >= 5:
+                        break
+                seen.add(x)
+            return {"error": f"Source has duplicate cell IDs (first 5): {dupes}"}
 
-        # --- Validation 2: Target clean ---
-        with open_h5ad(target_path, backed=None) as target:
-            target_obs_columns = list(target.obs.columns)
-            existing_cap_cols = [c for c in target_obs_columns if "--" in c]
-
-            if existing_cap_cols and not overwrite:
-                return {
-                    "error": (
-                        f"Target already has {len(existing_cap_cols)} CAP columns "
-                        f"(e.g., {existing_cap_cols[0]}). Use overwrite=True to replace."
-                    )
-                }
-
-            if existing_cap_cols and overwrite:
-                target.obs.drop(columns=existing_cap_cols, inplace=True)
-                for key in list(target.uns.keys()):
-                    if key in _CAP_UNS_KEYS:
-                        del target.uns[key]
-
-            # --- Validation 3: Cell identity match ---
-            if target.n_obs != source_n_obs:
-                return {
-                    "error": (
-                        f"Cell count mismatch: source has {source_n_obs}, "
-                        f"target has {target.n_obs}"
-                    )
-                }
-
-            target_index = set(target.obs.index)
-            if source_index != target_index:
-                missing_in_target = source_index - target_index
-                missing_in_source = target_index - source_index
-                return {
-                    "error": (
-                        f"Cell ID mismatch: {len(missing_in_target)} IDs in source "
-                        f"not in target, {len(missing_in_source)} IDs in target not "
-                        f"in source"
-                    )
-                }
-
-            # --- Copy obs columns (aligned by index) ---
-            aligned = source_obs_subset.loc[target.obs.index]
+        # Read obs columns via h5py and reconstruct as pandas DataFrame
+        source_obs_data = {}
+        with h5py.File(source_path, "r") as f:
+            obs_group = f["obs"]
             for col in obs_cols_to_copy:
-                target.obs[col] = aligned[col]
+                item = obs_group[col]
+                if isinstance(item, h5py.Group) and "categories" in item:
+                    categories = [_decode_bytes(v) for v in item["categories"][:]]
+                    codes = item["codes"][:]
+                    source_obs_data[col] = pd.Categorical.from_codes(codes, categories=categories)
+                else:
+                    source_obs_data[col] = [_decode_bytes(v) for v in item[:]]
 
-            # --- Copy uns metadata ---
-            uns_keys_added = []
-            for key in _UNS_COPY_TOPLEVEL:
-                if key in source_uns:
-                    target.uns[key] = source_uns[key]
-                    uns_keys_added.append(key)
+        source_obs_subset = pd.DataFrame(source_obs_data, index=source_index_list)
 
-            # Collect generic CAP keys into a container
-            cap_metadata = {k: source_uns[k] for k in _UNS_CAP_METADATA if k in source_uns}
-            if cap_metadata:
-                target.uns["cap_metadata"] = cap_metadata
-                uns_keys_added.append("cap_metadata")
+        # --- Step 2: Validate target via h5py (no AnnData load) ---
+        target_obs_columns = read_obs_column_names(target_path)
+        existing_cap_cols = [c for c in target_obs_columns if "--" in c]
 
-            # --- Edit log ---
-            source_basename = os.path.basename(source_path)
-            source_sha256 = _compute_sha256(source_path)
-            entry = {
-                "timestamp": datetime.now(timezone.utc).isoformat(),
-                "tool": "hca-anndata-tools",
-                "tool_version": __version__,
-                "operation": "import_cap_annotations",
-                "description": f"Copied CAP annotations from {source_basename}",
-                "details": {
-                    "cap_source_file": source_basename,
-                    "cap_source_sha256": source_sha256,
-                    "cap_schema_version": cap_schema_version,
-                    "annotation_sets": annotation_sets,
-                    "obs_columns_added": obs_cols_to_copy,
-                    "uns_keys_added": uns_keys_added,
-                },
+        if existing_cap_cols and not overwrite:
+            return {
+                "error": (
+                    f"Target already has {len(existing_cap_cols)} CAP columns "
+                    f"(e.g., {existing_cap_cols[0]}). Use overwrite=True to replace."
+                )
             }
 
-            # --- Write ---
-            result = write_h5ad(target, target_path, [entry])
+        target_index = read_obs_index(target_path)
+        target_n_obs = len(target_index)
 
-        if "error" in result:
-            return result
+        if target_n_obs != source_n_obs:
+            return {
+                "error": (
+                    f"Cell count mismatch: source has {source_n_obs}, "
+                    f"target has {target_n_obs}"
+                )
+            }
 
-        # --- Post-copy: validate marker genes ---
-        marker_validation = validate_marker_genes(result["output_path"])
+        target_index_set = set(target_index)
+        if source_index != target_index_set:
+            missing_in_target = source_index - target_index_set
+            missing_in_source = target_index_set - source_index
+            return {
+                "error": (
+                    f"Cell ID mismatch: {len(missing_in_target)} IDs in source "
+                    f"not in target, {len(missing_in_source)} IDs in target not "
+                    f"in source"
+                )
+            }
+
+        # --- Step 3: Build aligned temp AnnData ---
+        aligned_obs = source_obs_subset.loc[target_index]
+
+        temp_uns = {}
+        uns_keys_added = []
+        for key in _UNS_COPY_TOPLEVEL:
+            if key in source_uns:
+                temp_uns[key] = source_uns[key]
+                uns_keys_added.append(key)
+
+        cap_metadata = {k: source_uns[k] for k in _UNS_CAP_METADATA if k in source_uns}
+        if cap_metadata:
+            temp_uns["cap_metadata"] = cap_metadata
+            uns_keys_added.append("cap_metadata")
+
+        source_basename = os.path.basename(source_path)
+        source_sha256 = _compute_sha256(source_path)
+        target_sha256 = _compute_sha256(target_path)
+
+        entry = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "tool": "hca-anndata-tools",
+            "tool_version": __version__,
+            "operation": "import_cap_annotations",
+            "description": f"Copied CAP annotations from {source_basename}",
+            "details": {
+                "cap_source_file": source_basename,
+                "cap_source_sha256": source_sha256,
+                "cap_schema_version": cap_schema_version,
+                "annotation_sets": annotation_sets,
+                "obs_columns_added": obs_cols_to_copy,
+                "uns_keys_added": uns_keys_added,
+            },
+        }
+
+        with h5py.File(target_path, "r") as f:
+            uns = f.get("uns")
+            if uns and EDIT_LOG_KEY in uns:
+                raw_log = _decode_bytes(uns[EDIT_LOG_KEY][()])
+            else:
+                raw_log = "[]"
+
+        log_result = build_edit_log(raw_log, [entry], target_path, target_sha256)
+        if "error" in log_result:
+            return log_result
+
+        temp_uns[EDIT_LOG_KEY] = log_result["json"]
+
+        n_obs = len(target_index)
+        temp_adata = ad.AnnData(
+            X=sp.csr_matrix((n_obs, 0), dtype=np.float32),
+            obs=aligned_obs,
+            uns=temp_uns,
+        )
+        del aligned_obs
+
+        # --- Step 4: Write temp, copy target, transplant via h5py ---
+        output_path = generate_output_path(target_path)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            temp_path = os.path.join(tmpdir, "cap_temp.h5ad")
+            temp_adata.write_h5ad(temp_path)
+            del temp_adata
+
+            shutil.copy2(target_path, output_path)
+
+            # Transplant from temp into output
+            with h5py.File(temp_path, "r") as f_temp, \
+                 h5py.File(output_path, "a") as f_out:
+
+                # Overwrite: delete existing CAP columns and uns keys
+                deleted_cols = set()
+                if existing_cap_cols and overwrite:
+                    for col in existing_cap_cols:
+                        if col in f_out["obs"]:
+                            del f_out["obs"][col]
+                            deleted_cols.add(col)
+                    for key in list(f_out["uns"].keys()):
+                        if key in _CAP_UNS_KEYS:
+                            del f_out["uns"][key]
+
+                for col in obs_cols_to_copy:
+                    if col in f_temp["obs"]:
+                        f_temp.copy(f"obs/{col}", f_out["obs"])
+
+                # Update column-order (remove deleted, add new)
+                current_order = [
+                    _decode_bytes(c) for c in f_out["obs"].attrs["column-order"]
+                    if _decode_bytes(c) not in deleted_cols
+                ]
+                new_cols = [c for c in obs_cols_to_copy if c not in current_order]
+                f_out["obs"].attrs["column-order"] = current_order + new_cols
+
+                for key in uns_keys_added:
+                    if key in f_temp["uns"]:
+                        if key in f_out["uns"]:
+                            del f_out["uns"][key]
+                        f_temp.copy(f"uns/{key}", f_out["uns"])
+
+                if EDIT_LOG_KEY in f_out["uns"]:
+                    del f_out["uns"][EDIT_LOG_KEY]
+                if EDIT_LOG_KEY in f_temp["uns"]:
+                    f_temp.copy(f"uns/{EDIT_LOG_KEY}", f_out["uns"])
+
+        # --- Step 5: Verify transplant correctness ---
+        # Spot-check a few cells to catch alignment or encoding errors.
+        check_positions = [0, len(target_index) // 2, len(target_index) - 1]
+        check_cell_ids = [target_index[i] for i in check_positions]
+
+        with h5py.File(output_path, "r") as f_out:
+            for col in obs_cols_to_copy:
+                item = f_out["obs"][col]
+                if isinstance(item, h5py.Group) and "categories" in item:
+                    cats = [_decode_bytes(v) for v in item["categories"][:]]
+                    codes = item["codes"]
+                    for pos, cell_id in zip(check_positions, check_cell_ids):
+                        output_val = cats[codes[pos]] if codes[pos] >= 0 else None
+                        expected = source_obs_subset.at[cell_id, col]
+                        expected_str = str(expected) if not pd.isna(expected) else None
+                        if str(output_val) != str(expected_str):
+                            os.remove(output_path)
+                            return {
+                                "error": (
+                                    f"Verification failed: column '{col}', "
+                                    f"cell '{cell_id}' (pos {pos}): "
+                                    f"expected '{expected_str}', got '{output_val}'"
+                                )
+                            }
+                else:
+                    for pos, cell_id in zip(check_positions, check_cell_ids):
+                        output_val = str(_decode_bytes(item[pos]))
+                        expected = str(source_obs_subset.at[cell_id, col])
+                        if output_val != expected:
+                            os.remove(output_path)
+                            return {
+                                "error": (
+                                    f"Verification failed: column '{col}', "
+                                    f"cell '{cell_id}' (pos {pos}): "
+                                    f"expected '{expected}', got '{output_val}'"
+                                )
+                            }
+
+        del source_obs_subset
+
+        # --- Step 6: Cleanup + validate marker genes ---
+        cleanup_previous_version(target_path, output_path)
+
+        marker_validation = validate_marker_genes(output_path)
 
         return {
-            **result,
+            "output_path": output_path,
             "source": source_basename,
             "annotation_sets": annotation_sets,
             "obs_columns_added": obs_cols_to_copy,

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -11,7 +11,6 @@ import anndata as ad
 import h5py
 import numpy as np
 import pandas as pd
-import scipy.sparse as sp
 
 from ._io import open_h5ad, _decode_bytes
 from ._serialize import make_serializable
@@ -261,7 +260,7 @@ def copy_cap_annotations(
 
         n_obs = len(target_index)
         temp_adata = ad.AnnData(
-            X=sp.csr_matrix((n_obs, 0), dtype=np.float32),
+            X=np.empty((n_obs, 0), dtype=np.float32),
             obs=aligned_obs,
             uns=temp_uns,
         )

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -13,7 +13,7 @@ import numpy as np
 import pandas as pd
 import scipy.sparse as sp
 
-from ._io import open_h5ad, read_obs_column_names, read_obs_index, _decode_bytes
+from ._io import open_h5ad, _decode_bytes
 from ._serialize import make_serializable
 from .cap import _REQUIRED_SUFFIXES, _OPTIONAL_SUFFIXES
 from .marker_genes import validate_marker_genes
@@ -139,12 +139,27 @@ def copy_cap_annotations(
             source_uns = {k: make_serializable(source.uns[k]) for k in all_uns_keys if k in source.uns}
 
         # Read source obs via h5py (avoids slow backed-mode column access)
-        source_obs_columns = read_obs_column_names(source_path)
-        obs_cols_to_copy = _get_obs_columns_to_copy(annotation_sets, source_obs_columns)
+        with h5py.File(source_path, "r") as f:
+            obs_group = f["obs"]
+            source_obs_columns = [_decode_bytes(c) for c in obs_group.attrs["column-order"]]
+            obs_cols_to_copy = _get_obs_columns_to_copy(annotation_sets, source_obs_columns)
+
+            idx_key = _decode_bytes(obs_group.attrs.get("_index", "_index"))
+            source_index_list = [_decode_bytes(v) for v in obs_group[idx_key][:]]
+
+            source_obs_data = {}
+            for col in obs_cols_to_copy:
+                item = obs_group[col]
+                if isinstance(item, h5py.Group) and "categories" in item:
+                    categories = [_decode_bytes(v) for v in item["categories"][:]]
+                    codes = item["codes"][:]
+                    source_obs_data[col] = pd.Categorical.from_codes(codes, categories=categories)
+                else:
+                    source_obs_data[col] = [_decode_bytes(v) for v in item[:]]
+
         if not obs_cols_to_copy:
             return {"error": "No CAP obs columns found to copy"}
 
-        source_index_list = read_obs_index(source_path)
         source_n_obs = len(source_index_list)
         source_index = set(source_index_list)
         if len(source_index) != source_n_obs:
@@ -157,23 +172,21 @@ def copy_cap_annotations(
                 seen.add(x)
             return {"error": f"Source has duplicate cell IDs (first 5): {dupes}"}
 
-        # Read obs columns via h5py and reconstruct as pandas DataFrame
-        source_obs_data = {}
-        with h5py.File(source_path, "r") as f:
-            obs_group = f["obs"]
-            for col in obs_cols_to_copy:
-                item = obs_group[col]
-                if isinstance(item, h5py.Group) and "categories" in item:
-                    categories = [_decode_bytes(v) for v in item["categories"][:]]
-                    codes = item["codes"][:]
-                    source_obs_data[col] = pd.Categorical.from_codes(codes, categories=categories)
-                else:
-                    source_obs_data[col] = [_decode_bytes(v) for v in item[:]]
-
         source_obs_subset = pd.DataFrame(source_obs_data, index=source_index_list)
 
         # --- Step 2: Validate target via h5py (no AnnData load) ---
-        target_obs_columns = read_obs_column_names(target_path)
+        with h5py.File(target_path, "r") as f:
+            obs_group = f["obs"]
+            target_obs_columns = [_decode_bytes(c) for c in obs_group.attrs["column-order"]]
+            idx_key = _decode_bytes(obs_group.attrs.get("_index", "_index"))
+            target_index = [_decode_bytes(v) for v in obs_group[idx_key][:]]
+
+            uns = f.get("uns")
+            if uns and EDIT_LOG_KEY in uns:
+                raw_log = _decode_bytes(uns[EDIT_LOG_KEY][()])
+            else:
+                raw_log = "[]"
+
         existing_cap_cols = [c for c in target_obs_columns if "--" in c]
 
         if existing_cap_cols and not overwrite:
@@ -183,8 +196,6 @@ def copy_cap_annotations(
                     f"(e.g., {existing_cap_cols[0]}). Use overwrite=True to replace."
                 )
             }
-
-        target_index = read_obs_index(target_path)
         target_n_obs = len(target_index)
 
         if target_n_obs != source_n_obs:
@@ -241,13 +252,6 @@ def copy_cap_annotations(
                 "uns_keys_added": uns_keys_added,
             },
         }
-
-        with h5py.File(target_path, "r") as f:
-            uns = f.get("uns")
-            if uns and EDIT_LOG_KEY in uns:
-                raw_log = _decode_bytes(uns[EDIT_LOG_KEY][()])
-            else:
-                raw_log = "[]"
 
         log_result = build_edit_log(raw_log, [entry], target_path, target_sha256)
         if "error" in log_result:
@@ -316,6 +320,12 @@ def copy_cap_annotations(
         check_positions = [0, len(target_index) // 2, len(target_index) - 1]
         check_cell_ids = [target_index[i] for i in check_positions]
 
+        def _to_str(val) -> str:
+            """Normalize a value to string for comparison."""
+            if val is None or (isinstance(val, float) and pd.isna(val)):
+                return "<NA>"
+            return str(val)
+
         verification_error = None
         with h5py.File(output_path, "r") as f_out:
             for col in obs_cols_to_copy:
@@ -326,25 +336,24 @@ def copy_cap_annotations(
                     cats = [_decode_bytes(v) for v in item["categories"][:]]
                     codes = item["codes"]
                     for pos, cell_id in zip(check_positions, check_cell_ids):
-                        output_val = cats[codes[pos]] if codes[pos] >= 0 else None
-                        expected = source_obs_subset.at[cell_id, col]
-                        expected_str = str(expected) if not pd.isna(expected) else None
-                        if str(output_val) != str(expected_str):
+                        output_val = _to_str(cats[codes[pos]] if codes[pos] >= 0 else None)
+                        expected_val = _to_str(source_obs_subset.at[cell_id, col])
+                        if output_val != expected_val:
                             verification_error = (
                                 f"Verification failed: column '{col}', "
                                 f"cell '{cell_id}' (pos {pos}): "
-                                f"expected '{expected_str}', got '{output_val}'"
+                                f"expected '{expected_val}', got '{output_val}'"
                             )
                             break
                 else:
                     for pos, cell_id in zip(check_positions, check_cell_ids):
-                        output_val = str(_decode_bytes(item[pos]))
-                        expected = str(source_obs_subset.at[cell_id, col])
-                        if output_val != expected:
+                        output_val = _to_str(_decode_bytes(item[pos]))
+                        expected_val = _to_str(source_obs_subset.at[cell_id, col])
+                        if output_val != expected_val:
                             verification_error = (
                                 f"Verification failed: column '{col}', "
                                 f"cell '{cell_id}' (pos {pos}): "
-                                f"expected '{expected}', got '{output_val}'"
+                                f"expected '{expected_val}', got '{output_val}'"
                             )
                             break
 

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
@@ -100,6 +100,82 @@ def _is_timestamped(path: str) -> bool:
     return bool(_TIMESTAMP_PATTERN.search(os.path.basename(path)))
 
 
+def build_edit_log(
+    existing_log_raw: str | list,
+    edit_entries: list[dict],
+    source_path: str,
+    source_sha256: str | None = None,
+) -> dict:
+    """Build an updated edit log JSON string.
+
+    Validates entries, computes SHA-256 of the source file, stamps each
+    entry with source_file and source_sha256, and appends to the existing log.
+
+    Args:
+        existing_log_raw: Current edit log value (JSON string or list).
+            Use "[]" if no log exists.
+        edit_entries: New entries to append. Required keys:
+            timestamp, tool, tool_version, operation, description.
+        source_path: Path to the source .h5ad file on disk.
+        source_sha256: Pre-computed SHA-256 hex digest. If None, computed
+            from source_path.
+
+    Returns:
+        Dict with 'json' (updated JSON string) on success, or 'error'.
+    """
+    if not edit_entries:
+        return {"error": "edit_entries must not be empty — every write should document what changed"}
+
+    for i, entry in enumerate(edit_entries):
+        missing = _REQUIRED_ENTRY_KEYS - entry.keys()
+        if missing:
+            return {"error": f"edit_entries[{i}] missing required keys: {sorted(missing)}"}
+
+    sha256 = source_sha256 if source_sha256 is not None else _compute_sha256(source_path)
+    source_filename = os.path.basename(source_path)
+
+    stamped_entries = [
+        {**entry, "source_file": source_filename, "source_sha256": sha256}
+        for entry in edit_entries
+    ]
+
+    if isinstance(existing_log_raw, str):
+        try:
+            existing_log = json.loads(existing_log_raw)
+        except json.JSONDecodeError:
+            return {"error": f"Existing {EDIT_LOG_KEY} contains invalid JSON"}
+        if not isinstance(existing_log, list):
+            return {"error": f"Existing {EDIT_LOG_KEY} decoded to {type(existing_log).__name__}, expected list"}
+    elif isinstance(existing_log_raw, list):
+        existing_log = existing_log_raw
+    else:
+        return {
+            "error": (
+                f"Existing {EDIT_LOG_KEY} has unsupported type "
+                f"{type(existing_log_raw).__name__}; refusing to overwrite edit log"
+            )
+        }
+
+    return {"json": json.dumps(existing_log + stamped_entries)}
+
+
+def cleanup_previous_version(source_path: str, output_path: str) -> None:
+    """Delete previous timestamped version if applicable.
+
+    Never deletes the original (non-timestamped) file. Skips if output
+    overwrote source in place (same-second write).
+    """
+    if (
+        _is_timestamped(source_path)
+        and source_path != output_path
+        and os.path.isfile(source_path)
+    ):
+        try:
+            os.remove(source_path)
+        except OSError:
+            pass  # write succeeded; stale file is harmless
+
+
 def write_h5ad(
     adata: AnnData,
     source_path: str,
@@ -134,63 +210,21 @@ def write_h5ad(
         if not os.path.isfile(source_path):
             return {"error": f"Source file not found: {source_path}"}
 
-        if not edit_entries:
-            return {"error": "edit_entries must not be empty — every write should document what changed"}
+        log_result = build_edit_log(
+            adata.uns.get(EDIT_LOG_KEY, "[]"),
+            edit_entries,
+            source_path,
+        )
+        if "error" in log_result:
+            return log_result
 
-        # Validate edit entries have required fields
-        for i, entry in enumerate(edit_entries):
-            missing = _REQUIRED_ENTRY_KEYS - entry.keys()
-            if missing:
-                return {"error": f"edit_entries[{i}] missing required keys: {sorted(missing)}"}
+        adata.uns[EDIT_LOG_KEY] = log_result["json"]
 
-        # Compute source identity
-        sha256 = _compute_sha256(source_path)
-        source_filename = os.path.basename(source_path)
-
-        # Build new entries with provenance fields (don't mutate caller's dicts)
-        stamped_entries = [
-            {**entry, "source_file": source_filename, "source_sha256": sha256}
-            for entry in edit_entries
-        ]
-
-        # Append to existing edit log (preserve previous entries).
-        # The log is stored as a JSON string in uns because anndata's HDF5
-        # writer cannot serialize lists of dicts natively.
-        raw_log = adata.uns.get(EDIT_LOG_KEY, "[]")
-        if isinstance(raw_log, str):
-            try:
-                existing_log = json.loads(raw_log)
-            except json.JSONDecodeError:
-                return {"error": f"Existing {EDIT_LOG_KEY} contains invalid JSON"}
-            if not isinstance(existing_log, list):
-                return {"error": f"Existing {EDIT_LOG_KEY} decoded to {type(existing_log).__name__}, expected list"}
-        elif isinstance(raw_log, list):
-            existing_log = raw_log
-        else:
-            return {
-                "error": (
-                    f"Existing {EDIT_LOG_KEY} has unsupported type "
-                    f"{type(raw_log).__name__}; refusing to overwrite edit log"
-                )
-            }
-        adata.uns[EDIT_LOG_KEY] = json.dumps(existing_log + stamped_entries)
-
-        # Write to output path (caller-provided or auto-generated)
         if output_path is None:
             output_path = generate_output_path(source_path)
         adata.write_h5ad(output_path, compression="gzip")
 
-        # Delete previous timestamped version (never the original).
-        # Skip if output == source (same-second write overwrote in place).
-        if (
-            _is_timestamped(source_path)
-            and source_path != output_path
-            and os.path.isfile(source_path)
-        ):
-            try:
-                os.remove(source_path)
-            except OSError:
-                pass  # write succeeded; stale file is harmless
+        cleanup_previous_version(source_path, output_path)
 
         return {"output_path": output_path}
 


### PR DESCRIPTION
## Summary

`copy_cap_annotations` previously loaded the entire target h5ad into memory and rewrote it — for multi-GB files this meant loading and re-compressing the expression matrix, raw, layers, etc. even though none of them change.

### New approach: hybrid anndata + h5py copy-then-patch
- **Source uns** read via anndata backed mode (fast for nested dict metadata)
- **Source obs columns** read via h5py directly (avoids slow backed-mode column access)
- **Temp AnnData** written via anndata for correct HDF5 encoding (anndata handles all serialization)
- **Target copied** to output path via `shutil.copy2`, then obs columns and uns keys transplanted from temp via `h5py.File.copy()` (preserves all attributes and encoding)
- **Post-copy spot-check** verifies first/middle/last cells match source data, catches alignment or encoding errors
- **Expression matrix never loaded or rewritten**

### Also
- Extracts `build_edit_log` and `cleanup_previous_version` from `write_h5ad` for reuse (write_h5ad calls the extracted functions, no behavior change)
- Adds `read_obs_index` helper to `_io.py`

## Test plan
- [x] All 176 tests pass
- [x] All 16 `test_copy_cap.py` tests pass (including overwrite and index reorder)
- [x] All 26 `test_write.py` tests pass (no regressions from extraction)
- [x] Tested on real ocular outflow segment files (9GB target + 14GB source) via MCP — previously timed out, now completes successfully
- [x] Output verified: correct obs columns, uns keys, edit log, marker gene validation matches previous implementation

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)