### PR TITLE
refactor: shared factory for edit-log entries

### DIFF
--- a/packages/hca-anndata-tools/src/hca_anndata_tools/compress.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/compress.py
@@ -4,14 +4,12 @@ from __future__ import annotations
 
 import json
 import os
-from datetime import datetime, timezone
 from typing import Literal
 
 import h5py
 
-from . import __version__
 from ._io import open_h5ad, read_edit_log_h5py, write_edit_log_h5py
-from .write import resolve_latest, write_h5ad
+from .write import make_edit_entry, resolve_latest, write_h5ad
 
 
 def _detect_x_compression(path: str) -> str | None:
@@ -74,19 +72,16 @@ def compress_h5ad(
 
         size_before = os.path.getsize(path)
 
-        entry = {
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-            "tool": "hca-anndata-tools",
-            "tool_version": __version__,
-            "operation": "compress_h5ad",
-            "description": f"Rewrote file with {compression}:{compression_level} compression",
-            "details": {
+        entry = make_edit_entry(
+            operation="compress_h5ad",
+            description=f"Rewrote file with {compression}:{compression_level} compression",
+            details={
                 "compression": compression,
                 "compression_level": compression_level,
                 "previous_compression": current_filter,
                 "size_before_bytes": size_before,
             },
-        }
+        )
 
         with open_h5ad(path, backed="r") as adata:
             result = write_h5ad(

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/convert.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/convert.py
@@ -6,20 +6,19 @@ import os
 import re
 import shutil
 import tempfile
-from datetime import datetime, timezone
 
 import anndata as ad
 import h5py
 import numpy as np
 import pandas as pd
 
-from . import __version__
 from ._io import ensure_provenance_group, open_h5ad, read_obs_index, transplant_obs_columns, verify_obs_transplant
 from ._serialize import make_serializable
 from .write import (
     EDIT_LOG_KEY,
     build_edit_log,
     generate_timestamp,
+    make_edit_entry,
 )
 
 # CellxGENE reserved uns keys — moved to provenance/cellxgene
@@ -126,25 +125,21 @@ def convert_cellxgene_to_hca(
         if cellxgene_source:
             temp_uns["provenance"] = {"cellxgene": cellxgene_source}
 
-        # Build edit log
         slug = _slugify(title)
         timestamp = generate_timestamp()
         out_filename = f"{slug}-edit-{timestamp}.h5ad"
         directory = output_dir if output_dir is not None else os.path.dirname(path)
         output_path = os.path.join(directory, out_filename)
 
-        entry = {
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-            "tool": "hca-anndata-tools",
-            "tool_version": __version__,
-            "operation": "import_cellxgene",
-            "description": f"Imported from CellxGENE Discover: {title}",
-            "details": {
+        entry = make_edit_entry(
+            operation="import_cellxgene",
+            description=f"Imported from CellxGENE Discover: {title}",
+            details={
                 "source_schema_version": cellxgene_source.get("schema_version"),
                 "source_citation": cellxgene_source.get("citation"),
                 "conversions": conversions,
             },
-        }
+        )
 
         log_result = build_edit_log("[]", [entry], path)
         if "error" in log_result:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -7,14 +7,12 @@ import shutil
 import tempfile
 from collections.abc import Mapping
 from typing import Any
-from datetime import datetime, timezone
 
 import anndata as ad
 import h5py
 import numpy as np
 import pandas as pd
 
-from . import __version__
 from ._io import (
     _decode_bytes,
     ensure_provenance_group,
@@ -33,6 +31,7 @@ from .write import (
     build_edit_log,
     cleanup_previous_version,
     generate_output_path,
+    make_edit_entry,
     resolve_latest,
 )
 
@@ -259,13 +258,10 @@ def copy_cap_annotations(
         source_sha256 = _compute_sha256(source_path)
         target_sha256 = _compute_sha256(target_path)
 
-        entry = {
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-            "tool": "hca-anndata-tools",
-            "tool_version": __version__,
-            "operation": "import_cap_annotations",
-            "description": f"Copied CAP annotations from {source_basename}",
-            "details": {
+        entry = make_edit_entry(
+            operation="import_cap_annotations",
+            description=f"Copied CAP annotations from {source_basename}",
+            details={
                 "cap_source_file": source_basename,
                 "cap_source_sha256": source_sha256,
                 "cap_schema_version": cap_schema_version,
@@ -273,7 +269,7 @@ def copy_cap_annotations(
                 "obs_columns_added": obs_cols_to_copy,
                 "uns_keys_added": uns_keys_added,
             },
-        }
+        )
 
         log_result = build_edit_log(raw_log, [entry], target_path, target_sha256)
         if "error" in log_result:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
@@ -6,13 +6,11 @@ import os
 import shutil
 import types
 import typing
-from datetime import datetime, timezone
 
 import h5py
 import numpy as np
 from pydantic import TypeAdapter, ValidationError
 
-from . import __version__
 from ._io import (
     _decode_bytes,
     open_h5ad,
@@ -28,6 +26,7 @@ from .write import (
     build_edit_log,
     cleanup_previous_version,
     generate_output_path,
+    make_edit_entry,
     resolve_latest,
     write_h5ad,
 )
@@ -197,19 +196,15 @@ def set_uns(
             # Set the value
             adata.uns[field] = validated_value
 
-            # Build edit log entry
-            entry = {
-                "timestamp": datetime.now(timezone.utc).isoformat(),
-                "tool": "hca-anndata-tools",
-                "tool_version": __version__,
-                "operation": "set_uns",
-                "description": f"Set uns['{field}']",
-                "details": {
+            entry = make_edit_entry(
+                operation="set_uns",
+                description=f"Set uns['{field}']",
+                details={
                     "field": field,
                     "old_value": old_value,
                     "new_value": make_serializable(validated_value),
                 },
-            }
+            )
 
             result = write_h5ad(adata, path, [entry])
 
@@ -292,17 +287,14 @@ def replace_placeholder_values(
         total_affected = sum(sum(v.values()) for v in columns_fixed.values())
 
         target_sha256 = _compute_sha256(path)
-        entry = {
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-            "tool": "hca-anndata-tools",
-            "tool_version": __version__,
-            "operation": "replace_placeholder_values",
-            "description": f"Replaced placeholder values with NaN in {len(columns_fixed)} columns",
-            "details": {
+        entry = make_edit_entry(
+            operation="replace_placeholder_values",
+            description=f"Replaced placeholder values with NaN in {len(columns_fixed)} columns",
+            details={
                 "columns_fixed": {col: dict(vals) for col, vals in columns_fixed.items()},
                 "total_cells_affected": total_affected,
             },
-        }
+        )
 
         log_result = build_edit_log(raw_log, [entry], path, target_sha256)
         if "error" in log_result:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/normalize.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/normalize.py
@@ -2,14 +2,11 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-
 import h5py
 import numpy as np
 
-from . import __version__
 from ._io import open_h5ad
-from .write import resolve_latest, write_h5ad
+from .write import make_edit_entry, resolve_latest, write_h5ad
 
 _TARGET_SUM = 1e4
 # Sample ~2000 X entries for the integer/sign pre-check; enough to catch
@@ -82,21 +79,18 @@ def normalize_raw(path: str) -> dict:
             sc.pp.log1p(adata)
 
             n_obs, n_vars = adata.n_obs, adata.n_vars
-            entry = {
-                "timestamp": datetime.now(timezone.utc).isoformat(),
-                "tool": "hca-anndata-tools",
-                "tool_version": __version__,
-                "operation": "normalize_raw",
-                "description": (
+            entry = make_edit_entry(
+                operation="normalize_raw",
+                description=(
                     f"Moved raw counts to raw.X and normalized X with "
                     f"normalize_total(target_sum={_TARGET_SUM:g}) + log1p"
                 ),
-                "details": {
+                details={
                     "target_sum": _TARGET_SUM,
                     "n_obs": n_obs,
                     "n_vars": n_vars,
                 },
-            }
+            )
 
             result = write_h5ad(adata, path, [entry])
 

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
@@ -125,7 +125,7 @@ def make_edit_entry(
         "tool_version": __version__,
         "operation": operation,
         "description": description,
-        "details": details or {},
+        "details": details if details is not None else {},
     }
 
 

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
@@ -10,6 +10,8 @@ import re
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Literal
 
+from . import __version__
+
 if TYPE_CHECKING:
     from anndata import AnnData
 
@@ -99,6 +101,32 @@ def resolve_latest(path: str) -> str:
 def _is_timestamped(path: str) -> bool:
     """Check if a path has a timestamp suffix (i.e. it's an edit, not the original)."""
     return bool(_TIMESTAMP_PATTERN.search(os.path.basename(path)))
+
+
+def make_edit_entry(
+    operation: str,
+    description: str,
+    details: dict | None = None,
+) -> dict:
+    """Build an edit-log entry with timestamp, tool, and tool_version populated.
+
+    Args:
+        operation: Short machine-readable operation name (e.g. 'set_uns').
+        description: Human-readable description of the change.
+        details: Optional operation-specific structured data.
+
+    Returns:
+        A dict with the standard edit-log entry shape, ready to pass to
+        write_h5ad() or build_edit_log().
+    """
+    return {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "tool": "hca-anndata-tools",
+        "tool_version": __version__,
+        "operation": operation,
+        "description": description,
+        "details": details or {},
+    }
 
 
 def build_edit_log(


### PR DESCRIPTION
## Summary

- Adds `make_edit_entry(operation, description, details=None)` in `write.py`, populating `timestamp`, `tool`, and `tool_version` in one place.
- Migrates the 6 hand-rolled entry dicts to use it: `compress_h5ad`, `convert_cellxgene_to_hca`, `copy_cap_annotations`, `set_uns`, `replace_placeholder_values`, `normalize_raw`.
- No behavior change — JSON written to `uns/provenance/edit_history` is unchanged.

## Test plan

- [x] `make typecheck` — 0 errors across all pyright venvs
- [x] `cd packages/hca-anndata-tools && poetry run pytest tests/` — 227 passed
- [ ] Spot-check an edit log in a real h5ad after running a tool through MCP

Closes #320

Follow-ups split out per DRY review:
- #323 — extract `transplant_edit_history` helper
- #324 — shared `cleanup_on_error` helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)