### PR TITLE
refactor: move hca_edit_log to provenance/edit_history

### DIFF
--- a/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
@@ -118,6 +118,14 @@ def read_var_gene_names(path: str) -> tuple[set[str], dict[str, str]]:
         return gene_names, eid_to_var_name
 
 
+def ensure_provenance_group(f: h5py.File) -> h5py.Group:
+    """Get or create the uns/provenance group with correct encoding attrs."""
+    group = f.require_group("uns/provenance")
+    group.attrs.setdefault("encoding-type", "dict")
+    group.attrs.setdefault("encoding-version", "0.1.0")
+    return group
+
+
 def verify_obs_transplant(
     temp_path: str,
     output_path: str,

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/convert.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/convert.py
@@ -13,7 +13,7 @@ import h5py
 import numpy as np
 import pandas as pd
 
-from ._io import open_h5ad, read_obs_index, verify_obs_transplant, _decode_bytes
+from ._io import open_h5ad, read_obs_index, ensure_provenance_group, verify_obs_transplant, _decode_bytes
 from ._serialize import make_serializable
 from .write import (
     EDIT_LOG_KEY,
@@ -150,7 +150,7 @@ def convert_cellxgene_to_hca(
         if "error" in log_result:
             return log_result
 
-        temp_uns[EDIT_LOG_KEY] = log_result["json"]
+        temp_uns.setdefault("provenance", {})[EDIT_LOG_KEY] = log_result["json"]
 
         temp_adata = ad.AnnData(
             X=np.empty((n_obs, 0), dtype=np.float32),
@@ -181,11 +181,10 @@ def convert_cellxgene_to_hca(
                     if key in f_out["uns"]:
                         del f_out["uns"][key]
 
+                prov_out = ensure_provenance_group(f_out)
+
                 # Transplant provenance/cellxgene from temp (merge, don't replace whole group)
                 if "provenance" in f_temp["uns"] and "cellxgene" in f_temp["uns"]["provenance"]:
-                    prov_out = f_out.require_group("uns/provenance")
-                    prov_out.attrs.setdefault("encoding-type", "dict")
-                    prov_out.attrs.setdefault("encoding-version", "0.1.0")
                     if "cellxgene" in prov_out:
                         del prov_out["cellxgene"]
                     f_temp.copy("uns/provenance/cellxgene", prov_out, "cellxgene")
@@ -203,11 +202,11 @@ def convert_cellxgene_to_hca(
                 new_cols = [c for c in obs_cols_added if c not in current_order]
                 f_out["obs"].attrs["column-order"] = current_order + new_cols
 
-                # Transplant edit log from temp
-                if EDIT_LOG_KEY in f_out["uns"]:
-                    del f_out["uns"][EDIT_LOG_KEY]
-                if EDIT_LOG_KEY in f_temp["uns"]:
-                    f_temp.copy(f"uns/{EDIT_LOG_KEY}", f_out["uns"])
+                # Transplant edit_history into provenance
+                if EDIT_LOG_KEY in prov_out:
+                    del prov_out[EDIT_LOG_KEY]
+                if "provenance" in f_temp["uns"] and EDIT_LOG_KEY in f_temp["uns"]["provenance"]:
+                    f_temp.copy(f"uns/provenance/{EDIT_LOG_KEY}", prov_out, EDIT_LOG_KEY)
 
             # --- Step 5: Verify transplant ---
             verify_err = verify_obs_transplant(temp_path, output_path, obs_cols_added)

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -12,12 +12,13 @@ import h5py
 import numpy as np
 import pandas as pd
 
-from ._io import open_h5ad, verify_obs_transplant, _decode_bytes
+from ._io import open_h5ad, ensure_provenance_group, verify_obs_transplant, _decode_bytes
 from ._serialize import make_serializable
 from .cap import _REQUIRED_SUFFIXES, _OPTIONAL_SUFFIXES
 from .marker_genes import validate_marker_genes
 from .write import (
     EDIT_LOG_KEY,
+    _LEGACY_EDIT_LOG_KEY,
     build_edit_log,
     cleanup_previous_version,
     generate_output_path,
@@ -186,10 +187,14 @@ def copy_cap_annotations(
                 and isinstance(uns["provenance"], h5py.Group)
                 and "cap" in uns["provenance"]
             )
-            if uns and EDIT_LOG_KEY in uns:
-                raw_log = _decode_bytes(uns[EDIT_LOG_KEY][()])
-            else:
-                raw_log = "[]"
+            # Read edit log from provenance/edit_history, fall back to legacy
+            raw_log = "[]"
+            if uns:
+                prov = uns.get("provenance")
+                if prov and isinstance(prov, h5py.Group) and EDIT_LOG_KEY in prov:
+                    raw_log = _decode_bytes(prov[EDIT_LOG_KEY][()])
+                elif _LEGACY_EDIT_LOG_KEY in uns:
+                    raw_log = _decode_bytes(uns[_LEGACY_EDIT_LOG_KEY][()])
 
         target_n_obs = len(target_index)
         target_index_set = set(target_index)
@@ -273,7 +278,7 @@ def copy_cap_annotations(
         if "error" in log_result:
             return log_result
 
-        temp_uns[EDIT_LOG_KEY] = log_result["json"]
+        temp_uns.setdefault("provenance", {})[EDIT_LOG_KEY] = log_result["json"]
 
         n_obs = len(target_index)
         temp_adata = ad.AnnData(
@@ -327,9 +332,7 @@ def copy_cap_annotations(
                 for key in uns_keys_added:
                     if key == "provenance":
                         # Merge into existing provenance group, don't replace it
-                        prov_out = f_out.require_group("uns/provenance")
-                        prov_out.attrs.setdefault("encoding-type", "dict")
-                        prov_out.attrs.setdefault("encoding-version", "0.1.0")
+                        prov_out = ensure_provenance_group(f_out)
                         if "cap" in prov_out:
                             del prov_out["cap"]
                         f_temp.copy("uns/provenance/cap", prov_out, "cap")
@@ -338,10 +341,17 @@ def copy_cap_annotations(
                             del f_out["uns"][key]
                         f_temp.copy(f"uns/{key}", f_out["uns"])
 
-                if EDIT_LOG_KEY in f_out["uns"]:
-                    del f_out["uns"][EDIT_LOG_KEY]
-                if EDIT_LOG_KEY in f_temp["uns"]:
-                    f_temp.copy(f"uns/{EDIT_LOG_KEY}", f_out["uns"])
+                # Transplant edit_history into provenance
+                prov_out = f_out.require_group("uns/provenance")
+                prov_out.attrs.setdefault("encoding-type", "dict")
+                prov_out.attrs.setdefault("encoding-version", "0.1.0")
+                if EDIT_LOG_KEY in prov_out:
+                    del prov_out[EDIT_LOG_KEY]
+                if "provenance" in f_temp["uns"] and EDIT_LOG_KEY in f_temp["uns"]["provenance"]:
+                    f_temp.copy(f"uns/provenance/{EDIT_LOG_KEY}", prov_out, EDIT_LOG_KEY)
+                # Remove legacy key if present
+                if _LEGACY_EDIT_LOG_KEY in f_out["uns"]:
+                    del f_out["uns"][_LEGACY_EDIT_LOG_KEY]
 
             # --- Step 5: Verify transplant — full column comparison ---
             verify_err = verify_obs_transplant(temp_path, output_path, obs_cols_to_copy)

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -342,9 +342,7 @@ def copy_cap_annotations(
                         f_temp.copy(f"uns/{key}", f_out["uns"])
 
                 # Transplant edit_history into provenance
-                prov_out = f_out.require_group("uns/provenance")
-                prov_out.attrs.setdefault("encoding-type", "dict")
-                prov_out.attrs.setdefault("encoding-version", "0.1.0")
+                prov_out = ensure_provenance_group(f_out)
                 if EDIT_LOG_KEY in prov_out:
                     del prov_out[EDIT_LOG_KEY]
                 if "provenance" in f_temp["uns"] and EDIT_LOG_KEY in f_temp["uns"]["provenance"]:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
@@ -12,7 +12,7 @@ from pydantic import TypeAdapter, ValidationError
 from ._io import open_h5ad
 from ._serialize import make_serializable
 from .schema.helpers import uns_field_registry
-from .write import EDIT_LOG_KEY, resolve_latest, write_h5ad
+from .write import _LEGACY_EDIT_LOG_KEY, resolve_latest, write_h5ad
 from . import __version__
 
 
@@ -77,7 +77,7 @@ def list_uns_fields(path: str) -> dict:
                         missing_required.append(name)
 
             # Extra uns keys not in the HCA schema
-            schema_keys = set(registry.keys()) | {EDIT_LOG_KEY}
+            schema_keys = set(registry.keys()) | {"provenance", _LEGACY_EDIT_LOG_KEY}
             extra_uns_keys = sorted(k for k in adata.uns.keys() if k not in schema_keys)
 
             return {

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
@@ -15,7 +15,8 @@ if TYPE_CHECKING:
 
 _TIMESTAMP_PATTERN = re.compile(r"-edit-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}(?=\.h5ad$)")
 _TIMESTAMP_FORMAT = "%Y-%m-%d-%H-%M-%S"
-EDIT_LOG_KEY = "hca_edit_log"
+EDIT_LOG_KEY = "edit_history"
+_LEGACY_EDIT_LOG_KEY = "hca_edit_log"
 _HASH_CHUNK_SIZE = 1 << 20  # 1 MB — keeps syscall count low on multi-GB files
 _REQUIRED_ENTRY_KEYS = {"timestamp", "tool", "tool_version", "operation", "description"}
 
@@ -185,7 +186,7 @@ def write_h5ad(
     """Write adata to a new timestamped file with edit log entries.
 
     Computes SHA-256 of the source file, appends edit_entries to
-    adata.uns['hca_edit_log'], and writes to a new timestamped path.
+    adata.uns['provenance']['edit_history'], and writes to a new timestamped path.
     The original (non-timestamped) file is never modified. If source_path
     is a previous timestamped edit, it is deleted after the new file is
     successfully written — keeping only the original + latest edit on disk.
@@ -210,15 +211,21 @@ def write_h5ad(
         if not os.path.isfile(source_path):
             return {"error": f"Source file not found: {source_path}"}
 
-        log_result = build_edit_log(
-            adata.uns.get(EDIT_LOG_KEY, "[]"),
-            edit_entries,
-            source_path,
-        )
+        # Read existing edit log from provenance, fall back to legacy location
+        provenance = adata.uns.get("provenance", {})
+        if isinstance(provenance, dict) and EDIT_LOG_KEY in provenance:
+            existing_log_raw = provenance[EDIT_LOG_KEY]
+        else:
+            existing_log_raw = adata.uns.get(_LEGACY_EDIT_LOG_KEY, "[]")
+
+        log_result = build_edit_log(existing_log_raw, edit_entries, source_path)
         if "error" in log_result:
             return log_result
 
-        adata.uns[EDIT_LOG_KEY] = log_result["json"]
+        # Write to provenance/edit_history
+        adata.uns.setdefault("provenance", {})[EDIT_LOG_KEY] = log_result["json"]
+        # Remove legacy key if present
+        adata.uns.pop(_LEGACY_EDIT_LOG_KEY, None)
 
         if output_path is None:
             output_path = generate_output_path(source_path)

--- a/packages/hca-anndata-tools/tests/test_convert.py
+++ b/packages/hca-anndata-tools/tests/test_convert.py
@@ -107,7 +107,7 @@ def test_convert_edit_log(cellxgene_h5ad):
     result = convert_cellxgene_to_hca(str(cellxgene_h5ad))
     written = ad.read_h5ad(result["output_path"])
 
-    log = json.loads(written.uns[EDIT_LOG_KEY])
+    log = json.loads(written.uns["provenance"][EDIT_LOG_KEY])
     assert len(log) == 1
     assert log[0]["operation"] == "import_cellxgene"
     assert "CellxGENE" in log[0]["description"]

--- a/packages/hca-anndata-tools/tests/test_copy_cap.py
+++ b/packages/hca-anndata-tools/tests/test_copy_cap.py
@@ -195,8 +195,8 @@ def test_copy_skips_demographic_columns(cap_source, hca_target):
 def test_copy_edit_log(cap_source, hca_target):
     result = copy_cap_annotations(str(cap_source), str(hca_target))
     written = ad.read_h5ad(result["output_path"])
-    assert EDIT_LOG_KEY in written.uns
-    log = json.loads(written.uns[EDIT_LOG_KEY])
+    assert EDIT_LOG_KEY in written.uns["provenance"]
+    log = json.loads(written.uns["provenance"][EDIT_LOG_KEY])
     assert len(log) >= 1
     entry = log[-1]
     assert entry["operation"] == "import_cap_annotations"

--- a/packages/hca-anndata-tools/tests/test_edit.py
+++ b/packages/hca-anndata-tools/tests/test_edit.py
@@ -141,7 +141,7 @@ def test_set_uns_edit_log(sample_h5ad_for_write):
     assert "error" not in result
 
     written = ad.read_h5ad(result["output_path"])
-    log = json.loads(written.uns[EDIT_LOG_KEY])
+    log = json.loads(written.uns["provenance"][EDIT_LOG_KEY])
     assert len(log) == 1
     assert log[0]["operation"] == "set_uns"
     assert log[0]["details"]["field"] == "description"
@@ -153,7 +153,7 @@ def test_set_uns_previous_value_in_details(sample_h5ad_for_write):
     assert "error" not in result
 
     written = ad.read_h5ad(result["output_path"])
-    log = json.loads(written.uns[EDIT_LOG_KEY])
+    log = json.loads(written.uns["provenance"][EDIT_LOG_KEY])
     assert log[0]["details"]["old_value"] == "Test Dataset"
 
 

--- a/packages/hca-anndata-tools/tests/test_write.py
+++ b/packages/hca-anndata-tools/tests/test_write.py
@@ -101,7 +101,7 @@ def test_write_h5ad_edit_log_populated(sample_h5ad_for_write):
     result = write_h5ad(adata, str(sample_h5ad_for_write), [entry])
 
     written = ad.read_h5ad(result["output_path"])
-    log = json.loads(written.uns[EDIT_LOG_KEY])
+    log = json.loads(written.uns["provenance"][EDIT_LOG_KEY])
     assert isinstance(log, list)
     assert len(log) == 1
     assert log[0]["operation"] == "update_obs_column"
@@ -120,7 +120,7 @@ def test_write_h5ad_preserves_existing_log(sample_h5ad_for_write):
     result2 = write_h5ad(adata2, result1["output_path"], [_make_entry(description="edit 2")])
 
     written = ad.read_h5ad(result2["output_path"])
-    log = json.loads(written.uns[EDIT_LOG_KEY])
+    log = json.loads(written.uns["provenance"][EDIT_LOG_KEY])
     assert len(log) == 2
     assert log[0]["description"] == "edit 1"
     assert log[1]["description"] == "edit 2"
@@ -138,7 +138,7 @@ def test_write_h5ad_sha256_correct(sample_h5ad_for_write):
     result = write_h5ad(adata, str(sample_h5ad_for_write), [_make_entry()])
 
     written = ad.read_h5ad(result["output_path"])
-    log = json.loads(written.uns[EDIT_LOG_KEY])
+    log = json.loads(written.uns["provenance"][EDIT_LOG_KEY])
     assert log[0]["source_sha256"] == expected_sha
 
 
@@ -147,7 +147,7 @@ def test_write_h5ad_source_file_is_basename(sample_h5ad_for_write):
     result = write_h5ad(adata, str(sample_h5ad_for_write), [_make_entry()])
 
     written = ad.read_h5ad(result["output_path"])
-    log = json.loads(written.uns[EDIT_LOG_KEY])
+    log = json.loads(written.uns["provenance"][EDIT_LOG_KEY])
     source_file = log[0]["source_file"]
     assert source_file == os.path.basename(source_file)
     assert source_file == "test-dataset.h5ad"
@@ -203,7 +203,7 @@ def test_write_h5ad_roundtrip_edit_log(sample_h5ad_for_write):
 
     # Verify full chain
     final = ad.read_h5ad(r3["output_path"])
-    log = json.loads(final.uns[EDIT_LOG_KEY])
+    log = json.loads(final.uns["provenance"][EDIT_LOG_KEY])
     assert len(log) == 3
     assert [e["description"] for e in log] == ["first", "second", "third"]
 
@@ -222,7 +222,7 @@ def test_write_h5ad_missing_required_keys(sample_h5ad_for_write):
 
 def test_write_h5ad_corrupt_json_log(sample_h5ad_for_write):
     adata = ad.read_h5ad(str(sample_h5ad_for_write))
-    adata.uns[EDIT_LOG_KEY] = "not valid json {{"
+    adata.uns.setdefault("provenance", {})[EDIT_LOG_KEY] = "not valid json {{"
     result = write_h5ad(adata, str(sample_h5ad_for_write), [_make_entry()])
 
     assert "error" in result
@@ -231,7 +231,7 @@ def test_write_h5ad_corrupt_json_log(sample_h5ad_for_write):
 
 def test_write_h5ad_non_list_json_log(sample_h5ad_for_write):
     adata = ad.read_h5ad(str(sample_h5ad_for_write))
-    adata.uns[EDIT_LOG_KEY] = json.dumps({"not": "a list"})
+    adata.uns.setdefault("provenance", {})[EDIT_LOG_KEY] = json.dumps({"not": "a list"})
     result = write_h5ad(adata, str(sample_h5ad_for_write), [_make_entry()])
 
     assert "error" in result
@@ -240,7 +240,7 @@ def test_write_h5ad_non_list_json_log(sample_h5ad_for_write):
 
 def test_write_h5ad_unsupported_log_type(sample_h5ad_for_write):
     adata = ad.read_h5ad(str(sample_h5ad_for_write))
-    adata.uns[EDIT_LOG_KEY] = 42
+    adata.uns.setdefault("provenance", {})[EDIT_LOG_KEY] = 42
     result = write_h5ad(adata, str(sample_h5ad_for_write), [_make_entry()])
 
     assert "error" in result


### PR DESCRIPTION
## Summary

The edit log was an orphaned top-level uns key (`hca_edit_log`). It now lives under `uns['provenance']['edit_history']` alongside the other provenance data.

### New uns structure
```
uns/
├── cellannotation_metadata/   (HCA schema)
├── cellannotation_schema_version
├── default_embedding
├── provenance/
│   ├── cap/                   (CAP source metadata)
│   ├── cellxgene/             (CellxGENE source metadata)
│   └── edit_history           (operation audit trail)
└── title
```

### Changes
- `write_h5ad`: reads/writes edit log from `provenance/edit_history`, falls back to legacy `hca_edit_log`
- `copy_cap` and `convert`: write edit log into provenance group in temp AnnData, transplant via h5py
- Extract `ensure_provenance_group` helper into `_io.py` (replaces 3 inline occurrences)
- Use `_LEGACY_EDIT_LOG_KEY` constant instead of hardcoded `"hca_edit_log"` strings
- Legacy key removed on write for migration

## Test plan
- [x] All 191 tests pass
- [x] Tested full pipeline (convert + copy_cap) on real scRNA-seq file via MCP
- [x] Verified uns tree: edit_history under provenance, no orphaned hca_edit_log

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)