### PR TITLE
feat: add normalize_raw tool for files with raw counts in X

### DIFF
--- a/packages/hca-anndata-mcp/src/hca_anndata_mcp/server.py
+++ b/packages/hca-anndata-mcp/src/hca_anndata_mcp/server.py
@@ -11,6 +11,7 @@ from hca_anndata_tools import (
     get_summary,
     list_uns_fields,
     locate_files,
+    normalize_raw,
     replace_placeholder_values,
     set_uns,
     validate_marker_genes,
@@ -34,7 +35,9 @@ mcp = FastMCP(
         "validate_marker_genes to check CAP marker genes against var, "
         "copy_cap_annotations to copy CAP annotations from a source into an HCA target file, "
         "replace_placeholder_values to replace banned placeholder values with NaN in obs columns, "
-        "and compress_h5ad to rewrite a file with HDF5 gzip compression applied."
+        "compress_h5ad to rewrite a file with HDF5 gzip compression applied, "
+        "and normalize_raw to move raw counts from X to raw.X and normalize X "
+        "(normalize_total + log1p)."
     ),
 )
 
@@ -52,3 +55,4 @@ mcp.tool()(validate_marker_genes)
 mcp.tool()(copy_cap_annotations)
 mcp.tool()(replace_placeholder_values)
 mcp.tool()(compress_h5ad)
+mcp.tool()(normalize_raw)

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/__init__.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/__init__.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     from .edit import list_uns_fields, replace_placeholder_values, set_uns
     from .files import locate_files
     from .marker_genes import validate_marker_genes
+    from .normalize import normalize_raw
     from .plot import plot_embedding
     from .stats import get_descriptive_stats
     from .storage import get_storage_info
@@ -47,6 +48,7 @@ _LAZY_IMPORTS = {
     "validate_marker_genes": ".marker_genes",
     "copy_cap_annotations": ".copy_cap",
     "compress_h5ad": ".compress",
+    "normalize_raw": ".normalize",
 }
 
 __all__ = list(_LAZY_IMPORTS)  # pyright: ignore[reportUnsupportedDunderAll]

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/normalize.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/normalize.py
@@ -21,8 +21,9 @@ def _inspect_x_file(path: str) -> tuple[bool, np.ndarray]:
     """Return (has_raw, x_sample) read directly from the h5ad via h5py.
 
     Fail-fast inspection to avoid loading multi-GB files before checking
-    preconditions. For sparse X we sample X/data; for dense X we sample
-    the first row.
+    preconditions. Samples up to _SAMPLE_SIZE values from X: for sparse,
+    the first entries of X/data; for dense, the first _SAMPLE_SIZE cells
+    of row 0.
     """
     with h5py.File(path, "r") as f:
         has_raw = "raw/X" in f
@@ -32,7 +33,7 @@ def _inspect_x_file(path: str) -> tuple[bool, np.ndarray]:
             n = min(_SAMPLE_SIZE, len(data))  # pyright: ignore[reportArgumentType]
             sample = np.asarray(data[:n])  # pyright: ignore[reportIndexIssue]
         else:
-            sample = np.asarray(x[:1]).ravel()  # pyright: ignore[reportIndexIssue]
+            sample = np.asarray(x[0, :_SAMPLE_SIZE])  # pyright: ignore[reportIndexIssue]
         return has_raw, sample
 
 
@@ -43,9 +44,13 @@ def normalize_raw(path: str) -> dict:
     library-size-normalized, log1p-transformed values in X. Uses the
     scanpy recipe `normalize_total(target_sum=1e4)` + `log1p`.
 
-    Fails if raw.X already exists, or if X contains negative or non-integer
-    values (which would indicate it's already normalized). This is an
-    explicit wrangler action — there is no force flag.
+    Fails if raw.X already exists, or if a sample of X (up to 2000 values)
+    contains negative or non-integer values (which would indicate it's
+    already normalized). The X check is a fail-fast heuristic, not a
+    full-matrix guarantee — a file that looks like raw counts in its first
+    few thousand entries but has fractional values elsewhere will pass
+    this check. This is an explicit wrangler action — there is no force
+    flag.
 
     The output is written as an edit snapshot (`<stem>-edit-<ts>.h5ad`)
     and the operation is logged in `uns['provenance']['edit_history']`.
@@ -67,9 +72,9 @@ def normalize_raw(path: str) -> dict:
             return {"error": "raw.X already exists — refusing to overwrite"}
         if sample.size > 0:
             if (sample < 0).any():
-                return {"error": "X contains negative values — not raw counts"}
+                return {"error": "X sample contains negative values — not raw counts"}
             if not np.all(np.mod(sample, 1) == 0):
-                return {"error": "X contains non-integer values — appears already normalized"}
+                return {"error": "X sample contains non-integer values — appears already normalized"}
 
         with open_h5ad(path, backed=None) as adata:
             adata.raw = adata.copy()

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/normalize.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/normalize.py
@@ -1,0 +1,109 @@
+"""Normalize raw counts in X to standard CXG layout (normalized in X, raw in raw.X)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import h5py
+import numpy as np
+
+from . import __version__
+from ._io import open_h5ad
+from .write import resolve_latest, write_h5ad
+
+_TARGET_SUM = 1e4
+# Sample ~2000 X entries for the integer/sign pre-check; enough to catch
+# normalized data on real files while keeping the h5py read trivial.
+_SAMPLE_SIZE = 2000
+
+
+def _inspect_x_file(path: str) -> tuple[bool, np.ndarray]:
+    """Return (has_raw, x_sample) read directly from the h5ad via h5py.
+
+    Fail-fast inspection to avoid loading multi-GB files before checking
+    preconditions. For sparse X we sample X/data; for dense X we sample
+    the first row.
+    """
+    with h5py.File(path, "r") as f:
+        has_raw = "raw" in f
+        x = f["X"]
+        if isinstance(x, h5py.Group) and "data" in x:
+            data = x["data"]
+            n = min(_SAMPLE_SIZE, len(data))  # pyright: ignore[reportArgumentType]
+            sample = np.asarray(data[:n])  # pyright: ignore[reportIndexIssue]
+        else:
+            sample = np.asarray(x[:1]).ravel()  # pyright: ignore[reportIndexIssue]
+        return has_raw, sample
+
+
+def normalize_raw(path: str) -> dict:
+    """Normalize raw counts in X, moving originals to raw.X.
+
+    Produces the standard CXG layout: raw integer counts in raw.X, and
+    library-size-normalized, log1p-transformed values in X. Uses the
+    scanpy recipe `normalize_total(target_sum=1e4)` + `log1p`.
+
+    Fails if raw.X already exists, or if X contains negative or non-integer
+    values (which would indicate it's already normalized). This is an
+    explicit wrangler action — there is no force flag.
+
+    The output is written as an edit snapshot (`<stem>-edit-<ts>.h5ad`)
+    and the operation is logged in `uns['provenance']['edit_history']`.
+
+    Args:
+        path: Path to an .h5ad file.
+
+    Returns:
+        Dict with 'output_path', 'n_obs', 'n_vars', 'target_sum' on success,
+        or {'error': ...} on failure.
+    """
+    try:
+        import scanpy as sc
+
+        path = resolve_latest(path)
+
+        has_raw, sample = _inspect_x_file(path)
+        if has_raw:
+            return {"error": "raw.X already exists — refusing to overwrite"}
+        if sample.size > 0:
+            if (sample < 0).any():
+                return {"error": "X contains negative values — not raw counts"}
+            if not np.all(np.mod(sample, 1) == 0):
+                return {"error": "X contains non-integer values — appears already normalized"}
+
+        with open_h5ad(path, backed=None) as adata:
+            adata.raw = adata.copy()
+            sc.pp.normalize_total(adata, target_sum=_TARGET_SUM)
+            sc.pp.log1p(adata)
+
+            n_obs, n_vars = adata.n_obs, adata.n_vars
+            entry = {
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "tool": "hca-anndata-tools",
+                "tool_version": __version__,
+                "operation": "normalize_raw",
+                "description": (
+                    f"Moved raw counts to raw.X and normalized X with "
+                    f"normalize_total(target_sum={_TARGET_SUM:g}) + log1p"
+                ),
+                "details": {
+                    "target_sum": _TARGET_SUM,
+                    "n_obs": n_obs,
+                    "n_vars": n_vars,
+                },
+            }
+
+            result = write_h5ad(adata, path, [entry])
+
+        if "error" in result:
+            return result
+
+        return {
+            "output_path": result["output_path"],
+            "n_obs": n_obs,
+            "n_vars": n_vars,
+            "target_sum": _TARGET_SUM,
+        }
+
+    except Exception as e:
+        return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/normalize.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/normalize.py
@@ -25,7 +25,7 @@ def _inspect_x_file(path: str) -> tuple[bool, np.ndarray]:
     the first row.
     """
     with h5py.File(path, "r") as f:
-        has_raw = "raw" in f
+        has_raw = "raw/X" in f
         x = f["X"]
         if isinstance(x, h5py.Group) and "data" in x:
             data = x["data"]

--- a/packages/hca-anndata-tools/tests/test_normalize.py
+++ b/packages/hca-anndata-tools/tests/test_normalize.py
@@ -1,0 +1,139 @@
+"""Tests for normalize_raw."""
+
+import json
+
+import anndata as ad
+import h5py
+import numpy as np
+import pandas as pd
+import pytest
+import scipy.sparse as sp
+from hca_anndata_tools.normalize import normalize_raw
+
+
+def _write_raw_counts(path, *, density=0.3, n_obs=40, n_vars=15) -> None:
+    """Write an h5ad with raw integer counts in X and no raw.X."""
+    rng = np.random.default_rng(7)
+    dense = rng.integers(1, 10, size=(n_obs, n_vars)).astype(np.float32)
+    mask = rng.random((n_obs, n_vars)) < density
+    masked = dense * mask
+    # Guarantee at least one nonzero per row so normalize_total doesn't warn.
+    masked[np.arange(n_obs), rng.integers(0, n_vars, size=n_obs)] = dense[
+        np.arange(n_obs), rng.integers(0, n_vars, size=n_obs)
+    ]
+    X = sp.csr_matrix(masked)
+    obs = pd.DataFrame(
+        {"cell_type": pd.Categorical(rng.choice(["A", "B"], n_obs))},
+        index=[f"c{i}" for i in range(n_obs)],  # pyright: ignore[reportArgumentType]
+    )
+    var = pd.DataFrame(index=[f"g{i}" for i in range(n_vars)])  # pyright: ignore[reportArgumentType]
+    adata = ad.AnnData(X=X, obs=obs, var=var)
+    adata.write_h5ad(path)
+
+
+@pytest.fixture
+def raw_counts_h5ad(tmp_path):
+    path = tmp_path / "raw_counts.h5ad"
+    _write_raw_counts(path)
+    return path
+
+
+def test_normalize_raw_moves_counts_and_normalizes(raw_counts_h5ad):
+    original = ad.read_h5ad(raw_counts_h5ad)
+
+    result = normalize_raw(str(raw_counts_h5ad))
+    assert "error" not in result
+    assert result["target_sum"] == 1e4
+    assert result["n_obs"] == original.n_obs
+    assert result["n_vars"] == original.n_vars
+
+    out = ad.read_h5ad(result["output_path"])
+    assert out.raw is not None
+    np.testing.assert_array_equal(out.raw.X.toarray(), original.X.toarray())  # pyright: ignore[reportAttributeAccessIssue]
+
+    # X should now be normalized + log1p: non-negative floats, mostly non-integer
+    x_dense = out.X.toarray()  # pyright: ignore[reportAttributeAccessIssue]
+    assert (x_dense >= 0).all()
+    assert not np.all(np.mod(x_dense[x_dense > 0], 1) == 0)
+
+
+def test_normalize_raw_fails_when_raw_exists(raw_counts_h5ad):
+    # First normalize succeeds
+    result = normalize_raw(str(raw_counts_h5ad))
+    assert "error" not in result
+    # Second normalize on the output should fail — raw.X is now present
+    result2 = normalize_raw(result["output_path"])
+    assert "error" in result2
+    assert "raw" in result2["error"].lower()
+
+
+def test_normalize_raw_fails_when_x_has_non_integer(tmp_path):
+    rng = np.random.default_rng(3)
+    X = rng.random((20, 10)).astype(np.float32)  # floats in [0, 1)
+    adata = ad.AnnData(
+        X=sp.csr_matrix(X),
+        obs=pd.DataFrame(index=[f"c{i}" for i in range(20)]),  # pyright: ignore[reportArgumentType]
+        var=pd.DataFrame(index=[f"g{i}" for i in range(10)]),  # pyright: ignore[reportArgumentType]
+    )
+    path = tmp_path / "normalized.h5ad"
+    adata.write_h5ad(path)
+
+    result = normalize_raw(str(path))
+    assert "error" in result
+    assert "non-integer" in result["error"].lower()
+
+
+def test_normalize_raw_fails_on_negative_values(tmp_path):
+    X = np.array([[1.0, -2.0], [3.0, 4.0]], dtype=np.float32)
+    adata = ad.AnnData(
+        X=sp.csr_matrix(X),
+        obs=pd.DataFrame(index=["c0", "c1"]),  # pyright: ignore[reportArgumentType]
+        var=pd.DataFrame(index=["g0", "g1"]),  # pyright: ignore[reportArgumentType]
+    )
+    path = tmp_path / "negatives.h5ad"
+    adata.write_h5ad(path)
+
+    result = normalize_raw(str(path))
+    assert "error" in result
+    assert "negative" in result["error"].lower()
+
+
+def test_normalize_raw_edit_log_written(raw_counts_h5ad):
+    result = normalize_raw(str(raw_counts_h5ad))
+    assert "error" not in result
+
+    with h5py.File(result["output_path"], "r") as f:
+        log_raw = f["uns/provenance/edit_history"][()]
+    log = json.loads(log_raw.decode("utf-8") if isinstance(log_raw, bytes) else log_raw)
+    assert len(log) == 1
+    entry = log[0]
+    assert entry["operation"] == "normalize_raw"
+    assert entry["details"]["target_sum"] == 1e4
+    assert entry["details"]["n_obs"] == result["n_obs"]
+    assert entry["details"]["n_vars"] == result["n_vars"]
+    assert "source_sha256" in entry
+
+
+def test_normalize_raw_missing_file(tmp_path):
+    result = normalize_raw(str(tmp_path / "does-not-exist.h5ad"))
+    assert "error" in result
+
+
+def test_normalize_raw_dense_x(tmp_path):
+    """Dense X with integer values should also work."""
+    rng = np.random.default_rng(11)
+    X = rng.integers(0, 10, size=(20, 8)).astype(np.float32)
+    adata = ad.AnnData(
+        X=X,
+        obs=pd.DataFrame(index=[f"c{i}" for i in range(20)]),  # pyright: ignore[reportArgumentType]
+        var=pd.DataFrame(index=[f"g{i}" for i in range(8)]),  # pyright: ignore[reportArgumentType]
+    )
+    path = tmp_path / "dense.h5ad"
+    adata.write_h5ad(path)
+
+    result = normalize_raw(str(path))
+    assert "error" not in result
+
+    out = ad.read_h5ad(result["output_path"])
+    assert out.raw is not None
+    np.testing.assert_array_equal(np.asarray(out.raw.X), X)


### PR DESCRIPTION
## Summary

- Adds `normalize_raw` to `hca-anndata-tools` and registers it as an MCP tool
- Moves raw counts from X to `raw.X` and normalizes X via scanpy's `normalize_total(target_sum=1e4)` + `log1p`
- Fails fast (via h5py, before loading the file) if `raw.X` already exists, or X has negative / non-integer values

## Test plan

- [x] New tests in `tests/test_normalize.py`: success path (sparse + dense), fails-if-raw-exists, fails-on-non-integer, fails-on-negative, edit-log entry written, missing file
- [x] Full hca-anndata-tools suite: 227 passed
- [x] `make typecheck` clean

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)