### PR TITLE
feat: add view_edit_log tool to inspect h5ad edit history

### DIFF
--- a/docs/prd-cap-annotations-and-gene-validation.md
+++ b/docs/prd-cap-annotations-and-gene-validation.md
@@ -299,7 +299,7 @@ NOT copied (CXG fields, already in target or handled by HCA conversion):
 - Any var changes — target var is authoritative.
 
 ### Post-copy
-- Log the operation in `hca_edit_log` with:
+- Log the operation in `uns['provenance']['edit_history']` with:
   - `operation`: `import_cap_annotations`
   - `source_file`: filename of the CAP source file
   - `source_sha256`: hash of the CAP source file for provenance

--- a/docs/prd-h5ad-editing.md
+++ b/docs/prd-h5ad-editing.md
@@ -45,9 +45,9 @@ User-provided required fields: `title` (both cellxgene and HCA), `study_pi` (HCA
 
 Cellxgene does **not** store filename, dataset_id, or file hash in `uns` — those live in their external catalog. Our edit log fills a gap that doesn't conflict with existing conventions.
 
-### Proposed structure: `uns['hca_edit_log']`
+### Structure: `uns['provenance']['edit_history']`
 
-A list of edit entries stored in `uns['hca_edit_log']`. Each entry is a dict:
+A list of edit entries serialized as JSON in `uns['provenance']['edit_history']`. Each entry is a dict:
 
 ```python
 {
@@ -91,7 +91,7 @@ def write_h5ad(
     output_dir: str | None = None,  # defaults to same dir as source
 ) -> dict:
     """
-    Write adata to a new timestamped file. Appends edit_entries to uns['hca_edit_log'].
+    Write adata to a new timestamped file. Appends edit_entries to uns['provenance']['edit_history'].
 
     Returns dict with 'output_path' on success, or 'error' on failure.
     """
@@ -101,7 +101,7 @@ def write_h5ad(
 2. Strip existing timestamp suffix from source filename
 3. Generate new UTC timestamp
 4. Populate `source_file` and `source_sha256` on each edit entry
-5. Append `edit_entries` to `adata.uns['hca_edit_log']` (create if missing)
+5. Append `edit_entries` to `adata.uns['provenance']['edit_history']` (create if missing)
 6. Write to `{base}-edit-{timestamp}.h5ad`
 7. Return the output path
 
@@ -119,7 +119,7 @@ A single tool to update values in obs columns. Covers the most common curation t
 
 ### `view_edit_log` tool
 
-Read and return `uns['hca_edit_log']` for a given file. Useful for inspecting what edits have been applied.
+Read and return `uns['provenance']['edit_history']` for a given file. Useful for inspecting what edits have been applied.
 
 ## Tickets
 

--- a/packages/hca-anndata-mcp/src/hca_anndata_mcp/server.py
+++ b/packages/hca-anndata-mcp/src/hca_anndata_mcp/server.py
@@ -16,6 +16,7 @@ from hca_anndata_tools import (
     set_uns,
     validate_marker_genes,
     view_data,
+    view_edit_log,
 )
 
 from hca_anndata_mcp.tools.plot import plot_embedding_mcp
@@ -36,8 +37,9 @@ mcp = FastMCP(
         "copy_cap_annotations to copy CAP annotations from a source into an HCA target file, "
         "replace_placeholder_values to replace banned placeholder values with NaN in obs columns, "
         "compress_h5ad to rewrite a file with HDF5 gzip compression applied, "
-        "and normalize_raw to move raw counts from X to raw.X and normalize X "
-        "(normalize_total + log1p)."
+        "normalize_raw to move raw counts from X to raw.X and normalize X "
+        "(normalize_total + log1p), "
+        "and view_edit_log to inspect the edit history recorded in a file."
     ),
 )
 
@@ -56,3 +58,4 @@ mcp.tool()(copy_cap_annotations)
 mcp.tool()(replace_placeholder_values)
 mcp.tool()(compress_h5ad)
 mcp.tool()(normalize_raw)
+mcp.tool()(view_edit_log)

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/__init__.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/__init__.py
@@ -7,7 +7,12 @@ if TYPE_CHECKING:
     from .compress import compress_h5ad
     from .convert import convert_cellxgene_to_hca
     from .copy_cap import copy_cap_annotations
-    from .edit import list_uns_fields, replace_placeholder_values, set_uns
+    from .edit import (
+        list_uns_fields,
+        replace_placeholder_values,
+        set_uns,
+        view_edit_log,
+    )
     from .files import locate_files
     from .marker_genes import validate_marker_genes
     from .normalize import normalize_raw
@@ -44,6 +49,7 @@ _LAZY_IMPORTS = {
     "set_uns": ".edit",
     "list_uns_fields": ".edit",
     "replace_placeholder_values": ".edit",
+    "view_edit_log": ".edit",
     "convert_cellxgene_to_hca": ".convert",
     "validate_marker_genes": ".marker_genes",
     "copy_cap_annotations": ".copy_cap",

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import types
@@ -112,6 +113,35 @@ def list_uns_fields(path: str) -> dict:
                 "obs_columns": list(adata.obs.columns),
                 "obsm_keys": list(adata.obsm.keys()),
             }
+
+    except Exception as e:
+        return {"error": str(e)}
+
+
+def view_edit_log(path: str) -> dict:
+    """Return the edit-log entries recorded in an h5ad file.
+
+    Args:
+        path: Path to an .h5ad file.
+
+    Returns:
+        Dict with 'filename', 'edit_count', 'entries' on success, or 'error'.
+        If no edits have been recorded, also includes 'message'.
+    """
+    try:
+        path = resolve_latest(path)
+
+        with h5py.File(path, "r") as f:
+            entries = json.loads(read_edit_log_h5py(f))
+
+        result = {
+            "filename": os.path.basename(path),
+            "edit_count": len(entries),
+            "entries": entries,
+        }
+        if not entries:
+            result["message"] = "No edit history found"
+        return result
 
     except Exception as e:
         return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
 _TIMESTAMP_PATTERN = re.compile(r"-edit-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}(?=\.h5ad$)")
 _TIMESTAMP_FORMAT = "%Y-%m-%d-%H-%M-%S"
 EDIT_LOG_KEY = "edit_history"
-_LEGACY_EDIT_LOG_KEY = "hca_edit_log"
 _HASH_CHUNK_SIZE = 1 << 20  # 1 MB — keeps syscall count low on multi-GB files
 _REQUIRED_ENTRY_KEYS = {"timestamp", "tool", "tool_version", "operation", "description"}
 

--- a/packages/hca-anndata-tools/tests/test_edit.py
+++ b/packages/hca-anndata-tools/tests/test_edit.py
@@ -6,7 +6,12 @@ import anndata as ad
 import numpy as np
 import pandas as pd
 import scipy.sparse as sp
-from hca_anndata_tools.edit import list_uns_fields, replace_placeholder_values, set_uns
+from hca_anndata_tools.edit import (
+    list_uns_fields,
+    replace_placeholder_values,
+    set_uns,
+    view_edit_log,
+)
 from hca_anndata_tools.write import EDIT_LOG_KEY
 
 # --- list_uns_fields ---
@@ -357,3 +362,46 @@ def test_replace_placeholder_edit_log(tmp_path):
     log = json.loads(written.uns["provenance"][EDIT_LOG_KEY])
     assert len(log) >= 1
     assert log[-1]["operation"] == "replace_placeholder_values"
+
+
+# --- view_edit_log ---
+
+
+def test_view_edit_log_empty(sample_h5ad_for_write):
+    """Unedited file returns edit_count 0 with a message."""
+    result = view_edit_log(str(sample_h5ad_for_write))
+    assert "error" not in result
+    assert result["edit_count"] == 0
+    assert result["entries"] == []
+    assert "message" in result
+    assert result["filename"] == sample_h5ad_for_write.name
+
+
+def test_view_edit_log_after_edits(sample_h5ad_for_write):
+    """After edits, entries are returned with operation and details."""
+    set_uns(str(sample_h5ad_for_write), "description", "first")
+    set_uns(str(sample_h5ad_for_write), "title", "second")
+
+    result = view_edit_log(str(sample_h5ad_for_write))
+    assert "error" not in result
+    assert result["edit_count"] == 2
+    assert "message" not in result
+    assert [e["operation"] for e in result["entries"]] == ["set_uns", "set_uns"]
+    assert result["entries"][0]["details"]["field"] == "description"
+    assert result["entries"][1]["details"]["field"] == "title"
+    assert all("timestamp" in e for e in result["entries"])
+    assert all("source_sha256" in e for e in result["entries"])
+
+
+def test_view_edit_log_auto_resolves_latest(sample_h5ad_for_write):
+    """Passing the original path reads the latest timestamped version."""
+    set_uns(str(sample_h5ad_for_write), "description", "logged")
+    result = view_edit_log(str(sample_h5ad_for_write))
+    assert "error" not in result
+    assert result["edit_count"] == 1
+    assert result["filename"] != sample_h5ad_for_write.name  # resolved to timestamped
+
+
+def test_view_edit_log_bad_path():
+    result = view_edit_log("/nonexistent/file.h5ad")
+    assert "error" in result


### PR DESCRIPTION
Closes #230

## Summary
- Adds `view_edit_log(path)` in `hca_anndata_tools.edit` — reads `uns/provenance/edit_history` via h5py (read-only, no matrix load) and returns parsed entries with count
- Auto-resolves to the latest timestamped version so callers can pass the original path
- Registers the tool on the MCP server alongside the other editing tools

## Test plan
- [x] `poetry run pytest tests/test_edit.py` — 42 passed (4 new `view_edit_log` tests)
- [x] `make typecheck` — 0 errors
- [ ] Try `view_edit_log` via the MCP server on a file with edits and an unedited file

🤖 Generated with [Claude Code](https://claude.com/claude-code)