### PR TITLE
fix: auto-resolve latest edit snapshot in all read-only tools

### DIFF
--- a/packages/hca-anndata-tools/src/hca_anndata_tools/cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/cap.py
@@ -2,6 +2,7 @@
 
 from ._io import open_h5ad
 from ._serialize import make_serializable as _make_serializable
+from .write import resolve_latest
 
 # CAP obs column suffixes per the cell-annotation-schema spec
 _REQUIRED_SUFFIXES = [
@@ -73,6 +74,7 @@ def get_cap_annotations(path: str, annotation_set: str | None = None) -> dict:
         annotation_set: Specific annotation set name to inspect. If None, lists all sets found.
     """
     try:
+        path = resolve_latest(path)
         with open_h5ad(path) as adata:
             obs_columns = list(adata.obs.columns)
 

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/marker_genes.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/marker_genes.py
@@ -9,6 +9,7 @@ from ._io import (
     read_var_gene_names,
 )
 from .cap import _find_annotation_sets
+from .write import resolve_latest
 
 _SKIP_VALUES = {"unknown", "", "NA", "na", "none", "None"}
 
@@ -71,6 +72,7 @@ def validate_marker_genes(path: str, annotation_set: str | None = None) -> dict:
         Dict with validation results, or 'error' on failure.
     """
     try:
+        path = resolve_latest(path)
         obs_columns = read_obs_column_names(path)
 
         if "organism_ontology_term_id" not in obs_columns:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/plot.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/plot.py
@@ -4,6 +4,7 @@ import base64
 import io
 
 from ._io import open_h5ad
+from .write import resolve_latest
 
 
 def plot_embedding(
@@ -41,6 +42,7 @@ def plot_embedding(
     fig = None
     plt = None
     try:
+        path = resolve_latest(path)
         # Lazy imports — scanpy/matplotlib are heavy and only needed for plotting
         import matplotlib
         if matplotlib.get_backend().lower() != "agg":

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/stats.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/stats.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 
 from ._io import open_h5ad
+from .write import resolve_latest
 
 
 def get_descriptive_stats(
@@ -34,6 +35,7 @@ def get_descriptive_stats(
         if attribute not in ("obs", "var"):
             return {"error": f"attribute must be 'obs' or 'var', got '{attribute}'"}
 
+        path = resolve_latest(path)
         with open_h5ad(path) as adata:
             df: pd.DataFrame = getattr(adata, attribute)
 

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/storage.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/storage.py
@@ -4,6 +4,8 @@ import os
 
 import h5py
 
+from .write import resolve_latest
+
 
 def _dataset_info(ds: h5py.Dataset) -> dict:
     """Extract storage info from an HDF5 dataset."""
@@ -52,6 +54,7 @@ def get_storage_info(path: str) -> dict:
         if not path.endswith(".h5ad"):
             return {"error": "Only .h5ad files supported (not zarr)"}
 
+        path = resolve_latest(path)
         file_bytes = os.path.getsize(path)
         result = {
             "file_size_bytes": file_bytes,

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/summary.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/summary.py
@@ -1,6 +1,7 @@
 """Summary overview of an AnnData object."""
 
 from ._io import open_h5ad
+from .write import resolve_latest
 
 
 def _dtype_str(arr) -> str:
@@ -34,6 +35,7 @@ def get_summary(path: str) -> dict:
         path: Absolute path to an .h5ad file.
     """
     try:
+        path = resolve_latest(path)
         with open_h5ad(path) as adata:
             return {
                 "n_obs": adata.n_obs,

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/view.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/view.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 
 from ._io import open_h5ad
+from .write import resolve_latest
 
 _ALLOWED_ATTRIBUTES = {"obs", "var", "X", "obsm", "varm", "obsp", "varp", "layers", "uns"}
 _KEY_REQUIRED_ATTRIBUTES = {"obsm", "varm", "obsp", "varp", "layers"}
@@ -40,6 +41,7 @@ def view_data(
         if attribute not in _ALLOWED_ATTRIBUTES:
             return {"error": f"attribute must be one of {sorted(_ALLOWED_ATTRIBUTES)}, got '{attribute}'"}
 
+        path = resolve_latest(path)
         with open_h5ad(path) as adata:
             attr_obj = getattr(adata, attribute, None)
             if attr_obj is None:

--- a/packages/hca-anndata-tools/tests/test_auto_resolve_latest.py
+++ b/packages/hca-anndata-tools/tests/test_auto_resolve_latest.py
@@ -1,0 +1,96 @@
+"""Verify read-only tools auto-resolve to the latest edit snapshot.
+
+Mutating tools already carry their own test coverage for resolve_latest
+behavior. These tests cover the previously-inconsistent read-only path
+(#339): when both ``foo.h5ad`` and ``foo-edit-<UTC>.h5ad`` exist, calling
+a tool with the original path should operate on the snapshot.
+"""
+
+from pathlib import Path
+
+import anndata as ad
+import numpy as np
+import pandas as pd
+import pytest
+import scipy.sparse as sp
+from hca_anndata_tools.cap import get_cap_annotations
+from hca_anndata_tools.marker_genes import validate_marker_genes
+from hca_anndata_tools.stats import get_descriptive_stats
+from hca_anndata_tools.storage import get_storage_info
+from hca_anndata_tools.summary import get_summary
+from hca_anndata_tools.view import view_data
+
+
+def _make_file(path: Path, *, n_obs: int, marker: str) -> None:
+    """Write a minimal h5ad with an identifiable obs column + uns title."""
+    X = sp.csr_matrix(np.zeros((n_obs, 3), dtype=np.float32))
+    obs = pd.DataFrame(
+        {"kind": pd.Categorical([marker] * n_obs)},
+        index=[f"c{i}" for i in range(n_obs)],  # pyright: ignore[reportArgumentType]
+    )
+    var = pd.DataFrame(index=[f"g{i}" for i in range(3)])  # pyright: ignore[reportArgumentType]
+    adata = ad.AnnData(X=X, obs=obs, var=var)
+    adata.uns["title"] = marker
+    adata.write_h5ad(path)
+
+
+@pytest.fixture
+def lineage(tmp_path):
+    """Create an original file plus a later timestamped edit with differing n_obs."""
+    original = tmp_path / "dataset.h5ad"
+    _make_file(original, n_obs=3, marker="original")
+
+    # The snapshot has more cells and a different uns title/obs marker so we
+    # can tell which one the tool actually read.
+    edit = tmp_path / "dataset-edit-2026-04-17-06-00-00.h5ad"
+    _make_file(edit, n_obs=7, marker="edit")
+    return original, edit
+
+
+def test_get_summary_resolves_latest(lineage):
+    original, edit = lineage
+    result = get_summary(str(original))
+    assert result["n_obs"] == 7
+
+
+def test_get_storage_info_resolves_latest(lineage):
+    original, edit = lineage
+    result = get_storage_info(str(original))
+    # n_obs not surfaced directly, but X shape is.
+    assert result["X"]["indptr"]["shape"] == [8]  # n_obs + 1 for CSR
+
+
+def test_get_descriptive_stats_resolves_latest(lineage):
+    original, edit = lineage
+    result = get_descriptive_stats(str(original), columns=["kind"], value_counts=True)
+    assert result["n_rows"] == 7
+    assert result["columns"]["kind"]["value_counts"] == {"edit": 7}
+
+
+def test_view_data_resolves_latest(lineage):
+    original, edit = lineage
+    result = view_data(str(original), attribute="obs", columns=["kind"], row_end=10)
+    values = result["data"]["kind"]
+    assert len(values) == 7
+    assert all(v == "edit" for v in values)
+
+
+def test_get_cap_annotations_resolves_latest(lineage):
+    """CAP reports title from uns — should reflect the snapshot."""
+    original, edit = lineage
+    result = get_cap_annotations(str(original))
+    # title is in uns_metadata.required_present when set.
+    assert "title" in result["uns_metadata"]["required_present"]
+    # The exact n_obs isn't in this result, but we can verify it opened the edit
+    # by checking that has_cap_annotations handling reached its logic at all (no error).
+    assert "error" not in result
+
+
+def test_validate_marker_genes_resolves_latest(lineage):
+    """validate_marker_genes reads obs columns via h5py — confirm it reads the edit."""
+    original, edit = lineage
+    result = validate_marker_genes(str(original))
+    # The fixture has no CAP columns, so this returns an informational result
+    # rather than an error. The key check: resolve_latest succeeds (no file-not-found
+    # or path-mismatch error).
+    assert "error" not in result or "organism_ontology_term_id" in result.get("error", "")

--- a/packages/hca-anndata-tools/tests/test_auto_resolve_latest.py
+++ b/packages/hca-anndata-tools/tests/test_auto_resolve_latest.py
@@ -1,10 +1,4 @@
-"""Verify read-only tools auto-resolve to the latest edit snapshot.
-
-Mutating tools already carry their own test coverage for resolve_latest
-behavior. These tests cover the previously-inconsistent read-only path
-(#339): when both ``foo.h5ad`` and ``foo-edit-<UTC>.h5ad`` exist, calling
-a tool with the original path should operate on the snapshot.
-"""
+"""Verify each read-only tool returns results from the latest edit snapshot when one exists beside the given path."""
 
 from pathlib import Path
 
@@ -22,7 +16,6 @@ from hca_anndata_tools.view import view_data
 
 
 def _make_file(path: Path, *, n_obs: int, marker: str) -> None:
-    """Write a minimal h5ad with an identifiable obs column + uns title."""
     X = sp.csr_matrix(np.zeros((n_obs, 3), dtype=np.float32))
     obs = pd.DataFrame(
         {"kind": pd.Categorical([marker] * n_obs)},
@@ -35,62 +28,49 @@ def _make_file(path: Path, *, n_obs: int, marker: str) -> None:
 
 
 @pytest.fixture
-def lineage(tmp_path):
-    """Create an original file plus a later timestamped edit with differing n_obs."""
+def original_path(tmp_path):
+    """Write an original + a later timestamped edit; return the original path.
+
+    The edit has different n_obs and obs marker so tools reading the wrong
+    file will fail their assertions.
+    """
     original = tmp_path / "dataset.h5ad"
     _make_file(original, n_obs=3, marker="original")
-
-    # The snapshot has more cells and a different uns title/obs marker so we
-    # can tell which one the tool actually read.
     edit = tmp_path / "dataset-edit-2026-04-17-06-00-00.h5ad"
     _make_file(edit, n_obs=7, marker="edit")
-    return original, edit
+    return original
 
 
-def test_get_summary_resolves_latest(lineage):
-    original, edit = lineage
-    result = get_summary(str(original))
-    assert result["n_obs"] == 7
+def test_get_summary_resolves_latest(original_path):
+    assert get_summary(str(original_path))["n_obs"] == 7
 
 
-def test_get_storage_info_resolves_latest(lineage):
-    original, edit = lineage
-    result = get_storage_info(str(original))
-    # n_obs not surfaced directly, but X shape is.
-    assert result["X"]["indptr"]["shape"] == [8]  # n_obs + 1 for CSR
+def test_get_storage_info_resolves_latest(original_path):
+    # CSR indptr length is n_obs + 1 — the shape field isn't surfaced directly.
+    assert get_storage_info(str(original_path))["X"]["indptr"]["shape"] == [8]
 
 
-def test_get_descriptive_stats_resolves_latest(lineage):
-    original, edit = lineage
-    result = get_descriptive_stats(str(original), columns=["kind"], value_counts=True)
+def test_get_descriptive_stats_resolves_latest(original_path):
+    result = get_descriptive_stats(str(original_path), columns=["kind"], value_counts=True)
     assert result["n_rows"] == 7
     assert result["columns"]["kind"]["value_counts"] == {"edit": 7}
 
 
-def test_view_data_resolves_latest(lineage):
-    original, edit = lineage
-    result = view_data(str(original), attribute="obs", columns=["kind"], row_end=10)
-    values = result["data"]["kind"]
+def test_view_data_resolves_latest(original_path):
+    values = view_data(str(original_path), attribute="obs", columns=["kind"], row_end=10)["data"]["kind"]
     assert len(values) == 7
     assert all(v == "edit" for v in values)
 
 
-def test_get_cap_annotations_resolves_latest(lineage):
-    """CAP reports title from uns — should reflect the snapshot."""
-    original, edit = lineage
-    result = get_cap_annotations(str(original))
-    # title is in uns_metadata.required_present when set.
+def test_get_cap_annotations_resolves_latest(original_path):
+    result = get_cap_annotations(str(original_path))
+    # title is in uns so the snapshot's uns was read.
     assert "title" in result["uns_metadata"]["required_present"]
-    # The exact n_obs isn't in this result, but we can verify it opened the edit
-    # by checking that has_cap_annotations handling reached its logic at all (no error).
-    assert "error" not in result
 
 
-def test_validate_marker_genes_resolves_latest(lineage):
-    """validate_marker_genes reads obs columns via h5py — confirm it reads the edit."""
-    original, edit = lineage
-    result = validate_marker_genes(str(original))
-    # The fixture has no CAP columns, so this returns an informational result
-    # rather than an error. The key check: resolve_latest succeeds (no file-not-found
-    # or path-mismatch error).
-    assert "error" not in result or "organism_ontology_term_id" in result.get("error", "")
+def test_validate_marker_genes_resolves_latest(original_path):
+    result = validate_marker_genes(str(original_path))
+    # The snapshot has no organism_ontology_term_id, so the tool returns a
+    # specific error from that file — confirming it read the snapshot rather
+    # than blowing up earlier on path resolution.
+    assert result.get("error") == "organism_ontology_term_id not found in obs columns"

--- a/packages/hca-anndata-tools/tests/test_auto_resolve_latest.py
+++ b/packages/hca-anndata-tools/tests/test_auto_resolve_latest.py
@@ -9,6 +9,7 @@ import pytest
 import scipy.sparse as sp
 from hca_anndata_tools.cap import get_cap_annotations
 from hca_anndata_tools.marker_genes import validate_marker_genes
+from hca_anndata_tools.plot import plot_embedding
 from hca_anndata_tools.stats import get_descriptive_stats
 from hca_anndata_tools.storage import get_storage_info
 from hca_anndata_tools.summary import get_summary
@@ -34,6 +35,7 @@ def _make_file(path: Path, *, n_obs: int, marker: str, edit_only: bool) -> None:
     adata.uns["title"] = marker
     if edit_only:
         adata.uns["cellannotation_schema_version"] = "1.0.0"
+        adata.obsm["X_umap"] = np.random.default_rng(0).normal(size=(n_obs, 2)).astype(np.float32)
     adata.write_h5ad(path)
 
 
@@ -76,6 +78,15 @@ def test_get_cap_annotations_resolves_latest(original_path):
     # cellannotation_schema_version is set only on the snapshot.
     result = get_cap_annotations(str(original_path))
     assert "cellannotation_schema_version" in result["uns_metadata"]["required_present"]
+
+
+def test_plot_embedding_resolves_latest(original_path):
+    # obsm['X_umap'] exists only on the snapshot — asking for it on the original
+    # would error "embedding not found". A successful PNG result therefore
+    # proves the snapshot was read.
+    result = plot_embedding(str(original_path), color="kind", embedding="X_umap")
+    assert "error" not in result
+    assert result["mime_type"] == "image/png"
 
 
 def test_validate_marker_genes_resolves_latest(original_path):

--- a/packages/hca-anndata-tools/tests/test_auto_resolve_latest.py
+++ b/packages/hca-anndata-tools/tests/test_auto_resolve_latest.py
@@ -15,15 +15,25 @@ from hca_anndata_tools.summary import get_summary
 from hca_anndata_tools.view import view_data
 
 
-def _make_file(path: Path, *, n_obs: int, marker: str) -> None:
-    X = sp.csr_matrix(np.zeros((n_obs, 3), dtype=np.float32))
+def _make_file(path: Path, *, n_obs: int, marker: str, edit_only: bool) -> None:
+    obs_data = {"kind": pd.Categorical([marker] * n_obs)}
+    if edit_only:
+        # Added only to the snapshot so tools that observe these signals fail
+        # assertions when they accidentally read the original file.
+        obs_data["organism_ontology_term_id"] = pd.Categorical(["NCBITaxon:9606"] * n_obs)
     obs = pd.DataFrame(
-        {"kind": pd.Categorical([marker] * n_obs)},
+        obs_data,
         index=[f"c{i}" for i in range(n_obs)],  # pyright: ignore[reportArgumentType]
     )
     var = pd.DataFrame(index=[f"g{i}" for i in range(3)])  # pyright: ignore[reportArgumentType]
-    adata = ad.AnnData(X=X, obs=obs, var=var)
+    adata = ad.AnnData(
+        X=sp.csr_matrix(np.zeros((n_obs, 3), dtype=np.float32)),
+        obs=obs,
+        var=var,
+    )
     adata.uns["title"] = marker
+    if edit_only:
+        adata.uns["cellannotation_schema_version"] = "1.0.0"
     adata.write_h5ad(path)
 
 
@@ -31,13 +41,13 @@ def _make_file(path: Path, *, n_obs: int, marker: str) -> None:
 def original_path(tmp_path):
     """Write an original + a later timestamped edit; return the original path.
 
-    The edit has different n_obs and obs marker so tools reading the wrong
-    file will fail their assertions.
+    The edit has different n_obs, obs marker, extra uns keys, and extra obs
+    columns so every tool's output differs based on which file it reads.
     """
     original = tmp_path / "dataset.h5ad"
-    _make_file(original, n_obs=3, marker="original")
+    _make_file(original, n_obs=3, marker="original", edit_only=False)
     edit = tmp_path / "dataset-edit-2026-04-17-06-00-00.h5ad"
-    _make_file(edit, n_obs=7, marker="edit")
+    _make_file(edit, n_obs=7, marker="edit", edit_only=True)
     return original
 
 
@@ -63,14 +73,16 @@ def test_view_data_resolves_latest(original_path):
 
 
 def test_get_cap_annotations_resolves_latest(original_path):
+    # cellannotation_schema_version is set only on the snapshot.
     result = get_cap_annotations(str(original_path))
-    # title is in uns so the snapshot's uns was read.
-    assert "title" in result["uns_metadata"]["required_present"]
+    assert "cellannotation_schema_version" in result["uns_metadata"]["required_present"]
 
 
 def test_validate_marker_genes_resolves_latest(original_path):
+    # The snapshot adds organism_ontology_term_id = NCBITaxon:9606; the original
+    # lacks it entirely. Reading the original returns the "missing column" error;
+    # reading the snapshot passes the organism gate and falls through to the
+    # no-marker-sets branch.
     result = validate_marker_genes(str(original_path))
-    # The snapshot has no organism_ontology_term_id, so the tool returns a
-    # specific error from that file — confirming it read the snapshot rather
-    # than blowing up earlier on path resolution.
-    assert result.get("error") == "organism_ontology_term_id not found in obs columns"
+    assert "error" not in result
+    assert result["annotation_sets_with_markers"] == []


### PR DESCRIPTION
Closes #339

## Summary
Add \`path = resolve_latest(path)\` to the seven read-only tools that previously skipped it so every tool in the suite picks up the latest \`-edit-<UTC>.h5ad\` snapshot consistently.

Before this change:
- **Auto-resolved** (mutating + verdict tools): compress_h5ad, copy_cap_annotations, normalize_raw, set_uns, list_uns_fields, replace_placeholder_values, view_edit_log, check_x_normalization, check_schema_type
- **Did NOT auto-resolve** (read-only reporters): get_summary, get_storage_info, get_cap_annotations, get_descriptive_stats, view_data, validate_marker_genes, plot_embedding

Surfaced by Copilot on #332: a skill like \`/evaluate-h5ad\` that mixes both would stitch its report from two physical files when edit snapshots exist.

## Scope
- Seven one-line additions + imports in the library. No MCP-server changes needed.
- Mechanically mirrors the pattern already used by \`edit.py\`, \`inspect.py\`, \`compress.py\`, \`copy_cap.py\`, \`normalize.py\`.
- **Out of scope:** \`convert_cellxgene_to_hca\` left alone — conversion is typically the first step on a file and the wrangler should be explicit about which file to convert. Can be revisited separately.

## Test plan
- [x] New \`tests/test_auto_resolve_latest.py\` — for each of the six tools whose output is easy to assert against (summary, storage, stats, view_data, cap, marker_genes), create a lineage (\`foo.h5ad\` + \`foo-edit-<ts>.h5ad\` with differing content), call the tool with the original path, confirm it reads the snapshot. 6 passed.
- [x] Full \`hca-anndata-tools\` suite — 257 passed.
- [x] \`make typecheck\` — 0 errors.

## Follow-up
Unpause PR #332 (evaluate-h5ad skill) and PR #334 (curate-h5ad skill) once this lands — both depend on consistent resolve behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)