### PR TITLE
feat: allow partial obs overlap in copy_cap_annotations

### DIFF
--- a/.claude/skills/curate-h5ad/SKILL.md
+++ b/.claude/skills/curate-h5ad/SKILL.md
@@ -40,7 +40,7 @@ Only these are in Bucket A. Nothing else.
 - **`normalize_raw`** — when `check_x_normalization` reports `verdict: "raw_counts"` and `has_raw_x: false`. Deterministic: moves X→raw.X, normalizes X with `normalize_total(target_sum=10000) + log1p`.
 - **`replace_placeholder_values` on `library_preparation_batch`** — only if the column actually contains placeholder values flagged by the validator.
 - **`replace_placeholder_values` on `library_sequencing_run`** — same condition.
-- **`copy_cap_annotations`** — only if the wrangler provided a CAP source file in Step 3. Copies annotation sets + `cellannotation_schema_version` + `cellannotation_metadata` from the source into the target.
+- **`copy_cap_annotations`** — only if the wrangler provided a CAP source file in Step 3. Copies annotation sets + `cellannotation_schema_version` + `cellannotation_metadata` from the source into the target. Partial overlap is allowed: the source and target obs indexes only need to match at ≥95% in both directions (target-covered and source-covered); target rows absent from source get NaN in the new CAP columns. If the overlap is below 95% the tool aborts — treat that as a Bucket B item and bring it back to the wrangler (usually the CAP source is stale or wrong).
 - **`compress_h5ad`** — when `get_storage_info` shows no HDF5 filter on X's underlying dataset (`X.data.compression` for sparse X, `X.compression` for dense X). If the file is already compressed, the tool safely returns `{skipped: true, reason: ...}` rather than rewriting. Pure compression, no data change.
 
 ### Bucket B — Needs wrangler input (todo — stop and ask)
@@ -86,6 +86,7 @@ Each tool writes a new timestamped file. For most subsequent calls, passing eith
 
 - Call `view_edit_log` on the final file; list the entries added this session.
 - Re-run the validator; report error/warning deltas vs. Step 1.
+- If `copy_cap_annotations` ran, surface its cell-overlap stats as their own line: `source_n_obs`, `target_n_obs`, `matched_n_obs`, `match_fraction_of_source`, `match_fraction_of_target`. These come back in the tool result and also live in the edit-log entry's `details`.
 - Summarize:
   - **Fixed this session** — each Bucket A action that ran, with the resulting validator change.
   - **Still to do** — every Bucket B question the wrangler didn't answer, plus every Bucket C item.

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -183,14 +183,20 @@ def copy_cap_annotations(
             source_obs_data = {}
             for col in obs_cols_to_copy:
                 item = obs_group[col]
-                if isinstance(item, h5py.Group) and "categories" in item:
-                    categories, codes = read_categorical_data(item)
-                    source_obs_data[col] = pd.Categorical.from_codes(codes, categories=categories)
-                else:
-                    # Wrap in Categorical so partial-overlap reindex (target rows
-                    # absent from source) injects NaN cleanly — plain object
-                    # columns with mixed str/NaN break anndata's writer.
-                    source_obs_data[col] = pd.Categorical([_decode_bytes(v) for v in item[:]])
+                # CAP serializes all annotation columns as categorical. Enforce
+                # that contract — non-categorical columns would either force a
+                # dtype coercion on copy (schema drift) or break the writer on
+                # the NaN rows that partial-overlap introduces.
+                if not (isinstance(item, h5py.Group) and "categories" in item):
+                    return {
+                        "error": (
+                            f"CAP source column '{col}' is not categorical. "
+                            "CAP is expected to serialize all annotation columns "
+                            "as categorical; please report upstream."
+                        )
+                    }
+                categories, codes = read_categorical_data(item)
+                source_obs_data[col] = pd.Categorical.from_codes(codes, categories=categories)
 
         if not obs_cols_to_copy:
             return {"error": "No CAP obs columns found to copy"}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -62,6 +62,27 @@ _SKIP_SETS = {"sex", "development_stage", "self_reported_ethnicity"}
 # provenance/cap is handled separately via merge logic.
 _OVERWRITE_UNS_KEYS = set(_UNS_SCHEMA_TOPLEVEL)
 
+# Minimum fraction of source and target cell IDs that must be in the
+# intersection. Applied to both fractions (source-covered and target-covered).
+_MIN_OVERLAP_FRACTION = 0.95
+
+
+def _compute_overlap_stats(
+    source_index_set: set[str],
+    target_index_set: set[str],
+) -> dict[str, int | float]:
+    """Count overlap between source and target cell IDs."""
+    source_n = len(source_index_set)
+    target_n = len(target_index_set)
+    matched_n = len(source_index_set & target_index_set)
+    return {
+        "source_n_obs": source_n,
+        "target_n_obs": target_n,
+        "matched_n_obs": matched_n,
+        "match_fraction_of_source": matched_n / source_n if source_n else 0.0,
+        "match_fraction_of_target": matched_n / target_n if target_n else 0.0,
+    }
+
 
 def _check_duplicate_ids(index: list[str], label: str) -> str | None:
     """Return an error message if index has duplicates, else None."""
@@ -166,7 +187,10 @@ def copy_cap_annotations(
                     categories, codes = read_categorical_data(item)
                     source_obs_data[col] = pd.Categorical.from_codes(codes, categories=categories)
                 else:
-                    source_obs_data[col] = [_decode_bytes(v) for v in item[:]]
+                    # Wrap in Categorical so partial-overlap reindex (target rows
+                    # absent from source) injects NaN cleanly — plain object
+                    # columns with mixed str/NaN break anndata's writer.
+                    source_obs_data[col] = pd.Categorical([_decode_bytes(v) for v in item[:]])
 
         if not obs_cols_to_copy:
             return {"error": "No CAP obs columns found to copy"}
@@ -219,27 +243,23 @@ def copy_cap_annotations(
                 )
             }
 
-        if target_n_obs != source_n_obs:
+        overlap_stats = _compute_overlap_stats(source_index, target_index_set)
+        frac_source = overlap_stats["match_fraction_of_source"]
+        frac_target = overlap_stats["match_fraction_of_target"]
+        if frac_source < _MIN_OVERLAP_FRACTION or frac_target < _MIN_OVERLAP_FRACTION:
             return {
                 "error": (
-                    f"Cell count mismatch: source has {source_n_obs}, "
-                    f"target has {target_n_obs}"
-                )
-            }
-
-        if source_index != target_index_set:
-            missing_in_target = source_index - target_index_set
-            missing_in_source = target_index_set - source_index
-            return {
-                "error": (
-                    f"Cell ID mismatch: {len(missing_in_target)} IDs in source "
-                    f"not in target, {len(missing_in_source)} IDs in target not "
-                    f"in source"
-                )
+                    f"Cell ID overlap below {_MIN_OVERLAP_FRACTION:.0%}: "
+                    f"source has {source_n_obs}, target has {target_n_obs}, "
+                    f"matched {overlap_stats['matched_n_obs']} "
+                    f"(source covered {frac_source:.2%}, "
+                    f"target covered {frac_target:.2%})"
+                ),
+                **overlap_stats,
             }
 
         # --- Step 3: Build aligned temp AnnData ---
-        aligned_obs = source_obs_subset.loc[target_index]
+        aligned_obs = source_obs_subset.reindex(target_index)
         del source_obs_subset
 
         temp_uns = {}
@@ -268,6 +288,7 @@ def copy_cap_annotations(
                 "annotation_sets": annotation_sets,
                 "obs_columns_added": obs_cols_to_copy,
                 "uns_keys_added": uns_keys_added,
+                **overlap_stats,
             },
         )
 
@@ -357,6 +378,7 @@ def copy_cap_annotations(
             "obs_columns_added": obs_cols_to_copy,
             "uns_keys_added": uns_keys_added,
             "marker_gene_validation": marker_validation,
+            **overlap_stats,
         }
 
     except Exception as e:

--- a/packages/hca-anndata-tools/tests/test_copy_cap.py
+++ b/packages/hca-anndata-tools/tests/test_copy_cap.py
@@ -225,15 +225,18 @@ def test_copy_cell_mismatch_fails(cap_source, tmp_path):
     assert result["matched_n_obs"] == 0
 
 
-def test_copy_cell_count_mismatch_fails(cap_source, tmp_path):
-    # 5 cells, none overlapping with source (cap_source has cell_0..cell_9),
-    # so both fractions collapse to 0 and the threshold gate trips.
-    fewer_cells = _make_hca_target(
-        tmp_path / "fewer.h5ad", [f"other_{i}" for i in range(5)]
+def test_copy_source_uncovered_fails(cap_source, tmp_path):
+    # Target is a strict subset of source (5 of source's 10 cells). Target is
+    # 100% covered but source is only 50% covered — exercises the asymmetric
+    # failure: source-fraction below threshold while target-fraction passes.
+    subset = _make_hca_target(
+        tmp_path / "subset.h5ad", [f"cell_{i}" for i in range(5)]
     )
-    result = copy_cap_annotations(str(cap_source), str(fewer_cells))
+    result = copy_cap_annotations(str(cap_source), str(subset))
     assert "error" in result
     assert "overlap" in result["error"].lower()
+    assert result["match_fraction_of_target"] == pytest.approx(1.0)
+    assert result["match_fraction_of_source"] == pytest.approx(0.5)
 
 
 def test_copy_partial_overlap_succeeds(tmp_path):

--- a/packages/hca-anndata-tools/tests/test_copy_cap.py
+++ b/packages/hca-anndata-tools/tests/test_copy_cap.py
@@ -210,16 +210,60 @@ def test_copy_cell_mismatch_fails(cap_source, tmp_path):
     )
     result = copy_cap_annotations(str(cap_source), str(different_cells))
     assert "error" in result
-    assert "mismatch" in result["error"].lower()
+    assert "overlap" in result["error"].lower()
+    assert result["matched_n_obs"] == 0
 
 
 def test_copy_cell_count_mismatch_fails(cap_source, tmp_path):
+    # 5 cells, none overlapping with source (cap_source has cell_0..cell_9),
+    # so both fractions collapse to 0 and the threshold gate trips.
     fewer_cells = _make_hca_target(
-        tmp_path / "fewer.h5ad", [f"cell_{i}" for i in range(5)]
+        tmp_path / "fewer.h5ad", [f"other_{i}" for i in range(5)]
     )
     result = copy_cap_annotations(str(cap_source), str(fewer_cells))
     assert "error" in result
-    assert "mismatch" in result["error"].lower()
+    assert "overlap" in result["error"].lower()
+
+
+def test_copy_partial_overlap_succeeds(cap_source, tmp_path):
+    # 19/20 target cells present in source → 95% of target covered;
+    # 19/20 source cells present in target (one extra in source) → 95% of source.
+    # Threshold is inclusive, so this should succeed and the missing target
+    # row should end up with NaN in the new CAP columns.
+    target_ids = [f"cell_{i}" for i in range(19)] + ["target_only"]
+    # Rebuild a cap_source with 20 cells so both fractions land at 19/20.
+    cap_20 = _make_cap_source(
+        tmp_path / "cap_20.h5ad", [f"cell_{i}" for i in range(20)]
+    )
+    target = _make_hca_target(tmp_path / "target_20.h5ad", target_ids)
+
+    result = copy_cap_annotations(str(cap_20), str(target))
+
+    assert "error" not in result
+    assert result["source_n_obs"] == 20
+    assert result["target_n_obs"] == 20
+    assert result["matched_n_obs"] == 19
+    assert result["match_fraction_of_source"] == pytest.approx(0.95)
+    assert result["match_fraction_of_target"] == pytest.approx(0.95)
+
+    written = ad.read_h5ad(result["output_path"])
+    # Target-only cell should have NaN in a copied categorical CAP column.
+    col = "author_cell_type--cell_ontology_term_id"
+    assert col in written.obs.columns
+    assert pd.isna(written.obs.loc["target_only", col])
+
+
+def test_copy_below_threshold_fails(cap_source, tmp_path):
+    # 9/10 target cells in source → target covered 90%, below 0.95.
+    target_ids = [f"cell_{i}" for i in range(9)] + ["target_only"]
+    target = _make_hca_target(tmp_path / "target_below.h5ad", target_ids)
+
+    result = copy_cap_annotations(str(cap_source), str(target))
+
+    assert "error" in result
+    assert "overlap" in result["error"].lower()
+    assert result["matched_n_obs"] == 9
+    assert result["match_fraction_of_target"] == pytest.approx(0.9)
 
 
 def test_copy_no_cap_source_fails(hca_target, tmp_path):

--- a/packages/hca-anndata-tools/tests/test_copy_cap.py
+++ b/packages/hca-anndata-tools/tests/test_copy_cap.py
@@ -236,7 +236,7 @@ def test_copy_cell_count_mismatch_fails(cap_source, tmp_path):
     assert "overlap" in result["error"].lower()
 
 
-def test_copy_partial_overlap_succeeds(cap_source, tmp_path):
+def test_copy_partial_overlap_succeeds(tmp_path):
     # 19/20 target cells present in source → 95% of target covered;
     # 19/20 source cells present in target (one extra in source) → 95% of source.
     # Threshold is inclusive, so this should succeed and the missing target

--- a/packages/hca-anndata-tools/tests/test_copy_cap.py
+++ b/packages/hca-anndata-tools/tests/test_copy_cap.py
@@ -22,31 +22,42 @@ def _make_cap_source(path: Path, cell_ids: list[str]) -> Path:
     X = sp.random(n, 5, density=0.3, format="csr", dtype=np.float32, random_state=rng)
 
     labels = rng.choice(["typeA", "typeB"], n)
+    # CAP serializes all annotation columns as categorical — mirror that here.
     obs = pd.DataFrame(
         {
             "author_cell_type": pd.Categorical(labels),
-            "author_cell_type--cell_fullname": [f"{label} cell" for label in labels],
-            "author_cell_type--cell_ontology_exists": [True] * n,
+            "author_cell_type--cell_fullname": pd.Categorical(
+                [f"{label} cell" for label in labels]
+            ),
+            "author_cell_type--cell_ontology_exists": pd.Categorical(["True"] * n),
             "author_cell_type--cell_ontology_term_id": pd.Categorical(
                 rng.choice(["CL:0000540", "CL:0000127"], n)
             ),
             "author_cell_type--cell_ontology_term": pd.Categorical(
                 rng.choice(["neuron", "astrocyte"], n)
             ),
-            "author_cell_type--rationale": ["morphology"] * n,
+            "author_cell_type--rationale": pd.Categorical(["morphology"] * n),
             "author_cell_type--marker_gene_evidence": pd.Categorical(
                 rng.choice(["GFAP", "AIF1"], n)
             ),
-            "author_cell_type--canonical_marker_genes": ["unknown"] * n,
-            "author_cell_type--synonyms": ["unknown"] * n,
-            "author_cell_type--category_fullname": ["neural cell"] * n,
-            "author_cell_type--category_cell_ontology_term_id": ["CL:0002319"] * n,
-            "author_cell_type--category_cell_ontology_term": ["neural cell"] * n,
+            "author_cell_type--canonical_marker_genes": pd.Categorical(["unknown"] * n),
+            "author_cell_type--synonyms": pd.Categorical(["unknown"] * n),
+            "author_cell_type--category_fullname": pd.Categorical(["neural cell"] * n),
+            "author_cell_type--category_cell_ontology_term_id": pd.Categorical(
+                ["CL:0002319"] * n
+            ),
+            "author_cell_type--category_cell_ontology_term": pd.Categorical(
+                ["neural cell"] * n
+            ),
             # Demographic columns (should NOT be copied)
-            "sex--cell_ontology_term_id": ["PATO:0000384"] * n,
-            "development_stage--cell_ontology_term_id": ["HsapDv:0000087"] * n,
-            "self_reported_ethnicity--cell_ontology_term_id": ["HANCESTRO:0005"] * n,
-            "cell_type--cell_ontology_term_id": ["CL:0000540"] * n,
+            "sex--cell_ontology_term_id": pd.Categorical(["PATO:0000384"] * n),
+            "development_stage--cell_ontology_term_id": pd.Categorical(
+                ["HsapDv:0000087"] * n
+            ),
+            "self_reported_ethnicity--cell_ontology_term_id": pd.Categorical(
+                ["HANCESTRO:0005"] * n
+            ),
+            "cell_type--cell_ontology_term_id": pd.Categorical(["CL:0000540"] * n),
         },
         index=cell_ids,
     )
@@ -251,6 +262,36 @@ def test_copy_partial_overlap_succeeds(cap_source, tmp_path):
     col = "author_cell_type--cell_ontology_term_id"
     assert col in written.obs.columns
     assert pd.isna(written.obs.loc["target_only", col])
+
+
+def test_copy_preserves_column_dtype(cap_source, hca_target):
+    # Every copied CAP obs column must remain categorical (CAP's serialization
+    # contract). The copy must not coerce dtypes.
+    result = copy_cap_annotations(str(cap_source), str(hca_target))
+    assert "error" not in result
+    written = ad.read_h5ad(result["output_path"])
+    for col in result["obs_columns_added"]:
+        assert isinstance(written.obs[col].dtype, pd.CategoricalDtype), (
+            f"{col} dtype changed to {written.obs[col].dtype}"
+        )
+
+
+@pytest.mark.filterwarnings("ignore::anndata._warnings.OldFormatWarning")
+def test_copy_rejects_non_categorical_source_column(cap_source, hca_target):
+    # Rewrite one CAP column in the source as a plain string dataset (via h5py,
+    # bypassing anndata's auto-coercion to categorical) to simulate a source
+    # that violates CAP's categorical-everywhere serialization contract.
+    import h5py
+    col = "author_cell_type--rationale"
+    with h5py.File(cap_source, "a") as f:
+        del f["obs"][col]
+        f["obs"].create_dataset(col, data=np.array(["morphology"] * len(CELL_IDS), dtype="S"))
+
+    result = copy_cap_annotations(str(cap_source), str(hca_target))
+
+    assert "error" in result
+    assert "not categorical" in result["error"].lower()
+    assert col in result["error"]
 
 
 def test_copy_below_threshold_fails(cap_source, tmp_path):

--- a/packages/hca-anndata-tools/tests/test_copy_cap.py
+++ b/packages/hca-anndata-tools/tests/test_copy_cap.py
@@ -209,7 +209,13 @@ def test_copy_edit_log(cap_source, hca_target):
     assert len(log) >= 1
     entry = log[-1]
     assert entry["operation"] == "import_cap_annotations"
-    assert "author_cell_type" in entry["details"]["annotation_sets"]
+    details = entry["details"]
+    assert "author_cell_type" in details["annotation_sets"]
+    assert details["source_n_obs"] == len(CELL_IDS)
+    assert details["target_n_obs"] == len(CELL_IDS)
+    assert details["matched_n_obs"] == len(CELL_IDS)
+    assert details["match_fraction_of_source"] == pytest.approx(1.0)
+    assert details["match_fraction_of_target"] == pytest.approx(1.0)
 
 
 # --- Failure cases ---


### PR DESCRIPTION
## Summary
- `copy_cap_annotations` no longer requires exact source/target cell-ID match. It now requires ≥95% overlap in both directions (source-covered and target-covered) and fails with a clear error below that threshold.
- Target rows absent from source get NaN in the new CAP columns (via `DataFrame.reindex`, replacing `.loc`); source rows absent from target are silently dropped.
- **CAP source must serialize every annotation column as categorical.** This matches CAP's observed output (verified across all 5 cap-source files in the gut-v1 workspace — zero non-categorical CAP columns). Non-categorical source columns are rejected with a clear error rather than coerced, so dtype drift is caught rather than hidden.
- Overlap stats (`source_n_obs`, `target_n_obs`, `matched_n_obs`, `match_fraction_of_source`, `match_fraction_of_target`) land in the returned dict and in the `import_cap_annotations` edit-log entry's `details`. Curate-h5ad skill updated to surface them in Step 5 and to treat below-threshold aborts as a Bucket B item.
- Threshold is hard-coded at 0.95 (no parameter) per the issue — revisit once we see more real data.

Closes #344

## Test plan
- [x] `poetry run pytest tests/test_copy_cap.py` — 19 passed, zero warnings. Covers partial-overlap success, both asymmetric-failure directions, dtype preservation, and rejection of non-categorical source columns.
- [x] Ran against real files at `/Users/dave/hca-tracker-upload/prod/gut-v1/integrated-objects`: source 52311 / target 50296 / matched 49904 (source covered 95.40%, target covered 99.22%) — previously would have failed with "Cell count mismatch"; now succeeds.
- [x] `make typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)