### PR TITLE
chore: fix E501 (line-too-long) violations and enable rule

### DIFF
--- a/packages/hca-anndata-tools/src/hca_anndata_tools/view.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/view.py
@@ -28,7 +28,8 @@ def view_data(
     Args:
         path: Absolute path to an .h5ad file.
         attribute: One of 'obs', 'var', 'X', 'obsm', 'varm', 'obsp', 'varp', 'layers', 'uns'.
-        key: Key within the attribute. Required for obsm, varm, obsp, varp, layers. Optional for uns (omit for a summarized view).
+        key: Key within the attribute. Required for obsm, varm, obsp, varp, layers.
+            Optional for uns (omit for a summarized view).
         columns: Column names to include (for obs/var only).
         row_start: Start row index for slicing. Defaults to 0.
         row_end: End row index for slicing. Defaults to 10.

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,7 +1,10 @@
 target-version = "py310"
 line-length = 120
-extend-exclude = ["*/_vendored/*", "*/schema/generated/*"]
+extend-exclude = [
+    "*/_vendored/*",
+    "*/schema/generated/*",
+    "packages/hca-anndata-tools/src/hca_anndata_tools/schema/core.py",
+]
 
 [lint]
 select = ["E", "F", "I", "W"]
-ignore = ["E501"]  # line length — too many to fix at once

--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -25,7 +25,7 @@ import anndata
 import pandas as pd
 
 
-# Somewhat less than the actual value of 256KiB, to make room for small unforseen deviations
+# Somewhat less than the actual value of 256KiB, to make room for small unforeseen deviations
 MAX_SNS_MESSAGE_LENGTH = 250_000
 TRUNCATED_MESSAGES_MESSAGE = "Messages truncated"
 # When truncating to fit SNS limits, error lists from higher-priority tools are preserved longer.

--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -25,7 +25,8 @@ import anndata
 import pandas as pd
 
 
-MAX_SNS_MESSAGE_LENGTH = 250_000 # Somewhat less than the actual value of 256KiB, to make room for small unforseen deviations
+# Somewhat less than the actual value of 256KiB, to make room for small unforseen deviations
+MAX_SNS_MESSAGE_LENGTH = 250_000
 TRUNCATED_MESSAGES_MESSAGE = "Messages truncated"
 # When truncating to fit SNS limits, error lists from higher-priority tools are preserved longer.
 # Unknown tools default to priority 0 (truncated first among errors).
@@ -146,9 +147,15 @@ class ValidationMessage:
         if self.tool_reports is None or len(full_message) < max_length:
             return full_message
         
-        # Create a list of message arrays from tool_reports, represented as (key in tool_reports, attribute in tool report object) pairs
-        list_paths = [(key, message_type) for key in self.tool_reports.keys() for message_type in ["errors", "warnings"]]
-        # Truncation priority: warnings first, then cellxgene errors, then cap errors, then hcaSchema errors (preserved longest)
+        # Create a list of message arrays from tool_reports, represented as
+        # (key in tool_reports, attribute in tool report object) pairs
+        list_paths = [
+            (key, message_type)
+            for key in self.tool_reports.keys()
+            for message_type in ["errors", "warnings"]
+        ]
+        # Truncation priority: warnings first, then cellxgene errors, then cap errors,
+        # then hcaSchema errors (preserved longest)
         list_paths.sort(key=lambda p: (
             0 if p[1] == "warnings" else 1 + TOOL_ERROR_PRIORITY.get(p[0], 0),
             -self._json_length_of_report_list(*p),
@@ -165,20 +172,25 @@ class ValidationMessage:
                 threshold_path = p
                 break
         
-        # If all lists have been truncated and somehow none have made the message small enough, give up and try using it anyway
+        # If all lists have been truncated and somehow none have made the message small enough,
+        # give up and try using it anyway
         if threshold_path is None:
             return truncated_message.to_json()
         
         # Get the original value of the list that was the threshold for making the message small enough
         message_list = self._get_report_message_list(*threshold_path)
 
-        # Do a binary search to determine how much of the list can be retained, ensuring that the truncated message remains at a valid length
+        # Do a binary search to determine how much of the list can be retained,
+        # ensuring that the truncated message remains at a valid length
         max_valid_length = 0
         min_invalid_length = len(message_list)
         while min_invalid_length - max_valid_length > 1:
             truncated_list_before = truncated_message._get_report_message_list(*threshold_path)
             middle_length = int((max_valid_length + min_invalid_length)/2)
-            truncated_message._set_report_message_list(*threshold_path, [*message_list[:middle_length], TRUNCATED_MESSAGES_MESSAGE])
+            truncated_message._set_report_message_list(
+                *threshold_path,
+                [*message_list[:middle_length], TRUNCATED_MESSAGES_MESSAGE],
+            )
             if len(truncated_message.to_json()) < max_length:
                 max_valid_length = middle_length
             else:
@@ -477,21 +489,27 @@ def apply_external_validator(
     validator_name: str
 ) -> ValidationToolReport:
     """
-    Apply an external validator to the given file by calling a Python script via command line, and create a validation report.
+    Apply an external validator to the given file by calling a Python script via command line,
+    and create a validation report.
 
     Args:
         file_path: Path of the file to validate
         script_path_var: Name of environment variable to get the path of the script from
-        venv_path_var: Name of the environment variable from which to get the path of the virtual environment to call the script with
-        get_default_root_path: Function to use to get the root path of a Poetry project containing the script if the environment variables don't exist
-        default_package_name: Name of the folder in which the script is contained if the environment variables don't exist
+        venv_path_var: Name of the environment variable from which to get the path of the virtual
+            environment to call the script with
+        get_default_root_path: Function to use to get the root path of a Poetry project containing
+            the script if the environment variables don't exist
+        default_package_name: Name of the folder in which the script is contained if the
+            environment variables don't exist
         validator_name: Name of the validator to use in error messages
 
     Returns:
         Validation report
-    
+
     Note:
-        - The validator script should take the file path as a command-line argument, and print as output a JSON object containing a `valid` boolean, an `errors` array of strings, and a `warnings` array of strings
+        - The validator script should take the file path as a command-line argument, and print as
+          output a JSON object containing a `valid` boolean, an `errors` array of strings, and a
+          `warnings` array of strings
         - The default Poetry project should contain the script at src/{default_package_name}/main.py
     """
 

--- a/services/dataset-validator/tests/mock-modules/cap_validator.py
+++ b/services/dataset-validator/tests/mock-modules/cap_validator.py
@@ -6,6 +6,10 @@ if __name__ == "__main__":
     # Allow tests to inject an error via environment variable
     error = os.environ.get("CAP_MOCK_ERROR")
     if error:
-        print(json.dumps({"valid": False, "errors": [f"Encountered an unexpected error while calling CAP validator: {error}"], "warnings": []}))
+        print(json.dumps({
+            "valid": False,
+            "errors": [f"Encountered an unexpected error while calling CAP validator: {error}"],
+            "warnings": [],
+        }))
     else:
         print(json.dumps({"valid": True, "errors": [], "warnings": []}))

--- a/services/dataset-validator/tests/test_dataset_validator.py
+++ b/services/dataset-validator/tests/test_dataset_validator.py
@@ -230,7 +230,13 @@ def test_missing_sns_topic_logs_error_and_exits(caplog, env_manager, base_env_va
         "adata": {
             "obs": {
                 "assay": ["assay-a", "assay-b", "assay-b", "assay-c", "assay-a"],
-                "suspension_type": ["suspension-type-a", "suspension-type-a", "suspension-type-a", "suspension-type-a", "suspension-type-a"],
+                "suspension_type": [
+                    "suspension-type-a",
+                    "suspension-type-a",
+                    "suspension-type-a",
+                    "suspension-type-a",
+                    "suspension-type-a",
+                ],
                 "tissue": ["tissue-a", "tissue-a", "tissue-b", "tissue-a", "tissue-a"],
                 "disease": ["disease-a", "disease-b", "disease-c", "disease-d", "disease-e"]
             },
@@ -637,7 +643,13 @@ def test_local_file_mode(mock_read_h5ad, caplog, env_manager, tmp_path, test_cas
         "adata": {
             "obs": {
                 "assay": ["assay-a", "assay-b", "assay-b", "assay-c", "assay-a"],
-                "suspension_type": ["suspension-type-a", "suspension-type-a", "suspension-type-a", "suspension-type-a", "suspension-type-a"],
+                "suspension_type": [
+                    "suspension-type-a",
+                    "suspension-type-a",
+                    "suspension-type-a",
+                    "suspension-type-a",
+                    "suspension-type-a",
+                ],
                 "tissue": ["tissue-a", "tissue-a", "tissue-b", "tissue-a", "tissue-a"],
                 "disease": ["disease-a", "disease-b", "disease-c", "disease-d", "disease-e"]
             },
@@ -725,7 +737,9 @@ def test_local_file_mode(mock_read_h5ad, caplog, env_manager, tmp_path, test_cas
         "file_id": "test-file-789",
         "batch_job_id": "job-101",
         "batch_job_name": None,
-        "setup_s3": lambda s3_client, bucket_name: _setup_corrupt_s3_file(s3_client, bucket_name, "datasets/corrupt.h5ad"),
+        "setup_s3": lambda s3_client, bucket_name: _setup_corrupt_s3_file(
+            s3_client, bucket_name, "datasets/corrupt.h5ad"
+        ),
         "adata": None,
         "expected_exit_code": 1,
         "expected_logs": [
@@ -789,7 +803,13 @@ def test_local_file_mode(mock_read_h5ad, caplog, env_manager, tmp_path, test_cas
         "adata": {
             "obs": {
                 "assay": ["assay-a", "assay-b", "assay-b", "assay-c", "assay-a"],
-                "suspension_type": ["suspension-type-a", "suspension-type-a", "suspension-type-a", "suspension-type-a", "suspension-type-a"],
+                "suspension_type": [
+                    "suspension-type-a",
+                    "suspension-type-a",
+                    "suspension-type-a",
+                    "suspension-type-a",
+                    "suspension-type-a",
+                ],
                 "tissue": ["tissue-a", "tissue-a", "tissue-b", "tissue-a", "tissue-a"],
                 "disease": ["disease-a", "disease-b", "disease-c", "disease-d", "disease-e"]
             },
@@ -938,8 +958,13 @@ def _validate_sns_message(mock_aws, caplog, expected_message):
     message = _get_last_sns_message(sns_backend, topic_arn)
     
     # Validate key fields that use constants - these should fail if constants change
-    assert message["status"] == expected_message["status"], f"Expected status '{expected_message['status']}', got '{message['status']}'"
-    assert message["integrity_status"] == expected_message["integrity_status"], f"Expected integrity_status '{expected_message['integrity_status']}', got '{message['integrity_status']}'"
+    assert message["status"] == expected_message["status"], (
+        f"Expected status '{expected_message['status']}', got '{message['status']}'"
+    )
+    assert message["integrity_status"] == expected_message["integrity_status"], (
+        f"Expected integrity_status '{expected_message['integrity_status']}', "
+        f"got '{message['integrity_status']}'"
+    )
     assert message["file_id"] == expected_message["file_id"]
     assert message["batch_job_id"] == expected_message["batch_job_id"]
     assert message["batch_job_name"] == expected_message["batch_job_name"]
@@ -951,7 +976,10 @@ def _validate_sns_message(mock_aws, caplog, expected_message):
     if expected_message["tool_reports"] is None:
         assert message["tool_reports"] is None
     else:
-        tool_reports_without_times = {tool: {k: v for k, v in report.items() if k not in {"started_at", "finished_at"}} for tool, report in message["tool_reports"].items()}
+        tool_reports_without_times = {
+            tool: {k: v for k, v in report.items() if k not in {"started_at", "finished_at"}}
+            for tool, report in message["tool_reports"].items()
+        }
         assert tool_reports_without_times == expected_message["tool_reports"]
     
     # For success case, verify error_message is None

--- a/services/dataset-validator/tests/test_validation_message.py
+++ b/services/dataset-validator/tests/test_validation_message.py
@@ -83,7 +83,10 @@ from dataset_validator.main import ValidationToolReport, ValidationMessage, TRUN
     },
     {
         "name": "hca_errors_prioritized_over_cellxgene_errors",
-        "description": "Small cellxgene errors truncated before large cap/hcaSchema errors, proving tool priority over length",
+        "description": (
+            "Small cellxgene errors truncated before large cap/hcaSchema errors, "
+            "proving tool priority over length"
+        ),
         "message_length": 100,
         "message_counts": {
           "cap": {
@@ -133,7 +136,11 @@ def test_length_limited_json_scenarios(test_case):
   parsed = json.loads(message_json)
   if test_case.get("expect_errors_preserved"):
     for tool_report in parsed["tool_reports"].values():
-      assert TRUNCATED_MESSAGES_MESSAGE not in tool_report["errors"], "Errors should not be truncated when warnings can be truncated instead"
+      assert TRUNCATED_MESSAGES_MESSAGE not in tool_report["errors"], (
+        "Errors should not be truncated when warnings can be truncated instead"
+      )
   if test_case.get("expect_tool_errors_preserved"):
     for tool_key in test_case["expect_tool_errors_preserved"]:
-      assert TRUNCATED_MESSAGES_MESSAGE not in parsed["tool_reports"][tool_key]["errors"], f"{tool_key} errors should not be truncated"
+      assert TRUNCATED_MESSAGES_MESSAGE not in parsed["tool_reports"][tool_key]["errors"], (
+        f"{tool_key} errors should not be truncated"
+      )

--- a/services/entry-sheet-validator/src/entry_sheet_validator_lambda/handler.py
+++ b/services/entry-sheet-validator/src/entry_sheet_validator_lambda/handler.py
@@ -201,7 +201,10 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         # Log memory usage after validation
         post_validation_memory = get_memory_usage()
         logger.info(f"Memory usage after validation: {post_validation_memory}")
-        logger.info(f"Validation completed with error_code: {validation_result.error_code}, http_status_code: {http_status_code}")
+        logger.info(
+            f"Validation completed with error_code: {validation_result.error_code}, "
+            f"http_status_code: {http_status_code}"
+        )
         
         # Prepare the response data
         response_data = {

--- a/shared/src/hca_validation/data_dictionary/generate_dictionary.py
+++ b/shared/src/hca_validation/data_dictionary/generate_dictionary.py
@@ -72,7 +72,8 @@ def transform_schema_to_data_dictionary(schemaview: SchemaView) -> Dict[str, Any
             # Create the attribute entry with the exact structure requested
             attribute = {
                 "name": slot_info.name,
-                "title": slot_info.title if slot_info.title is not None else slot_info.name,  # Use title from schema if available
+                # Use title from schema if available
+                "title": slot_info.title if slot_info.title is not None else slot_info.name,
                 "description": slot_info.description or "",
                 "range": slot_info.range if slot_info.range is not None else "string",
                 "required": slot_info.required if slot_info.required is not None else False,

--- a/shared/src/hca_validation/entry_sheet_validator/apply_fixes.py
+++ b/shared/src/hca_validation/entry_sheet_validator/apply_fixes.py
@@ -58,7 +58,12 @@ def get_fix_value_ranges_by_entity_type(errors: List[SheetErrorInfo], entity_typ
   return value_ranges
 
 
-def apply_fixes(validation_result: SheetValidationResult, entity_types: List[str], worksheets: List[gspread.Worksheet], sheet_id: str) -> bool:
+def apply_fixes(
+    validation_result: SheetValidationResult,
+    entity_types: List[str],
+    worksheets: List[gspread.Worksheet],
+    sheet_id: str,
+) -> bool:
   """
   Apply available fixes from the given validation result to the given gspread worksheets
   

--- a/shared/src/hca_validation/entry_sheet_validator/find_fixes.py
+++ b/shared/src/hca_validation/entry_sheet_validator/find_fixes.py
@@ -20,14 +20,18 @@ sheet_value_fix_map = {
 }
 
 
-def get_fixed_value(entity_type: str, entity_induced_class: ClassDefinition, slot_name: str, value: str) -> Optional[str]:
+def get_fixed_value(
+    entity_type: str, entity_induced_class: ClassDefinition, slot_name: str, value: str
+) -> Optional[str]:
     # We only need to check `attributes`, since an induced class has nothing in `slots`
     if slot_name not in entity_induced_class.attributes:
         return None
     return sheet_value_fix_map.get((entity_type, slot_name, value))
 
 
-def add_fix_to_error_if_available(error: SheetErrorInfo, bionetwork: Optional[str], schemaview: SchemaView) -> SheetErrorInfo:
+def add_fix_to_error_if_available(
+    error: SheetErrorInfo, bionetwork: Optional[str], schemaview: SchemaView
+) -> SheetErrorInfo:
     # If the error doesn't have the required values, return it unchanged
     # Require string input value to avoid values that consist of the entire input row
     if error.entity_type is None or error.column is None or not isinstance(error.input, str):
@@ -41,7 +45,8 @@ def add_fix_to_error_if_available(error: SheetErrorInfo, bionetwork: Optional[st
 
 def add_fixes_to_errors(errors: List[SheetErrorInfo], bionetwork: Optional[str]) -> List[SheetErrorInfo]:
     """
-    Identify fixes for the given errors where possible, and return copies of the error objects with fixed values specified.
+    Identify fixes for the given errors where possible, and return copies of the error objects with fixed values
+    specified.
 
     Args:
         errors: List of error info objects

--- a/shared/src/hca_validation/entry_sheet_validator/process_sheet.py
+++ b/shared/src/hca_validation/entry_sheet_validator/process_sheet.py
@@ -2,7 +2,15 @@ import dataclasses
 from typing import List, Optional
 import gspread
 
-from .validate_sheet import SheetReadError, SheetValidationResult, init_apis, make_read_error_validation_result, make_validation_result_for_whole_sheet_error, read_sheet_with_service_account, validate_google_sheet
+from .validate_sheet import (
+    SheetReadError,
+    SheetValidationResult,
+    init_apis,
+    make_read_error_validation_result,
+    make_validation_result_for_whole_sheet_error,
+    read_sheet_with_service_account,
+    validate_google_sheet,
+)
 from .find_fixes import add_fixes_to_errors
 from .apply_fixes import apply_fixes
 from .common import default_entity_types
@@ -21,7 +29,8 @@ def process_google_sheet(
 
     Args:
         sheet_id: The ID of the Google Sheet (required)
-        entity_types: List of entity types to validate. Determines which worksheets are read and which schema is used for each.
+        entity_types: List of entity types to validate. Determines which worksheets are read and which schema is
+            used for each.
         bionetwork: Optional string identifying the biological network context.
         
     Returns:
@@ -42,10 +51,18 @@ def process_google_sheet(
         sheet_data, gspread_worksheets = read_sheet_with_service_account(sheet_id, entity_types, apis)
 
         # Get validation result
-        validation_result = validate_google_sheet(sheet_id, entity_types=entity_types, bionetwork=bionetwork, sheet_read_result=sheet_data)
+        validation_result = validate_google_sheet(
+            sheet_id,
+            entity_types=entity_types,
+            bionetwork=bionetwork,
+            sheet_read_result=sheet_data,
+        )
 
         # Add available fixes to errors
-        validation_result = dataclasses.replace(validation_result, errors=add_fixes_to_errors(validation_result.errors, bionetwork))
+        validation_result = dataclasses.replace(
+            validation_result,
+            errors=add_fixes_to_errors(validation_result.errors, bionetwork),
+        )
 
         # If the spreadsheet is editable, apply any available fixes
         if validation_result.spreadsheet_metadata is not None and validation_result.spreadsheet_metadata.can_edit:
@@ -53,7 +70,9 @@ def process_google_sheet(
 
             # If the spreadsheet was updated, re-validate
             if made_changes:
-                validation_result = validate_google_sheet(sheet_id, entity_types=entity_types, bionetwork=bionetwork, apis=apis)
+                validation_result = validate_google_sheet(
+                    sheet_id, entity_types=entity_types, bionetwork=bionetwork, apis=apis
+                )
                 # Verify that fixes are no longer available, and log an error otherwise
                 errors_with_fix_info = add_fixes_to_errors(validation_result.errors, bionetwork)
                 if any(error.input_fix is not None for error in errors_with_fix_info):

--- a/shared/src/hca_validation/entry_sheet_validator/validate_sheet.py
+++ b/shared/src/hca_validation/entry_sheet_validator/validate_sheet.py
@@ -232,7 +232,9 @@ def init_apis() -> ApiInstances:
         service_account_json = os.environ.get('GOOGLE_SERVICE_ACCOUNT', None)
     
     if not service_account_json:
-        error_msg = "No service account credentials found in GOOGLE_SERVICE_ACCOUNT environment variable or Secrets Extension"
+        error_msg = (
+            "No service account credentials found in GOOGLE_SERVICE_ACCOUNT environment variable or Secrets Extension"
+        )
         logger.error(error_msg)
         raise SheetReadError(error_code='auth_missing')
     
@@ -242,14 +244,26 @@ def init_apis() -> ApiInstances:
     # Check if the credentials contain unresolved secret references
     # Check for CloudFormation resolve syntax
     if service_account_json.startswith('{{resolve:'):
-        logger.error(f"Service account credentials were not resolved from Secrets Manager (CloudFormation syntax): {service_account_json[:50]}...")
-        logger.error("Check that the Lambda function has the correct permissions to access the secret and that the secret exists.")
+        logger.error(
+            f"Service account credentials were not resolved from Secrets Manager (CloudFormation syntax): "
+            f"{service_account_json[:50]}..."
+        )
+        logger.error(
+            "Check that the Lambda function has the correct permissions to access the secret and that the secret "
+            "exists."
+        )
         raise SheetReadError(error_code='auth_unresolved')
-    
+
     # Check for AWS shorthand syntax
     if service_account_json.startswith('aws:secretsmanager:'):
-        logger.error(f"Service account credentials were not resolved from Secrets Manager (AWS shorthand syntax): {service_account_json[:50]}...")
-        logger.error("Check that the Lambda function has the correct permissions to access the secret and that the secret exists.")
+        logger.error(
+            f"Service account credentials were not resolved from Secrets Manager (AWS shorthand syntax): "
+            f"{service_account_json[:50]}..."
+        )
+        logger.error(
+            "Check that the Lambda function has the correct permissions to access the secret and that the secret "
+            "exists."
+        )
         raise SheetReadError(error_code='auth_unresolved')
     
     try:
@@ -268,7 +282,10 @@ def init_apis() -> ApiInstances:
         if missing_fields:
             error_msg = f"Service account credentials missing required fields: {missing_fields}"
             logger.error(error_msg)
-            logger.error(f"Error: {error_msg}. Check that the service account JSON has the correct format and contains all required fields.")
+            logger.error(
+                f"Error: {error_msg}. Check that the service account JSON has the correct format and contains all "
+                "required fields."
+            )
             raise SheetReadError(error_code='auth_invalid_format')
         
         logger.info(f"Creating credentials object for service account: {credentials_dict.get('client_email')}")
@@ -347,10 +364,16 @@ def read_worksheets(
     all_worksheets = spreadsheet.worksheets()
     worksheets: List[gspread.Worksheet] = []
 
-    logger.info(f"Attempting to get worksheets of spreadsheet {sheet_id} at indices: {', '.join(str(i) for i in sheet_indices)}")
+    logger.info(
+        f"Attempting to get worksheets of spreadsheet {sheet_id} at indices: "
+        f"{', '.join(str(i) for i in sheet_indices)}"
+    )
     for sheet_index in sheet_indices:
         if not sheet_index < len(all_worksheets):
-            logger.error(f"Error accessing Google Sheet with service account: Worksheet index {sheet_index} not found in sheet {sheet_id}")
+            logger.error(
+                f"Error accessing Google Sheet with service account: Worksheet index {sheet_index} not found in "
+                f"sheet {sheet_id}"
+            )
             raise SheetReadError(error_code='worksheet_not_found', spreadsheet_metadata=spreadsheet_metadata)
         worksheets.append(all_worksheets[sheet_index])
     
@@ -360,7 +383,9 @@ def read_worksheets(
     
     logger.info("Retrieving worksheets data...")
 
-    api_result = spreadsheet.values_batch_get([gspread.utils.absolute_range_name(worksheet.title) for worksheet in worksheets])
+    api_result = spreadsheet.values_batch_get(
+        [gspread.utils.absolute_range_name(worksheet.title) for worksheet in worksheets]
+    )
 
     worksheets_info = []
 
@@ -368,7 +393,10 @@ def read_worksheets(
         data = gspread.utils.fill_gaps(value_range.get("values", [[]]))
          # Convert to DataFrame
         if len(data) >= 1:
-            logger.info(f"Successfully retrieved data from worksheet index {sheet_index}: {len(data)} rows, {len(data[0]) if data[0] else 0} columns")
+            logger.info(
+                f"Successfully retrieved data from worksheet index {sheet_index}: {len(data)} rows, "
+                f"{len(data[0]) if data[0] else 0} columns"
+            )
             source_columns = data[0]
             source_rows_start_index = 1
             df = pd.DataFrame(data[source_rows_start_index:], columns=source_columns)  # First row as header
@@ -382,11 +410,19 @@ def read_worksheets(
             )
         else:
             logger.warning(f"Sheet {sheet_id} (index {sheet_index}) appears to be empty")
-            raise SheetReadError(error_code="sheet_data_empty", spreadsheet_metadata=spreadsheet_metadata, worksheet_id=worksheet.id)
+            raise SheetReadError(
+                error_code="sheet_data_empty",
+                spreadsheet_metadata=spreadsheet_metadata,
+                worksheet_id=worksheet.id,
+            )
     
     return worksheets_info, worksheets
 
-def read_sheet_with_service_account(sheet_id: str, entity_types: List[str] = ["dataset"], apis: Optional[ApiInstances] = None) -> tuple[SpreadsheetInfo, List[gspread.Worksheet]]:
+def read_sheet_with_service_account(
+    sheet_id: str,
+    entity_types: List[str] = ["dataset"],
+    apis: Optional[ApiInstances] = None,
+) -> tuple[SpreadsheetInfo, List[gspread.Worksheet]]:
     """
     Read data from a Google Sheet using a service account for authentication.
     
@@ -417,7 +453,8 @@ def read_sheet_with_service_account(sheet_id: str, entity_types: List[str] = ["d
     if apis is None:
         apis = init_apis()
 
-    # Set up a variable to hold spreadsheet metadata so that it can be referenced if an unexpected type of error occurs after metadata is obtained
+    # Set up a variable to hold spreadsheet metadata so that it can be referenced if an unexpected type of error
+    # occurs after metadata is obtained
     spreadsheet_metadata = None
 
     try:
@@ -432,7 +469,10 @@ def read_sheet_with_service_account(sheet_id: str, entity_types: List[str] = ["d
 
             # Get the spreadsheet metadata from Drive
             logger.info(f"Attempting to get metadata for spreadsheet with ID: {sheet_id}")
-            file_metadata = apis.drive.files().get(fileId=sheet_id, fields="modifiedTime, lastModifyingUser(displayName, emailAddress), capabilities(canModifyContent)").execute()
+            file_metadata = apis.drive.files().get(
+                fileId=sheet_id,
+                fields="modifiedTime, lastModifyingUser(displayName, emailAddress), capabilities(canModifyContent)",
+            ).execute()
             last_updated_date = file_metadata["modifiedTime"]
             last_modifying_user = file_metadata.get("lastModifyingUser", {})
             last_updated_by = last_modifying_user.get("displayName", "unknown")
@@ -449,13 +489,18 @@ def read_sheet_with_service_account(sheet_id: str, entity_types: List[str] = ["d
             )
 
             # Get all worksheets
-            sheets_info, gspread_worksheets = read_worksheets(sheet_id, spreadsheet_metadata, spreadsheet, sheet_indices)
+            sheets_info, gspread_worksheets = read_worksheets(
+                sheet_id, spreadsheet_metadata, spreadsheet, sheet_indices
+            )
             
             return SpreadsheetInfo(spreadsheet_metadata, sheets_info), gspread_worksheets
         
         except gspread.exceptions.SpreadsheetNotFound:
             logger.error(f"Sheet {sheet_id} not found. Check if the sheet ID is correct.")
-            logger.error(f"Error accessing Google Sheet with service account: Sheet {sheet_id} not found or not accessible with provided credentials")
+            logger.error(
+                f"Error accessing Google Sheet with service account: Sheet {sheet_id} not found or not accessible "
+                "with provided credentials"
+            )
             raise SheetReadError(error_code='sheet_not_found', spreadsheet_metadata=spreadsheet_metadata)
         except PermissionError as e:
             logger.error(f"Permission denied accessing sheet {sheet_id}: {e}")
@@ -496,7 +541,8 @@ def normalize_dataframe_values(df: pd.DataFrame, schemaview: SchemaView, class_n
         slot.name: slot for slot in schemaview.class_induced_slots(class_name)
     }
 
-    # An integer should consist of an optional negative sign, followed by either a nonzero number of non-seperated digits,
+    # An integer should consist of an optional negative sign, followed by either a nonzero number of non-seperated
+    # digits,
     # or 1-3 digits followed by a nonzero number of comma-separated three-digit groups
     int_re = re.compile(r"^-?(?:\d+|\d{1,3}(?:,\d{3})+)$")
     
@@ -519,8 +565,13 @@ def normalize_dataframe_values(df: pd.DataFrame, schemaview: SchemaView, class_n
             parse_value = lambda v: parse_list(v, parse_item)
 
         # Map over the column, converting whitespace-only value to None and parsing other values where applicable
-        # Use the Series constructor with a list comprehension to ensure that values are put directly into an object series and can't be cast by Pandas
-        return pd.Series([None if value.strip() == "" else parse_value(value) for value in df[name]], dtype="object", index=df.index)
+        # Use the Series constructor with a list comprehension to ensure that values are put directly into an object
+        # series and can't be cast by Pandas
+        return pd.Series(
+            [None if value.strip() == "" else parse_value(value) for value in df[name]],
+            dtype="object",
+            index=df.index,
+        )
 
     return pd.DataFrame({
         name: map_column(name)
@@ -528,7 +579,9 @@ def normalize_dataframe_values(df: pd.DataFrame, schemaview: SchemaView, class_n
         if name and name.strip() != ""
     })
 
-def make_summary_without_entities(error_count: int, entity_types: List[str] = default_entity_types) -> dict[str, int | None]:
+def make_summary_without_entities(
+    error_count: int, entity_types: List[str] = default_entity_types
+) -> dict[str, int | None]:
     return {
         **{f"{entity_type}_count": None for entity_type in entity_types},
         "error_count": error_count
@@ -558,7 +611,9 @@ def make_validation_result_for_whole_sheet_error(
         errors=[error_info]
     )
 
-def make_read_error_validation_result(sheet_id: str, entity_types: List[str], read_error: SheetReadError) -> SheetValidationResult:
+def make_read_error_validation_result(
+    sheet_id: str, entity_types: List[str], read_error: SheetReadError
+) -> SheetValidationResult:
     import logging
     logger = logging.getLogger()
 
@@ -635,7 +690,8 @@ def validate_google_sheet(
     
     Args:
         sheet_id: The ID of the Google Sheet (required)
-        entity_types: List of entity types to validate. Determines which worksheets are read and which schema is used for each.
+        entity_types: List of entity types to validate. Determines which worksheets are read and which schema is
+            used for each.
         bionetwork: Optional string identifying the biological network context.
         
     Returns:
@@ -675,7 +731,8 @@ def validate_google_sheet(
         except SheetReadError as read_error:
             return make_read_error_validation_result(sheet_id, entity_types, read_error)
     
-    # Mapping from entity type to dataframe of rows to validate, with normalized values, and an index containing the original 1-based indices of the rows
+    # Mapping from entity type to dataframe of rows to validate, with normalized values, and an index containing
+    # the original 1-based indices of the rows
     rows_to_validate_by_entity_type = {}
 
     for entity_type, sheet_info in zip(entity_types, sheet_read_result.worksheets):
@@ -746,9 +803,14 @@ def validate_google_sheet(
     }
 
     # Check for sheets without rows to validate
-    entity_types_missing_rows = [entity_type for entity_type in entity_types if validation_summary[f"{entity_type}_count"] == 0]
+    entity_types_missing_rows = [
+        entity_type for entity_type in entity_types if validation_summary[f"{entity_type}_count"] == 0
+    ]
     if entity_types_missing_rows:
-        error_msg = f"No data found to validate starting from row 6 for entity type(s): {', '.join(entity_types_missing_rows)}"
+        error_msg = (
+            f"No data found to validate starting from row 6 for entity type(s): "
+            f"{', '.join(entity_types_missing_rows)}"
+        )
         logger.warning(error_msg)
         error_worksheet_id = None
         error_entity_type = None
@@ -792,7 +854,9 @@ def validate_google_sheet(
                 sheet_info=sheet_info
             )
         # Validate references and report results
-        references_validation_error = validate_referential_integrity(rows_to_validate_by_entity_type, schemaview, class_name)
+        references_validation_error = validate_referential_integrity(
+            rows_to_validate_by_entity_type, schemaview, class_name
+        )
         if references_validation_error:
             all_valid_in_worksheet = False
             handle_validation_error(
@@ -808,7 +872,9 @@ def validate_google_sheet(
             row_dict = row.to_dict()
             
             primary_key_field = sheet_structure_by_entity_type[entity_type]["primary_key_field"]
-            row_primary_key = f"{primary_key_field}:{row_dict[primary_key_field]}" if primary_key_field in row_dict else None
+            row_primary_key = (
+                f"{primary_key_field}:{row_dict[primary_key_field]}" if primary_key_field in row_dict else None
+            )
 
             # Validate the data
             try:
@@ -846,7 +912,10 @@ def validate_google_sheet(
             all_valid = False
             logger.warning(f"Validation found errors in some of the {len(rows_to_validate)} {entity_type} rows.")
             logger.warning("Please check the schema requirements and update the data accordingly.")
-            logger.info(f"Schema location: {os.path.join(os.path.dirname(__file__), f'../../schema/{entity_type}.yaml')}")
+            logger.info(
+                f"Schema location: "
+                f"{os.path.join(os.path.dirname(__file__), f'../../schema/{entity_type}.yaml')}"
+            )
     
     # Summary
     if all_valid:

--- a/shared/src/hca_validation/entry_sheet_validator/validate_sheet.py
+++ b/shared/src/hca_validation/entry_sheet_validator/validate_sheet.py
@@ -391,7 +391,7 @@ def read_worksheets(
 
     for sheet_index, worksheet, value_range in zip(sheet_indices, worksheets, api_result["valueRanges"]):
         data = gspread.utils.fill_gaps(value_range.get("values", [[]]))
-         # Convert to DataFrame
+        # Convert to DataFrame
         if len(data) >= 1:
             logger.info(
                 f"Successfully retrieved data from worksheet index {sheet_index}: {len(data)} rows, "
@@ -428,11 +428,12 @@ def read_sheet_with_service_account(
     
     Args:
         sheet_id (str): The ID of the Google Sheet to read.
-        sheet_indices (List[int], optional): The indices of the worksheets to read. Defaults to [0].
-        
+        entity_types (List[str], optional): The entity types whose worksheets to read. Defaults to ["dataset"].
+        apis (Optional[ApiInstances], optional): Pre-built API instances to use. If None, new ones are built.
+
     Returns:
         info: SpreadsheetInfo object containing list of WorksheetInfo corresponding to
-            the list of sheet indices
+            the provided entity_types
         worksheets: List of gspread worksheets
     
     Raises:

--- a/shared/src/hca_validation/entry_sheet_validator/validate_sheet.py
+++ b/shared/src/hca_validation/entry_sheet_validator/validate_sheet.py
@@ -541,7 +541,7 @@ def normalize_dataframe_values(df: pd.DataFrame, schemaview: SchemaView, class_n
         slot.name: slot for slot in schemaview.class_induced_slots(class_name)
     }
 
-    # An integer should consist of an optional negative sign, followed by either a nonzero number of non-seperated
+    # An integer should consist of an optional negative sign, followed by either a nonzero number of non-separated
     # digits,
     # or 1-3 digits followed by a nonzero number of comma-separated three-digit groups
     int_re = re.compile(r"^-?(?:\d+|\d{1,3}(?:,\d{3})+)$")

--- a/shared/src/hca_validation/schema_utils/__init__.py
+++ b/shared/src/hca_validation/schema_utils/__init__.py
@@ -4,4 +4,10 @@ HCA Validation Tools - Schema Utils Module
 This module provides utilities for interacting with the HCA schema.
 """
 
-from .schema_utils import load_schemaview, get_entity_class_name, get_class_entity_type, get_class_identifier_name, get_class_foreign_keys
+from .schema_utils import (
+    load_schemaview,
+    get_entity_class_name,
+    get_class_entity_type,
+    get_class_identifier_name,
+    get_class_foreign_keys,
+)

--- a/shared/src/hca_validation/schema_utils/schema_utils.py
+++ b/shared/src/hca_validation/schema_utils/schema_utils.py
@@ -25,7 +25,11 @@ schema_classes = {
 }
 
 # Derive mapping from class name to entity type
-entity_types_by_class = dict((class_name, entity_type) for entity_type, network_mapping in schema_classes.items() for _, class_name in network_mapping.items())
+entity_types_by_class = dict(
+    (class_name, entity_type)
+    for entity_type, network_mapping in schema_classes.items()
+    for _, class_name in network_mapping.items()
+)
 
 
 def load_schemaview():

--- a/shared/src/hca_validation/validator/validator.py
+++ b/shared/src/hca_validation/validator/validator.py
@@ -11,7 +11,11 @@ import pandas as pd
 from pydantic_core import InitErrorDetails, PydanticCustomError
 
 import hca_validation.schema.generated.core as schema
-from hca_validation.schema_utils.schema_utils import get_class_entity_type, get_class_foreign_keys, get_class_identifier_name
+from hca_validation.schema_utils.schema_utils import (
+    get_class_entity_type,
+    get_class_foreign_keys,
+    get_class_identifier_name,
+)
 
 # Map schema types and bionetworks to their corresponding class names
 schema_classes = {
@@ -104,9 +108,12 @@ def validate_id_uniqueness(data: pd.DataFrame, schemaview: SchemaView, class_nam
         ]
     )
 
-def validate_referential_integrity(data_by_entity_type: dict[str, pd.DataFrame], schemaview: SchemaView, class_name: str):
+def validate_referential_integrity(
+    data_by_entity_type: dict[str, pd.DataFrame], schemaview: SchemaView, class_name: str
+):
     """
-    Validate that no foreign references in the data for the specified class are missing corresponding rows in the foreign data.
+    Validate that no foreign references in the data for the specified class are missing corresponding rows in the
+    foreign data.
 
     Args:
         data_by_entity_type: Dict containing dataframes for all entity types, keyed by entity type
@@ -129,7 +136,11 @@ def validate_referential_integrity(data_by_entity_type: dict[str, pd.DataFrame],
             "foreign_key_value": fk_value
         }
         return {
-            "type": PydanticCustomError("missing_reference", "Referenced {foreign_entity_type} with ID {foreign_key_value} doesn't exist", ctx),
+            "type": PydanticCustomError(
+                "missing_reference",
+                "Referenced {foreign_entity_type} with ID {foreign_key_value} doesn't exist",
+                ctx,
+            ),
             "loc": (fk_slot_name,),
             "input": fk_value,
             "ctx": ctx
@@ -145,13 +156,20 @@ def validate_referential_integrity(data_by_entity_type: dict[str, pd.DataFrame],
         foreign_data = data_by_entity_type[fk_entity_type]
         foreign_id_name = get_class_identifier_name(schemaview, fk_class_name)
         if foreign_id_name not in foreign_data:
-            # If the foreign data's ID column doesn't exist, all non-empty reference IDs are missing a corresponding entry
+            # If the foreign data's ID column doesn't exist, all non-empty reference IDs are missing a corresponding
+            # entry
             missing_ref_rows = data[data[fk_slot_name].notna()]
         else:
             # Otherwise, get reference IDs that are not empty and are not in the foreign ID column
-            missing_ref_rows = data[data[fk_slot_name].notna() & ~data[fk_slot_name].isin(foreign_data[foreign_id_name])]
+            missing_ref_rows = data[
+                data[fk_slot_name].notna() & ~data[fk_slot_name].isin(foreign_data[foreign_id_name])
+            ]
         # Get iterable of row IDs; default to all-None if the ID column doesn't exist
-        missing_ref_row_ids = missing_ref_rows[id_name] if id_name in missing_ref_rows else itertools.repeat(None, len(missing_ref_rows))
+        missing_ref_row_ids = (
+            missing_ref_rows[id_name]
+            if id_name in missing_ref_rows
+            else itertools.repeat(None, len(missing_ref_rows))
+        )
         # Add errors to list
         line_errors.extend(
             get_row_error_details(index, id_value, fk_value, fk_slot_name, fk_entity_type)

--- a/shared/tests/test_entry_sheet_validator.py
+++ b/shared/tests/test_entry_sheet_validator.py
@@ -403,7 +403,7 @@ class TestReadSheetWithServiceAccount:
         # Set credentials to a string that looks like an unresolved secret reference
         original_env = os.environ.copy()
         os.environ['GOOGLE_SERVICE_ACCOUNT'] = 'aws:secretsmanager:dev/hca-atlas-tracker/google-service-account'
-        
+
         try:
             # The function should return read error containing only 'auth_unresolved' code when credentials weren't
             # resolved
@@ -426,7 +426,7 @@ class TestReadSheetWithServiceAccount:
             "project_id": "test-project"
             # Missing required fields: private_key, client_email, token_uri
         })
-        
+
         try:
             # The function should return read error containing only 'auth_invalid_format' code when credentials are
             # missing required fields

--- a/shared/tests/test_entry_sheet_validator.py
+++ b/shared/tests/test_entry_sheet_validator.py
@@ -54,7 +54,10 @@ SAMPLE_SHEET_DATA_WITH_CASTS = pd.DataFrame({
 })
 # Data to test parsing of integers, including invalid values that will be left as strings
 SAMPLE_SHEET_DATA_WITH_INTEGERS = pd.DataFrame({
-    'cell_number_loaded': ['', '', '', '', '1', '-23', '456', '', '7890', '1,234', '-56,789', '123,456', '78,901,234', '56,78', '9,012345'],
+    'cell_number_loaded': [
+        '', '', '', '', '1', '-23', '456', '', '7890', '1,234', '-56,789', '123,456', '78,901,234', '56,78',
+        '9,012345',
+    ],
     # Required to prevent the empty value above from being treated as the end of the data
     'sample_id': ['', '', '', '', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k']
 })
@@ -76,7 +79,10 @@ SAMPLE_DATASETS_SHEET_DATA_WITH_REFERENCES = pd.DataFrame({
 })
 SAMPLE_DONORS_SHEET_DATA_WITH_REFERENCES = pd.DataFrame({
     # References to datasets, which do have an ID column; contains empty cells and references to missing datasets
-    'dataset_id': ['', '', '', '', 'dataset_b', 'dataset_a', '', 'dataset_missing_a', 'dataset_missing_b', 'dataset_b', '', 'dataset_a', 'dataset_missing_b'],
+    'dataset_id': [
+        '', '', '', '', 'dataset_b', 'dataset_a', '', 'dataset_missing_a', 'dataset_missing_b', 'dataset_b', '',
+        'dataset_a', 'dataset_missing_b',
+    ],
     # Prevent the empty IDs from being treated as the end of the data
     'description': ['', '', '', '', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']
 })
@@ -89,7 +95,10 @@ SAMPLE_SAMPLES_SHEET_DATA_WITH_REFERENCES = pd.DataFrame({
 })
 # Data to test automatic fixes
 SAMPLE_SHEET_DATA_WITH_FIXES = pd.DataFrame({
-    'manner_of_death': ['', '', '', '', '1', 'unknown', 'not_applicable', '4', 'not applicable', 'not a manner of death', 'not_applicable'],
+    'manner_of_death': [
+        '', '', '', '', '1', 'unknown', 'not_applicable', '4', 'not applicable', 'not a manner of death',
+        'not_applicable',
+    ],
 })
 
 # Data to be compared with derived values
@@ -189,7 +198,8 @@ def _test_validation_with_mock_sheets_response(
     expected_error_code='validation_error',
     additional_arguments={}
 ) -> SheetValidationResult:
-    """Helper function for testing validation with service account access, for a validation function with a call signature like validate_google_sheet."""
+    """Helper function for testing validation with service account access, for a validation function with a call
+    signature like validate_google_sheet."""
 
     # Mock successful service account read
     mock_spreadsheet_info = _create_mock_spreadsheet_info(
@@ -206,7 +216,9 @@ def _test_validation_with_mock_sheets_response(
     entity_types = default_entity_types[:len(mock_spreadsheet_info.worksheets)]
 
     # Run validation
-    validation_result = validation_function(PUBLIC_SHEET_ID, bionetwork=bionetwork, entity_types=entity_types, **additional_arguments)
+    validation_result = validation_function(
+        PUBLIC_SHEET_ID, bionetwork=bionetwork, entity_types=entity_types, **additional_arguments
+    )
 
     if expect_read_call:
         # If expected, verify service account method was used
@@ -237,7 +249,9 @@ class TestReadSheetWithServiceAccount:
             "type": "service_account",
             "project_id": "test-project",
             "private_key_id": "test-key-id",
-            "private_key": "-----BEGIN PRIVATE KEY-----\nMOCK_PRIVATE_KEY_FOR_TESTING_ONLY\n-----END PRIVATE KEY-----\n",
+            "private_key": (
+                "-----BEGIN PRIVATE KEY-----\nMOCK_PRIVATE_KEY_FOR_TESTING_ONLY\n-----END PRIVATE KEY-----\n"
+            ),
             "client_email": "test@test-project.iam.gserviceaccount.com",
             "client_id": "123456789",
             "auth_uri": "https://accounts.google.com/o/oauth2/auth",
@@ -298,7 +312,14 @@ class TestReadSheetWithServiceAccount:
     @patch('hca_validation.entry_sheet_validator.validate_sheet.create_requests_session')
     @patch('gspread.authorize')
     @patch('google.oauth2.service_account.Credentials.from_service_account_info')
-    def test_with_service_account_credentials(self, mock_credentials, mock_authorize, mock_create_requests_session, mock_build, mock_env_with_credentials):
+    def test_with_service_account_credentials(
+        self,
+        mock_credentials,
+        mock_authorize,
+        mock_create_requests_session,
+        mock_build,
+        mock_env_with_credentials,
+    ):
         """Test reading a sheet with service account credentials."""
         # Mock the gspread client
         mock_client = MagicMock()
@@ -336,7 +357,14 @@ class TestReadSheetWithServiceAccount:
     @patch('hca_validation.entry_sheet_validator.validate_sheet.create_requests_session')
     @patch('gspread.authorize')
     @patch('google.oauth2.service_account.Credentials.from_service_account_info')
-    def test_pre_initialize_apis(self, mock_credentials, mock_authorize, mock_create_requests_session, mock_build, mock_env_with_credentials):
+    def test_pre_initialize_apis(
+        self,
+        mock_credentials,
+        mock_authorize,
+        mock_create_requests_session,
+        mock_build,
+        mock_env_with_credentials,
+    ):
         """Test reading a sheet with pre-initialized APIs."""
 
         # Mock pre-initialized APIs
@@ -377,7 +405,8 @@ class TestReadSheetWithServiceAccount:
         os.environ['GOOGLE_SERVICE_ACCOUNT'] = 'aws:secretsmanager:dev/hca-atlas-tracker/google-service-account'
         
         try:
-            # The function should return read error containing only 'auth_unresolved' code when credentials weren't resolved
+            # The function should return read error containing only 'auth_unresolved' code when credentials weren't
+            # resolved
             with pytest.raises(SheetReadError) as error_info:
                 read_sheet_with_service_account(PUBLIC_SHEET_ID)
             assert error_info.value.error_code == 'auth_unresolved'
@@ -399,7 +428,8 @@ class TestReadSheetWithServiceAccount:
         })
         
         try:
-            # The function should return read error containing only 'auth_invalid_format' code when credentials are missing required fields
+            # The function should return read error containing only 'auth_invalid_format' code when credentials are
+            # missing required fields
             with pytest.raises(SheetReadError) as error_info:
                 read_sheet_with_service_account(PUBLIC_SHEET_ID)
             assert error_info.value.error_code == 'auth_invalid_format'
@@ -413,7 +443,13 @@ class TestReadSheetWithServiceAccount:
     @patch('hca_validation.entry_sheet_validator.validate_sheet.create_requests_session')
     @patch('gspread.authorize')
     @patch('google.oauth2.service_account.Credentials.from_service_account_info')
-    def test_sheet_not_found(self, mock_credentials, mock_authorize, mock_create_requests_session, mock_env_with_credentials):
+    def test_sheet_not_found(
+        self,
+        mock_credentials,
+        mock_authorize,
+        mock_create_requests_session,
+        mock_env_with_credentials,
+    ):
         """Test handling of sheet not found error."""
         # Mock the gspread client to raise SpreadsheetNotFound
         mock_client = MagicMock()
@@ -434,7 +470,14 @@ class TestReadSheetWithServiceAccount:
     @patch('hca_validation.entry_sheet_validator.validate_sheet.create_requests_session')
     @patch('gspread.authorize')
     @patch('google.oauth2.service_account.Credentials.from_service_account_info')
-    def test_worksheet_not_found(self, mock_credentials, mock_authorize, mock_create_requests_session, mock_build, mock_env_with_credentials):
+    def test_worksheet_not_found(
+        self,
+        mock_credentials,
+        mock_authorize,
+        mock_create_requests_session,
+        mock_build,
+        mock_env_with_credentials,
+    ):
         """Test handling of missing worksheet."""
         # Mock the gspread client
         mock_client = MagicMock()
@@ -443,7 +486,8 @@ class TestReadSheetWithServiceAccount:
         mock_client.open_by_key.return_value = mock_sheet
         mock_authorize.return_value = mock_client
 
-        # The function should return read error containing 'worksheet_not_found' code and spreadsheet metadata when the worksheet is not found
+        # The function should return read error containing 'worksheet_not_found' code and spreadsheet metadata when
+        # the worksheet is not found
         with pytest.raises(SheetReadError) as error_info:
             read_sheet_with_service_account(PUBLIC_SHEET_ID)
         assert error_info.value.error_code == 'worksheet_not_found'
@@ -457,7 +501,13 @@ class TestReadSheetWithServiceAccount:
     @patch('hca_validation.entry_sheet_validator.validate_sheet.create_requests_session')
     @patch('gspread.authorize')
     @patch('google.oauth2.service_account.Credentials.from_service_account_info')
-    def test_api_error(self, mock_credentials, mock_authorize, mock_create_requests_session, mock_env_with_credentials):
+    def test_api_error(
+        self,
+        mock_credentials,
+        mock_authorize,
+        mock_create_requests_session,
+        mock_env_with_credentials,
+    ):
         """Test handling of API error."""
         # Mock the gspread client
         mock_client = MagicMock()
@@ -479,7 +529,14 @@ class TestReadSheetWithServiceAccount:
     @patch('hca_validation.entry_sheet_validator.validate_sheet.create_requests_session')
     @patch('gspread.authorize')
     @patch('google.oauth2.service_account.Credentials.from_service_account_info')
-    def test_generic_exception_with_metadata(self, mock_credentials, mock_authorize, mock_create_requests_session, mock_build, mock_env_with_credentials):
+    def test_generic_exception_with_metadata(
+        self,
+        mock_credentials,
+        mock_authorize,
+        mock_create_requests_session,
+        mock_build,
+        mock_env_with_credentials,
+    ):
         """Test handling of generic exception after spreadsheet metadata is obtained."""
         # Mock the gspread client
         mock_client = MagicMock()
@@ -511,8 +568,11 @@ class TestValidateGoogleSheet:
     @patch('hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account')
     def test_service_account_access_with_bionetwork(self, mock_read_service_account):
         """Test validation using network-specific model."""
-        result = _test_validation_with_mock_sheets_response(validate_google_sheet, mock_read_service_account, bionetwork="gut")
-        # We expect there to be an error referencing `doublet_detection`, a field required by the Gut Network model but not by the default model
+        result = _test_validation_with_mock_sheets_response(
+            validate_google_sheet, mock_read_service_account, bionetwork="gut"
+        )
+        # We expect there to be an error referencing `doublet_detection`, a field required by the Gut Network model
+        # but not by the default model
         assert any(error.column == "doublet_detection" for error in result.errors)
 
     @patch('hca_validation.validator.validate')
@@ -526,7 +586,9 @@ class TestValidateGoogleSheet:
             return DEFAULT
         mock_validate.side_effect = save_data
         # Validate the mock sheet
-        _test_validation_with_mock_sheets_response(validate_google_sheet, mock_read_service_account, sheet_data=SAMPLE_SHEET_DATA_WITH_CASTS)
+        _test_validation_with_mock_sheets_response(
+            validate_google_sheet, mock_read_service_account, sheet_data=SAMPLE_SHEET_DATA_WITH_CASTS
+        )
         # Confirm that values were converted as expected
         assert validated_dicts == SAMPLE_SHEET_DATA_WITH_CASTS_EXPECTED_NORMALIZATION
 
@@ -541,14 +603,19 @@ class TestValidateGoogleSheet:
             return DEFAULT
         mock_validate.side_effect = save_data
         # Validate the mock sheet
-        _test_validation_with_mock_sheets_response(validate_google_sheet, mock_read_service_account, samples_sheet_data=SAMPLE_SHEET_DATA_WITH_INTEGERS)
+        _test_validation_with_mock_sheets_response(
+            validate_google_sheet,
+            mock_read_service_account,
+            samples_sheet_data=SAMPLE_SHEET_DATA_WITH_INTEGERS,
+        )
         # Confirm that values were converted as expected
         assert validated_dicts == SAMPLE_SHEET_DATA_WITH_INTEGERS_EXPECTED_NORMALIZATION
 
     @patch('hca_validation.validator.validate')
     @patch('hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account')
     def test_valid_and_missing_int_normalization_before_validation(self, mock_read_service_account, mock_validate):
-        """Test normalization of integer fields passed to the validation function, with only valid and missing integers."""
+        """Test normalization of integer fields passed to the validation function, with only valid and missing
+        integers."""
         # Store dicts that the validation function is called with
         validated_dicts = []
         def save_data(data, class_name):
@@ -556,7 +623,11 @@ class TestValidateGoogleSheet:
             return DEFAULT
         mock_validate.side_effect = save_data
         # Validate the mock sheet
-        _test_validation_with_mock_sheets_response(validate_google_sheet, mock_read_service_account, samples_sheet_data=SAMPLE_SHEET_DATA_WITH_VALID_AND_MISSING_INTEGERS)
+        _test_validation_with_mock_sheets_response(
+            validate_google_sheet,
+            mock_read_service_account,
+            samples_sheet_data=SAMPLE_SHEET_DATA_WITH_VALID_AND_MISSING_INTEGERS,
+        )
         # Confirm that values were converted as expected
         assert validated_dicts == SAMPLE_SHEET_DATA_WITH_VALID_AND_MISSING_INTEGERS_EXPECTED_NORMALIZATION
 
@@ -576,18 +647,29 @@ class TestValidateGoogleSheet:
         assert last_class_name_info["value"] == "Dataset"
         mock_read_service_account.reset_mock()
         # Validate the mock sheet with Gut Network dataset model
-        _test_validation_with_mock_sheets_response(validate_google_sheet, mock_read_service_account, bionetwork="gut")
+        _test_validation_with_mock_sheets_response(
+            validate_google_sheet, mock_read_service_account, bionetwork="gut"
+        )
         # Confirm that correct class was used
         assert last_class_name_info["value"] == "GutDataset"
 
     @patch('hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account')
     def test_duplicate_ids(self, mock_read_service_account):
         """Test validation of duplicate IDs."""
-        result = _test_validation_with_mock_sheets_response(validate_google_sheet, mock_read_service_account, sheet_data=SAMPLE_SHEET_DATA_WITH_DUPLICATE_IDS)
-        # Based on the mock data, expect five duplicate ID errors, for IDs "foo" and "baz" but not "bar" (which is not duplicated) or None (which is not an ID)
+        result = _test_validation_with_mock_sheets_response(
+            validate_google_sheet,
+            mock_read_service_account,
+            sheet_data=SAMPLE_SHEET_DATA_WITH_DUPLICATE_IDS,
+        )
+        # Based on the mock data, expect five duplicate ID errors, for IDs "foo" and "baz" but not "bar" (which is
+        # not duplicated) or None (which is not an ID)
         duplicate_id_errors = [error for error in result.errors if error.message.startswith("Duplicate identifier ")]
         assert len(duplicate_id_errors) == 5
-        assert all(("foo" in error.message or "baz" in error.message) and not ("bar" in error.message or "None" in error.message) for error in duplicate_id_errors)
+        assert all(
+            ("foo" in error.message or "baz" in error.message)
+            and not ("bar" in error.message or "None" in error.message)
+            for error in duplicate_id_errors
+        )
 
     @patch('hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account')
     def test_referential_integrity(self, mock_read_service_account):
@@ -602,8 +684,14 @@ class TestValidateGoogleSheet:
         # Based on the mock data, expect:
         # - Three missing reference errors for donors
         # - Four missing reference errors for samples, all for donor_id
-        donors_reference_errors = [error for error in result.errors if error.entity_type == "donor" and "doesn't exist" in error.message]
-        samples_reference_errors = [error for error in result.errors if error.entity_type == "sample" and "doesn't exist" in error.message]
+        donors_reference_errors = [
+            error for error in result.errors
+            if error.entity_type == "donor" and "doesn't exist" in error.message
+        ]
+        samples_reference_errors = [
+            error for error in result.errors
+            if error.entity_type == "sample" and "doesn't exist" in error.message
+        ]
         assert len(donors_reference_errors) == 3
         assert len(samples_reference_errors) == 4
         assert all(error.column == "donor_id" for error in samples_reference_errors)
@@ -611,7 +699,11 @@ class TestValidateGoogleSheet:
     @patch('hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account')
     def test_available_fixes(self, mock_read_service_account):
         """Test that validate_google_sheet does not provide fixes on its own."""
-        result = _test_validation_with_mock_sheets_response(validate_google_sheet, mock_read_service_account, donors_sheet_data=SAMPLE_SHEET_DATA_WITH_FIXES)
+        result = _test_validation_with_mock_sheets_response(
+            validate_google_sheet,
+            mock_read_service_account,
+            donors_sheet_data=SAMPLE_SHEET_DATA_WITH_FIXES,
+        )
         assert all(error.input_fix is None for error in result.errors)
 
     @patch('hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account')
@@ -656,7 +748,9 @@ class TestValidateGoogleSheet:
         assert validation_result.successful is False
         assert validation_result.spreadsheet_metadata is None
         assert validation_result.error_code == 'auth_missing'
-        assert validation_result.summary  == {"dataset_count": None, "donor_count": None, "sample_count": None, "error_count": 1}
+        assert validation_result.summary == {
+            "dataset_count": None, "donor_count": None, "sample_count": None, "error_count": 1
+        }
 
     def test_invalid_bionetwork(self):
         """Test validation when `bionetwork` parameter has an invalid value."""
@@ -667,7 +761,8 @@ class TestValidateGoogleSheet:
     
     @patch('hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account')
     def test_sheet_without_entities(self, mock_read_service_account):
-        """Test that entity counts are still returned when an error is generated due to a sheet lacking rows to validate."""
+        """Test that entity counts are still returned when an error is generated due to a sheet lacking rows to
+        validate."""
         result = _test_validation_with_mock_sheets_response(
             validate_google_sheet,
             mock_read_service_account,
@@ -694,7 +789,8 @@ class TestProcessGoogleSheet:
             donors_sheet_data=SAMPLE_SHEET_DATA_WITH_FIXES,
             expected_apis_parameter=mock_apis
         )
-        # Based on the mock data, expect three errors in the manner_of_death column, with appropriate input values and fixed values (or lack thereof)
+        # Based on the mock data, expect three errors in the manner_of_death column, with appropriate input values
+        # and fixed values (or lack thereof)
         mod_errors = [error for error in result.errors if error.column == "manner_of_death"]
         assert len(mod_errors) == 3
         assert mod_errors[0].input == "not_applicable"
@@ -720,7 +816,8 @@ class TestProcessGoogleSheet:
         mock_read_service_account_a.return_value = mock_read_result
         mock_read_service_account_b.return_value = mock_read_result
         process_google_sheet(PUBLIC_SHEET_ID, entity_types=["dataset", "donor"])
-        # Verify that batch_update was called only for the donors worksheet, and with the values expected for the mock data
+        # Verify that batch_update was called only for the donors worksheet, and with the values expected for the
+        # mock data
         mock_datasets_worksheet.batch_update.assert_not_called()
         mock_donors_worksheet.batch_update.assert_called_once_with(SAMPLE_SHEET_DATA_WITH_FIXES_EXPECTED_VALUE_RANGES)
         # Verify that spreadsheet was read twice
@@ -751,7 +848,8 @@ class TestProcessGoogleSheet:
     @patch('hca_validation.entry_sheet_validator.process_sheet.init_apis')
     @patch('hca_validation.entry_sheet_validator.process_sheet.read_sheet_with_service_account')
     def test_early_read_error(self, mock_read_service_account, mock_init_apis):
-        """Test that a validation result object is properly returned when the initial read call raises a SheetReadError."""
+        """Test that a validation result object is properly returned when the initial read call raises a
+        SheetReadError."""
         
         # Mock APIs
         mock_apis = MagicMock()
@@ -774,12 +872,16 @@ class TestProcessGoogleSheet:
         assert validation_result.successful is False
         assert validation_result.spreadsheet_metadata is None
         assert validation_result.error_code == 'sheet_not_found'
-        assert validation_result.summary  == {"dataset_count": None, "donor_count": None, "sample_count": None, "error_count": 1}
+        assert validation_result.summary == {
+            "dataset_count": None, "donor_count": None, "sample_count": None, "error_count": 1
+        }
 
     @patch('hca_validation.entry_sheet_validator.process_sheet.init_apis')
     @patch('hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account')
     @patch('hca_validation.entry_sheet_validator.process_sheet.read_sheet_with_service_account')
-    def test_google_error_while_applying_fixes(self, mock_read_service_account_a, mock_read_service_account_b, mock_init_apis):
+    def test_google_error_while_applying_fixes(
+        self, mock_read_service_account_a, mock_read_service_account_b, mock_init_apis
+    ):
         """Test that a validation result object is properly returned when an API error occurs while applying fixes."""
 
         mock_apis = MagicMock()


### PR DESCRIPTION
## Summary
- Wraps 288 E501 violations across the repo (services/dataset-validator, shared, packages/hca-anndata-tools, services/entry-sheet-validator) via mechanical line reflows — no functional changes.
- Removes `ignore = ["E501"]` from `ruff.toml` so the rule is enforced going forward.
- Excludes `packages/hca-anndata-tools/src/hca_anndata_tools/schema/core.py` from ruff — it's a bundled copy of the generated `shared/src/hca_validation/schema/generated/core.py` and shouldn't be hand-edited.

Closes #315

## Test plan
- [x] `ruff check . --select E501` — zero violations
- [x] `make typecheck` — 0 errors across all four pyright configs
- [x] `shared/tests/` — 33/33 pass (non-integration)
- [x] `services/dataset-validator/tests/` — 38/38 pass
- [x] `packages/hca-anndata-tools/tests/` — 208/208 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)