### PR TITLE
fix: drop scanpy's empty uns['log1p'] stamp in normalize_raw

### DIFF
--- a/packages/hca-anndata-tools/src/hca_anndata_tools/normalize.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/normalize.py
@@ -82,6 +82,9 @@ def normalize_raw(path: str) -> dict:
             adata.raw = raw_source
             sc.pp.normalize_total(adata, target_sum=_TARGET_SUM)
             sc.pp.log1p(adata)
+            # scanpy stamps uns['log1p'] = {'base': None}; None drops on h5ad
+            # write, leaving {} which CXG rejects.
+            adata.uns.pop("log1p", None)
 
             n_obs, n_vars = adata.n_obs, adata.n_vars
             entry = make_edit_entry(

--- a/packages/hca-anndata-tools/tests/test_normalize.py
+++ b/packages/hca-anndata-tools/tests/test_normalize.py
@@ -119,6 +119,15 @@ def test_normalize_raw_missing_file(tmp_path):
     assert "error" in result
 
 
+def test_normalize_raw_strips_log1p_uns_stamp(raw_counts_h5ad):
+    """scanpy's uns['log1p'] stamp roundtrips to an empty dict that CXG rejects (#327)."""
+    result = normalize_raw(str(raw_counts_h5ad))
+    assert "error" not in result
+
+    out = ad.read_h5ad(result["output_path"])
+    assert "log1p" not in out.uns
+
+
 def test_normalize_raw_strips_feature_is_filtered_from_raw_var(tmp_path):
     """raw.var must not contain feature_is_filtered per CXG schema (#326)."""
     rng = np.random.default_rng(13)


### PR DESCRIPTION
## Summary

- `normalize_raw` was leaving `uns['log1p']` as an empty dict in the output, which CXG validation rejects: `ERROR: uns['log1p'] cannot be an empty value.`
- Root cause: `sc.pp.log1p(adata)` stamps `adata.uns['log1p'] = {'base': None}`. The `None` value does not survive the h5ad serialization roundtrip — the dict comes back as `{}`. The CXG validator rejects empty containers in `uns`.
- Fix: pop `uns['log1p']` after `sc.pp.log1p`. Matches production CellxGENE files, which have no `log1p` key in `uns` at all.

## Test plan

- [x] Unit test added: asserts `'log1p' not in out.uns` after `normalize_raw`.
- [x] `pytest tests/test_normalize.py` passes (9/9).
- [x] `make typecheck` clean.
- [x] End-to-end verification on real gut file (`myeloid-r1-wip-10.h5ad`, 50k × 36k): the `uns['log1p']` error is gone from the HCA validator output. Remaining errors are all pre-existing data issues unrelated to `normalize_raw`.

Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)