### PR TITLE
fix: remove cell_type enrichment columns from copy_cap

### DIFF
--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -49,13 +49,6 @@ _UNS_CAP_METADATA = [
 # Demographic annotation sets — not real CAP annotations, just renamed CXG columns
 _SKIP_SETS = {"sex", "development_stage", "self_reported_ethnicity"}
 
-# cell_type enrichment columns to copy (but NOT cell_type--cell_ontology_term_id)
-_CELL_TYPE_ENRICHMENT = [
-    "cell_type--cell_fullname",
-    "cell_type--cell_ontology_exists",
-    "cell_type--cell_ontology_term",
-]
-
 # CAP uns keys to remove on overwrite
 _CAP_UNS_KEYS = set(_UNS_COPY_TOPLEVEL) | {"cap_metadata"}
 
@@ -97,11 +90,6 @@ def _get_obs_columns_to_copy(
             col = f"{setname}{suffix}"
             if col in source_obs_columns:
                 columns.append(col)
-
-    # cell_type enrichment columns (but not cell_type--cell_ontology_term_id)
-    for col in _CELL_TYPE_ENRICHMENT:
-        if col in source_obs_columns:
-            columns.append(col)
 
     return columns
 

--- a/packages/hca-anndata-tools/tests/test_copy_cap.py
+++ b/packages/hca-anndata-tools/tests/test_copy_cap.py
@@ -44,10 +44,6 @@ def _make_cap_source(path: Path, cell_ids: list[str]) -> Path:
             "author_cell_type--category_fullname": ["neural cell"] * n,
             "author_cell_type--category_cell_ontology_term_id": ["CL:0002319"] * n,
             "author_cell_type--category_cell_ontology_term": ["neural cell"] * n,
-            # cell_type enrichment columns
-            "cell_type--cell_fullname": ["neuron"] * n,
-            "cell_type--cell_ontology_exists": [True] * n,
-            "cell_type--cell_ontology_term": ["neuron"] * n,
             # Demographic columns (should NOT be copied)
             "sex--cell_ontology_term_id": ["PATO:0000384"] * n,
             "development_stage--cell_ontology_term_id": ["HsapDv:0000087"] * n,
@@ -156,13 +152,6 @@ def test_copy_marker_gene_validation(cap_source, hca_target):
     assert "found_in_var" in mv
 
 
-def test_copy_cell_type_enrichment(cap_source, hca_target):
-    result = copy_cap_annotations(str(cap_source), str(hca_target))
-    written = ad.read_h5ad(result["output_path"])
-    assert "cell_type--cell_fullname" in written.obs.columns
-    assert "cell_type--cell_ontology_exists" in written.obs.columns
-    assert "cell_type--cell_ontology_term" in written.obs.columns
-
 
 def test_copy_uns_direct(cap_source, hca_target):
     result = copy_cap_annotations(str(cap_source), str(hca_target))
@@ -198,11 +187,6 @@ def test_copy_skips_demographic_columns(cap_source, hca_target):
     assert "development_stage--cell_ontology_term_id" not in written.obs.columns
     assert "self_reported_ethnicity--cell_ontology_term_id" not in written.obs.columns
 
-
-def test_copy_skips_cell_type_ontology_id(cap_source, hca_target):
-    result = copy_cap_annotations(str(cap_source), str(hca_target))
-    written = ad.read_h5ad(result["output_path"])
-    assert "cell_type--cell_ontology_term_id" not in written.obs.columns
 
 
 # --- Edit log ---


### PR DESCRIPTION
## Summary

`copy_cap_annotations` was adding 3 `cell_type--*` enrichment columns that aren't from the CAP source — they were derived from the CellxGENE `cell_type_ontology_term_id` column. `copy_cap` should only copy CAP data.

### Changes
- Remove `_CELL_TYPE_ENRICHMENT` list and its usage in `_get_obs_columns_to_copy`
- Remove `test_copy_cell_type_enrichment` and `test_copy_skips_cell_type_ontology_id` tests
- Remove `cell_type--*` columns from test fixture

## Test plan
- [x] 190 tests pass (14 copy_cap tests, down from 16)
- [x] Verified on real scRNA-seq ocular file via MCP — 63 obs columns (was 66), no `cell_type--*` columns

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)