### PR TITLE
fix: strip feature_is_filtered from raw.var in normalize_raw

### DIFF
--- a/packages/hca-anndata-tools/src/hca_anndata_tools/normalize.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/normalize.py
@@ -74,7 +74,12 @@ def normalize_raw(path: str) -> dict:
                 return {"error": "X sample contains non-integer values — appears already normalized"}
 
         with open_h5ad(path, backed=None) as adata:
-            adata.raw = adata.copy()
+            # CXG schema forbids feature_is_filtered in raw.var.
+            raw_source = adata.copy()
+            raw_source.var = raw_source.var.drop(
+                columns=["feature_is_filtered"], errors="ignore"
+            )
+            adata.raw = raw_source
             sc.pp.normalize_total(adata, target_sum=_TARGET_SUM)
             sc.pp.log1p(adata)
 

--- a/packages/hca-anndata-tools/tests/test_normalize.py
+++ b/packages/hca-anndata-tools/tests/test_normalize.py
@@ -119,6 +119,37 @@ def test_normalize_raw_missing_file(tmp_path):
     assert "error" in result
 
 
+def test_normalize_raw_strips_feature_is_filtered_from_raw_var(tmp_path):
+    """raw.var must not contain feature_is_filtered per CXG schema (#326)."""
+    rng = np.random.default_rng(13)
+    n_obs, n_vars = 30, 10
+    X = rng.integers(0, 10, size=(n_obs, n_vars)).astype(np.float32)
+    var = pd.DataFrame(
+        {
+            "feature_is_filtered": [False] * n_vars,
+            "gene_symbol": [f"G{i}" for i in range(n_vars)],
+        },
+        index=[f"ENSG{i:011d}" for i in range(n_vars)],  # pyright: ignore[reportArgumentType]
+    )
+    adata = ad.AnnData(
+        X=sp.csr_matrix(X),
+        obs=pd.DataFrame(index=[f"c{i}" for i in range(n_obs)]),  # pyright: ignore[reportArgumentType]
+        var=var,
+    )
+    path = tmp_path / "with_feature_is_filtered.h5ad"
+    adata.write_h5ad(path)
+
+    result = normalize_raw(str(path))
+    assert "error" not in result
+
+    out = ad.read_h5ad(result["output_path"])
+    assert "feature_is_filtered" not in out.raw.var.columns  # pyright: ignore[reportOptionalMemberAccess]
+    # Other var columns preserved in raw.var
+    assert "gene_symbol" in out.raw.var.columns  # pyright: ignore[reportOptionalMemberAccess]
+    # Normalized var still has feature_is_filtered
+    assert "feature_is_filtered" in out.var.columns
+
+
 def test_normalize_raw_dense_x(tmp_path):
     """Dense X with integer values should also work."""
     rng = np.random.default_rng(11)


### PR DESCRIPTION
## Summary

- `normalize_raw` was producing h5ad files that fail CXG schema validation with `ERROR: Column 'feature_is_filtered' must not be present in 'raw.var'`.
- Root cause: `adata.raw = adata.copy()` copied the full var frame (including `feature_is_filtered`) into raw.var.
- Fix: drop `feature_is_filtered` from the var frame before assigning to `adata.raw`. Matches CellxGENE's own convention — real CellxGENE files have raw.var identical to var minus `feature_is_filtered`.

## Test plan

- [x] Unit test added: creates h5ad with `feature_is_filtered` + `gene_symbol` in var, asserts `feature_is_filtered` stripped from raw.var, other columns preserved in raw.var, `feature_is_filtered` still present on normalized var.
- [x] Full `pytest tests/test_normalize.py` passes (8/8).
- [x] `make typecheck` clean (0 errors across all pyright venvs).
- [x] End-to-end verification on real gut file (`myeloid-r1-wip-10.h5ad`, 50k × 36k): after re-running `normalize_raw`, `feature_is_filtered` is absent from raw.var and present in var. HCA validator no longer reports the `feature_is_filtered` error (4 pre-existing/unrelated errors remain — #327 `uns['log1p']`, library data issues).

Closes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)