### PR TITLE
chore: add pyright type checker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,4 +11,4 @@ repos:
         entry: make typecheck
         language: system
         pass_filenames: false
-        files: ^(packages/(hca-anndata-tools|hca-anndata-mcp|hca-schema-validator)|services/(dataset-validator|hca-schema-validator))/.*\.py$
+        files: ^(packages/(hca-anndata-tools|hca-anndata-mcp|hca-schema-validator)|services/(dataset-validator|hca-schema-validator))/src/.*\.py$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,4 +11,4 @@ repos:
         entry: make typecheck
         language: system
         pass_filenames: false
-        files: ^(packages/(hca-anndata-tools|hca-anndata-mcp|hca-schema-validator)|services/(dataset-validator|hca-schema-validator))/src/.*\.py$
+        files: ^(packages/(hca-anndata-tools|hca-anndata-mcp|hca-schema-validator)|services/(dataset-validator|hca-schema-validator))/src/.*\.py$|^(pyrightconfig\.json|Makefile)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,11 @@ repos:
     hooks:
       - id: ruff
         args: [--fix]
+  - repo: local
+    hooks:
+      - id: pyright
+        name: pyright
+        entry: make typecheck
+        language: system
+        pass_filenames: false
+        files: ^(packages/(hca-anndata-tools|hca-anndata-mcp|hca-schema-validator)|services/(dataset-validator|hca-schema-validator))/.*\.py$

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,3 @@
 {
-  "python.venvPath": "${env:HOME}/Library/Caches/pypoetry/virtualenvs",
   "python.terminal.activateEnvironment": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "python.venvPath": "${env:HOME}/Library/Caches/pypoetry/virtualenvs",
+  "python.terminal.activateEnvironment": false
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,18 @@ cd services/cellxgene-validator && poetry run pytest tests/ -v
 cd services/hca-schema-validator && poetry run pytest tests/ -v
 ```
 
+## Type Checking
+
+Pyright covers `packages/hca-anndata-tools`, `packages/hca-anndata-mcp`, `packages/hca-schema-validator`, `services/dataset-validator`, and `services/hca-schema-validator`. Config is `pyrightconfig.json` at repo root. Runs one pass per venv since each has a disjoint dep set.
+
+```bash
+make typecheck
+```
+
+Pre-commit hook runs it on `git commit`. One-time setup: `pip install pre-commit && pre-commit install`.
+
+For Pylance to match in-editor, open the repo via `hca-validation-tools.code-workspace` (File → Open Workspace from File). Each package/service becomes its own root with its own poetry venv, so imports resolve correctly per folder.
+
 ## Deployment Commands
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,8 @@ cd services/hca-schema-validator && poetry run pytest tests/ -v
 
 Pyright covers `packages/hca-anndata-tools`, `packages/hca-anndata-mcp`, `packages/hca-schema-validator`, `services/dataset-validator`, and `services/hca-schema-validator`. Config is `pyrightconfig.json` at repo root. Runs one pass per venv since each has a disjoint dep set.
 
+Note: `hca-anndata-tools` doesn't declare pyright as a dev dep — its files are checked from the `hca-anndata-mcp` venv (which depends on tools, so it's a superset). This asymmetry goes away when we migrate to uv workspaces (#248) and have one shared venv.
+
 ```bash
 make typecheck
 ```

--- a/Makefile
+++ b/Makefile
@@ -210,3 +210,14 @@ test-all:
 	@$(MAKE) -C services/cellxgene-validator test
 	@$(MAKE) -C services/hca-schema-validator test
 	@echo "✓ All tests passed"
+
+.PHONY: typecheck
+typecheck:
+	@echo "Running pyright (hca-anndata-tools, hca-anndata-mcp)..."
+	@cd packages/hca-anndata-mcp && poetry run pyright --project ../.. ../hca-anndata-tools/src ../hca-anndata-mcp/src
+	@echo "Running pyright (hca-schema-validator)..."
+	@cd packages/hca-schema-validator && poetry run pyright --project ../.. src
+	@echo "Running pyright (dataset-validator)..."
+	@cd services/dataset-validator && poetry run pyright --project ../../ src
+	@echo "Running pyright (hca-schema-validator service)..."
+	@cd services/hca-schema-validator && poetry run pyright --project ../../ src

--- a/hca-validation-tools.code-workspace
+++ b/hca-validation-tools.code-workspace
@@ -8,7 +8,6 @@
     { "name": "hca-schema-validator (service)", "path": "services/hca-schema-validator" }
   ],
   "settings": {
-    "python.venvPath": "${env:HOME}/Library/Caches/pypoetry/virtualenvs",
     "python.terminal.activateEnvironment": false
   }
 }

--- a/hca-validation-tools.code-workspace
+++ b/hca-validation-tools.code-workspace
@@ -1,0 +1,14 @@
+{
+  "folders": [
+    { "name": "repo", "path": "." },
+    { "name": "hca-anndata-tools", "path": "packages/hca-anndata-tools" },
+    { "name": "hca-anndata-mcp", "path": "packages/hca-anndata-mcp" },
+    { "name": "hca-schema-validator (package)", "path": "packages/hca-schema-validator" },
+    { "name": "dataset-validator", "path": "services/dataset-validator" },
+    { "name": "hca-schema-validator (service)", "path": "services/hca-schema-validator" }
+  ],
+  "settings": {
+    "python.venvPath": "${env:HOME}/Library/Caches/pypoetry/virtualenvs",
+    "python.terminal.activateEnvironment": false
+  }
+}

--- a/packages/hca-anndata-mcp/poetry.lock
+++ b/packages/hca-anndata-mcp/poetry.lock
@@ -1927,6 +1927,18 @@ test = ["pytest (>=7.2)", "pytest-cov (>=4.0)", "pytest-xdist (>=3.0)"]
 test-extras = ["pytest-mpl", "pytest-randomly"]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+description = "Node.js virtual environment builder"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+groups = ["dev"]
+files = [
+    {file = "nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827"},
+    {file = "nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb"},
+]
+
+[[package]]
 name = "numba"
 version = "0.64.0"
 description = "compiling Python code using LLVM"
@@ -2866,6 +2878,27 @@ files = [
     {file = "pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273"},
     {file = "pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6"},
 ]
+
+[[package]]
+name = "pyright"
+version = "1.1.408"
+description = "Command line wrapper for pyright"
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1"},
+    {file = "pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684"},
+]
+
+[package.dependencies]
+nodeenv = ">=1.6.0"
+typing-extensions = ">=4.1"
+
+[package.extras]
+all = ["nodejs-wheel-binaries", "twine (>=3.4.1)"]
+dev = ["twine (>=3.4.1)"]
+nodejs = ["nodejs-wheel-binaries"]
 
 [[package]]
 name = "pytest"
@@ -4012,7 +4045,6 @@ files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
 ]
-markers = {dev = "python_version < \"3.13\""}
 
 [[package]]
 name = "typing-inspection"
@@ -4220,4 +4252,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "b6d08334eff03eb1afcd78f0f50d7a40164e079e75bbd6cdf526de93cf7e61b1"
+content-hash = "abc63ee541942a6b8c2223aa3540dce3d7e2642c9c4c6ff409c6c744de260d9d"

--- a/packages/hca-anndata-mcp/pyproject.toml
+++ b/packages/hca-anndata-mcp/pyproject.toml
@@ -16,6 +16,7 @@ hca-anndata-tools = {path = "../hca-anndata-tools", develop = true}
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0"
 pytest-asyncio = ">=0.23"
+pyright = "^1.1.408"
 
 [tool.poetry.scripts]
 hca-anndata-mcp = "hca_anndata_mcp.main:run"

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/__init__.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/__init__.py
@@ -1,28 +1,29 @@
 """HCA AnnData Tools — inspection, summarization, and statistics for h5ad files."""
 
-__version__ = "0.3.1"
+from typing import TYPE_CHECKING
 
-__all__ = [
-    "locate_files",
-    "get_summary",
-    "get_descriptive_stats",
-    "view_data",
-    "get_storage_info",
-    "get_cap_annotations",
-    "plot_embedding",
-    "write_h5ad",
-    "strip_timestamp",
-    "generate_output_path",
-    "generate_timestamp",
-    "EDIT_LOG_KEY",
-    "resolve_latest",
-    "set_uns",
-    "list_uns_fields",
-    "replace_placeholder_values",
-    "convert_cellxgene_to_hca",
-    "validate_marker_genes",
-    "copy_cap_annotations",
-]
+if TYPE_CHECKING:
+    from .cap import get_cap_annotations
+    from .convert import convert_cellxgene_to_hca
+    from .copy_cap import copy_cap_annotations
+    from .edit import list_uns_fields, replace_placeholder_values, set_uns
+    from .files import locate_files
+    from .marker_genes import validate_marker_genes
+    from .plot import plot_embedding
+    from .stats import get_descriptive_stats
+    from .storage import get_storage_info
+    from .summary import get_summary
+    from .view import view_data
+    from .write import (
+        EDIT_LOG_KEY,
+        generate_output_path,
+        generate_timestamp,
+        resolve_latest,
+        strip_timestamp,
+        write_h5ad,
+    )
+
+__version__ = "0.3.1"
 
 _LAZY_IMPORTS = {
     "locate_files": ".files",
@@ -45,6 +46,8 @@ _LAZY_IMPORTS = {
     "validate_marker_genes": ".marker_genes",
     "copy_cap_annotations": ".copy_cap",
 }
+
+__all__ = list(_LAZY_IMPORTS)  # pyright: ignore[reportUnsupportedDunderAll]
 
 
 def __getattr__(name: str):

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
@@ -1,20 +1,26 @@
 """Internal I/O utilities for AnnData file access."""
 
+# pyright: reportArgumentType=none, reportReturnType=none
+# h5py stubs return Group | Dataset | Datatype from __getitem__; runtime is always
+# narrower (Group or Dataset). Asserting/casting at every site would add heavy
+# churn without catching real bugs — this module is the narrowing boundary.
+
 from __future__ import annotations
 
 import gc
 from contextlib import contextmanager
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import anndata as ad
 import h5py
+import pandas as pd
 
 if TYPE_CHECKING:
     import numpy as np
 
 
 @contextmanager
-def open_h5ad(path: str, backed: str | None = "r"):
+def open_h5ad(path: str, backed: Literal["r", "r+"] | None = "r"):
     """Open an h5ad file with automatic cleanup.
 
     Args:
@@ -153,18 +159,18 @@ def write_edit_log_h5py(f: h5py.File, log_json: str) -> None:
     ds.attrs["encoding-version"] = "0.2.0"
 
 
-def read_categorical_data(item: h5py.Group) -> tuple[list[str], "np.ndarray"]:
+def read_categorical_data(item: h5py.Group) -> tuple[pd.Index, "np.ndarray"]:
     """Read categories and codes from a categorical h5py group.
 
     Args:
         item: An h5py Group with 'categories' and 'codes' datasets.
 
     Returns:
-        (categories, codes) — list of decoded category strings and numpy codes array.
+        (categories, codes) — pandas Index of decoded category strings and numpy codes array.
     """
     categories = [_decode_bytes(v) for v in item["categories"][:]]
     codes = item["codes"][:]
-    return categories, codes
+    return pd.Index(categories), codes
 
 
 def update_column_order(

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/convert.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/convert.py
@@ -119,7 +119,7 @@ def convert_cellxgene_to_hca(
                 )
                 conversions.append(f"{key}: uns → obs (broadcast '{value}')")
 
-        obs = pd.DataFrame(obs_data, index=source_index)
+        obs = pd.DataFrame(obs_data, index=source_index)  # pyright: ignore[reportArgumentType]
 
         # Build uns for temp file
         temp_uns = {}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import os
 import shutil
 import tempfile
+from collections.abc import Mapping
+from typing import Any
 from datetime import datetime, timezone
 
 import anndata as ad
@@ -76,7 +78,7 @@ def _check_duplicate_ids(index: list[str], label: str) -> str | None:
     return f"{label} has duplicate cell IDs (first 5): {dupes}"
 
 
-def _get_annotation_sets(source_uns: dict) -> list[str]:
+def _get_annotation_sets(source_uns: Mapping[str, Any]) -> list[str]:
     """Get annotation sets defined in cellannotation_metadata."""
     meta = source_uns.get("cellannotation_metadata", {})
     if isinstance(meta, dict):
@@ -176,7 +178,7 @@ def copy_cap_annotations(
         if dupe_err:
             return {"error": dupe_err}
 
-        source_obs_subset = pd.DataFrame(source_obs_data, index=source_index_list)
+        source_obs_subset = pd.DataFrame(source_obs_data, index=source_index_list)  # pyright: ignore[reportArgumentType]
 
         # --- Step 2: Validate target via h5py (no AnnData load) ---
         with h5py.File(target_path, "r") as f:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
@@ -315,7 +315,7 @@ def replace_placeholder_values(
         with h5py.File(output_path, "a") as f:
             for col in columns_fixed:
                 item = f["obs"][col]
-                cats, codes = read_categorical_data(item)
+                cats, codes = read_categorical_data(item)  # pyright: ignore[reportArgumentType]
 
                 # Preserve original settings
                 encoding_type = item.attrs["encoding-type"]

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/plot.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/plot.py
@@ -65,7 +65,7 @@ def plot_embedding(
                 kwargs["palette"] = palette
 
             fig, ax = plt.subplots(figsize=(width, height))
-            sc.pl.embedding(adata, ax=ax, **kwargs)
+            sc.pl.embedding(adata, ax=ax, **kwargs)  # pyright: ignore[reportArgumentType]
 
         with io.BytesIO() as buf:
             fig.savefig(buf, format="png", dpi=dpi, bbox_inches="tight")

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/stats.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/stats.py
@@ -38,22 +38,21 @@ def get_descriptive_stats(
             df: pd.DataFrame = getattr(adata, attribute)
 
             # Apply filter
-            filter_params = [filter_column, filter_operator, filter_value]
-            if any(p is not None for p in filter_params) and not all(p is not None for p in filter_params):
-                return {"error": "filter_column, filter_operator, and filter_value must all be provided together"}
-            if filter_column is not None:
+            if filter_column is not None and filter_operator is not None and filter_value is not None:
                 if filter_column not in df.columns:
                     return {"error": f"Filter column '{filter_column}' not found in {attribute}"}
                 df = _apply_filter(df, filter_column, filter_operator, filter_value)
                 if len(df) == 0:
                     return {"error": "Filter resulted in zero rows"}
+            elif filter_column is not None or filter_operator is not None or filter_value is not None:
+                return {"error": "filter_column, filter_operator, and filter_value must all be provided together"}
 
             # Select columns
             if columns is not None:
                 missing = [c for c in columns if c not in df.columns]
                 if missing:
                     return {"error": f"Columns not found in {attribute}: {missing}"}
-                df = df[columns]
+                df = df[columns]  # pyright: ignore[reportAssignmentType]
 
             result = {"n_rows": len(df), "columns": {}}
 
@@ -64,7 +63,7 @@ def get_descriptive_stats(
                     result["columns"][col] = {
                         "dtype": str(series.dtype),
                         "type": "numeric",
-                        "count": int(desc["count"]),
+                        "count": int(desc["count"]),  # pyright: ignore[reportArgumentType]
                         "mean": _safe_float(desc["mean"]),
                         "std": _safe_float(desc["std"]),
                         "min": _safe_float(desc["min"]),
@@ -126,4 +125,4 @@ def _apply_filter(
     if operator not in ops:
         raise ValueError(f"Unknown operator: {operator}")
     mask = ops[operator](series, value)
-    return df[mask]
+    return df[mask]  # pyright: ignore[reportReturnType]

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/testing.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/testing.py
@@ -29,7 +29,7 @@ def create_sample_h5ad(path: Path) -> Path:
 
     # Sparse count matrix
     rng = np.random.default_rng(42)
-    X = sp.random(n_obs, n_vars, density=0.3, format="csr", dtype=np.float32, random_state=rng)
+    X = sp.random(n_obs, n_vars, density=0.3, format="csr", dtype=np.float32, random_state=rng)  # pyright: ignore[reportCallIssue]
 
     obs = pd.DataFrame(
         {
@@ -40,7 +40,7 @@ def create_sample_h5ad(path: Path) -> Path:
             )),
             "n_counts": rng.integers(500, 5000, n_obs).astype(np.float32),
         },
-        index=[f"cell_{i}" for i in range(n_obs)],
+        index=[f"cell_{i}" for i in range(n_obs)],  # pyright: ignore[reportArgumentType]
     )
 
     var = pd.DataFrame(
@@ -48,7 +48,7 @@ def create_sample_h5ad(path: Path) -> Path:
             "gene_name": [f"GENE{i}" for i in range(n_vars)],
             "highly_variable": rng.choice([True, False], n_vars),
         },
-        index=[f"ENSG{i:011d}" for i in range(n_vars)],
+        index=[f"ENSG{i:011d}" for i in range(n_vars)],  # pyright: ignore[reportArgumentType]
     )
 
     adata = ad.AnnData(X=X, obs=obs, var=var)
@@ -85,7 +85,7 @@ def create_cellxgene_h5ad(path: Path) -> Path:
     n_obs, n_vars = 30, 15
     rng = np.random.default_rng(99)
 
-    X = sp.random(n_obs, n_vars, density=0.3, format="csr", dtype=np.float32, random_state=rng)
+    X = sp.random(n_obs, n_vars, density=0.3, format="csr", dtype=np.float32, random_state=rng)  # pyright: ignore[reportCallIssue]
 
     obs = pd.DataFrame(
         {
@@ -117,7 +117,7 @@ def create_cellxgene_h5ad(path: Path) -> Path:
             "development_stage": pd.Categorical(["human adult stage"] * n_obs),
             "observation_joinid": [f"joinid_{i}" for i in range(n_obs)],
         },
-        index=[f"AACG{i:08d}-1" for i in range(n_obs)],
+        index=[f"AACG{i:08d}-1" for i in range(n_obs)],  # pyright: ignore[reportArgumentType]
     )
 
     var = pd.DataFrame(
@@ -129,7 +129,7 @@ def create_cellxgene_h5ad(path: Path) -> Path:
             "feature_length": [1000] * n_vars,
             "feature_type": ["gene"] * n_vars,
         },
-        index=[f"ENSG{i:011d}" for i in range(n_vars)],
+        index=[f"ENSG{i:011d}" for i in range(n_vars)],  # pyright: ignore[reportArgumentType]
     )
 
     adata = ad.AnnData(X=X, obs=obs, var=var)

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/view.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/view.py
@@ -80,7 +80,7 @@ def _view_dataframe(
         missing = [c for c in columns if c not in df.columns]
         if missing:
             return {"error": f"Columns not found: {missing}"}
-        df = df[columns]
+        df = df[columns]  # pyright: ignore[reportAssignmentType]
 
     sliced = df.iloc[row_start:row_end]
     return {

--- a/packages/hca-anndata-tools/tests/test_helpers.py
+++ b/packages/hca-anndata-tools/tests/test_helpers.py
@@ -55,7 +55,7 @@ def test_read_categorical_data(tmp_path):
 
     with h5py.File(path, "r") as f:
         cats, codes = read_categorical_data(f["obs"]["col"])
-        assert cats == ["a", "b"]
+        assert list(cats) == ["a", "b"]
         assert len(codes) == 3
         # Verify codes map correctly: a=0, b=1, a=0
         assert cats[codes[0]] == "a"

--- a/packages/hca-schema-validator/poetry.lock
+++ b/packages/hca-schema-validator/poetry.lock
@@ -984,6 +984,18 @@ fast = ["fastnumbers (>=2.0.0)"]
 icu = ["PyICU (>=1.0.0)"]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+description = "Node.js virtual environment builder"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+groups = ["dev"]
+files = [
+    {file = "nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827"},
+    {file = "nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb"},
+]
+
+[[package]]
 name = "numba"
 version = "0.62.1"
 description = "compiling Python code using LLVM"
@@ -1536,6 +1548,27 @@ files = [
 diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
+name = "pyright"
+version = "1.1.408"
+description = "Command line wrapper for pyright"
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1"},
+    {file = "pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684"},
+]
+
+[package.dependencies]
+nodeenv = ">=1.6.0"
+typing-extensions = ">=4.1"
+
+[package.extras]
+all = ["nodejs-wheel-binaries", "twine (>=3.4.1)"]
+dev = ["twine (>=3.4.1)"]
+nodejs = ["nodejs-wheel-binaries"]
+
+[[package]]
 name = "pysam"
 version = "0.23.3"
 description = "Package for reading, manipulating, and writing genomic data"
@@ -1954,7 +1987,6 @@ files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
 ]
-markers = {dev = "python_version == \"3.10\""}
 
 [[package]]
 name = "tzdata"
@@ -2254,4 +2286,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "856dfbb9e489f50e53d1c65333ef4a7230552afc421c88848198eefe6fea0881"
+content-hash = "0cb2c05e22f2ba2ae3660b413c3de8e14390617f03f4d439d57d3828ab4b3326"

--- a/packages/hca-schema-validator/pyproject.toml
+++ b/packages/hca-schema-validator/pyproject.toml
@@ -31,6 +31,7 @@ pysam = ">=0.13.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0"
+pyright = "^1.1.408"
 
 [build-system]
 requires = ["poetry-core"]

--- a/packages/hca-schema-validator/src/hca_schema_validator/validator.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/validator.py
@@ -164,7 +164,7 @@ class HCAValidator(Validator):
                     if len(column) > 0:
                         if "warning_message" in col_def:
                             self.warnings.append(col_def["warning_message"])
-                        self._validate_column(column, col_name, df_name, col_def)
+                        self._validate_column(column, col_name, df_name, col_def)  # pyright: ignore[reportArgumentType]
 
     def _validate_strongly_recommended(self, df, df_name, col_name, col_def):
         """Validate a strongly_recommended column: warn on missing/NaN, error on blocklist."""

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,26 @@
+{
+  "pythonVersion": "3.10",
+  "typeCheckingMode": "basic",
+  "include": [
+    "packages/hca-anndata-tools/src",
+    "packages/hca-anndata-mcp/src",
+    "packages/hca-schema-validator/src",
+    "services/dataset-validator/src",
+    "services/hca-schema-validator/src"
+  ],
+  "exclude": [
+    "**/__pycache__",
+    "**/.*",
+    "**/_vendored/**",
+    "**/schema/generated/**",
+    "**/.venv/**",
+    "**/node_modules/**"
+  ],
+  "reportMissingImports": true,
+  "reportUnusedImport": false,
+  "reportIndexIssue": "none",
+  "reportAttributeAccessIssue": "none",
+  "reportOperatorIssue": "none",
+  "reportGeneralTypeIssues": "none",
+  "reportInvalidTypeArguments": "none"
+}

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -22,5 +22,9 @@
   "reportAttributeAccessIssue": "none",
   "reportOperatorIssue": "none",
   "reportGeneralTypeIssues": "none",
-  "reportInvalidTypeArguments": "none"
+  "reportInvalidTypeArguments": "none",
+  "executionEnvironments": [
+    { "root": "services/dataset-validator/src", "pythonVersion": "3.11" },
+    { "root": "services/hca-schema-validator/src", "pythonVersion": "3.11" }
+  ]
 }

--- a/services/dataset-validator/poetry.lock
+++ b/services/dataset-validator/poetry.lock
@@ -771,6 +771,18 @@ fast = ["fastnumbers (>=2.0.0)"]
 icu = ["PyICU (>=1.0.0)"]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+description = "Node.js virtual environment builder"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+groups = ["dev"]
+files = [
+    {file = "nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827"},
+    {file = "nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb"},
+]
+
+[[package]]
 name = "numcodecs"
 version = "0.16.2"
 description = "A Python package providing buffer compression and transformation codecs for use in data storage and communication applications."
@@ -1037,6 +1049,27 @@ files = [
 windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
+name = "pyright"
+version = "1.1.408"
+description = "Command line wrapper for pyright"
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1"},
+    {file = "pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684"},
+]
+
+[package.dependencies]
+nodeenv = ">=1.6.0"
+typing-extensions = ">=4.1"
+
+[package.extras]
+all = ["nodejs-wheel-binaries", "twine (>=3.4.1)"]
+dev = ["twine (>=3.4.1)"]
+nodejs = ["nodejs-wheel-binaries"]
+
+[[package]]
 name = "pytest"
 version = "8.4.1"
 description = "pytest: simple powerful testing with Python"
@@ -1299,7 +1332,7 @@ version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
@@ -1395,4 +1428,4 @@ test = ["coverage (>=7.10)", "hypothesis", "mypy", "packaging", "pytest (<8.4)",
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "3b43338902d85d189b1aa875b7606ade9f2adfb13faec485b6e146608272a3c9"
+content-hash = "eff9de585e9a227ffa737c7590b1a47c272b38e3dd0b94314c7b87d8e73fb0bc"

--- a/services/dataset-validator/pyproject.toml
+++ b/services/dataset-validator/pyproject.toml
@@ -21,6 +21,7 @@ pytest = "^8.3.5"
 moto = "^4.2.0"
 # Additional dev dependencies - add back as needed
 # pytest-mock = "^3.14.0"
+pyright = "^1.1.408"
 
 [build-system]
 requires = ["poetry-core"]

--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -126,11 +126,13 @@ class ValidationMessage:
         return json.dumps(asdict(self), separators=(',', ':'))
     
     def _get_report_message_list(self, report_key: str, message_type: str) -> List[str]:
-        assert self.tool_reports is not None
+        if self.tool_reports is None:
+            raise RuntimeError("tool_reports not set")
         return getattr(self.tool_reports[report_key], message_type)
 
     def _set_report_message_list(self, report_key: str, message_type: str, value: List[str]):
-        assert self.tool_reports is not None
+        if self.tool_reports is None:
+            raise RuntimeError("tool_reports not set")
         setattr(self.tool_reports[report_key], message_type, value)
 
     def _json_length_of_report_list(self, report_key: str, message_type: str) -> int:

--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -741,7 +741,8 @@ def main() -> int:
         bucket = env_vars['bucket']
         key = env_vars['key']
         batch_job_id = env_vars['batch_job_id']
-        assert file_id is not None and bucket is not None and key is not None and batch_job_id is not None
+        if file_id is None or bucket is None or key is None or batch_job_id is None:
+            raise RuntimeError("Required env vars unexpectedly None after missing_vars check")
 
         # Initialize validation message with basic info
         validation_message = ValidationMessage(
@@ -757,7 +758,8 @@ def main() -> int:
         if local_mode:
             # Local file mode — skip S3 download and integrity checks
             local_file_path = env_vars['local_file']
-            assert local_file_path is not None  # local_mode implies LOCAL_FILE is set
+            if local_file_path is None:
+                raise RuntimeError("local_mode set but LOCAL_FILE env var is None")
             local_file = Path(local_file_path)
             logger.info("Local file mode: validating %s", local_file)
             validation_message.integrity_status = INTEGRITY_VALID

--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -126,9 +126,11 @@ class ValidationMessage:
         return json.dumps(asdict(self), separators=(',', ':'))
     
     def _get_report_message_list(self, report_key: str, message_type: str) -> List[str]:
+        assert self.tool_reports is not None
         return getattr(self.tool_reports[report_key], message_type)
 
     def _set_report_message_list(self, report_key: str, message_type: str, value: List[str]):
+        assert self.tool_reports is not None
         setattr(self.tool_reports[report_key], message_type, value)
 
     def _json_length_of_report_list(self, report_key: str, message_type: str) -> int:
@@ -365,12 +367,14 @@ def read_metadata(file_path: Path) -> MetadataSummary:
     try:
         adata = anndata.io.read_h5ad(file_path, backed="r")
         title = adata.uns.get("title")
+        # anndata.obs is typed DataFrame | Dataset2D (backed vs in-memory); runtime is DataFrame here
+        obs: pd.DataFrame = adata.obs  # pyright: ignore[reportAssignmentType]
         return MetadataSummary(
             title=title if isinstance(title, str) else "",
-            assay=get_column_unique_values_if_present(adata.obs, "assay"),
-            suspension_type=get_column_unique_values_if_present(adata.obs, "suspension_type"),
-            tissue=get_column_unique_values_if_present(adata.obs, "tissue"),
-            disease=get_column_unique_values_if_present(adata.obs, "disease"),
+            assay=get_column_unique_values_if_present(obs, "assay"),
+            suspension_type=get_column_unique_values_if_present(obs, "suspension_type"),
+            tissue=get_column_unique_values_if_present(obs, "tissue"),
+            disease=get_column_unique_values_if_present(obs, "disease"),
             cell_count=adata.n_obs,
             gene_count=adata.n_vars
         )
@@ -730,32 +734,41 @@ def main() -> int:
             exit_code = 1
             return exit_code
 
+        # Required env vars are guaranteed non-None after the missing_vars check above
+        file_id = env_vars['file_id']
+        bucket = env_vars['bucket']
+        key = env_vars['key']
+        batch_job_id = env_vars['batch_job_id']
+        assert file_id is not None and bucket is not None and key is not None and batch_job_id is not None
+
         # Initialize validation message with basic info
         validation_message = ValidationMessage(
-            file_id=env_vars['file_id'],
+            file_id=file_id,
             status="in_progress",
             timestamp=start_time.isoformat(),
-            bucket=env_vars['bucket'],
-            key=env_vars['key'],
-            batch_job_id=env_vars['batch_job_id'],
+            bucket=bucket,
+            key=key,
+            batch_job_id=batch_job_id,
             batch_job_name=env_vars['batch_job_name']
         )
 
         if local_mode:
             # Local file mode — skip S3 download and integrity checks
-            local_file = Path(env_vars['local_file'])
+            local_file_path = env_vars['local_file']
+            assert local_file_path is not None  # local_mode implies LOCAL_FILE is set
+            local_file = Path(local_file_path)
             logger.info("Local file mode: validating %s", local_file)
             validation_message.integrity_status = INTEGRITY_VALID
         else:
-            logger.info("Processing S3 file: s3://%s/%s", env_vars['bucket'], env_vars['key'])
+            logger.info("Processing S3 file: s3://%s/%s", bucket, key)
 
             # Create work directory
             work_dir = create_work_directory()
             logger.info("Work directory created: %s", work_dir)
 
             # Download file from S3
-            local_file = work_dir / Path(env_vars['key']).name
-            source_sha256 = download_s3_file(env_vars['bucket'], env_vars['key'], local_file)
+            local_file = work_dir / Path(key).name
+            source_sha256 = download_s3_file(bucket, key, local_file)
             logger.info("File ready for validation: %s", local_file)
             log_memory_usage("after download")
 

--- a/services/hca-schema-validator/poetry.lock
+++ b/services/hca-schema-validator/poetry.lock
@@ -916,6 +916,18 @@ fast = ["fastnumbers (>=2.0.0)"]
 icu = ["PyICU (>=1.0.0)"]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+description = "Node.js virtual environment builder"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+groups = ["dev"]
+files = [
+    {file = "nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827"},
+    {file = "nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb"},
+]
+
+[[package]]
 name = "numba"
 version = "0.62.1"
 description = "compiling Python code using LLVM"
@@ -1404,6 +1416,27 @@ files = [
 diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
+name = "pyright"
+version = "1.1.408"
+description = "Command line wrapper for pyright"
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1"},
+    {file = "pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684"},
+]
+
+[package.dependencies]
+nodeenv = ">=1.6.0"
+typing-extensions = ">=4.1"
+
+[package.extras]
+all = ["nodejs-wheel-binaries", "twine (>=3.4.1)"]
+dev = ["twine (>=3.4.1)"]
+nodejs = ["nodejs-wheel-binaries"]
+
+[[package]]
 name = "pysam"
 version = "0.23.3"
 description = "Package for reading, manipulating, and writing genomic data"
@@ -1762,7 +1795,7 @@ version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
@@ -2066,4 +2099,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "~=3.11"
-content-hash = "16ecf4255a6e983e8c19c8908129cb9b15c0c637633523162c82dbc662f6b57d"
+content-hash = "eaa16bdcec391b831d94552edef4dd94aaec06677b1ad961e18741b863dc1539"

--- a/services/hca-schema-validator/pyproject.toml
+++ b/services/hca-schema-validator/pyproject.toml
@@ -11,6 +11,7 @@ package-mode = false
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.4.2"
+pyright = "^1.1.408"
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]


### PR DESCRIPTION
## Summary

- Adds pyright across 5 packages/services (`packages/hca-anndata-{tools,mcp}`, `packages/hca-schema-validator`, `services/{dataset-validator,hca-schema-validator}`) with a shared `pyrightconfig.json` at repo root.
- `make typecheck` runs 4 passes (one per disjoint poetry venv); pre-commit hook delegates to the same target.
- h5py/pandas/scanpy/anndata stub imprecisions are silenced rule-level or per-site; reports that don't catch real bugs aren't worth the churn.
- Real bugs fixed along the way: `str | None` env var narrowing in `dataset-validator`, `Optional` subscript guards in `ValidationMessage`, `Literal["r", "r+"] | None` on `open_h5ad.backed`, `read_categorical_data` returns `pd.Index` so `pd.Categorical.from_codes` stubs accept it, filter narrowing in `get_descriptive_stats`.
- Adds `.vscode/settings.json` + multi-root `.code-workspace` so Pylance picks the right poetry venv per folder.
- Documents setup in CLAUDE.md.

## Test plan

- [x] `make typecheck` → 0 errors across all 4 passes
- [x] `pytest` per package: 307 tests pass (208 + 11 + 46 + 38 + 4)
- [ ] Reviewer: open via `hca-validation-tools.code-workspace` (File → Open Workspace from File) — Pylance import errors in services should be gone
- [ ] Reviewer: `pip install pre-commit && pre-commit install`, try a commit in one of the covered packages

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)