### PR TITLE
perf: optimize convert_cellxgene_to_hca with copy-then-patch

### DIFF
--- a/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
@@ -116,3 +116,36 @@ def read_var_gene_names(path: str) -> tuple[set[str], dict[str, str]]:
         }
 
         return gene_names, eid_to_var_name
+
+
+def verify_obs_transplant(
+    temp_path: str,
+    output_path: str,
+    columns: list[str],
+) -> str | None:
+    """Verify obs columns were transplanted correctly via full-column comparison.
+
+    Compares raw HDF5 data (categories + codes for categoricals, or full
+    dataset for non-categoricals) between temp and output for each column.
+
+    Returns:
+        None if all columns match, or an error message string on mismatch.
+    """
+    import numpy as np
+
+    with h5py.File(temp_path, "r") as f_temp, \
+         h5py.File(output_path, "r") as f_out:
+        for col in columns:
+            temp_item = f_temp["obs"][col]
+            out_item = f_out["obs"][col]
+
+            if isinstance(temp_item, h5py.Group) and "categories" in temp_item:
+                if not np.array_equal(temp_item["categories"][:], out_item["categories"][:]):
+                    return f"Verification failed: categories mismatch for column '{col}'"
+                if not np.array_equal(temp_item["codes"][:], out_item["codes"][:]):
+                    return f"Verification failed: codes mismatch for column '{col}'"
+            else:
+                if not np.array_equal(temp_item[:], out_item[:]):
+                    return f"Verification failed: data mismatch for column '{col}'"
+
+    return None

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/convert.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/convert.py
@@ -19,7 +19,6 @@ from .write import (
     EDIT_LOG_KEY,
     build_edit_log,
     generate_timestamp,
-    _compute_sha256,
 )
 from . import __version__
 

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/convert.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/convert.py
@@ -4,14 +4,23 @@ from __future__ import annotations
 
 import os
 import re
+import shutil
+import tempfile
 from datetime import datetime, timezone
 
+import anndata as ad
+import h5py
 import numpy as np
 import pandas as pd
 
-from ._io import open_h5ad
+from ._io import open_h5ad, read_obs_index, verify_obs_transplant, _decode_bytes
 from ._serialize import make_serializable
-from .write import generate_timestamp, write_h5ad
+from .write import (
+    EDIT_LOG_KEY,
+    build_edit_log,
+    generate_timestamp,
+    _compute_sha256,
+)
 from . import __version__
 
 # CellxGENE reserved uns keys — moved to cellxgene_source, not deleted
@@ -37,9 +46,13 @@ def convert_cellxgene_to_hca(
 ) -> dict:
     """Convert a CellxGENE h5ad file to HCA schema format.
 
+    Uses a hybrid anndata + h5py approach: reads uns via AnnData
+    (backed mode), writes a temp file via anndata for correct encoding,
+    then copies the source and transplants new data via h5py.copy().
+    Avoids loading the expression matrix into memory.
+
     Preserves cellxgene provenance in uns['cellxgene_source'], broadcasts
     organism from uns to obs, and renames the output from the dataset title.
-    Does not add missing HCA-specific fields — wranglers fill those later.
 
     Args:
         path: Path to a CellxGENE h5ad file.
@@ -49,9 +62,10 @@ def convert_cellxgene_to_hca(
         Dict with 'output_path', 'source', 'title', 'conversions' on success,
         or 'error' on failure.
     """
+    output_path = None
     try:
-        with open_h5ad(path, backed=None) as adata:
-            # Verify this is a cellxgene 6.0+ file (organism in uns, single species)
+        # --- Step 1: Read uns via anndata backed mode ---
+        with open_h5ad(path) as adata:
             if "schema_version" not in adata.uns:
                 return {"error": "Not a CellxGENE file — uns['schema_version'] is missing"}
 
@@ -71,66 +85,145 @@ def convert_cellxgene_to_hca(
             if not title:
                 return {"error": "File has no title in uns — cannot generate output filename"}
 
-            conversions = []
-
-            # --- 1. Preserve cellxgene provenance ---
+            # Snapshot uns values we need
             cellxgene_source = {}
             for key in _CELLXGENE_RESERVED_UNS:
                 if key in adata.uns:
                     cellxgene_source[key] = make_serializable(adata.uns[key])
-                    del adata.uns[key]
 
-            if cellxgene_source:
-                adata.uns["cellxgene_source"] = cellxgene_source
-                conversions.append(
-                    f"Moved cellxgene reserved keys to uns['cellxgene_source']: "
-                    f"{list(cellxgene_source.keys())}"
-                )
-
-            # --- 2. Broadcast organism from uns → obs ---
+            uns_to_broadcast = {}
             for key in _UNS_TO_OBS:
                 if key in adata.uns:
-                    value = adata.uns[key]
-                    adata.obs[key] = pd.Categorical.from_codes(
-                        np.zeros(adata.n_obs, dtype=np.int8),
-                        categories=[value],
-                    )
-                    del adata.uns[key]
-                    conversions.append(f"{key}: uns → obs (broadcast '{value}')")
+                    uns_to_broadcast[key] = make_serializable(adata.uns[key])
 
-            # --- 3. Build output path from title slug ---
-            slug = _slugify(title)
-            timestamp = generate_timestamp()
-            out_filename = f"{slug}-edit-{timestamp}.h5ad"
-            directory = output_dir if output_dir is not None else os.path.dirname(path)
-            output_path = os.path.join(directory, out_filename)
+        # --- Step 2: Read cell index and count via h5py ---
+        source_index = read_obs_index(path)
+        n_obs = len(source_index)
 
-            # --- 4. Build edit log entry ---
-            entry = {
-                "timestamp": datetime.now(timezone.utc).isoformat(),
-                "tool": "hca-anndata-tools",
-                "tool_version": __version__,
-                "operation": "import_cellxgene",
-                "description": f"Imported from CellxGENE Discover: {title}",
-                "details": {
-                    "source_schema_version": cellxgene_source.get("schema_version"),
-                    "source_citation": cellxgene_source.get("citation"),
-                    "conversions": conversions,
-                },
-            }
+        # --- Step 3: Build temp AnnData ---
+        conversions = []
 
-            # --- 5. Write ---
-            result = write_h5ad(adata, path, [entry], output_path=output_path)
+        if cellxgene_source:
+            conversions.append(
+                f"Moved cellxgene reserved keys to uns['cellxgene_source']: "
+                f"{list(cellxgene_source.keys())}"
+            )
 
-        if "error" in result:
-            return result
+        # Broadcast obs columns (categorical, 1 category, all codes=0)
+        obs_data = {}
+        for key in _UNS_TO_OBS:
+            if key in uns_to_broadcast:
+                value = uns_to_broadcast[key]
+                obs_data[key] = pd.Categorical.from_codes(
+                    np.zeros(n_obs, dtype=np.int8),
+                    categories=[value],
+                )
+                conversions.append(f"{key}: uns → obs (broadcast '{value}')")
+
+        obs = pd.DataFrame(obs_data, index=source_index)
+
+        # Build uns for temp file
+        temp_uns = {}
+        if cellxgene_source:
+            temp_uns["cellxgene_source"] = cellxgene_source
+
+        # Build edit log
+        slug = _slugify(title)
+        timestamp = generate_timestamp()
+        out_filename = f"{slug}-edit-{timestamp}.h5ad"
+        directory = output_dir if output_dir is not None else os.path.dirname(path)
+        output_path = os.path.join(directory, out_filename)
+
+        entry = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "tool": "hca-anndata-tools",
+            "tool_version": __version__,
+            "operation": "import_cellxgene",
+            "description": f"Imported from CellxGENE Discover: {title}",
+            "details": {
+                "source_schema_version": cellxgene_source.get("schema_version"),
+                "source_citation": cellxgene_source.get("citation"),
+                "conversions": conversions,
+            },
+        }
+
+        log_result = build_edit_log("[]", [entry], path)
+        if "error" in log_result:
+            return log_result
+
+        temp_uns[EDIT_LOG_KEY] = log_result["json"]
+
+        temp_adata = ad.AnnData(
+            X=np.empty((n_obs, 0), dtype=np.float32),
+            obs=obs,
+            uns=temp_uns,
+        )
+
+        # --- Step 4: Copy source + transplant via h5py ---
+        with tempfile.TemporaryDirectory() as tmpdir:
+            temp_path = os.path.join(tmpdir, "convert_temp.h5ad")
+            temp_adata.write_h5ad(temp_path)
+            del temp_adata
+
+            shutil.copy2(path, output_path)
+
+            with h5py.File(temp_path, "r") as f_temp, \
+                 h5py.File(output_path, "a") as f_out:
+
+                f_out.require_group("uns")
+
+                # Delete CellxGENE reserved keys from uns
+                for key in _CELLXGENE_RESERVED_UNS:
+                    if key in f_out["uns"]:
+                        del f_out["uns"][key]
+
+                # Delete organism keys from uns (now in obs)
+                for key in _UNS_TO_OBS:
+                    if key in f_out["uns"]:
+                        del f_out["uns"][key]
+
+                # Transplant cellxgene_source container from temp
+                if "cellxgene_source" in f_temp["uns"]:
+                    if "cellxgene_source" in f_out["uns"]:
+                        del f_out["uns"]["cellxgene_source"]
+                    f_temp.copy("uns/cellxgene_source", f_out["uns"])
+
+                # Transplant obs columns from temp
+                obs_cols_added = list(obs_data.keys())
+                for col in obs_cols_added:
+                    if col in f_out["obs"]:
+                        del f_out["obs"][col]
+                    if col in f_temp["obs"]:
+                        f_temp.copy(f"obs/{col}", f_out["obs"])
+
+                # Update column-order
+                current_order = [_decode_bytes(c) for c in f_out["obs"].attrs["column-order"]]
+                new_cols = [c for c in obs_cols_added if c not in current_order]
+                f_out["obs"].attrs["column-order"] = current_order + new_cols
+
+                # Transplant edit log from temp
+                if EDIT_LOG_KEY in f_out["uns"]:
+                    del f_out["uns"][EDIT_LOG_KEY]
+                if EDIT_LOG_KEY in f_temp["uns"]:
+                    f_temp.copy(f"uns/{EDIT_LOG_KEY}", f_out["uns"])
+
+            # --- Step 5: Verify transplant ---
+            verify_err = verify_obs_transplant(temp_path, output_path, obs_cols_added)
+            if verify_err:
+                os.remove(output_path)
+                return {"error": verify_err}
 
         return {
-            **result,
+            "output_path": output_path,
             "source": os.path.basename(path),
             "title": title,
             "conversions": conversions,
         }
 
     except Exception as e:
+        if output_path and os.path.isfile(output_path):
+            try:
+                os.remove(output_path)
+            except OSError:
+                pass
         return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -12,7 +12,7 @@ import h5py
 import numpy as np
 import pandas as pd
 
-from ._io import open_h5ad, _decode_bytes
+from ._io import open_h5ad, verify_obs_transplant, _decode_bytes
 from ._serialize import make_serializable
 from .cap import _REQUIRED_SUFFIXES, _OPTIONAL_SUFFIXES
 from .marker_genes import validate_marker_genes
@@ -336,24 +336,10 @@ def copy_cap_annotations(
                     f_temp.copy(f"uns/{EDIT_LOG_KEY}", f_out["uns"])
 
             # --- Step 5: Verify transplant — full column comparison ---
-            # Compare raw HDF5 data in temp vs output for every copied column.
-            with h5py.File(temp_path, "r") as f_temp, \
-                 h5py.File(output_path, "r") as f_out:
-                for col in obs_cols_to_copy:
-                    temp_item = f_temp["obs"][col]
-                    out_item = f_out["obs"][col]
-
-                    if isinstance(temp_item, h5py.Group) and "categories" in temp_item:
-                        if not np.array_equal(temp_item["categories"][:], out_item["categories"][:]):
-                            os.remove(output_path)
-                            return {"error": f"Verification failed: categories mismatch for column '{col}'"}
-                        if not np.array_equal(temp_item["codes"][:], out_item["codes"][:]):
-                            os.remove(output_path)
-                            return {"error": f"Verification failed: codes mismatch for column '{col}'"}
-                    else:
-                        if not np.array_equal(temp_item[:], out_item[:]):
-                            os.remove(output_path)
-                            return {"error": f"Verification failed: data mismatch for column '{col}'"}
+            verify_err = verify_obs_transplant(temp_path, output_path, obs_cols_to_copy)
+            if verify_err:
+                os.remove(output_path)
+                return {"error": verify_err}
 
         # --- Step 6: Cleanup + validate marker genes ---
         cleanup_previous_version(target_path, output_path)

--- a/packages/hca-anndata-tools/tests/test_helpers.py
+++ b/packages/hca-anndata-tools/tests/test_helpers.py
@@ -1,0 +1,205 @@
+"""Tests for extracted helper functions in _io.py and write.py."""
+
+from pathlib import Path
+
+import anndata as ad
+import h5py
+import numpy as np
+import pandas as pd
+import pytest
+import scipy.sparse as sp
+
+from hca_anndata_tools._io import read_obs_index, verify_obs_transplant
+from hca_anndata_tools.write import build_edit_log, cleanup_previous_version
+
+
+# -- read_obs_index -----------------------------------------------------------
+
+
+def test_read_obs_index(tmp_path):
+    ids = ["cell_A", "cell_B", "cell_C"]
+    adata = ad.AnnData(
+        X=sp.csr_matrix((3, 2), dtype=np.float32),
+        obs=pd.DataFrame(index=ids),
+    )
+    path = tmp_path / "test.h5ad"
+    adata.write_h5ad(path)
+    assert read_obs_index(str(path)) == ids
+
+
+def test_read_obs_index_preserves_order(tmp_path):
+    ids = ["z_last", "a_first", "m_middle"]
+    adata = ad.AnnData(
+        X=sp.csr_matrix((3, 2), dtype=np.float32),
+        obs=pd.DataFrame(index=ids),
+    )
+    path = tmp_path / "order.h5ad"
+    adata.write_h5ad(path)
+    assert read_obs_index(str(path)) == ids
+
+
+# -- verify_obs_transplant ----------------------------------------------------
+
+
+@pytest.fixture
+def _make_pair(tmp_path):
+    """Create a matching temp/output pair with obs columns."""
+    def _factory(obs_data: dict, index: list[str], mismatch_col: str | None = None):
+        n = len(index)
+        obs = pd.DataFrame(obs_data, index=index)
+        adata = ad.AnnData(
+            X=np.empty((n, 0), dtype=np.float32),
+            obs=obs,
+        )
+        temp_path = tmp_path / "temp.h5ad"
+        adata.write_h5ad(temp_path)
+
+        output_path = tmp_path / "output.h5ad"
+        adata.write_h5ad(output_path)
+
+        # Optionally corrupt a column in the output
+        if mismatch_col:
+            with h5py.File(output_path, "a") as f:
+                item = f["obs"][mismatch_col]
+                if isinstance(item, h5py.Group) and "codes" in item:
+                    codes = item["codes"][:]
+                    codes[0] = (codes[0] + 1) % max(codes.max() + 1, 2)
+                    item["codes"][...] = codes
+
+        return str(temp_path), str(output_path)
+    return _factory
+
+
+def test_verify_matching_categorical(_make_pair):
+    temp, output = _make_pair(
+        {"label": pd.Categorical(["typeA", "typeB", "typeA"])},
+        ["c0", "c1", "c2"],
+    )
+    assert verify_obs_transplant(temp, output, ["label"]) is None
+
+
+def test_verify_matching_string(_make_pair):
+    temp, output = _make_pair(
+        {"name": ["alice", "bob", "carol"]},
+        ["c0", "c1", "c2"],
+    )
+    assert verify_obs_transplant(temp, output, ["name"]) is None
+
+
+def test_verify_mismatch_detected(_make_pair):
+    temp, output = _make_pair(
+        {"label": pd.Categorical(["typeA", "typeB", "typeA"])},
+        ["c0", "c1", "c2"],
+        mismatch_col="label",
+    )
+    result = verify_obs_transplant(temp, output, ["label"])
+    assert result is not None
+    assert "codes mismatch" in result
+
+
+def test_verify_empty_columns(_make_pair):
+    temp, output = _make_pair({}, ["c0", "c1"])
+    assert verify_obs_transplant(temp, output, []) is None
+
+
+# -- build_edit_log ------------------------------------------------------------
+
+
+def test_build_edit_log_basic(tmp_path):
+    path = tmp_path / "test.h5ad"
+    path.write_bytes(b"fake content for sha256")
+
+    result = build_edit_log(
+        "[]",
+        [{"timestamp": "t", "tool": "test", "tool_version": "1", "operation": "op", "description": "d"}],
+        str(path),
+    )
+    assert "json" in result
+    assert "error" not in result
+
+    import json
+    log = json.loads(result["json"])
+    assert len(log) == 1
+    assert log[0]["tool"] == "test"
+    assert "source_file" in log[0]
+    assert "source_sha256" in log[0]
+
+
+def test_build_edit_log_appends(tmp_path):
+    import json
+    path = tmp_path / "test.h5ad"
+    path.write_bytes(b"content")
+
+    existing = json.dumps([{"old": "entry"}])
+    entry = {"timestamp": "t", "tool": "test", "tool_version": "1", "operation": "op", "description": "d"}
+    result = build_edit_log(existing, [entry], str(path))
+    log = json.loads(result["json"])
+    assert len(log) == 2
+    assert log[0]["old"] == "entry"
+    assert log[1]["tool"] == "test"
+
+
+def test_build_edit_log_precomputed_sha(tmp_path):
+    path = tmp_path / "test.h5ad"
+    path.write_bytes(b"content")
+
+    entry = {"timestamp": "t", "tool": "test", "tool_version": "1", "operation": "op", "description": "d"}
+    result = build_edit_log("[]", [entry], str(path), source_sha256="abc123")
+
+    import json
+    log = json.loads(result["json"])
+    assert log[0]["source_sha256"] == "abc123"
+
+
+def test_build_edit_log_missing_keys(tmp_path):
+    path = tmp_path / "test.h5ad"
+    path.write_bytes(b"content")
+    result = build_edit_log("[]", [{"timestamp": "t"}], str(path))
+    assert "error" in result
+    assert "missing required keys" in result["error"]
+
+
+def test_build_edit_log_empty_entries(tmp_path):
+    path = tmp_path / "test.h5ad"
+    path.write_bytes(b"content")
+    result = build_edit_log("[]", [], str(path))
+    assert "error" in result
+
+
+def test_build_edit_log_corrupt_json(tmp_path):
+    path = tmp_path / "test.h5ad"
+    path.write_bytes(b"content")
+    entry = {"timestamp": "t", "tool": "test", "tool_version": "1", "operation": "op", "description": "d"}
+    result = build_edit_log("{not json", [entry], str(path))
+    assert "error" in result
+    assert "invalid JSON" in result["error"]
+
+
+# -- cleanup_previous_version --------------------------------------------------
+
+
+def test_cleanup_deletes_timestamped(tmp_path):
+    old = tmp_path / "file-edit-2026-01-01-00-00-00.h5ad"
+    new = tmp_path / "file-edit-2026-01-02-00-00-00.h5ad"
+    old.write_bytes(b"old")
+    new.write_bytes(b"new")
+    cleanup_previous_version(str(old), str(new))
+    assert not old.exists()
+    assert new.exists()
+
+
+def test_cleanup_preserves_original(tmp_path):
+    original = tmp_path / "file.h5ad"
+    new = tmp_path / "file-edit-2026-01-01-00-00-00.h5ad"
+    original.write_bytes(b"original")
+    new.write_bytes(b"new")
+    cleanup_previous_version(str(original), str(new))
+    assert original.exists()
+    assert new.exists()
+
+
+def test_cleanup_same_path_noop(tmp_path):
+    path = tmp_path / "file-edit-2026-01-01-00-00-00.h5ad"
+    path.write_bytes(b"content")
+    cleanup_previous_version(str(path), str(path))
+    assert path.exists()

--- a/packages/hca-anndata-tools/tests/test_helpers.py
+++ b/packages/hca-anndata-tools/tests/test_helpers.py
@@ -97,6 +97,30 @@ def test_verify_mismatch_detected(_make_pair):
     assert "codes mismatch" in result
 
 
+def test_verify_categories_mismatch(tmp_path):
+    """Different category names should be detected."""
+    n = 3
+    index = ["c0", "c1", "c2"]
+
+    temp_adata = ad.AnnData(
+        X=np.empty((n, 0), dtype=np.float32),
+        obs=pd.DataFrame({"label": pd.Categorical(["typeA", "typeB", "typeA"])}, index=index),
+    )
+    temp_path = tmp_path / "temp.h5ad"
+    temp_adata.write_h5ad(temp_path)
+
+    out_adata = ad.AnnData(
+        X=np.empty((n, 0), dtype=np.float32),
+        obs=pd.DataFrame({"label": pd.Categorical(["typeX", "typeY", "typeX"])}, index=index),
+    )
+    out_path = tmp_path / "output.h5ad"
+    out_adata.write_h5ad(out_path)
+
+    result = verify_obs_transplant(str(temp_path), str(out_path), ["label"])
+    assert result is not None
+    assert "categories mismatch" in result
+
+
 def test_verify_empty_columns(_make_pair):
     temp, output = _make_pair({}, ["c0", "c1"])
     assert verify_obs_transplant(temp, output, []) is None

--- a/packages/hca-anndata-tools/tests/test_helpers.py
+++ b/packages/hca-anndata-tools/tests/test_helpers.py
@@ -1,7 +1,5 @@
 """Tests for extracted helper functions in _io.py and write.py."""
 
-from pathlib import Path
-
 import anndata as ad
 import h5py
 import numpy as np


### PR DESCRIPTION
## Summary

`convert_cellxgene_to_hca` previously loaded the entire CellxGENE file into memory and rewrote it — for a 14GB file this took 23+ minutes before being killed.

### New approach: same hybrid anndata + h5py pattern as #286
- **Source uns** read via anndata backed mode (fast for nested dict metadata)
- **Source obs index** read via h5py
- **Temp AnnData** written via anndata for correct HDF5 encoding (2 broadcast obs columns + restructured uns)
- **Source copied** to output path via `shutil.copy2`, then patched via `h5py.File.copy()`
- **Full-column verification** against temp file
- **Expression matrix never loaded or rewritten**

### Also
- Extracts `verify_obs_transplant` from inline code in `copy_cap.py` into `_io.py` for reuse
- Adds obs column guard in convert (del before copy, handles pre-existing columns)
- Adds 15 direct unit tests for extracted helpers: `read_obs_index`, `verify_obs_transplant`, `build_edit_log`, `cleanup_previous_version`

## Test plan
- [x] All 191 tests pass (176 existing + 15 new helper tests)
- [x] All 20 `test_convert.py` tests pass
- [x] All 16 `test_copy_cap.py` tests pass (no regressions from shared helper extraction)
- [x] Tested on real ocular outflow segment files (14GB snRNA-seq, 4.8GB scRNA-seq) via MCP — previously timed out at 23min, now completes in seconds
- [x] Output verified via MCP: cell/gene counts match, expression data preserved, CAP annotations correct

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)