### PR TITLE
fix: filter description from uns field registry (workaround for #343)

### DIFF
--- a/packages/hca-anndata-tools/src/hca_anndata_tools/schema/helpers.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/schema/helpers.py
@@ -9,6 +9,13 @@ from .core import AdiposeDataset, Dataset, GutDataset, MusculoskeletalDataset
 
 _BIONETWORK_CLASSES = [AdiposeDataset, GutDataset, MusculoskeletalDataset]
 
+# Fields that LinkML's Dataset model claims live in uns but that are not
+# actually uns fields per HCA Tier 1 / CELLxGENE. See issue #343. Dropping
+# them from the registry means list_uns_fields never surfaces them and
+# set_uns rejects them as unrecognized (the same path as any unknown field).
+# Remove an entry here once the LinkML source is corrected upstream.
+_SKIP_UNS_FIELDS: set[str] = {"description"}
+
 
 @dataclass(frozen=True)
 class UnsFieldInfo:
@@ -66,6 +73,8 @@ def get_uns_field_registry() -> dict[str, UnsFieldInfo]:
 
     # Base Dataset fields
     for name, fi in Dataset.model_fields.items():
+        if name in _SKIP_UNS_FIELDS:
+            continue
         if _get_ann_data_location(fi) == "uns":
             registry[name] = UnsFieldInfo(
                 name=name,
@@ -80,7 +89,7 @@ def get_uns_field_registry() -> dict[str, UnsFieldInfo]:
     # Bionetwork subclass fields (only add new ones not in base)
     for cls in _BIONETWORK_CLASSES:
         for name, fi in cls.model_fields.items():
-            if name in registry:
+            if name in registry or name in _SKIP_UNS_FIELDS:
                 continue
             if _get_ann_data_location(fi) == "uns":
                 registry[name] = UnsFieldInfo(

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/schema/helpers.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/schema/helpers.py
@@ -11,9 +11,12 @@ _BIONETWORK_CLASSES = [AdiposeDataset, GutDataset, MusculoskeletalDataset]
 
 # Fields that LinkML's Dataset model claims live in uns but that are not
 # actually uns fields per HCA Tier 1 / CELLxGENE. See issue #343. Dropping
-# them from the registry means list_uns_fields never surfaces them and
-# set_uns rejects them as unrecognized (the same path as any unknown field).
-# Remove an entry here once the LinkML source is corrected upstream.
+# them from the registry means list_uns_fields treats them as unrecognized:
+# they don't appear in `fields` or `missing_required`, and set_uns rejects
+# them as unknown. They *will* appear in `extra_uns_keys` if an existing
+# file happens to carry one — that's intentional, since flagging an
+# unexpected key is better than silently blessing it. Remove an entry here
+# once the LinkML source is corrected upstream.
 _SKIP_UNS_FIELDS: set[str] = {"description"}
 
 

--- a/packages/hca-anndata-tools/tests/test_edit.py
+++ b/packages/hca-anndata-tools/tests/test_edit.py
@@ -58,6 +58,12 @@ def test_list_uns_fields_filters_description(sample_h5ad_for_write):
     assert "description" not in field_names
     assert "description" not in result["missing_required"]
 
+    # set_uns must reject it via the unknown-field path so the workaround
+    # can't regress silently if the registry filter is removed.
+    set_result = set_uns(str(sample_h5ad_for_write), "description", "anything")
+    assert "error" in set_result
+    assert "not a recognized HCA uns field" in set_result["error"]
+
 
 def test_list_uns_fields_shows_bionetwork_fields(sample_h5ad_for_write):
     result = list_uns_fields(str(sample_h5ad_for_write))

--- a/packages/hca-anndata-tools/tests/test_edit.py
+++ b/packages/hca-anndata-tools/tests/test_edit.py
@@ -204,7 +204,10 @@ def test_set_uns_auto_resolves_latest(sample_h5ad_for_write):
 
 # --- empty value rejection ---
 
-
+# ambient_count_correction is the only required str uns field without a
+# Literal enum constraint, so it's the one field that exercises set_uns's
+# required+str+empty code path (enum-typed fields fail Pydantic type
+# validation before reaching the non-empty check).
 def test_set_uns_empty_string_rejected(sample_h5ad_for_write):
     result = set_uns(str(sample_h5ad_for_write), "ambient_count_correction", "")
     assert "error" in result

--- a/packages/hca-anndata-tools/tests/test_edit.py
+++ b/packages/hca-anndata-tools/tests/test_edit.py
@@ -42,12 +42,21 @@ def test_list_uns_fields_shows_batch_condition(sample_h5ad_for_write):
 
 def test_list_uns_fields_shows_missing_required(sample_h5ad_for_write):
     result = list_uns_fields(str(sample_h5ad_for_write))
-    # description and study_pi are required but not in the test fixture
-    assert "description" in result["missing_required"]
+    # study_pi is required but not in the test fixture
     assert "study_pi" in result["missing_required"]
     # bionetwork-only fields are in a separate list
     assert "ambient_count_correction" not in result["missing_required"]
     assert "ambient_count_correction" in result["missing_required_bionetwork"]
+
+
+def test_list_uns_fields_filters_description(sample_h5ad_for_write):
+    # Issue #343: LinkML's Dataset model marks `description` as a required uns
+    # field, but it isn't one per HCA Tier 1 / CELLxGENE. helpers._SKIP_UNS_FIELDS
+    # drops it from the registry so it's never surfaced as missing or settable.
+    result = list_uns_fields(str(sample_h5ad_for_write))
+    field_names = [f["name"] for f in result["fields"]]
+    assert "description" not in field_names
+    assert "description" not in result["missing_required"]
 
 
 def test_list_uns_fields_shows_bionetwork_fields(sample_h5ad_for_write):
@@ -82,12 +91,12 @@ def test_list_uns_fields_bad_path():
 
 
 def test_set_uns_string_field(sample_h5ad_for_write):
-    result = set_uns(str(sample_h5ad_for_write), "description", "A test dataset")
+    result = set_uns(str(sample_h5ad_for_write), "title", "A test dataset")
     assert "error" not in result
     assert "output_path" in result
 
     written = ad.read_h5ad(result["output_path"])
-    assert written.uns["description"] == "A test dataset"
+    assert written.uns["title"] == "A test dataset"
 
 
 def test_set_uns_list_field(sample_h5ad_for_write):
@@ -143,14 +152,14 @@ def test_set_uns_default_embedding_invalid(sample_h5ad_for_write):
 
 
 def test_set_uns_edit_log(sample_h5ad_for_write):
-    result = set_uns(str(sample_h5ad_for_write), "description", "Logged edit")
+    result = set_uns(str(sample_h5ad_for_write), "comments", "Logged edit")
     assert "error" not in result
 
     written = ad.read_h5ad(result["output_path"])
     log = json.loads(written.uns["provenance"][EDIT_LOG_KEY])
     assert len(log) == 1
     assert log[0]["operation"] == "set_uns"
-    assert log[0]["details"]["field"] == "description"
+    assert log[0]["details"]["field"] == "comments"
     assert log[0]["details"]["new_value"] == "Logged edit"
 
 
@@ -164,7 +173,7 @@ def test_set_uns_previous_value_in_details(sample_h5ad_for_write):
 
 
 def test_set_uns_output_in_same_dir(sample_h5ad_for_write):
-    result = set_uns(str(sample_h5ad_for_write), "description", "test")
+    result = set_uns(str(sample_h5ad_for_write), "comments", "test")
     assert "error" not in result
     assert result["output_path"].startswith(str(sample_h5ad_for_write.parent))
 
@@ -180,16 +189,16 @@ def test_set_uns_bad_path():
 def test_set_uns_auto_resolves_latest(sample_h5ad_for_write):
     """Passing the original path edits the latest timestamped version."""
     # First edit creates a timestamped copy
-    r1 = set_uns(str(sample_h5ad_for_write), "description", "first edit")
+    r1 = set_uns(str(sample_h5ad_for_write), "title", "first edit")
     assert "error" not in r1
 
     # Second edit: pass original path, should auto-resolve to the timestamped version
     r2 = set_uns(str(sample_h5ad_for_write), "comments", "second edit")
     assert "error" not in r2
 
-    # The second edit should have read from the first output (which has description set)
+    # The second edit should have read from the first output (which has title updated)
     written = ad.read_h5ad(r2["output_path"])
-    assert written.uns["description"] == "first edit"
+    assert written.uns["title"] == "first edit"
     assert written.uns["comments"] == "second edit"
 
 
@@ -197,13 +206,13 @@ def test_set_uns_auto_resolves_latest(sample_h5ad_for_write):
 
 
 def test_set_uns_empty_string_rejected(sample_h5ad_for_write):
-    result = set_uns(str(sample_h5ad_for_write), "description", "")
+    result = set_uns(str(sample_h5ad_for_write), "ambient_count_correction", "")
     assert "error" in result
     assert "non-empty" in result["error"]
 
 
 def test_set_uns_whitespace_string_rejected(sample_h5ad_for_write):
-    result = set_uns(str(sample_h5ad_for_write), "description", "   ")
+    result = set_uns(str(sample_h5ad_for_write), "ambient_count_correction", "   ")
     assert "error" in result
     assert "non-empty" in result["error"]
 
@@ -224,7 +233,7 @@ def test_set_uns_list_with_empty_element_rejected(sample_h5ad_for_write):
 
 
 def test_set_uns_list_to_string_field_rejected(sample_h5ad_for_write):
-    result = set_uns(str(sample_h5ad_for_write), "description", ["not", "a", "string"])
+    result = set_uns(str(sample_h5ad_for_write), "title", ["not", "a", "string"])
     assert "error" in result
 
 
@@ -379,7 +388,7 @@ def test_view_edit_log_empty(sample_h5ad_for_write):
 
 def test_view_edit_log_after_edits(sample_h5ad_for_write):
     """After edits, entries are returned with operation and details."""
-    set_uns(str(sample_h5ad_for_write), "description", "first")
+    set_uns(str(sample_h5ad_for_write), "comments", "first")
     set_uns(str(sample_h5ad_for_write), "title", "second")
 
     result = view_edit_log(str(sample_h5ad_for_write))
@@ -387,7 +396,7 @@ def test_view_edit_log_after_edits(sample_h5ad_for_write):
     assert result["edit_count"] == 2
     assert "message" not in result
     assert [e["operation"] for e in result["entries"]] == ["set_uns", "set_uns"]
-    assert result["entries"][0]["details"]["field"] == "description"
+    assert result["entries"][0]["details"]["field"] == "comments"
     assert result["entries"][1]["details"]["field"] == "title"
     assert all("timestamp" in e for e in result["entries"])
     assert all("source_sha256" in e for e in result["entries"])
@@ -395,7 +404,7 @@ def test_view_edit_log_after_edits(sample_h5ad_for_write):
 
 def test_view_edit_log_auto_resolves_latest(sample_h5ad_for_write):
     """Passing the original path reads the latest timestamped version."""
-    set_uns(str(sample_h5ad_for_write), "description", "logged")
+    set_uns(str(sample_h5ad_for_write), "comments", "logged")
     result = view_edit_log(str(sample_h5ad_for_write))
     assert "error" not in result
     assert result["edit_count"] == 1


### PR DESCRIPTION
## Summary
- `list_uns_fields` and therefore the curate/evaluate skills were asking wranglers to set `description` as a required uns field, but it isn't one per HCA Tier 1 or CELLxGENE — the LinkML source-of-truth marks it required and that's incorrect.
- Adds `_SKIP_UNS_FIELDS = {"description"}` in `schema.helpers` and filters it out of the registry. `list_uns_fields` no longer mentions `description`; `set_uns description` returns the normal `"not a recognized HCA uns field"` error (same path as any unknown field).
- Swaps `description`-dependent tests to `title` / `comments` / `ambient_count_correction`, adds one test asserting the filter.
- No file-on-disk migration needed — there are no existing h5ad files in our tracker that rely on `uns['description']`.

This is a **narrow workaround for the symptom**. The broader audit called for in #343 (classify every uns field against HCA Tier 1 / CELLxGENE) is still pending, so #343 remains open.

Refs #343

## Test plan
- [x] `poetry run pytest tests/test_edit.py` — 43 passed.
- [x] `make typecheck` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)