### PR TITLE
feat: move ambient_count_correction and doublet_detection from uns to obs

### DIFF
--- a/.claude/skills/curate-h5ad/SKILL.md
+++ b/.claude/skills/curate-h5ad/SKILL.md
@@ -47,8 +47,7 @@ Only these are in Bucket A. Nothing else.
 
 For each of these, write a concrete question, not a suggested answer:
 
-- Missing required `uns` fields (e.g. `description`) — ask for the text.
-- Missing bionetwork-required `uns` fields (e.g. `ambient_count_correction`, `doublet_detection`) — ask which value from the allowed set applies. If `predicted_doublet` / `doublet_score` columns exist, mention that as context but still ask which tool was used.
+- Missing required `uns` fields (e.g. `study_pi`) — ask for the value(s).
 - `default_embedding` — list the obsm keys and ask which one.
 - **No CAP annotation set present** — the file must ship with at least one CAP annotation set (see the [HCA Cell Annotation schema](https://data.humancellatlas.org/metadata/cell-annotation)). Ask the wrangler to provide a local path to a CAP-exported version of this file (same cells, with CAP annotation sets populated) — `copy_cap_annotations` reads the source via AnnData/h5py so a URL must be downloaded locally first. If supplied, `copy_cap_annotations` becomes a mechanical fix for Step 4.
 - Any other `uns` field the validator flags as missing.
@@ -60,6 +59,7 @@ If the wrangler answers during the session, those answers become additional mech
 Report these but don't attempt to fix:
 
 - High NaN rates on non-allowed columns (e.g. `library_id`) — needs real values from source.
+- Sparse or missing `ambient_count_correction` / `doublet_detection` obs columns — per-cell values must come from the upstream source (each source dataset's processing record). Do not broadcast a single value. Report fill rate and move on.
 - Delimited-list values in single-identifier columns (e.g. `library_preparation_batch` containing `"lib1; lib2; lib3"`) — needs per-cell resolution, not placeholder replacement.
 - Gene IDs missing from the current GENCODE — needs annotation-version decision.
 - Inconsistent `author_cell_type` variants — needs a curator mapping.

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
@@ -185,12 +185,11 @@ def set_uns(
         except ValidationError as e:
             return {"error": f"Invalid value for '{field}': {e}"}
 
-        # Reject empty values for required fields. The str branch is defensive:
-        # no current required uns str field is an unconstrained plain str —
-        # they're all Literal enums, so empty values already fail Pydantic
-        # validation above. Required list-typed fields (e.g. study_pi) are
-        # exercised by the list branch below. Kept for a future plain-str
-        # required uns field.
+        # Reject empty values for required fields. The str branch currently has
+        # no active caller — the registry contains no required uns field typed
+        # as plain str. Required list-typed fields (e.g. study_pi) are exercised
+        # by the list branch below. Keep the str check for a future required
+        # plain-str uns field.
         if info.required:
             if isinstance(validated_value, str) and not validated_value.strip():
                 return {"error": f"Invalid value for '{field}': must be non-empty"}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
@@ -185,10 +185,12 @@ def set_uns(
         except ValidationError as e:
             return {"error": f"Invalid value for '{field}': {e}"}
 
-        # Reject empty values for required fields. The str branch is defensive —
-        # no current required uns field is a plain str (they all have Literal
-        # enums, so empty values fail Pydantic validation above). Kept for when
-        # a future plain-str required uns field is added.
+        # Reject empty values for required fields. The str branch is defensive:
+        # no current required uns str field is an unconstrained plain str —
+        # they're all Literal enums, so empty values already fail Pydantic
+        # validation above. Required list-typed fields (e.g. study_pi) are
+        # exercised by the list branch below. Kept for a future plain-str
+        # required uns field.
         if info.required:
             if isinstance(validated_value, str) and not validated_value.strip():
                 return {"error": f"Invalid value for '{field}': must be non-empty"}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
@@ -185,7 +185,10 @@ def set_uns(
         except ValidationError as e:
             return {"error": f"Invalid value for '{field}': {e}"}
 
-        # Reject empty values for required fields
+        # Reject empty values for required fields. The str branch is defensive —
+        # no current required uns field is a plain str (they all have Literal
+        # enums, so empty values fail Pydantic validation above). Kept for when
+        # a future plain-str required uns field is added.
         if info.required:
             if isinstance(validated_value, str) and not validated_value.strip():
                 return {"error": f"Invalid value for '{field}': must be non-empty"}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/schema/core.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/schema/core.py
@@ -368,15 +368,16 @@ class AdiposeDataset(Dataset):
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/bionetwork/adipose'})
 
     ambient_count_correction: str = Field(default=..., title="Ambient Count Correction", description="""Method used to correct ambient RNA contamination in single-cell data.""", json_schema_extra = { "linkml_meta": {'alias': 'ambient_count_correction',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
          'domain_of': ['AdiposeDataset', 'GutDataset', 'MusculoskeletalDataset'],
          'examples': [{'value': 'none'}, {'value': 'soupx'}, {'value': 'cellbender'}]} })
     doublet_detection: str = Field(default=..., title="Doublet Detection", description="""Was doublet detection software used during CELLxGENE processing? If so, which software?""", json_schema_extra = { "linkml_meta": {'alias': 'doublet_detection',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
          'domain_of': ['AdiposeDataset', 'GutDataset', 'MusculoskeletalDataset'],
          'examples': [{'value': 'none'},
                       {'value': 'doublet_finder'},
-                      {'value': 'manual'}]} })
+                      {'value': 'manual'},
+                      {'value': 'doublet_finder;manual'}]} })
     alignment_software: str = Field(default=..., title="Alignment Software", description="""Protocol used for alignment analysis, please specify which version was used e.g. cell ranger 2.0, 2.1.1 etc.""", json_schema_extra = { "linkml_meta": {'alias': 'alignment_software',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
          'comments': ['Affects which cells are filtered per dataset, and which reads '
@@ -510,15 +511,16 @@ class GutDataset(Dataset):
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/bionetwork/gut'})
 
     ambient_count_correction: str = Field(default=..., title="Ambient Count Correction", description="""Method used to correct ambient RNA contamination in single-cell data.""", json_schema_extra = { "linkml_meta": {'alias': 'ambient_count_correction',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
          'domain_of': ['AdiposeDataset', 'GutDataset', 'MusculoskeletalDataset'],
          'examples': [{'value': 'none'}, {'value': 'soupx'}, {'value': 'cellbender'}]} })
     doublet_detection: str = Field(default=..., title="Doublet Detection", description="""Was doublet detection software used during CELLxGENE processing? If so, which software?""", json_schema_extra = { "linkml_meta": {'alias': 'doublet_detection',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
          'domain_of': ['AdiposeDataset', 'GutDataset', 'MusculoskeletalDataset'],
          'examples': [{'value': 'none'},
                       {'value': 'doublet_finder'},
-                      {'value': 'manual'}]} })
+                      {'value': 'manual'},
+                      {'value': 'doublet_finder;manual'}]} })
     alignment_software: str = Field(default=..., title="Alignment Software", description="""Protocol used for alignment analysis, please specify which version was used e.g. cell ranger 2.0, 2.1.1 etc.""", json_schema_extra = { "linkml_meta": {'alias': 'alignment_software',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
          'comments': ['Affects which cells are filtered per dataset, and which reads '
@@ -1405,15 +1407,16 @@ class MusculoskeletalDataset(Dataset):
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/bionetwork/musculoskeletal'})
 
     ambient_count_correction: str = Field(default=..., title="Ambient Count Correction", description="""Method used to correct ambient RNA contamination in single-cell data.""", json_schema_extra = { "linkml_meta": {'alias': 'ambient_count_correction',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
          'domain_of': ['AdiposeDataset', 'GutDataset', 'MusculoskeletalDataset'],
          'examples': [{'value': 'none'}, {'value': 'soupx'}, {'value': 'cellbender'}]} })
     doublet_detection: str = Field(default=..., title="Doublet Detection", description="""Was doublet detection software used during CELLxGENE processing? If so, which software?""", json_schema_extra = { "linkml_meta": {'alias': 'doublet_detection',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
          'domain_of': ['AdiposeDataset', 'GutDataset', 'MusculoskeletalDataset'],
          'examples': [{'value': 'none'},
                       {'value': 'doublet_finder'},
-                      {'value': 'manual'}]} })
+                      {'value': 'manual'},
+                      {'value': 'doublet_finder;manual'}]} })
     alignment_software: str = Field(default=..., title="Alignment Software", description="""Protocol used for alignment analysis, please specify which version was used e.g. cell ranger 2.0, 2.1.1 etc.""", json_schema_extra = { "linkml_meta": {'alias': 'alignment_software',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
          'comments': ['Affects which cells are filtered per dataset, and which reads '

--- a/packages/hca-anndata-tools/tests/test_edit.py
+++ b/packages/hca-anndata-tools/tests/test_edit.py
@@ -46,6 +46,21 @@ def test_list_uns_fields_shows_missing_required(sample_h5ad_for_write):
     assert "study_pi" in result["missing_required"]
 
 
+def test_ambient_and_doublet_are_not_uns_fields(sample_h5ad_for_write):
+    # Issue #348: these were uns fields before; they now live in obs. Guard
+    # against a regression that would resurface them in the uns registry or
+    # allow set_uns to write them.
+    result = list_uns_fields(str(sample_h5ad_for_write))
+    field_names = [f["name"] for f in result["fields"]]
+    for name in ("ambient_count_correction", "doublet_detection"):
+        assert name not in field_names
+        assert name not in result["missing_required"]
+        assert name not in result["missing_required_bionetwork"]
+        set_result = set_uns(str(sample_h5ad_for_write), name, "anything")
+        assert "error" in set_result
+        assert "not a recognized HCA uns field" in set_result["error"]
+
+
 def test_list_uns_fields_filters_description(sample_h5ad_for_write):
     # Issue #343: LinkML's Dataset model marks `description` as a required uns
     # field, but it isn't one per HCA Tier 1 / CELLxGENE. helpers._SKIP_UNS_FIELDS

--- a/packages/hca-anndata-tools/tests/test_edit.py
+++ b/packages/hca-anndata-tools/tests/test_edit.py
@@ -44,9 +44,6 @@ def test_list_uns_fields_shows_missing_required(sample_h5ad_for_write):
     result = list_uns_fields(str(sample_h5ad_for_write))
     # study_pi is required but not in the test fixture
     assert "study_pi" in result["missing_required"]
-    # bionetwork-only fields are in a separate list
-    assert "ambient_count_correction" not in result["missing_required"]
-    assert "ambient_count_correction" in result["missing_required_bionetwork"]
 
 
 def test_list_uns_fields_filters_description(sample_h5ad_for_write):
@@ -63,15 +60,6 @@ def test_list_uns_fields_filters_description(sample_h5ad_for_write):
     set_result = set_uns(str(sample_h5ad_for_write), "description", "anything")
     assert "error" in set_result
     assert "not a recognized HCA uns field" in set_result["error"]
-
-
-def test_list_uns_fields_shows_bionetwork_fields(sample_h5ad_for_write):
-    result = list_uns_fields(str(sample_h5ad_for_write))
-    field_names = [f["name"] for f in result["fields"]]
-    assert "ambient_count_correction" in field_names
-    assert "doublet_detection" in field_names
-    acc = next(f for f in result["fields"] if f["name"] == "ambient_count_correction")
-    assert acc["bionetwork_only"] is True
 
 
 def test_list_uns_fields_extra_keys(sample_h5ad_for_write):
@@ -210,21 +198,6 @@ def test_set_uns_auto_resolves_latest(sample_h5ad_for_write):
 
 # --- empty value rejection ---
 
-# ambient_count_correction is the only required str uns field without a
-# Literal enum constraint, so it's the one field that exercises set_uns's
-# required+str+empty code path (enum-typed fields fail Pydantic type
-# validation before reaching the non-empty check).
-def test_set_uns_empty_string_rejected(sample_h5ad_for_write):
-    result = set_uns(str(sample_h5ad_for_write), "ambient_count_correction", "")
-    assert "error" in result
-    assert "non-empty" in result["error"]
-
-
-def test_set_uns_whitespace_string_rejected(sample_h5ad_for_write):
-    result = set_uns(str(sample_h5ad_for_write), "ambient_count_correction", "   ")
-    assert "error" in result
-    assert "non-empty" in result["error"]
-
 
 def test_set_uns_empty_list_rejected(sample_h5ad_for_write):
     result = set_uns(str(sample_h5ad_for_write), "study_pi", [])
@@ -249,29 +222,6 @@ def test_set_uns_list_to_string_field_rejected(sample_h5ad_for_write):
 def test_set_uns_string_to_list_field_rejected(sample_h5ad_for_write):
     result = set_uns(str(sample_h5ad_for_write), "study_pi", "not a list")
     assert "error" in result
-
-
-# --- bionetwork-only fields ---
-
-
-def test_set_uns_ambient_count_correction(sample_h5ad_for_write):
-    result = set_uns(str(sample_h5ad_for_write), "ambient_count_correction", "SoupX")
-    assert "error" not in result
-    written = ad.read_h5ad(result["output_path"])
-    assert written.uns["ambient_count_correction"] == "SoupX"
-
-
-def test_set_uns_doublet_detection(sample_h5ad_for_write):
-    result = set_uns(str(sample_h5ad_for_write), "doublet_detection", "none")
-    assert "error" not in result
-    written = ad.read_h5ad(result["output_path"])
-    assert written.uns["doublet_detection"] == "none"
-
-
-def test_set_uns_bionetwork_empty_rejected(sample_h5ad_for_write):
-    result = set_uns(str(sample_h5ad_for_write), "ambient_count_correction", "")
-    assert "error" in result
-    assert "non-empty" in result["error"]
 
 
 # --- replace_placeholder_values ---

--- a/shared/src/hca_validation/schema/generated/core.py
+++ b/shared/src/hca_validation/schema/generated/core.py
@@ -385,15 +385,16 @@ class AdiposeDataset(Dataset):
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/bionetwork/adipose'})
 
     ambient_count_correction: str = Field(default=..., title="Ambient Count Correction", description="""Method used to correct ambient RNA contamination in single-cell data.""", json_schema_extra = { "linkml_meta": {'alias': 'ambient_count_correction',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
          'domain_of': ['AdiposeDataset', 'GutDataset', 'MusculoskeletalDataset'],
          'examples': [{'value': 'none'}, {'value': 'soupx'}, {'value': 'cellbender'}]} })
     doublet_detection: str = Field(default=..., title="Doublet Detection", description="""Was doublet detection software used during CELLxGENE processing? If so, which software?""", json_schema_extra = { "linkml_meta": {'alias': 'doublet_detection',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
          'domain_of': ['AdiposeDataset', 'GutDataset', 'MusculoskeletalDataset'],
          'examples': [{'value': 'none'},
                       {'value': 'doublet_finder'},
-                      {'value': 'manual'}]} })
+                      {'value': 'manual'},
+                      {'value': 'doublet_finder;manual'}]} })
     alignment_software: str = Field(default=..., title="Alignment Software", description="""Protocol used for alignment analysis, please specify which version was used e.g. cell ranger 2.0, 2.1.1 etc.""", json_schema_extra = { "linkml_meta": {'alias': 'alignment_software',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
          'comments': ['Affects which cells are filtered per dataset, and which reads '
@@ -527,15 +528,16 @@ class GutDataset(Dataset):
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/bionetwork/gut'})
 
     ambient_count_correction: str = Field(default=..., title="Ambient Count Correction", description="""Method used to correct ambient RNA contamination in single-cell data.""", json_schema_extra = { "linkml_meta": {'alias': 'ambient_count_correction',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
          'domain_of': ['AdiposeDataset', 'GutDataset', 'MusculoskeletalDataset'],
          'examples': [{'value': 'none'}, {'value': 'soupx'}, {'value': 'cellbender'}]} })
     doublet_detection: str = Field(default=..., title="Doublet Detection", description="""Was doublet detection software used during CELLxGENE processing? If so, which software?""", json_schema_extra = { "linkml_meta": {'alias': 'doublet_detection',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
          'domain_of': ['AdiposeDataset', 'GutDataset', 'MusculoskeletalDataset'],
          'examples': [{'value': 'none'},
                       {'value': 'doublet_finder'},
-                      {'value': 'manual'}]} })
+                      {'value': 'manual'},
+                      {'value': 'doublet_finder;manual'}]} })
     alignment_software: str = Field(default=..., title="Alignment Software", description="""Protocol used for alignment analysis, please specify which version was used e.g. cell ranger 2.0, 2.1.1 etc.""", json_schema_extra = { "linkml_meta": {'alias': 'alignment_software',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
          'comments': ['Affects which cells are filtered per dataset, and which reads '
@@ -1422,15 +1424,16 @@ class MusculoskeletalDataset(Dataset):
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/bionetwork/musculoskeletal'})
 
     ambient_count_correction: str = Field(default=..., title="Ambient Count Correction", description="""Method used to correct ambient RNA contamination in single-cell data.""", json_schema_extra = { "linkml_meta": {'alias': 'ambient_count_correction',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
          'domain_of': ['AdiposeDataset', 'GutDataset', 'MusculoskeletalDataset'],
          'examples': [{'value': 'none'}, {'value': 'soupx'}, {'value': 'cellbender'}]} })
     doublet_detection: str = Field(default=..., title="Doublet Detection", description="""Was doublet detection software used during CELLxGENE processing? If so, which software?""", json_schema_extra = { "linkml_meta": {'alias': 'doublet_detection',
-         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'uns'}},
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
          'domain_of': ['AdiposeDataset', 'GutDataset', 'MusculoskeletalDataset'],
          'examples': [{'value': 'none'},
                       {'value': 'doublet_finder'},
-                      {'value': 'manual'}]} })
+                      {'value': 'manual'},
+                      {'value': 'doublet_finder;manual'}]} })
     alignment_software: str = Field(default=..., title="Alignment Software", description="""Protocol used for alignment analysis, please specify which version was used e.g. cell ranger 2.0, 2.1.1 etc.""", json_schema_extra = { "linkml_meta": {'alias': 'alignment_software',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'}},
          'comments': ['Affects which cells are filtered per dataset, and which reads '

--- a/shared/src/hca_validation/schema/slots.yaml
+++ b/shared/src/hca_validation/schema/slots.yaml
@@ -35,7 +35,7 @@ slots:
       - value: "soupx"
       - value: "cellbender"
     annotations:
-      annDataLocation: uns
+      annDataLocation: obs
 
   doublet_detection:
     title: Doublet Detection
@@ -46,8 +46,9 @@ slots:
       - value: "none"
       - value: "doublet_finder"
       - value: "manual"
+      - value: "doublet_finder;manual"
     annotations:
-      annDataLocation: uns
+      annDataLocation: obs
 
   dataset_id:
     title: Dataset ID


### PR DESCRIPTION
## Summary
- Both fields now live in `obs` (per-cell) instead of `uns` (per-file). Integrated HCA files combine cells from multiple source datasets that may have used different ambient-correction / doublet-detection tools, so a single uns value cannot represent the data accurately.
- `doublet_detection` gains a `doublet_finder;manual` example documenting the `;`-delimited multi-value convention already used by `cell_enrichment`. LinkML stays `range: string` — format is communicated by example, matching how `cell_enrichment` is declared.
- **Deliberate deviation from HCA Tier 1** (which places both fields in uns). Tier 1 does not yet formalize the integrated-object case. An upstream Tier 1 correction should be filed separately.
- `_SKIP_UNS_FIELDS` is untouched — once the two slots flip to obs they drop out of the uns registry automatically.
- The curate-h5ad skill drops these from Bucket B1 (not auto-fixable — no legitimate way to broadcast one value across cells that were processed differently) and adds a Bucket C bullet so sparse or missing columns are reported, not fabricated.

Closes #348

## Test plan
- [x] `poetry run pytest packages/hca-anndata-tools/tests/test_edit.py` — 37 passed after deleting 5 tests that asserted these fields as uns (no longer reachable).
- [x] `make test-all` — clean across all services.
- [x] `make typecheck` — clean.
- [x] `make gen-schema` (run from `shared/`) — Pydantic regenerates with obs locations.

## Follow-ups
- Upstream: DataBiosphere/data-portal#2988 filed to move these two fields to obs in the Tier 1 spec.
- Manual-copy chore: the hand-maintained `packages/hca-anndata-tools/src/hca_anndata_tools/schema/core.py` mirror of the generated file is a systemic cost — separate issue to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)