### PR TITLE
feat: add check_x_normalization tool to classify X as raw-counts vs normalized

### DIFF
--- a/packages/hca-anndata-mcp/src/hca_anndata_mcp/server.py
+++ b/packages/hca-anndata-mcp/src/hca_anndata_mcp/server.py
@@ -9,6 +9,7 @@ from hca_anndata_tools import (
     get_descriptive_stats,
     get_storage_info,
     get_summary,
+    inspect_x,
     list_uns_fields,
     locate_files,
     normalize_raw,
@@ -39,6 +40,7 @@ mcp = FastMCP(
         "compress_h5ad to rewrite a file with HDF5 gzip compression applied, "
         "normalize_raw to move raw counts from X to raw.X and normalize X "
         "(normalize_total + log1p), "
+        "inspect_x to classify X as raw-counts / normalized / indeterminate, "
         "and view_edit_log to inspect the edit history recorded in a file."
     ),
 )
@@ -59,3 +61,4 @@ mcp.tool()(replace_placeholder_values)
 mcp.tool()(compress_h5ad)
 mcp.tool()(normalize_raw)
 mcp.tool()(view_edit_log)
+mcp.tool()(inspect_x)

--- a/packages/hca-anndata-mcp/src/hca_anndata_mcp/server.py
+++ b/packages/hca-anndata-mcp/src/hca_anndata_mcp/server.py
@@ -9,7 +9,7 @@ from hca_anndata_tools import (
     get_descriptive_stats,
     get_storage_info,
     get_summary,
-    inspect_x,
+    check_x_normalization,
     list_uns_fields,
     locate_files,
     normalize_raw,
@@ -40,7 +40,7 @@ mcp = FastMCP(
         "compress_h5ad to rewrite a file with HDF5 gzip compression applied, "
         "normalize_raw to move raw counts from X to raw.X and normalize X "
         "(normalize_total + log1p), "
-        "inspect_x to classify X as raw-counts / normalized / indeterminate, "
+        "check_x_normalization to classify X as raw-counts / normalized / indeterminate, "
         "and view_edit_log to inspect the edit history recorded in a file."
     ),
 )
@@ -61,4 +61,4 @@ mcp.tool()(replace_placeholder_values)
 mcp.tool()(compress_h5ad)
 mcp.tool()(normalize_raw)
 mcp.tool()(view_edit_log)
-mcp.tool()(inspect_x)
+mcp.tool()(check_x_normalization)

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/__init__.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/__init__.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
         view_edit_log,
     )
     from .files import locate_files
+    from .inspect import inspect_x
     from .marker_genes import validate_marker_genes
     from .normalize import normalize_raw
     from .plot import plot_embedding
@@ -55,6 +56,7 @@ _LAZY_IMPORTS = {
     "copy_cap_annotations": ".copy_cap",
     "compress_h5ad": ".compress",
     "normalize_raw": ".normalize",
+    "inspect_x": ".inspect",
 }
 
 __all__ = list(_LAZY_IMPORTS)  # pyright: ignore[reportUnsupportedDunderAll]

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/__init__.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/__init__.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
         view_edit_log,
     )
     from .files import locate_files
-    from .inspect import inspect_x
+    from .inspect import check_x_normalization
     from .marker_genes import validate_marker_genes
     from .normalize import normalize_raw
     from .plot import plot_embedding
@@ -56,7 +56,7 @@ _LAZY_IMPORTS = {
     "copy_cap_annotations": ".copy_cap",
     "compress_h5ad": ".compress",
     "normalize_raw": ".normalize",
-    "inspect_x": ".inspect",
+    "check_x_normalization": ".inspect",
 }
 
 __all__ = list(_LAZY_IMPORTS)  # pyright: ignore[reportUnsupportedDunderAll]

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/inspect.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/inspect.py
@@ -26,6 +26,57 @@ def _sample_x(f: h5py.File, sample_size: int) -> np.ndarray:
     return np.asarray(x[0, :sample_size])  # pyright: ignore[reportIndexIssue]
 
 
+def classify_x_at_path(path: str, sample_size: int) -> dict:
+    """Sample X at an already-resolved path and return the verdict dict.
+
+    Package-internal: skips ``resolve_latest`` and input validation so
+    callers that have already resolved the latest path (e.g.
+    ``normalize_raw``) don't pay a second directory glob. External
+    callers should use :func:`check_x_normalization`.
+    """
+    with h5py.File(path, "r") as f:
+        has_raw = "raw/X" in f
+        sample = _sample_x(f, sample_size)
+        dtype = str(sample.dtype)
+
+    nonzero = sample[sample != 0]
+    nonzero_count = int(nonzero.size)
+    has_negative = bool((sample < 0).any()) if sample.size else False
+    is_integer_valued = (
+        bool(np.all(np.mod(nonzero, 1) == 0)) if nonzero_count else False
+    )
+
+    if nonzero_count == 0:
+        verdict = "indeterminate"
+    elif has_negative or not is_integer_valued:
+        verdict = "normalized"
+    else:
+        verdict = "raw_counts"
+
+    nonzero_min: float | None = None
+    nonzero_max: float | None = None
+    if nonzero_count > 0:
+        # Filter NaN/inf before min/max — those values aren't strict
+        # JSON-serializable and some MCP clients reject them.
+        finite = nonzero[np.isfinite(nonzero)]
+        if finite.size:
+            nonzero_min = float(finite.min())
+            nonzero_max = float(finite.max())
+
+    return {
+        "filename": os.path.basename(path),
+        "dtype": dtype,
+        "sample_size": int(sample.size),
+        "nonzero_count": nonzero_count,
+        "nonzero_min": nonzero_min,
+        "nonzero_max": nonzero_max,
+        "is_integer_valued": is_integer_valued,
+        "has_negative": has_negative,
+        "has_raw_x": has_raw,
+        "verdict": verdict,
+    }
+
+
 def check_x_normalization(path: str, sample_size: int = _DEFAULT_SAMPLE_SIZE) -> dict:
     """Sample X and report whether it looks like raw counts or normalized data.
 
@@ -36,7 +87,10 @@ def check_x_normalization(path: str, sample_size: int = _DEFAULT_SAMPLE_SIZE) ->
 
     Args:
         path: Path to an .h5ad file.
-        sample_size: Number of X entries to inspect (default 2000). Must be >= 1.
+        sample_size: Requested maximum number of X entries to inspect
+            (default 2000). Must be >= 1. The returned ``sample_size``
+            is the actual number sampled, which may be less when fewer
+            entries are available (e.g. sparse X with small nnz).
 
     Returns:
         Dict with a fixed shape: ``filename``, ``dtype``, ``sample_size``,
@@ -54,49 +108,6 @@ def check_x_normalization(path: str, sample_size: int = _DEFAULT_SAMPLE_SIZE) ->
     try:
         if not isinstance(sample_size, int) or sample_size < 1:
             return {"error": f"sample_size must be a positive int, got {sample_size!r}"}
-
-        path = resolve_latest(path)
-        with h5py.File(path, "r") as f:
-            has_raw = "raw/X" in f
-            sample = _sample_x(f, sample_size)
-            dtype = str(sample.dtype)
-
-        nonzero = sample[sample != 0]
-        nonzero_count = int(nonzero.size)
-        has_negative = bool((sample < 0).any()) if sample.size else False
-        is_integer_valued = (
-            bool(np.all(np.mod(nonzero, 1) == 0)) if nonzero_count else False
-        )
-
-        if nonzero_count == 0:
-            verdict = "indeterminate"
-        elif has_negative or not is_integer_valued:
-            verdict = "normalized"
-        else:
-            verdict = "raw_counts"
-
-        nonzero_min: float | None = None
-        nonzero_max: float | None = None
-        if nonzero_count > 0:
-            # Filter NaN/inf before min/max — those values aren't strict
-            # JSON-serializable and some MCP clients reject them.
-            finite = nonzero[np.isfinite(nonzero)]
-            if finite.size:
-                nonzero_min = float(finite.min())
-                nonzero_max = float(finite.max())
-
-        return {
-            "filename": os.path.basename(path),
-            "dtype": dtype,
-            "sample_size": int(sample.size),
-            "nonzero_count": nonzero_count,
-            "nonzero_min": nonzero_min,
-            "nonzero_max": nonzero_max,
-            "is_integer_valued": is_integer_valued,
-            "has_negative": has_negative,
-            "has_raw_x": has_raw,
-            "verdict": verdict,
-        }
-
+        return classify_x_at_path(resolve_latest(path), sample_size)
     except Exception as e:
         return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/inspect.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/inspect.py
@@ -42,7 +42,8 @@ def check_x_normalization(path: str, sample_size: int = _DEFAULT_SAMPLE_SIZE) ->
         Dict with ``dtype``, ``sample_size``, ``nonzero_count``,
         ``is_integer_valued``, ``has_negative``, ``has_raw_x``,
         ``verdict``, and (when nonzero values were seen) ``nonzero_min``
-        and ``nonzero_max``. On failure, ``error`` is returned instead.
+        and ``nonzero_max``. The min/max are ``None`` if every nonzero
+        value is non-finite. On failure, ``error`` is returned instead.
 
         ``verdict`` is one of:
         - ``"raw_counts"`` — all sampled nonzero values are non-negative integers.
@@ -81,8 +82,11 @@ def check_x_normalization(path: str, sample_size: int = _DEFAULT_SAMPLE_SIZE) ->
             "verdict": verdict,
         }
         if nonzero_count > 0:
-            result["nonzero_min"] = float(nonzero.min())
-            result["nonzero_max"] = float(nonzero.max())
+            # Filter out NaN/inf before min/max — those values aren't
+            # strict-JSON-serializable and some MCP clients reject them.
+            finite = nonzero[np.isfinite(nonzero)]
+            result["nonzero_min"] = float(finite.min()) if finite.size else None
+            result["nonzero_max"] = float(finite.max()) if finite.size else None
         return result
 
     except Exception as e:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/inspect.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/inspect.py
@@ -36,14 +36,15 @@ def check_x_normalization(path: str, sample_size: int = _DEFAULT_SAMPLE_SIZE) ->
 
     Args:
         path: Path to an .h5ad file.
-        sample_size: Number of X entries to inspect (default 2000).
+        sample_size: Number of X entries to inspect (default 2000). Must be >= 1.
 
     Returns:
-        Dict with ``dtype``, ``sample_size``, ``nonzero_count``,
-        ``is_integer_valued``, ``has_negative``, ``has_raw_x``,
-        ``verdict``, and (when nonzero values were seen) ``nonzero_min``
-        and ``nonzero_max``. The min/max are ``None`` if every nonzero
-        value is non-finite. On failure, ``error`` is returned instead.
+        Dict with a fixed shape: ``filename``, ``dtype``, ``sample_size``,
+        ``nonzero_count``, ``nonzero_min``, ``nonzero_max``,
+        ``is_integer_valued``, ``has_negative``, ``has_raw_x``, ``verdict``.
+        ``nonzero_min`` and ``nonzero_max`` are ``None`` when no nonzero
+        values were seen, or when every nonzero value is non-finite. On
+        failure, ``error`` is returned instead.
 
         ``verdict`` is one of:
         - ``"raw_counts"`` — all sampled nonzero values are non-negative integers.
@@ -51,6 +52,9 @@ def check_x_normalization(path: str, sample_size: int = _DEFAULT_SAMPLE_SIZE) ->
         - ``"indeterminate"`` — sample contained no nonzero values.
     """
     try:
+        if not isinstance(sample_size, int) or sample_size < 1:
+            return {"error": f"sample_size must be a positive int, got {sample_size!r}"}
+
         path = resolve_latest(path)
         with h5py.File(path, "r") as f:
             has_raw = "raw/X" in f
@@ -71,23 +75,28 @@ def check_x_normalization(path: str, sample_size: int = _DEFAULT_SAMPLE_SIZE) ->
         else:
             verdict = "raw_counts"
 
-        result = {
+        nonzero_min: float | None = None
+        nonzero_max: float | None = None
+        if nonzero_count > 0:
+            # Filter NaN/inf before min/max — those values aren't strict
+            # JSON-serializable and some MCP clients reject them.
+            finite = nonzero[np.isfinite(nonzero)]
+            if finite.size:
+                nonzero_min = float(finite.min())
+                nonzero_max = float(finite.max())
+
+        return {
             "filename": os.path.basename(path),
             "dtype": dtype,
             "sample_size": int(sample.size),
             "nonzero_count": nonzero_count,
+            "nonzero_min": nonzero_min,
+            "nonzero_max": nonzero_max,
             "is_integer_valued": is_integer_valued,
             "has_negative": has_negative,
             "has_raw_x": has_raw,
             "verdict": verdict,
         }
-        if nonzero_count > 0:
-            # Filter out NaN/inf before min/max — those values aren't
-            # strict-JSON-serializable and some MCP clients reject them.
-            finite = nonzero[np.isfinite(nonzero)]
-            result["nonzero_min"] = float(finite.min()) if finite.size else None
-            result["nonzero_max"] = float(finite.max()) if finite.size else None
-        return result
 
     except Exception as e:
         return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/inspect.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/inspect.py
@@ -16,13 +16,16 @@ def _sample_x(f: h5py.File, sample_size: int) -> np.ndarray:
     """Return a 1-D numpy array sample of X from an open h5py File.
 
     Sparse: first ``sample_size`` entries of X/data. Dense: first
-    ``sample_size`` entries of row 0.
+    ``sample_size`` entries of row 0. Returns an empty array if either
+    X dimension is zero (degenerate 0-cell or 0-gene file).
     """
     x = f["X"]
     if isinstance(x, h5py.Group) and "data" in x:
         data = x["data"]
         n = min(sample_size, len(data))  # pyright: ignore[reportArgumentType]
         return np.asarray(data[:n])  # pyright: ignore[reportIndexIssue]
+    if x.shape[0] == 0 or x.shape[1] == 0:  # pyright: ignore[reportAttributeAccessIssue]
+        return np.asarray([])
     return np.asarray(x[0, :sample_size])  # pyright: ignore[reportIndexIssue]
 
 

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/inspect.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/inspect.py
@@ -1,0 +1,89 @@
+"""Inspect X to report whether it looks like raw counts or normalized data."""
+
+from __future__ import annotations
+
+import os
+
+import h5py
+import numpy as np
+
+from .write import resolve_latest
+
+_DEFAULT_SAMPLE_SIZE = 2000
+
+
+def _sample_x(f: h5py.File, sample_size: int) -> np.ndarray:
+    """Return a 1-D numpy array sample of X from an open h5py File.
+
+    Sparse: first ``sample_size`` entries of X/data. Dense: first
+    ``sample_size`` entries of row 0.
+    """
+    x = f["X"]
+    if isinstance(x, h5py.Group) and "data" in x:
+        data = x["data"]
+        n = min(sample_size, len(data))  # pyright: ignore[reportArgumentType]
+        return np.asarray(data[:n])  # pyright: ignore[reportIndexIssue]
+    return np.asarray(x[0, :sample_size])  # pyright: ignore[reportIndexIssue]
+
+
+def inspect_x(path: str, sample_size: int = _DEFAULT_SAMPLE_SIZE) -> dict:
+    """Sample X and report whether it looks like raw counts or normalized data.
+
+    Reads a small slice via h5py without loading the full matrix. The
+    heuristic is fail-fast, not a full-matrix guarantee: a file whose
+    first entries are integers but whose later entries are fractional
+    will be classified as ``raw_counts``.
+
+    Args:
+        path: Path to an .h5ad file.
+        sample_size: Number of X entries to inspect (default 2000).
+
+    Returns:
+        Dict with ``dtype``, ``sample_size``, ``nonzero_count``,
+        ``is_integer_valued``, ``has_negative``, ``has_raw_x``,
+        ``verdict``, and (when nonzero values were seen) ``nonzero_min``
+        and ``nonzero_max``. On failure, ``error`` is returned instead.
+
+        ``verdict`` is one of:
+        - ``"raw_counts"`` — all sampled nonzero values are non-negative integers.
+        - ``"normalized"`` — sample contains non-integer or negative values.
+        - ``"indeterminate"`` — sample contained no nonzero values.
+    """
+    try:
+        path = resolve_latest(path)
+        with h5py.File(path, "r") as f:
+            has_raw = "raw/X" in f
+            sample = _sample_x(f, sample_size)
+            dtype = str(sample.dtype)
+
+        nonzero = sample[sample != 0]
+        nonzero_count = int(nonzero.size)
+        has_negative = bool((sample < 0).any()) if sample.size else False
+        is_integer_valued = (
+            bool(np.all(np.mod(nonzero, 1) == 0)) if nonzero_count else False
+        )
+
+        if nonzero_count == 0:
+            verdict = "indeterminate"
+        elif has_negative or not is_integer_valued:
+            verdict = "normalized"
+        else:
+            verdict = "raw_counts"
+
+        result = {
+            "filename": os.path.basename(path),
+            "dtype": dtype,
+            "sample_size": int(sample.size),
+            "nonzero_count": nonzero_count,
+            "is_integer_valued": is_integer_valued,
+            "has_negative": has_negative,
+            "has_raw_x": has_raw,
+            "verdict": verdict,
+        }
+        if nonzero_count > 0:
+            result["nonzero_min"] = float(nonzero.min())
+            result["nonzero_max"] = float(nonzero.max())
+        return result
+
+    except Exception as e:
+        return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/inspect.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/inspect.py
@@ -1,4 +1,4 @@
-"""Inspect X to report whether it looks like raw counts or normalized data."""
+"""Check whether X contains raw counts or already-normalized data."""
 
 from __future__ import annotations
 
@@ -26,7 +26,7 @@ def _sample_x(f: h5py.File, sample_size: int) -> np.ndarray:
     return np.asarray(x[0, :sample_size])  # pyright: ignore[reportIndexIssue]
 
 
-def inspect_x(path: str, sample_size: int = _DEFAULT_SAMPLE_SIZE) -> dict:
+def check_x_normalization(path: str, sample_size: int = _DEFAULT_SAMPLE_SIZE) -> dict:
     """Sample X and report whether it looks like raw counts or normalized data.
 
     Reads a small slice via h5py without loading the full matrix. The

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/inspect.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/inspect.py
@@ -29,7 +29,7 @@ def _sample_x(f: h5py.File, sample_size: int) -> np.ndarray:
     return np.asarray(x[0, :sample_size])  # pyright: ignore[reportIndexIssue]
 
 
-def classify_x_at_path(path: str, sample_size: int) -> dict:
+def _classify_x_at_path(path: str, sample_size: int) -> dict:
     """Sample X at an already-resolved path and return the verdict dict.
 
     Package-internal: skips ``resolve_latest`` and input validation so
@@ -39,8 +39,16 @@ def classify_x_at_path(path: str, sample_size: int) -> dict:
     """
     with h5py.File(path, "r") as f:
         has_raw = "raw/X" in f
+        # Read dtype from HDF5 directly — an empty sample array defaults
+        # to float64 regardless of the on-disk type.
+        x = f["X"]
+        stored_dtype = (
+            x["data"].dtype  # pyright: ignore[reportAttributeAccessIssue,reportIndexIssue]
+            if isinstance(x, h5py.Group) and "data" in x
+            else x.dtype  # pyright: ignore[reportAttributeAccessIssue]
+        )
+        dtype = str(stored_dtype)
         sample = _sample_x(f, sample_size)
-        dtype = str(sample.dtype)
 
     nonzero = sample[sample != 0]
     nonzero_count = int(nonzero.size)
@@ -111,6 +119,6 @@ def check_x_normalization(path: str, sample_size: int = _DEFAULT_SAMPLE_SIZE) ->
     try:
         if not isinstance(sample_size, int) or sample_size < 1:
             return {"error": f"sample_size must be a positive int, got {sample_size!r}"}
-        return classify_x_at_path(resolve_latest(path), sample_size)
+        return _classify_x_at_path(resolve_latest(path), sample_size)
     except Exception as e:
         return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/normalize.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/normalize.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from ._io import open_h5ad
-from .inspect import inspect_x
+from .inspect import check_x_normalization
 from .write import make_edit_entry, resolve_latest, write_h5ad
 
 _TARGET_SUM = 1e4
@@ -39,7 +39,7 @@ def normalize_raw(path: str) -> dict:
 
         path = resolve_latest(path)
 
-        check = inspect_x(path)
+        check = check_x_normalization(path)
         if "error" in check:
             return check
         if check["has_raw_x"]:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/normalize.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/normalize.py
@@ -2,36 +2,11 @@
 
 from __future__ import annotations
 
-import h5py
-import numpy as np
-
 from ._io import open_h5ad
+from .inspect import inspect_x
 from .write import make_edit_entry, resolve_latest, write_h5ad
 
 _TARGET_SUM = 1e4
-# Sample ~2000 X entries for the integer/sign pre-check; enough to catch
-# normalized data on real files while keeping the h5py read trivial.
-_SAMPLE_SIZE = 2000
-
-
-def _inspect_x_file(path: str) -> tuple[bool, np.ndarray]:
-    """Return (has_raw, x_sample) read directly from the h5ad via h5py.
-
-    Fail-fast inspection to avoid loading multi-GB files before checking
-    preconditions. Samples up to _SAMPLE_SIZE values from X: for sparse,
-    the first entries of X/data; for dense, the first _SAMPLE_SIZE cells
-    of row 0.
-    """
-    with h5py.File(path, "r") as f:
-        has_raw = "raw/X" in f
-        x = f["X"]
-        if isinstance(x, h5py.Group) and "data" in x:
-            data = x["data"]
-            n = min(_SAMPLE_SIZE, len(data))  # pyright: ignore[reportArgumentType]
-            sample = np.asarray(data[:n])  # pyright: ignore[reportIndexIssue]
-        else:
-            sample = np.asarray(x[0, :_SAMPLE_SIZE])  # pyright: ignore[reportIndexIssue]
-        return has_raw, sample
 
 
 def normalize_raw(path: str) -> dict:
@@ -64,14 +39,15 @@ def normalize_raw(path: str) -> dict:
 
         path = resolve_latest(path)
 
-        has_raw, sample = _inspect_x_file(path)
-        if has_raw:
+        check = inspect_x(path)
+        if "error" in check:
+            return check
+        if check["has_raw_x"]:
             return {"error": "raw.X already exists — refusing to overwrite"}
-        if sample.size > 0:
-            if (sample < 0).any():
-                return {"error": "X sample contains negative values — not raw counts"}
-            if not np.all(np.mod(sample, 1) == 0):
-                return {"error": "X sample contains non-integer values — appears already normalized"}
+        if check["has_negative"]:
+            return {"error": "X sample contains negative values — not raw counts"}
+        if check["nonzero_count"] > 0 and not check["is_integer_valued"]:
+            return {"error": "X sample contains non-integer values — appears already normalized"}
 
         with open_h5ad(path, backed=None) as adata:
             # CXG schema forbids feature_is_filtered in raw.var.

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/normalize.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/normalize.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from ._io import open_h5ad
-from .inspect import check_x_normalization
+from .inspect import _DEFAULT_SAMPLE_SIZE, classify_x_at_path
 from .write import make_edit_entry, resolve_latest, write_h5ad
 
 _TARGET_SUM = 1e4
@@ -39,9 +39,7 @@ def normalize_raw(path: str) -> dict:
 
         path = resolve_latest(path)
 
-        check = check_x_normalization(path)
-        if "error" in check:
-            return check
+        check = classify_x_at_path(path, _DEFAULT_SAMPLE_SIZE)
         if check["has_raw_x"]:
             return {"error": "raw.X already exists — refusing to overwrite"}
         if check["has_negative"]:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/normalize.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/normalize.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from ._io import open_h5ad
-from .inspect import _DEFAULT_SAMPLE_SIZE, classify_x_at_path
+from .inspect import _DEFAULT_SAMPLE_SIZE, _classify_x_at_path
 from .write import make_edit_entry, resolve_latest, write_h5ad
 
 _TARGET_SUM = 1e4
@@ -39,7 +39,7 @@ def normalize_raw(path: str) -> dict:
 
         path = resolve_latest(path)
 
-        check = classify_x_at_path(path, _DEFAULT_SAMPLE_SIZE)
+        check = _classify_x_at_path(path, _DEFAULT_SAMPLE_SIZE)
         if check["has_raw_x"]:
             return {"error": "raw.X already exists — refusing to overwrite"}
         if check["has_negative"]:

--- a/packages/hca-anndata-tools/tests/test_inspect.py
+++ b/packages/hca-anndata-tools/tests/test_inspect.py
@@ -97,3 +97,13 @@ def test_check_x_normalization_custom_sample_size(tmp_path):
 def test_check_x_normalization_missing_file():
     result = check_x_normalization("/nonexistent/does-not-exist.h5ad")
     assert "error" in result
+
+
+def test_check_x_normalization_filters_nan_from_min_max(tmp_path):
+    """NaN/inf in X must not leak into nonzero_min/max (breaks strict JSON)."""
+    X = sp.csr_matrix(np.array([[1.0, np.nan], [np.inf, 3.0]], dtype=np.float32))
+    path = _write_h5ad(tmp_path / "nan.h5ad", X)
+
+    result = check_x_normalization(str(path))
+    assert result["nonzero_min"] == 1.0
+    assert result["nonzero_max"] == 3.0

--- a/packages/hca-anndata-tools/tests/test_inspect.py
+++ b/packages/hca-anndata-tools/tests/test_inspect.py
@@ -95,6 +95,8 @@ def test_check_x_normalization_dense_zero_rows(tmp_path):
     assert "error" not in result
     assert result["verdict"] == "indeterminate"
     assert result["nonzero_count"] == 0
+    # dtype must reflect the on-disk type, not the empty-array fallback (float64).
+    assert result["dtype"] == "float32"
 
 
 def test_check_x_normalization_custom_sample_size(tmp_path):

--- a/packages/hca-anndata-tools/tests/test_inspect.py
+++ b/packages/hca-anndata-tools/tests/test_inspect.py
@@ -1,0 +1,99 @@
+"""Tests for inspect_x."""
+
+import anndata as ad
+import numpy as np
+import pandas as pd
+import scipy.sparse as sp
+from hca_anndata_tools.inspect import inspect_x
+
+
+def _write_h5ad(path, X, include_raw=False):
+    adata = ad.AnnData(
+        X=X,
+        obs=pd.DataFrame(index=[f"c{i}" for i in range(X.shape[0])]),  # pyright: ignore[reportArgumentType]
+        var=pd.DataFrame(index=[f"g{i}" for i in range(X.shape[1])]),  # pyright: ignore[reportArgumentType]
+    )
+    if include_raw:
+        adata.raw = adata.copy()
+    adata.write_h5ad(path)
+    return path
+
+
+def test_inspect_x_detects_raw_counts(tmp_path):
+    rng = np.random.default_rng(5)
+    X = sp.csr_matrix(rng.integers(0, 10, size=(20, 15)).astype(np.float32))
+    path = _write_h5ad(tmp_path / "raw.h5ad", X)
+
+    result = inspect_x(str(path))
+    assert "error" not in result
+    assert result["verdict"] == "raw_counts"
+    assert result["is_integer_valued"] is True
+    assert result["has_negative"] is False
+    assert result["has_raw_x"] is False
+    assert result["nonzero_count"] > 0
+    assert result["nonzero_min"] >= 1.0
+    assert "dtype" in result
+
+
+def test_inspect_x_detects_normalized_floats(tmp_path):
+    rng = np.random.default_rng(5)
+    X = sp.csr_matrix(rng.random((20, 15)).astype(np.float32))  # floats in [0, 1)
+    path = _write_h5ad(tmp_path / "normalized.h5ad", X)
+
+    result = inspect_x(str(path))
+    assert "error" not in result
+    assert result["verdict"] == "normalized"
+    assert result["is_integer_valued"] is False
+
+
+def test_inspect_x_detects_negative_values(tmp_path):
+    X = sp.csr_matrix(np.array([[1.0, -2.0], [3.0, 4.0]], dtype=np.float32))
+    path = _write_h5ad(tmp_path / "neg.h5ad", X)
+
+    result = inspect_x(str(path))
+    assert result["verdict"] == "normalized"
+    assert result["has_negative"] is True
+
+
+def test_inspect_x_reports_has_raw_x(tmp_path):
+    rng = np.random.default_rng(5)
+    X = sp.csr_matrix(rng.integers(0, 10, size=(10, 8)).astype(np.float32))
+    path = _write_h5ad(tmp_path / "with_raw.h5ad", X, include_raw=True)
+
+    result = inspect_x(str(path))
+    assert result["has_raw_x"] is True
+
+
+def test_inspect_x_indeterminate_when_all_zero(tmp_path):
+    X = sp.csr_matrix(np.zeros((10, 5), dtype=np.float32))
+    path = _write_h5ad(tmp_path / "empty.h5ad", X)
+
+    result = inspect_x(str(path))
+    assert result["verdict"] == "indeterminate"
+    assert result["nonzero_count"] == 0
+    assert "nonzero_min" not in result
+    assert "nonzero_max" not in result
+
+
+def test_inspect_x_dense_x(tmp_path):
+    rng = np.random.default_rng(5)
+    X = rng.integers(0, 10, size=(10, 8)).astype(np.float32)
+    path = _write_h5ad(tmp_path / "dense.h5ad", X)
+
+    result = inspect_x(str(path))
+    assert "error" not in result
+    assert result["verdict"] == "raw_counts"
+
+
+def test_inspect_x_custom_sample_size(tmp_path):
+    rng = np.random.default_rng(5)
+    X = sp.csr_matrix(rng.integers(0, 10, size=(30, 20)).astype(np.float32))
+    path = _write_h5ad(tmp_path / "sized.h5ad", X)
+
+    result = inspect_x(str(path), sample_size=5)
+    assert result["sample_size"] <= 5
+
+
+def test_inspect_x_missing_file():
+    result = inspect_x("/nonexistent/does-not-exist.h5ad")
+    assert "error" in result

--- a/packages/hca-anndata-tools/tests/test_inspect.py
+++ b/packages/hca-anndata-tools/tests/test_inspect.py
@@ -86,6 +86,17 @@ def test_check_x_normalization_dense_x(tmp_path):
     assert result["verdict"] == "raw_counts"
 
 
+def test_check_x_normalization_dense_zero_rows(tmp_path):
+    """Degenerate 0-cell dense X must not raise IndexError; returns indeterminate."""
+    X = np.zeros((0, 5), dtype=np.float32)
+    path = _write_h5ad(tmp_path / "zero_rows.h5ad", X)
+
+    result = check_x_normalization(str(path))
+    assert "error" not in result
+    assert result["verdict"] == "indeterminate"
+    assert result["nonzero_count"] == 0
+
+
 def test_check_x_normalization_custom_sample_size(tmp_path):
     rng = np.random.default_rng(5)
     X = sp.csr_matrix(rng.integers(0, 10, size=(30, 20)).astype(np.float32))

--- a/packages/hca-anndata-tools/tests/test_inspect.py
+++ b/packages/hca-anndata-tools/tests/test_inspect.py
@@ -1,10 +1,10 @@
-"""Tests for inspect_x."""
+"""Tests for check_x_normalization."""
 
 import anndata as ad
 import numpy as np
 import pandas as pd
 import scipy.sparse as sp
-from hca_anndata_tools.inspect import inspect_x
+from hca_anndata_tools.inspect import check_x_normalization
 
 
 def _write_h5ad(path, X, include_raw=False):
@@ -19,12 +19,12 @@ def _write_h5ad(path, X, include_raw=False):
     return path
 
 
-def test_inspect_x_detects_raw_counts(tmp_path):
+def test_check_x_normalization_detects_raw_counts(tmp_path):
     rng = np.random.default_rng(5)
     X = sp.csr_matrix(rng.integers(0, 10, size=(20, 15)).astype(np.float32))
     path = _write_h5ad(tmp_path / "raw.h5ad", X)
 
-    result = inspect_x(str(path))
+    result = check_x_normalization(str(path))
     assert "error" not in result
     assert result["verdict"] == "raw_counts"
     assert result["is_integer_valued"] is True
@@ -35,65 +35,65 @@ def test_inspect_x_detects_raw_counts(tmp_path):
     assert "dtype" in result
 
 
-def test_inspect_x_detects_normalized_floats(tmp_path):
+def test_check_x_normalization_detects_normalized_floats(tmp_path):
     rng = np.random.default_rng(5)
     X = sp.csr_matrix(rng.random((20, 15)).astype(np.float32))  # floats in [0, 1)
     path = _write_h5ad(tmp_path / "normalized.h5ad", X)
 
-    result = inspect_x(str(path))
+    result = check_x_normalization(str(path))
     assert "error" not in result
     assert result["verdict"] == "normalized"
     assert result["is_integer_valued"] is False
 
 
-def test_inspect_x_detects_negative_values(tmp_path):
+def test_check_x_normalization_detects_negative_values(tmp_path):
     X = sp.csr_matrix(np.array([[1.0, -2.0], [3.0, 4.0]], dtype=np.float32))
     path = _write_h5ad(tmp_path / "neg.h5ad", X)
 
-    result = inspect_x(str(path))
+    result = check_x_normalization(str(path))
     assert result["verdict"] == "normalized"
     assert result["has_negative"] is True
 
 
-def test_inspect_x_reports_has_raw_x(tmp_path):
+def test_check_x_normalization_reports_has_raw_x(tmp_path):
     rng = np.random.default_rng(5)
     X = sp.csr_matrix(rng.integers(0, 10, size=(10, 8)).astype(np.float32))
     path = _write_h5ad(tmp_path / "with_raw.h5ad", X, include_raw=True)
 
-    result = inspect_x(str(path))
+    result = check_x_normalization(str(path))
     assert result["has_raw_x"] is True
 
 
-def test_inspect_x_indeterminate_when_all_zero(tmp_path):
+def test_check_x_normalization_indeterminate_when_all_zero(tmp_path):
     X = sp.csr_matrix(np.zeros((10, 5), dtype=np.float32))
     path = _write_h5ad(tmp_path / "empty.h5ad", X)
 
-    result = inspect_x(str(path))
+    result = check_x_normalization(str(path))
     assert result["verdict"] == "indeterminate"
     assert result["nonzero_count"] == 0
     assert "nonzero_min" not in result
     assert "nonzero_max" not in result
 
 
-def test_inspect_x_dense_x(tmp_path):
+def test_check_x_normalization_dense_x(tmp_path):
     rng = np.random.default_rng(5)
     X = rng.integers(0, 10, size=(10, 8)).astype(np.float32)
     path = _write_h5ad(tmp_path / "dense.h5ad", X)
 
-    result = inspect_x(str(path))
+    result = check_x_normalization(str(path))
     assert "error" not in result
     assert result["verdict"] == "raw_counts"
 
 
-def test_inspect_x_custom_sample_size(tmp_path):
+def test_check_x_normalization_custom_sample_size(tmp_path):
     rng = np.random.default_rng(5)
     X = sp.csr_matrix(rng.integers(0, 10, size=(30, 20)).astype(np.float32))
     path = _write_h5ad(tmp_path / "sized.h5ad", X)
 
-    result = inspect_x(str(path), sample_size=5)
+    result = check_x_normalization(str(path), sample_size=5)
     assert result["sample_size"] <= 5
 
 
-def test_inspect_x_missing_file():
-    result = inspect_x("/nonexistent/does-not-exist.h5ad")
+def test_check_x_normalization_missing_file():
+    result = check_x_normalization("/nonexistent/does-not-exist.h5ad")
     assert "error" in result

--- a/packages/hca-anndata-tools/tests/test_inspect.py
+++ b/packages/hca-anndata-tools/tests/test_inspect.py
@@ -71,8 +71,9 @@ def test_check_x_normalization_indeterminate_when_all_zero(tmp_path):
     result = check_x_normalization(str(path))
     assert result["verdict"] == "indeterminate"
     assert result["nonzero_count"] == 0
-    assert "nonzero_min" not in result
-    assert "nonzero_max" not in result
+    # Fixed return shape: keys always present, None when indeterminate.
+    assert result["nonzero_min"] is None
+    assert result["nonzero_max"] is None
 
 
 def test_check_x_normalization_dense_x(tmp_path):
@@ -107,3 +108,28 @@ def test_check_x_normalization_filters_nan_from_min_max(tmp_path):
     result = check_x_normalization(str(path))
     assert result["nonzero_min"] == 1.0
     assert result["nonzero_max"] == 3.0
+
+
+def test_check_x_normalization_rejects_non_positive_sample_size(tmp_path):
+    rng = np.random.default_rng(5)
+    X = sp.csr_matrix(rng.integers(0, 10, size=(5, 5)).astype(np.float32))
+    path = _write_h5ad(tmp_path / "sized.h5ad", X)
+
+    for bad in (0, -1):
+        result = check_x_normalization(str(path), sample_size=bad)
+        assert "error" in result
+        assert "sample_size" in result["error"]
+
+
+def test_check_x_normalization_return_shape_is_fixed(tmp_path):
+    """All documented keys are always present on success."""
+    rng = np.random.default_rng(5)
+    X = sp.csr_matrix(rng.integers(0, 10, size=(5, 5)).astype(np.float32))
+    path = _write_h5ad(tmp_path / "shape.h5ad", X)
+
+    expected = {
+        "filename", "dtype", "sample_size", "nonzero_count",
+        "nonzero_min", "nonzero_max", "is_integer_valued",
+        "has_negative", "has_raw_x", "verdict",
+    }
+    assert set(check_x_normalization(str(path)).keys()) == expected


### PR DESCRIPTION
Closes #335

## Summary
- New public \`check_x_normalization()\` in \`hca_anndata_tools.inspect\` — promotes the private \`_inspect_x_file\` helper that \`normalize_raw\` used to carry.
- Return shape: \`{filename, dtype, sample_size, nonzero_count, nonzero_min, nonzero_max, is_integer_valued, has_negative, has_raw_x, verdict}\` — \`verdict\` is one of \`raw_counts | normalized | indeterminate\`.
- \`normalize_raw\` now consumes the shared function for its preconditions; the old private helper is deleted.
- Registered as an MCP tool.

## Why
Multiple callers (skill-level curate flow, \`normalize_raw\` internals, future evaluate enhancements) all need the same signal: "does X look like raw counts?" Centralising it keeps the heuristic identical everywhere and removes hand-rolled \`view_data\` sampling from skill instructions.

## Test plan
- [x] \`poetry run pytest tests/test_inspect.py tests/test_normalize.py -v\` — 17 passed (8 new inspect tests + all normalize tests green)
- [x] Full \`hca-anndata-tools\` suite — 241 passed
- [x] \`make typecheck\` — 0 errors
- [ ] Call \`check_x_normalization\` via the MCP server on the gut myeloid file and confirm \`verdict = "raw_counts"\`, \`has_raw_x = false\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)