### PR TITLE
feat: add curate-h5ad skill for interactive h5ad wrangling

### DIFF
--- a/.claude/skills/curate-h5ad/SKILL.md
+++ b/.claude/skills/curate-h5ad/SKILL.md
@@ -27,7 +27,7 @@ The target schemas are:
 Run in parallel:
 
 - `/evaluate-h5ad $ARGUMENTS` — produces the structured overview report (schema type, X verdict, metadata, storage, embeddings, CAP, edit history, summary). This already calls `check_schema_type` and `check_x_normalization`, so their verdicts are available for Step 2 gating without a separate tool call.
-- `validate_schema` — the HCA schema validator (`is_valid`, full `errors` and `warnings` lists). These are the authoritative blocking/advisory signals for Bucket A decisions. Feature-ID warnings are ordered last; summarize repeated shapes in the punch list rather than pasting thousands of lines verbatim.
+- `validate_schema $ARGUMENTS` — the HCA schema validator (`is_valid`, full `errors` and `warnings` lists). These are the authoritative blocking/advisory signals for Bucket A decisions. Feature-ID warnings are ordered last; summarize repeated shapes in the punch list rather than pasting thousands of lines verbatim.
 
 ## Step 2 — Classify every finding into one bucket
 
@@ -79,7 +79,7 @@ Order:
 2. Content edits: `normalize_raw`, each `replace_placeholder_values`, `copy_cap_annotations` (if a source was supplied), and any `set_uns` approved in Step 3.
 3. `compress_h5ad` last.
 
-Each tool writes a new timestamped file. Subsequent calls can pass either the original path or the latest — `resolve_latest` picks up the newest variant automatically.
+Each tool writes a new timestamped file. For most subsequent calls, passing either the original path or the latest works — `resolve_latest` picks up the newest variant automatically. Two exceptions: `convert_cellxgene_to_hca` does not auto-resolve (call it with the exact path you want to convert), and `copy_cap_annotations` only auto-resolves its `target_path` (the `source_path` is used verbatim).
 
 ## Step 5 — Report
 

--- a/.claude/skills/curate-h5ad/SKILL.md
+++ b/.claude/skills/curate-h5ad/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: curate-h5ad
+description: Interactively curate an h5ad file toward HCA readiness — runs the mechanical fixes the validator and evaluator agree on, and enumerates everything still requiring wrangler input or upstream data. Sibling to /evaluate-h5ad.
+---
+
+# Curate H5AD File
+
+Curate the h5ad file at: `{{path}}`
+
+`/evaluate-h5ad` identifies problems. `/curate-h5ad` applies the safe, mechanical fixes and hands back a punch list of everything still needing a curator's decision or upstream data.
+
+The target schemas are:
+- **HCA Tier 1 metadata** — https://data.humancellatlas.org/metadata/tier-1 (dataset / donor / sample / cell metadata; drives the validator's error list)
+- **HCA Cell Annotation schema** — https://data.humancellatlas.org/metadata/cell-annotation (CAP annotation sets, `cellannotation_schema_version`, `cellannotation_metadata`)
+
+## Rules (do not break)
+
+1. **Never invent metadata values.** If a required value isn't already in the file or derivable from it, emit a todo asking the wrangler for it. Do NOT guess a default. Examples of fields that always need wrangler input: `description`, `ambient_count_correction`, `doublet_detection`, `default_embedding`.
+2. **Ground every fix in validator + evaluator output.** Run both before proposing anything — don't assume what's wrong.
+3. **`replace_placeholder_values` is restricted to `library_preparation_batch` and `library_sequencing_run`.** Never run it on other columns. Other placeholder-looking values (e.g. "unknown" in `author_cell_type`) need curator-reviewed mappings, not a blanket NaN conversion.
+
+## Step 1 — Gather findings
+
+Run in parallel:
+
+- `/evaluate-h5ad {{path}}` — produces the 8-section report (metadata, storage, embeddings, CAP, cell-type concordance, edit history, summary)
+- `hca-schema-validator` — captures errors and warnings not covered by the evaluator:
+
+  ```bash
+  cd packages/hca-schema-validator && poetry run python -u <<'EOF'
+  from hca_schema_validator import HCAValidator
+  v = HCAValidator()
+  v.validate_adata("{{path}}")
+  print("is_valid:", v.is_valid)
+  print(f"=== ERRORS ({len(v.errors)}) ===")
+  for e in v.errors: print("-", e)
+  print(f"=== WARNINGS ({len(v.warnings)}) ===")
+  # Summarize repeated warnings by shape, don't print thousands of lines.
+  EOF
+  ```
+
+Confirm X's dtype and integer-ness via `view_data` on a small slice before deciding whether `normalize_raw` applies.
+
+## Step 2 — Classify every finding into one bucket
+
+### Bucket A — Mechanical (safe to run after approval)
+
+Only these are in Bucket A. Nothing else.
+
+- **`normalize_raw`** — when `has_raw = false` AND a sample of X is integer-valued (raw counts). Deterministic: moves X→raw.X, normalizes X with `normalize_total(target_sum=10000) + log1p`.
+- **`replace_placeholder_values` on `library_preparation_batch`** — only if the column actually contains placeholder values flagged by the validator.
+- **`replace_placeholder_values` on `library_sequencing_run`** — same condition.
+- **`compress_h5ad`** — when `get_storage_info` shows `compression: null` on X. Pure compression, no data change.
+
+### Bucket B — Needs wrangler input (todo — stop and ask)
+
+For each of these, write a concrete question, not a suggested answer:
+
+- Missing required `uns` fields (e.g. `description`) — ask for the text.
+- Missing bionetwork-required `uns` fields (e.g. `ambient_count_correction`, `doublet_detection`) — ask which value from the allowed set applies. If `predicted_doublet` / `doublet_score` columns exist, mention that as context but still ask which tool was used.
+- `default_embedding` — list the obsm keys and ask which one.
+- Any other `uns` field the validator flags as missing.
+
+If the wrangler answers during the session, those answers become additional mechanical fixes (`set_uns ...`) to run in Step 4.
+
+### Bucket C — Upstream / curator judgment (out of scope for this skill)
+
+Report these but don't attempt to fix:
+
+- High NaN rates on non-allowed columns (e.g. `library_id`) — needs real values from source.
+- Delimited-list values in single-identifier columns (e.g. `library_preparation_batch` containing `"lib1; lib2; lib3"`) — needs per-cell resolution, not placeholder replacement.
+- Gene IDs missing from the current GENCODE — needs annotation-version decision.
+- Inconsistent `author_cell_type` variants — needs a curator mapping.
+- Missing CAP annotations — needs a source CAP file + `copy_cap_annotations`. See the [HCA Cell Annotation schema](https://data.humancellatlas.org/metadata/cell-annotation) for the required shape (`cellannotation_schema_version`, `cellannotation_metadata`, annotation sets).
+- Cells whose labels don't match the atlas focus (e.g. non-myeloid labels in a myeloid atlas) — needs a curator decision on keep/drop.
+
+## Step 3 — Present the punch list
+
+Show three sections: **A (will run)**, **B (needs your answer)**, **C (still to do, out of scope)**. Then stop and wait for explicit approval before running anything.
+
+If the wrangler answers any Bucket B items, promote those to Bucket A as `set_uns` calls.
+
+## Step 4 — Run the mechanical fixes
+
+Order:
+
+1. Content edits first: `normalize_raw`, then each `replace_placeholder_values`, then any `set_uns` approved in Step 3.
+2. `compress_h5ad` last.
+
+Each tool writes a new timestamped file. Subsequent calls can pass either the original path or the latest — `resolve_latest` picks up the newest variant automatically.
+
+## Step 5 — Report
+
+- Call `view_edit_log` on the final file; list the entries added this session.
+- Re-run the validator; report error/warning deltas vs. Step 1.
+- Summarize:
+  - **Fixed this session** — each Bucket A action that ran, with the resulting validator change.
+  - **Still to do** — every Bucket B question the wrangler didn't answer, plus every Bucket C item.

--- a/.claude/skills/curate-h5ad/SKILL.md
+++ b/.claude/skills/curate-h5ad/SKILL.md
@@ -24,10 +24,11 @@ The target schemas are:
 
 ## Step 1 — Gather findings
 
-Run in parallel:
+Start with the evaluator, then gate the HCA validator on the schema it reports:
 
-- `/evaluate-h5ad $ARGUMENTS` — produces the structured overview report (schema type, X verdict, metadata, storage, embeddings, CAP, edit history, summary). This already calls `check_schema_type` and `check_x_normalization`, so their verdicts are available for Step 2 gating without a separate tool call.
-- `validate_schema $ARGUMENTS` — the HCA schema validator (`is_valid`, full `errors` and `warnings` lists). These are the authoritative blocking/advisory signals for Bucket A decisions. Feature-ID warnings are ordered last; summarize repeated shapes in the punch list rather than pasting thousands of lines verbatim.
+- Run `/evaluate-h5ad $ARGUMENTS` — produces the structured overview report (schema type, X verdict, metadata, storage, embeddings, CAP, edit history, summary). This already calls `check_schema_type` and `check_x_normalization`, so their verdicts are available for Step 2 gating without a separate tool call.
+- If the evaluator reports `schema: "hca"`, run `validate_schema $ARGUMENTS` — the HCA schema validator (`is_valid`, full `errors` and `warnings` lists). These are the authoritative blocking/advisory signals for Bucket A decisions. Feature-ID warnings are ordered last; summarize repeated shapes in the punch list rather than pasting thousands of lines verbatim.
+- If the evaluator reports `schema: "cellxgene"`, **do not** run `validate_schema` yet — the HCA validator would report a large, mostly irrelevant error list. `convert_cellxgene_to_hca` moves into Bucket A; after it runs, re-enter Step 1 on the converted file to get the accurate HCA findings.
 
 ## Step 2 — Classify every finding into one bucket
 
@@ -35,7 +36,7 @@ Run in parallel:
 
 Only these are in Bucket A. Nothing else.
 
-- **`convert_cellxgene_to_hca`** — when `check_schema_type` reports `schema: "cellxgene"`. Must run **first**: it reshapes the file into HCA layout before any other fix makes sense, and the other tools assume HCA layout. After conversion, re-run the validator + evaluator on the new file to get an accurate Bucket A/B/C list.
+- **`convert_cellxgene_to_hca`** — when `check_schema_type` reports `schema: "cellxgene"`. Must run **first**: it reshapes the file into HCA layout before any other fix makes sense, and the other tools (including `validate_schema`) assume HCA layout. After conversion, re-enter Step 1 on the converted file to get an accurate Bucket A/B/C list.
 - **`normalize_raw`** — when `check_x_normalization` reports `verdict: "raw_counts"` and `has_raw_x: false`. Deterministic: moves X→raw.X, normalizes X with `normalize_total(target_sum=10000) + log1p`.
 - **`replace_placeholder_values` on `library_preparation_batch`** — only if the column actually contains placeholder values flagged by the validator.
 - **`replace_placeholder_values` on `library_sequencing_run`** — same condition.
@@ -49,7 +50,7 @@ For each of these, write a concrete question, not a suggested answer:
 - Missing required `uns` fields (e.g. `description`) — ask for the text.
 - Missing bionetwork-required `uns` fields (e.g. `ambient_count_correction`, `doublet_detection`) — ask which value from the allowed set applies. If `predicted_doublet` / `doublet_score` columns exist, mention that as context but still ask which tool was used.
 - `default_embedding` — list the obsm keys and ask which one.
-- **No CAP annotation set present** — the file must ship with at least one CAP annotation set (see the [HCA Cell Annotation schema](https://data.humancellatlas.org/metadata/cell-annotation)). Ask the wrangler to provide a path or URL to a CAP-exported version of this file (same cells, with CAP annotation sets populated). If supplied, `copy_cap_annotations` becomes a mechanical fix for Step 4.
+- **No CAP annotation set present** — the file must ship with at least one CAP annotation set (see the [HCA Cell Annotation schema](https://data.humancellatlas.org/metadata/cell-annotation)). Ask the wrangler to provide a local path to a CAP-exported version of this file (same cells, with CAP annotation sets populated) — `copy_cap_annotations` reads the source via AnnData/h5py so a URL must be downloaded locally first. If supplied, `copy_cap_annotations` becomes a mechanical fix for Step 4.
 - Any other `uns` field the validator flags as missing.
 
 If the wrangler answers during the session, those answers become additional mechanical fixes (`set_uns ...`, `copy_cap_annotations`, ...) to run in Step 4.

--- a/.claude/skills/curate-h5ad/SKILL.md
+++ b/.claude/skills/curate-h5ad/SKILL.md
@@ -40,7 +40,7 @@ Only these are in Bucket A. Nothing else.
 - **`replace_placeholder_values` on `library_preparation_batch`** — only if the column actually contains placeholder values flagged by the validator.
 - **`replace_placeholder_values` on `library_sequencing_run`** — same condition.
 - **`copy_cap_annotations`** — only if the wrangler provided a CAP source file in Step 3. Copies annotation sets + `cellannotation_schema_version` + `cellannotation_metadata` from the source into the target.
-- **`compress_h5ad`** — when `get_storage_info` shows `compression: null` on X. Pure compression, no data change.
+- **`compress_h5ad`** — when `get_storage_info` shows no HDF5 filter on X's underlying dataset (`X.data.compression` for sparse X, `X.compression` for dense X). If the file is already compressed, the tool safely returns `{skipped: true, reason: ...}` rather than rewriting. Pure compression, no data change.
 
 ### Bucket B — Needs wrangler input (todo — stop and ask)
 

--- a/.claude/skills/curate-h5ad/SKILL.md
+++ b/.claude/skills/curate-h5ad/SKILL.md
@@ -47,6 +47,7 @@ Confirm X's dtype and integer-ness via `view_data` on a small slice before decid
 
 Only these are in Bucket A. Nothing else.
 
+- **`convert_cellxgene_to_hca`** — when `uns['schema_version']` is present (CellxGENE 6.0+). Must run **first**: it reshapes the file into HCA layout before any other fix makes sense, and the other tools assume HCA layout. After conversion, re-run the validator + evaluator on the new file to get an accurate Bucket A/B/C list.
 - **`normalize_raw`** — when `has_raw = false` AND a sample of X is integer-valued (raw counts). Deterministic: moves X→raw.X, normalizes X with `normalize_total(target_sum=10000) + log1p`.
 - **`replace_placeholder_values` on `library_preparation_batch`** — only if the column actually contains placeholder values flagged by the validator.
 - **`replace_placeholder_values` on `library_sequencing_run`** — same condition.
@@ -86,8 +87,9 @@ If the wrangler answers any Bucket B items, promote those to Bucket A as `set_un
 
 Order:
 
-1. Content edits first: `normalize_raw`, then each `replace_placeholder_values`, then any `set_uns` approved in Step 3.
-2. `compress_h5ad` last.
+1. `convert_cellxgene_to_hca` first if applicable — then stop, re-run Steps 1–3 on the converted file before continuing (conversion changes the layout enough that the prior punch list is stale).
+2. Content edits: `normalize_raw`, each `replace_placeholder_values`, `copy_cap_annotations` (if a source was supplied), and any `set_uns` approved in Step 3.
+3. `compress_h5ad` last.
 
 Each tool writes a new timestamped file. Subsequent calls can pass either the original path or the latest — `resolve_latest` picks up the newest variant automatically.
 

--- a/.claude/skills/curate-h5ad/SKILL.md
+++ b/.claude/skills/curate-h5ad/SKILL.md
@@ -1,11 +1,14 @@
 ---
 name: curate-h5ad
 description: Interactively curate an h5ad file toward HCA readiness — runs the mechanical fixes the validator and evaluator agree on, and enumerates everything still requiring wrangler input or upstream data. Sibling to /evaluate-h5ad.
+argument-hint: <absolute-path-to-h5ad-file>
 ---
 
 # Curate H5AD File
 
-Curate the h5ad file at: `{{path}}`
+Curate the h5ad file at absolute path: `$ARGUMENTS`
+
+Pass an absolute path to the `.h5ad` file. Relative paths are resolved against the MCP server's working directory, which may not match the user's.
 
 `/evaluate-h5ad` identifies problems. `/curate-h5ad` applies the safe, mechanical fixes and hands back a punch list of everything still needing a curator's decision or upstream data.
 
@@ -23,23 +26,8 @@ The target schemas are:
 
 Run in parallel:
 
-- `/evaluate-h5ad {{path}}` — produces the 8-section report (metadata, storage, embeddings, CAP, cell-type concordance, edit history, summary)
-- `hca-schema-validator` — captures errors and warnings not covered by the evaluator:
-
-  ```bash
-  cd packages/hca-schema-validator && poetry run python -u <<'EOF'
-  from hca_schema_validator import HCAValidator
-  v = HCAValidator()
-  v.validate_adata("{{path}}")
-  print("is_valid:", v.is_valid)
-  print(f"=== ERRORS ({len(v.errors)}) ===")
-  for e in v.errors: print("-", e)
-  print(f"=== WARNINGS ({len(v.warnings)}) ===")
-  # Summarize repeated warnings by shape, don't print thousands of lines.
-  EOF
-  ```
-
-Confirm X's dtype and integer-ness via `view_data` on a small slice before deciding whether `normalize_raw` applies.
+- `/evaluate-h5ad $ARGUMENTS` — produces the structured overview report (schema type, X verdict, metadata, storage, embeddings, CAP, edit history, summary). This already calls `check_schema_type` and `check_x_normalization`, so their verdicts are available for Step 2 gating without a separate tool call.
+- `validate_schema` — the HCA schema validator (`is_valid`, full `errors` and `warnings` lists). These are the authoritative blocking/advisory signals for Bucket A decisions. Feature-ID warnings are ordered last; summarize repeated shapes in the punch list rather than pasting thousands of lines verbatim.
 
 ## Step 2 — Classify every finding into one bucket
 
@@ -47,8 +35,8 @@ Confirm X's dtype and integer-ness via `view_data` on a small slice before decid
 
 Only these are in Bucket A. Nothing else.
 
-- **`convert_cellxgene_to_hca`** — when `uns['schema_version']` is present (CellxGENE 6.0+). Must run **first**: it reshapes the file into HCA layout before any other fix makes sense, and the other tools assume HCA layout. After conversion, re-run the validator + evaluator on the new file to get an accurate Bucket A/B/C list.
-- **`normalize_raw`** — when `has_raw = false` AND a sample of X is integer-valued (raw counts). Deterministic: moves X→raw.X, normalizes X with `normalize_total(target_sum=10000) + log1p`.
+- **`convert_cellxgene_to_hca`** — when `check_schema_type` reports `schema: "cellxgene"`. Must run **first**: it reshapes the file into HCA layout before any other fix makes sense, and the other tools assume HCA layout. After conversion, re-run the validator + evaluator on the new file to get an accurate Bucket A/B/C list.
+- **`normalize_raw`** — when `check_x_normalization` reports `verdict: "raw_counts"` and `has_raw_x: false`. Deterministic: moves X→raw.X, normalizes X with `normalize_total(target_sum=10000) + log1p`.
 - **`replace_placeholder_values` on `library_preparation_batch`** — only if the column actually contains placeholder values flagged by the validator.
 - **`replace_placeholder_values` on `library_sequencing_run`** — same condition.
 - **`copy_cap_annotations`** — only if the wrangler provided a CAP source file in Step 3. Copies annotation sets + `cellannotation_schema_version` + `cellannotation_metadata` from the source into the target.

--- a/.claude/skills/curate-h5ad/SKILL.md
+++ b/.claude/skills/curate-h5ad/SKILL.md
@@ -50,6 +50,7 @@ Only these are in Bucket A. Nothing else.
 - **`normalize_raw`** — when `has_raw = false` AND a sample of X is integer-valued (raw counts). Deterministic: moves X→raw.X, normalizes X with `normalize_total(target_sum=10000) + log1p`.
 - **`replace_placeholder_values` on `library_preparation_batch`** — only if the column actually contains placeholder values flagged by the validator.
 - **`replace_placeholder_values` on `library_sequencing_run`** — same condition.
+- **`copy_cap_annotations`** — only if the wrangler provided a CAP source file in Step 3. Copies annotation sets + `cellannotation_schema_version` + `cellannotation_metadata` from the source into the target.
 - **`compress_h5ad`** — when `get_storage_info` shows `compression: null` on X. Pure compression, no data change.
 
 ### Bucket B — Needs wrangler input (todo — stop and ask)
@@ -59,9 +60,10 @@ For each of these, write a concrete question, not a suggested answer:
 - Missing required `uns` fields (e.g. `description`) — ask for the text.
 - Missing bionetwork-required `uns` fields (e.g. `ambient_count_correction`, `doublet_detection`) — ask which value from the allowed set applies. If `predicted_doublet` / `doublet_score` columns exist, mention that as context but still ask which tool was used.
 - `default_embedding` — list the obsm keys and ask which one.
+- **No CAP annotation set present** — the file must ship with at least one CAP annotation set (see the [HCA Cell Annotation schema](https://data.humancellatlas.org/metadata/cell-annotation)). Ask the wrangler to provide a path or URL to a CAP-exported version of this file (same cells, with CAP annotation sets populated). If supplied, `copy_cap_annotations` becomes a mechanical fix for Step 4.
 - Any other `uns` field the validator flags as missing.
 
-If the wrangler answers during the session, those answers become additional mechanical fixes (`set_uns ...`) to run in Step 4.
+If the wrangler answers during the session, those answers become additional mechanical fixes (`set_uns ...`, `copy_cap_annotations`, ...) to run in Step 4.
 
 ### Bucket C — Upstream / curator judgment (out of scope for this skill)
 
@@ -71,7 +73,7 @@ Report these but don't attempt to fix:
 - Delimited-list values in single-identifier columns (e.g. `library_preparation_batch` containing `"lib1; lib2; lib3"`) — needs per-cell resolution, not placeholder replacement.
 - Gene IDs missing from the current GENCODE — needs annotation-version decision.
 - Inconsistent `author_cell_type` variants — needs a curator mapping.
-- Missing CAP annotations — needs a source CAP file + `copy_cap_annotations`. See the [HCA Cell Annotation schema](https://data.humancellatlas.org/metadata/cell-annotation) for the required shape (`cellannotation_schema_version`, `cellannotation_metadata`, annotation sets).
+- (CAP annotations are handled in Bucket B above — the wrangler provides a CAP source file and `copy_cap_annotations` runs mechanically.)
 - Cells whose labels don't match the atlas focus (e.g. non-myeloid labels in a myeloid atlas) — needs a curator decision on keep/drop.
 
 ## Step 3 — Present the punch list


### PR DESCRIPTION
Closes #333

## Summary
- New \`.claude/skills/curate-h5ad/SKILL.md\` — sibling to \`/evaluate-h5ad\`. Evaluate finds problems, curate applies the mechanical fixes and enumerates everything still needing wrangler input or upstream data.
- Encodes three hard rules: never invent metadata values, ground every fix in validator + evaluator output, and restrict \`replace_placeholder_values\` to \`library_preparation_batch\` and \`library_sequencing_run\`.
- Links out to the authoritative schemas: [HCA Tier 1 metadata](https://data.humancellatlas.org/metadata/tier-1) and the [HCA Cell Annotation schema](https://data.humancellatlas.org/metadata/cell-annotation).

## Skill flow
1. Gather findings — run \`/evaluate-h5ad\` + \`hca-schema-validator\`.
2. Classify into Bucket A (mechanical, safe), B (needs wrangler answer), C (upstream / curator judgment, out of scope).
3. Present the punch list; wait for approval.
4. Run mechanical fixes, compress last.
5. Re-run \`view_edit_log\` and the validator; report what was fixed vs. still to do.

## Test plan
- [ ] Run \`/curate-h5ad <path>\` on the gut myeloid file and confirm Bucket A / B / C are classified as expected
- [ ] Confirm the skill never auto-fills \`description\`, \`ambient_count_correction\`, \`doublet_detection\`, or \`default_embedding\`
- [ ] Confirm \`replace_placeholder_values\` is only proposed for the two allowed library columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)