### PR TITLE
feat: add check_schema_type tool to identify CellxGENE vs HCA layout

### DIFF
--- a/packages/hca-anndata-mcp/src/hca_anndata_mcp/server.py
+++ b/packages/hca-anndata-mcp/src/hca_anndata_mcp/server.py
@@ -2,6 +2,8 @@
 
 from fastmcp import FastMCP
 from hca_anndata_tools import (
+    check_schema_type,
+    check_x_normalization,
     compress_h5ad,
     convert_cellxgene_to_hca,
     copy_cap_annotations,
@@ -9,7 +11,6 @@ from hca_anndata_tools import (
     get_descriptive_stats,
     get_storage_info,
     get_summary,
-    check_x_normalization,
     list_uns_fields,
     locate_files,
     normalize_raw,
@@ -41,6 +42,7 @@ mcp = FastMCP(
         "normalize_raw to move raw counts from X to raw.X and normalize X "
         "(normalize_total + log1p), "
         "check_x_normalization to classify X as raw-counts / normalized / indeterminate, "
+        "check_schema_type to identify CellxGENE vs HCA layout and report the schema version, "
         "and view_edit_log to inspect the edit history recorded in a file."
     ),
 )
@@ -62,3 +64,4 @@ mcp.tool()(compress_h5ad)
 mcp.tool()(normalize_raw)
 mcp.tool()(view_edit_log)
 mcp.tool()(check_x_normalization)
+mcp.tool()(check_schema_type)

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/__init__.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/__init__.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
         view_edit_log,
     )
     from .files import locate_files
-    from .inspect import check_x_normalization
+    from .inspect import check_schema_type, check_x_normalization
     from .marker_genes import validate_marker_genes
     from .normalize import normalize_raw
     from .plot import plot_embedding
@@ -57,6 +57,7 @@ _LAZY_IMPORTS = {
     "compress_h5ad": ".compress",
     "normalize_raw": ".normalize",
     "check_x_normalization": ".inspect",
+    "check_schema_type": ".inspect",
 }
 
 __all__ = list(_LAZY_IMPORTS)  # pyright: ignore[reportUnsupportedDunderAll]

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/inspect.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/inspect.py
@@ -1,4 +1,4 @@
-"""Check whether X contains raw counts or already-normalized data."""
+"""Small verdict tools for h5ad files (X normalization, schema type)."""
 
 from __future__ import annotations
 
@@ -7,6 +7,7 @@ import os
 import h5py
 import numpy as np
 
+from ._io import _decode_bytes
 from .write import resolve_latest
 
 _DEFAULT_SAMPLE_SIZE = 2000
@@ -120,5 +121,59 @@ def check_x_normalization(path: str, sample_size: int = _DEFAULT_SAMPLE_SIZE) ->
         if not isinstance(sample_size, int) or sample_size < 1:
             return {"error": f"sample_size must be a positive int, got {sample_size!r}"}
         return _classify_x_at_path(resolve_latest(path), sample_size)
+    except Exception as e:
+        return {"error": str(e)}
+
+
+def _read_schema_version(f: h5py.File) -> str | None:
+    """Read and decode ``uns['schema_version']`` from an open h5py File.
+
+    Returns the stripped string, or None if absent or empty.
+    ``schema_version`` is stored as a scalar string dataset in AnnData's
+    h5ad format.
+    """
+    uns = f.get("uns")
+    if not isinstance(uns, h5py.Group) or "schema_version" not in uns:
+        return None
+    raw = uns["schema_version"][()]  # pyright: ignore[reportIndexIssue]
+    value = _decode_bytes(raw)
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
+def check_schema_type(path: str) -> dict:
+    """Report whether an h5ad file declares the CellxGENE or HCA schema.
+
+    Detection is conservative: the presence of a non-empty
+    ``uns['schema_version']`` is the CellxGENE signal. HCA-authored files
+    (or anything else) fall through to ``"hca"``.
+
+    Reads via h5py without loading the matrix.
+
+    Args:
+        path: Path to an .h5ad file.
+
+    Returns:
+        Dict with ``filename``, ``schema`` (``"cellxgene"`` or ``"hca"``),
+        and ``schema_version`` (string when CellxGENE, ``None`` otherwise).
+        On failure, ``error`` is returned instead.
+    """
+    try:
+        path = resolve_latest(path)
+        with h5py.File(path, "r") as f:
+            version = _read_schema_version(f)
+        if version:
+            return {
+                "filename": os.path.basename(path),
+                "schema": "cellxgene",
+                "schema_version": version,
+            }
+        return {
+            "filename": os.path.basename(path),
+            "schema": "hca",
+            "schema_version": None,
+        }
     except Exception as e:
         return {"error": str(e)}

--- a/packages/hca-anndata-tools/tests/test_check_schema_type.py
+++ b/packages/hca-anndata-tools/tests/test_check_schema_type.py
@@ -58,3 +58,29 @@ def test_check_schema_type_return_shape_is_fixed(tmp_path):
 
     expected = {"filename", "schema", "schema_version"}
     assert set(check_schema_type(str(path)).keys()) == expected
+
+
+def test_check_schema_type_hca_when_cellxgene_in_provenance_only(tmp_path):
+    """After convert_cellxgene_to_hca, the CellxGENE fields live in
+    uns/provenance/cellxgene and the top-level schema_version is gone —
+    the file must classify as HCA, not CellxGENE."""
+    X = sp.csr_matrix(np.zeros((5, 5), dtype=np.float32))
+    adata = ad.AnnData(
+        X=X,
+        obs=pd.DataFrame(index=[f"c{i}" for i in range(5)]),  # pyright: ignore[reportArgumentType]
+        var=pd.DataFrame(index=[f"g{i}" for i in range(5)]),  # pyright: ignore[reportArgumentType]
+    )
+    # Matches what convert_cellxgene_to_hca produces: CellxGENE fields
+    # relocated under provenance, no top-level schema_version.
+    adata.uns["provenance"] = {
+        "cellxgene": {
+            "schema_version": "6.0.0",
+            "schema_reference": "https://github.com/chanzuckerberg/single-cell-curation/...",
+        }
+    }
+    path = tmp_path / "converted.h5ad"
+    adata.write_h5ad(path)
+
+    result = check_schema_type(str(path))
+    assert result["schema"] == "hca"
+    assert result["schema_version"] is None

--- a/packages/hca-anndata-tools/tests/test_check_schema_type.py
+++ b/packages/hca-anndata-tools/tests/test_check_schema_type.py
@@ -1,0 +1,60 @@
+"""Tests for check_schema_type."""
+
+import anndata as ad
+import numpy as np
+import pandas as pd
+import scipy.sparse as sp
+from hca_anndata_tools.inspect import check_schema_type
+
+
+def _write_h5ad(path, *, schema_version=None):
+    X = sp.csr_matrix(np.zeros((5, 5), dtype=np.float32))
+    adata = ad.AnnData(
+        X=X,
+        obs=pd.DataFrame(index=[f"c{i}" for i in range(5)]),  # pyright: ignore[reportArgumentType]
+        var=pd.DataFrame(index=[f"g{i}" for i in range(5)]),  # pyright: ignore[reportArgumentType]
+    )
+    if schema_version is not None:
+        adata.uns["schema_version"] = schema_version
+    adata.write_h5ad(path)
+    return path
+
+
+def test_check_schema_type_cellxgene(tmp_path):
+    path = _write_h5ad(tmp_path / "cxg.h5ad", schema_version="6.0.0")
+
+    result = check_schema_type(str(path))
+    assert "error" not in result
+    assert result["schema"] == "cellxgene"
+    assert result["schema_version"] == "6.0.0"
+    assert result["filename"] == "cxg.h5ad"
+
+
+def test_check_schema_type_hca_when_no_schema_version(tmp_path):
+    path = _write_h5ad(tmp_path / "hca.h5ad")
+
+    result = check_schema_type(str(path))
+    assert "error" not in result
+    assert result["schema"] == "hca"
+    assert result["schema_version"] is None
+
+
+def test_check_schema_type_empty_schema_version_treated_as_hca(tmp_path):
+    """An empty/whitespace schema_version is not a usable CellxGENE marker."""
+    path = _write_h5ad(tmp_path / "empty_ver.h5ad", schema_version="   ")
+
+    result = check_schema_type(str(path))
+    assert result["schema"] == "hca"
+    assert result["schema_version"] is None
+
+
+def test_check_schema_type_missing_file():
+    result = check_schema_type("/nonexistent/does-not-exist.h5ad")
+    assert "error" in result
+
+
+def test_check_schema_type_return_shape_is_fixed(tmp_path):
+    path = _write_h5ad(tmp_path / "shape.h5ad", schema_version="6.0.0")
+
+    expected = {"filename", "schema", "schema_version"}
+    assert set(check_schema_type(str(path)).keys()) == expected


### PR DESCRIPTION
Closes #336

## Summary
- New \`check_schema_type()\` in \`hca_anndata_tools.inspect\`, paired with \`check_x_normalization\`. Reads \`uns['schema_version']\` via h5py (no matrix load) and returns \`{filename, schema, schema_version}\`.
- \`schema\` is \`"cellxgene"\` when a non-empty \`schema_version\` is present, else \`"hca"\`. \`schema_version\` is the stripped string for CellxGENE files, \`None\` for HCA.
- Registered as an MCP tool.

Deliberately narrow. Version-gating (e.g. "CellxGENE must be >= 6.0") stays inside \`convert_cellxgene_to_hca\` — that's convert's policy, not the detector's. \`convert.py\` itself is not touched in this PR to keep the change focused; a follow-up can swap its inline \`schema_version\` check for \`check_schema_type\`.

## Consumers
- \`/curate-h5ad\` Bucket A step 1 — replaces the hand-rolled "check \`uns['schema_version']\`" instruction.
- \`/evaluate-h5ad\` overview section — can display the schema inline.
- Future \`convert.py\` refactor.

## Test plan
- [x] \`poetry run pytest tests/test_check_schema_type.py -v\` — 5 passed
- [x] Full \`hca-anndata-tools\` suite — 250 passed
- [x] \`make typecheck\` — 0 errors
- [ ] Call \`check_schema_type\` via MCP on the gut myeloid file and confirm \`schema: "hca"\`, \`schema_version: null\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)