### PR TITLE
chore: add ruff linter, fix unused imports and import sorting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.8
+    hooks:
+      - id: ruff
+        args: [--fix]

--- a/packages/hca-anndata-mcp/src/hca_anndata_mcp/server.py
+++ b/packages/hca-anndata-mcp/src/hca_anndata_mcp/server.py
@@ -1,21 +1,21 @@
 """FastMCP server definition and tool registration."""
 
 from fastmcp import FastMCP
-
 from hca_anndata_tools import (
-    get_summary,
-    get_descriptive_stats,
-    view_data,
-    locate_files,
-    get_storage_info,
-    get_cap_annotations,
-    set_uns,
-    list_uns_fields,
     convert_cellxgene_to_hca,
-    validate_marker_genes,
     copy_cap_annotations,
+    get_cap_annotations,
+    get_descriptive_stats,
+    get_storage_info,
+    get_summary,
+    list_uns_fields,
+    locate_files,
     replace_placeholder_values,
+    set_uns,
+    validate_marker_genes,
+    view_data,
 )
+
 from hca_anndata_mcp.tools.plot import plot_embedding_mcp
 
 mcp = FastMCP(

--- a/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/plot.py
+++ b/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/plot.py
@@ -2,9 +2,8 @@
 
 import functools
 
-from mcp.types import ImageContent
-
 from hca_anndata_tools.plot import plot_embedding as _plot_embedding
+from mcp.types import ImageContent
 
 
 @functools.wraps(_plot_embedding, updated=[])

--- a/packages/hca-anndata-mcp/tests/conftest.py
+++ b/packages/hca-anndata-mcp/tests/conftest.py
@@ -3,7 +3,6 @@
 from pathlib import Path
 
 import pytest
-
 from hca_anndata_tools.testing import create_sample_h5ad
 
 

--- a/packages/hca-anndata-mcp/tests/test_e2e.py
+++ b/packages/hca-anndata-mcp/tests/test_e2e.py
@@ -5,7 +5,6 @@ import json
 import pytest
 import pytest_asyncio
 from fastmcp.client import Client
-
 from hca_anndata_mcp.server import mcp
 
 

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/convert.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/convert.py
@@ -13,14 +13,14 @@ import h5py
 import numpy as np
 import pandas as pd
 
-from ._io import open_h5ad, read_obs_index, ensure_provenance_group, transplant_obs_columns, verify_obs_transplant
+from . import __version__
+from ._io import ensure_provenance_group, open_h5ad, read_obs_index, transplant_obs_columns, verify_obs_transplant
 from ._serialize import make_serializable
 from .write import (
     EDIT_LOG_KEY,
     build_edit_log,
     generate_timestamp,
 )
-from . import __version__
 
 # CellxGENE reserved uns keys — moved to provenance/cellxgene
 _CELLXGENE_RESERVED_UNS = ["schema_version", "schema_reference", "citation"]

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -12,27 +12,27 @@ import h5py
 import numpy as np
 import pandas as pd
 
+from . import __version__
 from ._io import (
-    open_h5ad,
+    _decode_bytes,
     ensure_provenance_group,
+    open_h5ad,
     read_categorical_data,
     read_edit_log_h5py,
     update_column_order,
     verify_obs_transplant,
-    _decode_bytes,
 )
 from ._serialize import make_serializable
-from .cap import _REQUIRED_SUFFIXES, _OPTIONAL_SUFFIXES
+from .cap import _OPTIONAL_SUFFIXES, _REQUIRED_SUFFIXES
 from .marker_genes import validate_marker_genes
 from .write import (
     EDIT_LOG_KEY,
+    _compute_sha256,
     build_edit_log,
     cleanup_previous_version,
     generate_output_path,
     resolve_latest,
-    _compute_sha256,
 )
-from . import __version__
 
 # Cell-annotation-schema uns keys — stay at top level (HCA schema)
 _UNS_SCHEMA_TOPLEVEL = [

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
@@ -12,18 +12,25 @@ import h5py
 import numpy as np
 from pydantic import TypeAdapter, ValidationError
 
-from ._io import open_h5ad, read_categorical_data, read_edit_log_h5py, verify_categorical_integrity, write_edit_log_h5py, _decode_bytes
+from . import __version__
+from ._io import (
+    _decode_bytes,
+    open_h5ad,
+    read_categorical_data,
+    read_edit_log_h5py,
+    verify_categorical_integrity,
+    write_edit_log_h5py,
+)
 from ._serialize import make_serializable
 from .schema.helpers import uns_field_registry
 from .write import (
+    _compute_sha256,
     build_edit_log,
     cleanup_previous_version,
     generate_output_path,
     resolve_latest,
     write_h5ad,
-    _compute_sha256,
 )
-from . import __version__
 
 # Default HCA placeholder values (case-insensitive)
 _DEFAULT_PLACEHOLDERS = [

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/schema/core.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/schema/core.py
@@ -3,31 +3,11 @@
 # To refresh: copy the generated file here after regeneration.
 from __future__ import annotations
 
-import re
-import sys
-from datetime import (
-    date,
-    datetime,
-    time
-)
-from decimal import Decimal 
-from enum import Enum 
-from typing import (
-    Any,
-    ClassVar,
-    Literal,
-    Optional,
-    Union
-)
+from decimal import Decimal
+from enum import Enum
+from typing import Any, ClassVar, Optional, Union
 
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    Field,
-    RootModel,
-    field_validator
-)
-
+from pydantic import BaseModel, ConfigDict, Field, RootModel
 
 metamodel_version = "None"
 version = "0.1.0"

--- a/packages/hca-anndata-tools/tests/conftest.py
+++ b/packages/hca-anndata-tools/tests/conftest.py
@@ -3,7 +3,6 @@
 from pathlib import Path
 
 import pytest
-
 from hca_anndata_tools.testing import create_cellxgene_h5ad, create_sample_h5ad
 
 

--- a/packages/hca-anndata-tools/tests/test_cap.py
+++ b/packages/hca-anndata-tools/tests/test_cap.py
@@ -7,9 +7,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import scipy.sparse as sp
-
-from hca_anndata_tools.cap import get_cap_annotations, _make_serializable
-
+from hca_anndata_tools.cap import _make_serializable, get_cap_annotations
 
 # -- _make_serializable tests --------------------------------------------------
 

--- a/packages/hca-anndata-tools/tests/test_cap.py
+++ b/packages/hca-anndata-tools/tests/test_cap.py
@@ -103,7 +103,7 @@ def cap_h5ad(tmp_path_factory) -> Path:
     obs = pd.DataFrame(
         {
             "my_labels": pd.Categorical(labels),
-            "my_labels--cell_fullname": [f"{l} cell" for l in labels],
+            "my_labels--cell_fullname": [f"{label} cell" for label in labels],
             "my_labels--cell_ontology_exists": rng.choice([True, False], n_obs),
             "my_labels--cell_ontology_term_id": rng.choice(
                 ["CL:0000540", "CL:0000127", "CL:0000129"], n_obs

--- a/packages/hca-anndata-tools/tests/test_convert.py
+++ b/packages/hca-anndata-tools/tests/test_convert.py
@@ -5,10 +5,8 @@ import os
 import re
 
 import anndata as ad
-
 from hca_anndata_tools.convert import _slugify, convert_cellxgene_to_hca
 from hca_anndata_tools.write import EDIT_LOG_KEY
-
 
 # --- _slugify ---
 

--- a/packages/hca-anndata-tools/tests/test_copy_cap.py
+++ b/packages/hca-anndata-tools/tests/test_copy_cap.py
@@ -25,7 +25,7 @@ def _make_cap_source(path: Path, cell_ids: list[str]) -> Path:
     obs = pd.DataFrame(
         {
             "author_cell_type": pd.Categorical(labels),
-            "author_cell_type--cell_fullname": [f"{l} cell" for l in labels],
+            "author_cell_type--cell_fullname": [f"{label} cell" for label in labels],
             "author_cell_type--cell_ontology_exists": [True] * n,
             "author_cell_type--cell_ontology_term_id": pd.Categorical(
                 rng.choice(["CL:0000540", "CL:0000127"], n)

--- a/packages/hca-anndata-tools/tests/test_copy_cap.py
+++ b/packages/hca-anndata-tools/tests/test_copy_cap.py
@@ -8,10 +8,8 @@ import numpy as np
 import pandas as pd
 import pytest
 import scipy.sparse as sp
-
 from hca_anndata_tools.copy_cap import copy_cap_annotations
 from hca_anndata_tools.write import EDIT_LOG_KEY
-
 
 # --- Fixtures ---
 

--- a/packages/hca-anndata-tools/tests/test_edit.py
+++ b/packages/hca-anndata-tools/tests/test_edit.py
@@ -6,10 +6,8 @@ import anndata as ad
 import numpy as np
 import pandas as pd
 import scipy.sparse as sp
-
 from hca_anndata_tools.edit import list_uns_fields, replace_placeholder_values, set_uns
 from hca_anndata_tools.write import EDIT_LOG_KEY
-
 
 # --- list_uns_fields ---
 

--- a/packages/hca-anndata-tools/tests/test_helpers.py
+++ b/packages/hca-anndata-tools/tests/test_helpers.py
@@ -6,7 +6,6 @@ import numpy as np
 import pandas as pd
 import pytest
 import scipy.sparse as sp
-
 from hca_anndata_tools._io import (
     read_categorical_data,
     read_obs_index,
@@ -16,7 +15,6 @@ from hca_anndata_tools._io import (
     verify_obs_transplant,
 )
 from hca_anndata_tools.write import build_edit_log, cleanup_previous_version
-
 
 # -- read_obs_index -----------------------------------------------------------
 

--- a/packages/hca-anndata-tools/tests/test_marker_genes.py
+++ b/packages/hca-anndata-tools/tests/test_marker_genes.py
@@ -7,14 +7,12 @@ import numpy as np
 import pandas as pd
 import pytest
 import scipy.sparse as sp
-
 from hca_anndata_tools._gencode import load_gencode_reference
 from hca_anndata_tools._io import read_var_gene_names
 from hca_anndata_tools.marker_genes import (
     _extract_marker_genes_from_categories,
     validate_marker_genes,
 )
-
 
 # -- GENCODE reference loader tests --------------------------------------------
 

--- a/packages/hca-anndata-tools/tests/test_summary.py
+++ b/packages/hca-anndata-tools/tests/test_summary.py
@@ -35,7 +35,7 @@ def test_summary_obsm(sample_h5ad):
 
 def test_summary_layers(sample_h5ad):
     result = get_summary(str(sample_h5ad))
-    layer_names = [l["name"] for l in result["layers"]]
+    layer_names = [layer["name"] for layer in result["layers"]]
     assert "raw_counts" in layer_names
 
 

--- a/packages/hca-anndata-tools/tests/test_write.py
+++ b/packages/hca-anndata-tools/tests/test_write.py
@@ -6,7 +6,6 @@ import os
 import re
 
 import anndata as ad
-
 from hca_anndata_tools.write import (
     EDIT_LOG_KEY,
     generate_output_path,

--- a/packages/hca-schema-validator/src/hca_schema_validator/validator.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/validator.py
@@ -27,11 +27,11 @@ SCHEMA_FILENAME = "hca_schema_definition.yaml"
 class HCAValidator(Validator):
     """
     HCA-specific validator extending cellxgene schema validation.
-    
+
     Uses a custom schema definition that differs from CELLxGENE in key areas:
     - organism and organism_ontology_term_id are in obs (not uns)
     """
-    
+
     def __init__(self, ignore_labels=True):
         """
         Initialize HCA validator.
@@ -43,22 +43,22 @@ class HCAValidator(Validator):
         # Initialize all validator state so the exception handler in
         # validate_adata() works even if reset() hasn't been called yet.
         self.reset()
-    
+
     def _set_schema_def(self):
         """
         Sets schema dictionary using HCA-specific schema definition.
-        
+
         Overrides the base method to load HCA's custom schema instead of
         the default CELLxGENE schema.
         """
         if not self.schema_version:
             # Use HCA schema version
             self.schema_version = HCA_SCHEMA_VERSION
-        
+
         if not self.schema_def:
             # Load HCA-specific schema
             schema_path = Path(__file__).parent / SCHEMA_DIR / SCHEMA_FILENAME
-            
+
             with open(schema_path) as fp:
                 self.schema_def = yaml.safe_load(fp)
 

--- a/packages/hca-schema-validator/src/hca_schema_validator/validator.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/validator.py
@@ -9,8 +9,9 @@ import yaml
 from hca_schema_validator._vendored.cellxgene_schema import gencode
 from hca_schema_validator._vendored.cellxgene_schema.gencode import get_gene_checker
 from hca_schema_validator._vendored.cellxgene_schema.ontology_parser import ONTOLOGY_PARSER
-from hca_schema_validator._vendored.cellxgene_schema.validate import Validator
 from hca_schema_validator._vendored.cellxgene_schema.utils import getattr_anndata
+from hca_schema_validator._vendored.cellxgene_schema.validate import Validator
+
 from . import __schema_version__ as HCA_SCHEMA_VERSION
 
 # GENCODE version info (loaded once at module level)

--- a/packages/hca-schema-validator/tests/test_validator.py
+++ b/packages/hca-schema-validator/tests/test_validator.py
@@ -59,7 +59,7 @@ def test_instantiate():
 def test_inheritance():
     """Test that HCAValidator inherits from Validator."""
     from hca_schema_validator._vendored.cellxgene_schema.validate import Validator
-    
+
     validator = HCAValidator()
     assert isinstance(validator, Validator)
 
@@ -67,10 +67,10 @@ def test_inheritance():
 def test_has_validation_methods():
     """Test that HCAValidator has expected validation methods."""
     validator = HCAValidator()
-    
+
     # Public methods
     assert hasattr(validator, 'validate_adata')
-    
+
     # Protected methods (can override later)
     assert hasattr(validator, '_deep_check')
     assert hasattr(validator, '_validate_feature_ids')
@@ -80,18 +80,18 @@ def test_has_validation_methods():
 def test_validate_valid_h5ad():
     """
     Test validation of a CELLxGENE v6+ h5ad file.
-    
+
     This test verifies that HCA schema correctly rejects CELLxGENE v6+ files
     that have organism in uns instead of obs.
     """
     test_file = FIXTURES_DIR / "example_valid.h5ad"
-    
+
     if not test_file.exists():
         pytest.skip(f"Test fixture not found: {test_file}")
-    
+
     validator = HCAValidator()
     is_valid = validator.validate_adata(str(test_file))
-    
+
     # Should FAIL validation because CELLxGENE v6+ files have organism in uns,
     # but HCA schema requires it in obs
     assert is_valid is False
@@ -104,13 +104,13 @@ def test_validate_valid_h5ad():
 def test_validate_invalid_h5ad():
     """Test validation of an invalid h5ad file."""
     test_file = FIXTURES_DIR / "example_invalid_CL.h5ad"
-    
+
     if not test_file.exists():
         pytest.skip(f"Test fixture not found: {test_file}")
-    
+
     validator = HCAValidator()
     is_valid = validator.validate_adata(str(test_file))
-    
+
     # Should fail validation
     assert is_valid is False
     assert len(validator.errors) > 0

--- a/packages/hca-schema-validator/tests/test_validator.py
+++ b/packages/hca-schema-validator/tests/test_validator.py
@@ -152,7 +152,6 @@ def test_valid_adata_passes():
 
 def test_study_pi_missing():
     """Test that removing study_pi from uns produces an error."""
-    import anndata
     from .fixtures.hca_fixtures import adata
 
     modified = adata.copy()
@@ -165,7 +164,6 @@ def test_study_pi_missing():
 
 def test_study_pi_empty_list():
     """Test that an empty study_pi list produces an error."""
-    import anndata
     from .fixtures.hca_fixtures import adata
 
     modified = adata.copy()
@@ -178,7 +176,6 @@ def test_study_pi_empty_list():
 
 def test_study_pi_non_string_element():
     """Test that a non-string element in study_pi produces an error."""
-    import anndata
     from .fixtures.hca_fixtures import adata
 
     modified = adata.copy()
@@ -195,7 +192,8 @@ def test_missing_required_obs_column():
     import anndata
     import numpy
     from scipy import sparse
-    from .fixtures.hca_fixtures import good_obs, good_var, good_uns, good_obsm
+
+    from .fixtures.hca_fixtures import good_obs, good_obsm, good_uns, good_var
 
     obs = good_obs.copy()
     obs = obs.drop(columns=["sample_id"])
@@ -215,7 +213,8 @@ def test_enum_invalid_value():
     import anndata
     import numpy
     from scipy import sparse
-    from .fixtures.hca_fixtures import good_obs, good_var, good_uns, good_obsm
+
+    from .fixtures.hca_fixtures import good_obs, good_obsm, good_uns, good_var
 
     obs = good_obs.copy()
     obs["manner_of_death"] = obs["manner_of_death"].cat.add_categories(["invalid_value"])
@@ -234,7 +233,8 @@ def test_enum_invalid_value():
 def test_manner_of_death_empty_string_allowed_for_prenatal():
     """Test that manner_of_death='' is allowed when development_stage is prenatal."""
     import anndata
-    from .fixtures.hca_fixtures import good_obs, good_var, good_uns, good_obsm, non_raw_X, X
+
+    from .fixtures.hca_fixtures import X, good_obs, good_obsm, good_uns, good_var, non_raw_X
 
     obs = good_obs.copy()
     # good_obs already uses HsapDv:0000003 (Carnegie stage 01), which is prenatal
@@ -252,7 +252,8 @@ def test_manner_of_death_empty_string_allowed_for_prenatal():
 def test_manner_of_death_empty_string_allowed_for_postnatal():
     """Test that manner_of_death='' is allowed even when development_stage is postnatal."""
     import anndata
-    from .fixtures.hca_fixtures import good_obs, good_var, good_uns, good_obsm, non_raw_X, X
+
+    from .fixtures.hca_fixtures import X, good_obs, good_obsm, good_uns, good_var, non_raw_X
 
     obs = good_obs.copy()
     # Change to a postnatal development stage (2-year-old stage)
@@ -271,7 +272,8 @@ def test_manner_of_death_empty_string_allowed_for_postnatal():
 def test_manner_of_death_invalid_value_rejected():
     """Test that an invalid manner_of_death value is rejected."""
     import anndata
-    from .fixtures.hca_fixtures import good_obs, good_var, good_uns, good_obsm, non_raw_X, X
+
+    from .fixtures.hca_fixtures import X, good_obs, good_obsm, good_uns, good_var, non_raw_X
 
     obs = good_obs.copy()
     obs["manner_of_death"] = obs["manner_of_death"].cat.add_categories(["banana"])
@@ -292,7 +294,8 @@ def test_pattern_invalid_cell_enrichment():
     import anndata
     import numpy
     from scipy import sparse
-    from .fixtures.hca_fixtures import good_obs, good_var, good_uns, good_obsm
+
+    from .fixtures.hca_fixtures import good_obs, good_obsm, good_uns, good_var
 
     obs = good_obs.copy()
     obs["cell_enrichment"] = obs["cell_enrichment"].cat.add_categories(["INVALID"])
@@ -315,7 +318,8 @@ def test_pattern_invalid_gene_annotation_version():
     import anndata
     import numpy
     from scipy import sparse
-    from .fixtures.hca_fixtures import good_obs, good_var, good_uns, good_obsm
+
+    from .fixtures.hca_fixtures import good_obs, good_obsm, good_uns, good_var
 
     obs = good_obs.copy()
     obs["gene_annotation_version"] = obs["gene_annotation_version"].cat.add_categories(["v50"])
@@ -336,7 +340,8 @@ def test_pattern_invalid_gene_annotation_version():
 def test_pattern_valid_na_cell_enrichment():
     """Test that 'na' is a valid value for cell_enrichment (matches pattern)."""
     import anndata
-    from .fixtures.hca_fixtures import good_obs, good_var, good_uns, good_obsm, non_raw_X, X
+
+    from .fixtures.hca_fixtures import X, good_obs, good_obsm, good_uns, good_var, non_raw_X
 
     obs = good_obs.copy()
     obs["cell_enrichment"] = obs["cell_enrichment"].cat.add_categories(["na"])
@@ -353,7 +358,8 @@ def test_pattern_valid_na_cell_enrichment():
 def test_pattern_valid_multi_cell_enrichment():
     """Test that semicolon-separated cell_enrichment values are accepted."""
     import anndata
-    from .fixtures.hca_fixtures import good_obs, good_var, good_uns, good_obsm, non_raw_X, X
+
+    from .fixtures.hca_fixtures import X, good_obs, good_obsm, good_uns, good_var, non_raw_X
 
     obs = good_obs.copy()
     obs["cell_enrichment"] = obs["cell_enrichment"].cat.add_categories(["CL:0000057+;CL:0000058-"])
@@ -372,7 +378,8 @@ def test_pattern_rejects_cell_enrichment_with_trailing_garbage():
     import anndata
     import numpy
     from scipy import sparse
-    from .fixtures.hca_fixtures import good_obs, good_var, good_uns, good_obsm
+
+    from .fixtures.hca_fixtures import good_obs, good_obsm, good_uns, good_var
 
     obs = good_obs.copy()
     obs["cell_enrichment"] = obs["cell_enrichment"].cat.add_categories(["CL:0000066+garbage"])
@@ -394,7 +401,8 @@ def test_pattern_rejects_gene_annotation_version_with_trailing_garbage():
     import anndata
     import numpy
     from scipy import sparse
-    from .fixtures.hca_fixtures import good_obs, good_var, good_uns, good_obsm
+
+    from .fixtures.hca_fixtures import good_obs, good_obsm, good_uns, good_var
 
     obs = good_obs.copy()
     obs["gene_annotation_version"] = obs["gene_annotation_version"].cat.add_categories(["v101xyz"])
@@ -504,7 +512,8 @@ class TestValidateColumn:
         import anndata
         import numpy
         from scipy import sparse
-        from .fixtures.hca_fixtures import good_obs, good_var, good_uns, good_obsm
+
+        from .fixtures.hca_fixtures import good_obs, good_obsm, good_uns, good_var
 
         obs = good_obs.copy()
         obs["library_id"] = obs["library_id"].astype(object)
@@ -525,7 +534,8 @@ class TestValidateColumn:
         import anndata
         import numpy
         from scipy import sparse
-        from .fixtures.hca_fixtures import good_obs, good_var, good_uns, good_obsm
+
+        from .fixtures.hca_fixtures import good_obs, good_obsm, good_uns, good_var
 
         obs = good_obs.copy()
         obs.drop(columns=["library_id"], inplace=True)
@@ -544,7 +554,8 @@ class TestValidateColumn:
         import anndata
         import numpy
         from scipy import sparse
-        from .fixtures.hca_fixtures import good_obs, good_var, good_uns, good_obsm
+
+        from .fixtures.hca_fixtures import good_obs, good_obsm, good_uns, good_var
 
         obs = good_obs.copy()
         obs["library_preparation_batch"] = obs["library_preparation_batch"].astype(object)
@@ -565,7 +576,8 @@ class TestValidateColumn:
         import anndata
         import numpy
         from scipy import sparse
-        from .fixtures.hca_fixtures import good_obs, good_var, good_uns, good_obsm
+
+        from .fixtures.hca_fixtures import good_obs, good_obsm, good_uns, good_var
 
         obs = good_obs.copy()
         obs["library_preparation_batch"] = obs["library_preparation_batch"].astype(object)
@@ -616,7 +628,8 @@ def test_missing_optional_column_is_silent():
     import anndata
     import numpy
     from scipy import sparse
-    from .fixtures.hca_fixtures import good_obs, good_var, good_uns, good_obsm
+
+    from .fixtures.hca_fixtures import good_obs, good_obsm, good_uns, good_var
 
     obs = good_obs.copy()
     obs.drop(columns=["cell_type_ontology_term_id"], inplace=True)
@@ -636,7 +649,8 @@ def test_present_optional_column_with_invalid_value_is_error():
     import anndata
     import numpy
     from scipy import sparse
-    from .fixtures.hca_fixtures import good_obs, good_var, good_uns, good_obsm
+
+    from .fixtures.hca_fixtures import good_obs, good_obsm, good_uns, good_var
 
     obs = good_obs.copy()
     obs["cell_type_ontology_term_id"] = pd.Categorical(["INVALID:9999"] * len(obs))
@@ -656,7 +670,8 @@ def test_optional_column_emits_warning_message():
     import anndata
     import numpy
     from scipy import sparse
-    from .fixtures.hca_fixtures import good_obs, good_var, good_uns, good_obsm
+
+    from .fixtures.hca_fixtures import good_obs, good_obsm, good_uns, good_var
 
     obs = good_obs.copy()
     X = sparse.csr_matrix((obs.shape[0], good_var.shape[0]), dtype=numpy.float32)

--- a/packages/hca-schema-validator/validate_file.py
+++ b/packages/hca-schema-validator/validate_file.py
@@ -33,42 +33,42 @@ Examples:
         action="store_true",
         help="Include label validation (gene ID checks, etc.). Default: skip labels"
     )
-    
+
     args = parser.parse_args()
     h5ad_file = args.file
     ignore_labels = not args.with_labels
-    
+
     print(f"\n{'=' * SEPARATOR_WIDTH}")
     print("HCA Schema Validator")
     print(f"{'=' * SEPARATOR_WIDTH}")
     print(f"File: {h5ad_file}")
     print(f"Ignore Labels: {ignore_labels}")
     print(f"{'=' * SEPARATOR_WIDTH}\n")
-    
+
     validator = HCAValidator(ignore_labels=ignore_labels)
     is_valid = validator.validate_adata(h5ad_file)
-    
+
     print(f"\n{'=' * SEPARATOR_WIDTH}")
     if is_valid:
         print("✅ VALID - File passes HCA schema validation")
     else:
         print("❌ INVALID - File has validation errors")
     print(f"{'=' * SEPARATOR_WIDTH}\n")
-    
+
     if validator.errors:
         print(f"ERRORS ({len(validator.errors)}):")
         print("-" * SEPARATOR_WIDTH)
         for i, error in enumerate(validator.errors, 1):
             print(f"{i}. {error}")
         print()
-    
+
     if validator.warnings:
         print(f"WARNINGS ({len(validator.warnings)}):")
         print("-" * SEPARATOR_WIDTH)
         for i, warning in enumerate(validator.warnings, 1):
             print(f"{i}. {warning}")
         print()
-    
+
     if not validator.errors and not validator.warnings:
         print("No errors or warnings! 🎉\n")
 

--- a/packages/hca-schema-validator/validate_file.py
+++ b/packages/hca-schema-validator/validate_file.py
@@ -7,6 +7,7 @@ Usage:
     poetry run python validate_file.py <path/to/file.h5ad> --with-labels
 """
 import argparse
+
 from hca_schema_validator import HCAValidator
 
 # Display constants
@@ -38,7 +39,7 @@ Examples:
     ignore_labels = not args.with_labels
     
     print(f"\n{'=' * SEPARATOR_WIDTH}")
-    print(f"HCA Schema Validator")
+    print("HCA Schema Validator")
     print(f"{'=' * SEPARATOR_WIDTH}")
     print(f"File: {h5ad_file}")
     print(f"Ignore Labels: {ignore_labels}")

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,6 @@
+target-version = "py310"
+line-length = 120
+exclude = ["*/_vendored/*"]
+
+[lint]
+select = ["F", "I"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,6 @@
 target-version = "py310"
 line-length = 120
-extend-exclude = ["*/_vendored/*"]
+extend-exclude = ["*/_vendored/*", "*/schema/generated/*"]
 
 [lint]
 select = ["E", "F", "I", "W"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,6 @@
 target-version = "py310"
 line-length = 120
-exclude = ["*/_vendored/*"]
+extend-exclude = ["*/_vendored/*"]
 
 [lint]
 select = ["E", "F", "I", "W"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -3,4 +3,5 @@ line-length = 120
 exclude = ["*/_vendored/*"]
 
 [lint]
-select = ["F", "I"]
+select = ["E", "F", "I", "W"]
+ignore = ["E501"]  # line length — too many to fix at once


### PR DESCRIPTION
## Summary

Add ruff linter and pre-commit hook at repo level.

### Phase 1: F + I rules (commit 1)
- **20 unused imports** removed (F401)
- **25 import blocks** sorted (I001)
- **2 f-strings** without placeholders (F541)

### Phase 2: E + W rules (commit 2)
- **23 whitespace issues** fixed (W293, W291)
- **3 ambiguous variables** renamed `l` → `label`/`layer` (E741)
- **E501** (line length) deferred to #315 — 288 violations, too many to fix at once

### Config
```toml
# ruff.toml (repo root)
target-version = "py310"
line-length = 120
extend-exclude = ["*/_vendored/*", "*/schema/generated/*"]

[lint]
select = ["E", "F", "I", "W"]
ignore = ["E501"]
```

### Pre-commit hook
```yaml
# .pre-commit-config.yaml
repos:
  - repo: https://github.com/astral-sh/ruff-pre-commit
    rev: v0.11.8
    hooks:
      - id: ruff
        args: [--fix]
```

Run `pre-commit install` to enable.

### Follow-ups
- E501 line-length fixes → #315
- Pyright type checker → #314
- ruff-format (code formatter) → #313

## Test plan
- [x] All 208 hca-anndata-tools tests pass
- [x] All 46 hca-schema-validator tests pass
- [x] `ruff check packages/` — all checks passed

Partially addresses #311 (ruff + pre-commit done, pyright deferred to #314)

🤖 Generated with [Claude Code](https://claude.com/claude-code)