### PR TITLE
feat: add HCALabeler for post-curate label generation

### DIFF
--- a/packages/hca-schema-validator/PRD-hca-add-labels.md
+++ b/packages/hca-schema-validator/PRD-hca-add-labels.md
@@ -64,7 +64,9 @@ CELLxGENE's vendored `cellxgene-schema add-labels` almost does what we need but:
   - Read `obs['<field>_ontology_term_id']` (required input).
   - Write the human-readable label to `obs['<field>']` via `ONTOLOGY_PARSER`.
 - If `obs['<field>']` already exists: **overwrite** unconditionally.
-- If `obs['<field>_ontology_term_id']` is missing entirely, preflight raises `ValueError` (see R7). HCA files are expected to carry all required ontology term ID inputs; a missing column means the file is malformed, not something to silently skip.
+- If `obs['<field>_ontology_term_id']` is missing entirely, behavior depends on the field's `requirement_level` in `hca_schema_definition.yaml`:
+  - **Default (required):** preflight raises `ValueError` (see R7) — the file is malformed.
+  - **`optional` or `strongly_recommended`:** the labeler skips that field silently. The derived `obs['<field>']` column is not written. Currently only `cell_type_ontology_term_id` is marked optional.
 - Write `obs['observation_joinid']` — a per-cell hash used for dataset deduplication at Discover ingest. Computed via `cellxgene_schema.utils.get_hash_digest_column(adata.obs)` from the vendored module (same source CELLxGENE uses). Overwrites if already present.
 
 ### R3. Scope: derived fields only
@@ -73,15 +75,15 @@ The labeler touches **only** the columns it derives:
 - `var['feature_name']`, `var['feature_reference']`, `var['feature_biotype']`, `var['feature_length']`, `var['feature_type']` (and their `raw.var` mirrors)
 - `obs['tissue']`, `obs['cell_type']`, `obs['assay']`, `obs['disease']`, `obs['sex']`, `obs['organism']`, `obs['development_stage']`, `obs['self_reported_ethnicity']`
 - `obs['observation_joinid']`
-- `uns['organism_ontology_term_id']` (under R4)
 
-All other columns (producer `gene_symbol`, `*_ontology_term` drift variants, custom author fields, etc.) are left untouched. Decisions about those columns belong outside this tool.
+All other columns and all `uns` keys are left untouched. The labeler does not write to `uns` at all. Decisions about extra/drift columns belong outside this tool.
 
 ### R4. uns handling
 
-- If `obs['organism_ontology_term_id']` is present and single-valued, also write the same value to `uns['organism_ontology_term_id']` (HCA canonical is obs; uns duplicate makes CELLxGENE-v7 tooling happy without harming HCA validation).
-- Do **not** write `uns['schema_version']`, `uns['schema_reference']`, or `uns['organism']` (the label-form).
-- Edit-log / provenance is **not** the labeler's responsibility — the MCP wrapper (R6) handles that when the labeler is invoked through the `label_h5ad` tool.
+The labeler does **not** write to `uns` at all. It does not mirror organism from obs to uns, does not add CELLxGENE schema keys, and does not maintain any provenance entries.
+
+- Edit-log / provenance is the MCP wrapper's responsibility (R6), triggered by `label_h5ad` — not the labeler's.
+- If the caller needs `uns['organism_ontology_term_id']` populated for CELLxGENE-v7 tooling, the caller sets it before or after invoking the labeler. HCA canonical location is `obs`.
 
 ### R5. Overwrite behavior
 
@@ -93,13 +95,12 @@ Any UX around surfacing overwrites (showing the wrangler "these columns are abou
 
 Before any labeling work, `write_labels` runs a preflight that raises a single `ValueError` (aggregating all issues) if any of the following hold:
 
-- An obs column referenced by an `add_labels` directive in the HCA schema is missing — e.g. `obs['cell_type_ontology_term_id']` isn't present.
+- A **required** obs column referenced by an `add_labels` directive in the HCA schema is missing — e.g. `obs['organism_ontology_term_id']` isn't present. Columns whose `requirement_level` is `optional` or `strongly_recommended` (currently just `cell_type_ontology_term_id`) are allowed to be absent; the labeler skips the corresponding derived field instead of failing.
 - `uns['schema_version']` is present — signals the file has already been processed by `cellxgene-schema add-labels`; running HCALabeler on top would produce a mess.
 - `uns['schema_reference']` is present — same reason.
+- `obs['organism_ontology_term_id']` contains any value other than `NCBITaxon:9606` — HCALabeler supports only human (see R1 rationale). Adding another organism is a deliberate code change.
 
-`uns['organism_ontology_term_id']` may be present or absent — this labeler writes it itself when `obs['organism_ontology_term_id']` is single-valued, and we expect HCA files to carry organism in obs either way. The label-form `uns['organism']` is not checked.
-
-The labeler does not scrub stale CELLxGENE keys beyond refusing to run; that cleanup belongs in upstream tooling or a separate utility.
+The labeler does not validate or modify `uns['organism_ontology_term_id']` or `uns['organism']` (label-form) — those keys are producer-owned. Similarly, the labeler does not scrub stale CELLxGENE keys beyond refusing to run; that cleanup belongs in upstream tooling or a separate utility.
 
 ### R6. Entry points and package boundaries
 
@@ -135,7 +136,7 @@ Implementation strategy — subclass `AnnDataLabelAppender` from a **new** modul
 | `__init__` | Load `hca_schema_definition.yaml` instead of CELLxGENE's schema definition. |
 | `_get_mapping_dict_feature_id` | Wrap the GENCODE lookup so unknown-organism IDs yield NaN instead of raising. |
 | `_get_mapping_dict_feature_reference` / `_biotype` / `_length` / `_type` | Same NaN-on-unknown behavior. |
-| `write_labels` | Skip the CELLxGENE-only `uns['schema_version']`, `uns['schema_reference']`, `uns['organism']` writes. Add the `uns['organism_ontology_term_id']` write (R4) and `observation_joinid` write (R2). |
+| `write_labels` | Skip the CELLxGENE-only `uns['schema_version']`, `uns['schema_reference']`, `uns['organism']` writes. Run `_preflight` first, then apply labels and the `observation_joinid` write (R2). No uns writes. |
 
 The vendored code stays byte-identical. Future upstream bumps pull cleanly.
 
@@ -148,9 +149,10 @@ Use `hca_schema_definition.yaml` as-is. It already contains `add_labels` directi
 | Input state | Behavior |
 |---|---|
 | Ensembl ID in `var.index` not in GENCODE | All five `feature_*` columns NaN for that row. |
-| `obs['<field>_ontology_term_id']` absent | Preflight raises `ValueError` (R7); nothing is written. |
+| `obs['<field>_ontology_term_id']` absent (required field) | Preflight raises `ValueError` (R7); nothing is written. |
+| `obs['cell_type_ontology_term_id']` absent (optional field) | `obs['cell_type']` is not added; other labels are written normally. |
 | `uns['schema_version']` or `uns['schema_reference']` already set | Preflight raises `ValueError` (R7); nothing is written. |
-| `obs['organism_ontology_term_id']` has >1 unique value | Do not write to `uns`; continue. |
+| `obs['organism_ontology_term_id']` contains any non-human value | Preflight raises `ValueError` (R7); nothing is written. |
 | `var['feature_is_filtered']` absent | Do not generate. Existing `feature_is_filtered` validator catches this as a downstream error. |
 | `raw.var` absent | Skip raw-var labeling. Label only `var`. |
 | Existing `var['feature_name']` populated | Overwrite. |
@@ -166,7 +168,7 @@ Running the HCA labeler on gut-v1 myeloid (post-curate) produces a file where:
 - `var['feature_name']` is populated for 34,505 / 35,574 rows and NaN for the 1,069 deprecated IDs.
 - `obs` labels (`tissue`, `cell_type`, `assay`, `disease`, `sex`, `organism`, `development_stage`, `self_reported_ethnicity`) are populated from their `_ontology_term_id` inputs, overwriting the producer-drifted versions.
 - `obs['observation_joinid']` is present.
-- `uns['organism_ontology_term_id']` is set. The labeler refuses to run on inputs that already have `uns['schema_version']` or `uns['schema_reference']`, so those keys never appear on output. The label-form `uns['organism']` is not checked — HCA inputs are expected not to have it, but if one does it passes through untouched.
+- `uns` is unchanged by the labeler. The labeler refuses to run on inputs that carry `uns['schema_version']` or `uns['schema_reference']` (preflight), but if those pass and any other `uns` keys exist on input they pass through untouched. The caller (or a subsequent tool) is responsible for any desired `uns['organism_ontology_term_id']` duplication for CELLxGENE-v7 tooling.
 - Producer `*_ontology_term` drift columns and custom columns like `gene_symbol` are untouched (the labeler does not drop them; that decision lives in `/curate-h5ad`).
 - `hca-schema-validator` introduces no new errors from labeling. The two pre-existing errors (`library_id` NaN, `library_preparation_batch` delimited lists) remain — they are independent Bucket C items unrelated to labeling.
 - CAP marker validation finds 54 / 56 markers in `var['feature_name']` (matching what we observed in yesterday's scratch experiment).

--- a/packages/hca-schema-validator/PRD-hca-add-labels.md
+++ b/packages/hca-schema-validator/PRD-hca-add-labels.md
@@ -91,17 +91,6 @@ The labeler overwrites the fields listed in R3 unconditionally. No bookkeeping, 
 
 Any UX around surfacing overwrites (showing the wrangler "these columns are about to change") is the caller's job. `/curate-h5ad` already knows the file state and the labeler's controlled field list (from this PRD), so it can render the diff on its own before invoking the labeler.
 
-### R7. Preflight validation
-
-Before any labeling work, `write_labels` runs a preflight that raises a single `ValueError` (aggregating all issues) if any of the following hold:
-
-- A **required** obs column referenced by an `add_labels` directive in the HCA schema is missing — e.g. `obs['organism_ontology_term_id']` isn't present. Columns whose `requirement_level` is `optional` or `strongly_recommended` (currently just `cell_type_ontology_term_id`) are allowed to be absent; the labeler skips the corresponding derived field instead of failing.
-- `uns['schema_version']` is present — signals the file has already been processed by `cellxgene-schema add-labels`; running HCALabeler on top would produce a mess.
-- `uns['schema_reference']` is present — same reason.
-- `obs['organism_ontology_term_id']` contains any value other than `NCBITaxon:9606` — HCALabeler supports only human (see R1 rationale). Adding another organism is a deliberate code change.
-
-The labeler does not validate or modify `uns['organism_ontology_term_id']` or `uns['organism']` (label-form) — those keys are producer-owned. Similarly, the labeler does not scrub stale CELLxGENE keys beyond refusing to run; that cleanup belongs in upstream tooling or a separate utility.
-
 ### R6. Entry points and package boundaries
 
 The labeler lives entirely in `hca-schema-validator`. `hca-anndata-tools` is not modified. The MCP server (which depends on both packages) provides the edit-snapshot + provenance-logging wrapper.
@@ -123,6 +112,17 @@ No CLI. Invocation is via the MCP `label_h5ad` tool (interactive curation) or di
 
 Rationale: keeps the validator package free of any dep on `hca-anndata-tools` (which would be a reverse layering). All user-visible labeling happens through the MCP tool, which owns the edit-log + snapshot conventions.
 
+### R7. Preflight validation
+
+Before any labeling work, `write_labels` runs a preflight that raises a single `ValueError` (aggregating all issues) if any of the following hold:
+
+- A **required** obs column referenced by an `add_labels` directive in the HCA schema is missing — e.g. `obs['organism_ontology_term_id']` isn't present. Columns whose `requirement_level` is `optional` or `strongly_recommended` (currently just `cell_type_ontology_term_id`) are allowed to be absent; the labeler skips the corresponding derived field instead of failing.
+- `uns['schema_version']` is present — signals the file has already been processed by `cellxgene-schema add-labels`; running HCALabeler on top would produce a mess.
+- `uns['schema_reference']` is present — same reason.
+- `obs['organism_ontology_term_id']` contains any value other than `NCBITaxon:9606` — HCALabeler supports only human (see R1 rationale). Adding another organism is a deliberate code change.
+
+The labeler does not validate or modify `uns['organism_ontology_term_id']` or `uns['organism']` (label-form) — those keys are producer-owned. Similarly, the labeler does not scrub stale CELLxGENE keys beyond refusing to run; that cleanup belongs in upstream tooling or a separate utility.
+
 ## Design
 
 ### Patch, do not modify
@@ -131,12 +131,14 @@ The vendored CELLxGENE code lives at `packages/hca-schema-validator/src/hca_sche
 
 Implementation strategy — subclass `AnnDataLabelAppender` from a **new** module outside `_vendored/` and override only what needs HCA behavior:
 
-| Override | Reason |
+| Override / new | Reason |
 |---|---|
 | `__init__` | Load `hca_schema_definition.yaml` instead of CELLxGENE's schema definition. |
 | `_get_mapping_dict_feature_id` | Wrap the GENCODE lookup so unknown-organism IDs yield NaN instead of raising. |
 | `_get_mapping_dict_feature_reference` / `_biotype` / `_length` / `_type` | Same NaN-on-unknown behavior. |
+| `_add_column` | Silently skip when the source column is absent from the target dataframe (handles optional `_ontology_term_id` columns like `cell_type`). Preflight catches required-missing before we get here. |
 | `write_labels` | Skip the CELLxGENE-only `uns['schema_version']`, `uns['schema_reference']`, `uns['organism']` writes. Run `_preflight` first, then apply labels and the `observation_joinid` write (R2). No uns writes. |
+| `_preflight` (new method) | Aggregated precondition check; see R7. |
 
 The vendored code stays byte-identical. Future upstream bumps pull cleanly.
 

--- a/packages/hca-schema-validator/PRD-hca-add-labels.md
+++ b/packages/hca-schema-validator/PRD-hca-add-labels.md
@@ -64,7 +64,7 @@ CELLxGENE's vendored `cellxgene-schema add-labels` almost does what we need but:
   - Read `obs['<field>_ontology_term_id']` (required input).
   - Write the human-readable label to `obs['<field>']` via `ONTOLOGY_PARSER`.
 - If `obs['<field>']` already exists: **overwrite** unconditionally.
-- If `obs['<field>_ontology_term_id']` is missing entirely, skip that label. No partial column; no error.
+- If `obs['<field>_ontology_term_id']` is missing entirely, preflight raises `ValueError` (see R7). HCA files are expected to carry all required ontology term ID inputs; a missing column means the file is malformed, not something to silently skip.
 - Write `obs['observation_joinid']` — a per-cell hash used for dataset deduplication at Discover ingest. Computed via `cellxgene_schema.utils.get_hash_digest_column(adata.obs)` from the vendored module (same source CELLxGENE uses). Overwrites if already present.
 
 ### R3. Scope: derived fields only
@@ -88,6 +88,18 @@ All other columns (producer `gene_symbol`, `*_ontology_term` drift variants, cus
 The labeler overwrites the fields listed in R3 unconditionally. No bookkeeping, no approval hooks, no `plan_*` API — that coupling belongs in the caller, not the labeler.
 
 Any UX around surfacing overwrites (showing the wrangler "these columns are about to change") is the caller's job. `/curate-h5ad` already knows the file state and the labeler's controlled field list (from this PRD), so it can render the diff on its own before invoking the labeler.
+
+### R7. Preflight validation
+
+Before any labeling work, `write_labels` runs a preflight that raises a single `ValueError` (aggregating all issues) if any of the following hold:
+
+- An obs column referenced by an `add_labels` directive in the HCA schema is missing — e.g. `obs['cell_type_ontology_term_id']` isn't present.
+- `uns['schema_version']` is present — signals the file has already been processed by `cellxgene-schema add-labels`; running HCALabeler on top would produce a mess.
+- `uns['schema_reference']` is present — same reason.
+
+`uns['organism_ontology_term_id']` may be present or absent — this labeler writes it itself when `obs['organism_ontology_term_id']` is single-valued, and we expect HCA files to carry organism in obs either way. The label-form `uns['organism']` is not checked.
+
+The labeler does not scrub stale CELLxGENE keys beyond refusing to run; that cleanup belongs in upstream tooling or a separate utility.
 
 ### R6. Entry points and package boundaries
 
@@ -136,7 +148,8 @@ Use `hca_schema_definition.yaml` as-is. It already contains `add_labels` directi
 | Input state | Behavior |
 |---|---|
 | Ensembl ID in `var.index` not in GENCODE | All five `feature_*` columns NaN for that row. |
-| `obs['<field>_ontology_term_id']` absent | Skip that label; do not write a partial `obs['<field>']`. |
+| `obs['<field>_ontology_term_id']` absent | Preflight raises `ValueError` (R7); nothing is written. |
+| `uns['schema_version']` or `uns['schema_reference']` already set | Preflight raises `ValueError` (R7); nothing is written. |
 | `obs['organism_ontology_term_id']` has >1 unique value | Do not write to `uns`; continue. |
 | `var['feature_is_filtered']` absent | Do not generate. Existing `feature_is_filtered` validator catches this as a downstream error. |
 | `raw.var` absent | Skip raw-var labeling. Label only `var`. |
@@ -153,7 +166,7 @@ Running the HCA labeler on gut-v1 myeloid (post-curate) produces a file where:
 - `var['feature_name']` is populated for 34,505 / 35,574 rows and NaN for the 1,069 deprecated IDs.
 - `obs` labels (`tissue`, `cell_type`, `assay`, `disease`, `sex`, `organism`, `development_stage`, `self_reported_ethnicity`) are populated from their `_ontology_term_id` inputs, overwriting the producer-drifted versions.
 - `obs['observation_joinid']` is present.
-- `uns['organism_ontology_term_id']` is set; no `uns['schema_version']`, `uns['schema_reference']`, or `uns['organism']`.
+- `uns['organism_ontology_term_id']` is set. The labeler refuses to run on inputs that already have `uns['schema_version']` or `uns['schema_reference']`, so those keys never appear on output. The label-form `uns['organism']` is not checked — HCA inputs are expected not to have it, but if one does it passes through untouched.
 - Producer `*_ontology_term` drift columns and custom columns like `gene_symbol` are untouched (the labeler does not drop them; that decision lives in `/curate-h5ad`).
 - `hca-schema-validator` introduces no new errors from labeling. The two pre-existing errors (`library_id` NaN, `library_preparation_batch` delimited lists) remain — they are independent Bucket C items unrelated to labeling.
 - CAP marker validation finds 54 / 56 markers in `var['feature_name']` (matching what we observed in yesterday's scratch experiment).

--- a/packages/hca-schema-validator/PRD-hca-add-labels.md
+++ b/packages/hca-schema-validator/PRD-hca-add-labels.md
@@ -1,0 +1,159 @@
+# PRD: HCA Add-Labels
+
+## Background
+
+HCA producers ship integrated h5ad files with inconsistent var/obs layouts:
+
+- Some use `gene_symbol` (gut-v1, breast); some use `feature_name` (adipose); some ship neither.
+- Some pre-populate obs labels (gut-v1 has `tissue`, `assay`, `disease`, `organism`); others don't.
+- Some carry `_ontology_term` (no `_id`) columns that aren't part of any public schema.
+- Pre-populated labels drift from their `_ontology_term_id` source (gut-v1 myeloid: `disease` has 5 uniques vs `disease_ontology_term` 7).
+
+Downstream consumers — CAP marker validation, CELLxGENE Explorer, `hca-schema-validator` — read the canonical post-labels layout: `var['feature_name']` for gene symbols, and bare `obs['tissue']` / `obs['cell_type']` / ... for ontology labels. Without a single labeling step each atlas needs per-file workarounds.
+
+CELLxGENE's vendored `cellxgene-schema add-labels` almost does what we need but:
+
+1. Is bound to the CELLxGENE schema (requires `uns['organism_ontology_term_id']`, injects `uns['schema_version']` / `uns['schema_reference']` that HCA does not want).
+2. Raises `ValueError: None not supported` on any Ensembl ID it cannot map to a supported organism. We routinely see files with deprecated IDs (1,069 / 35,574 in gut-v1 myeloid).
+3. Silently preserves pre-existing obs/var label columns, so producer drift is never corrected.
+
+## Workflow positioning
+
+**Recommendation:** run the HCA labeler before handing a file to CAP, as part of the post-curate, pre-handoff pass.
+
+**Reasoning:**
+
+1. CAP annotators search genes by symbol (e.g. `CD3E`) in their curation UI. The UI reads `var['feature_name']`. Without that column populated, annotators are stuck searching by Ensembl ID or relying on whatever custom column the producer chose (`gene_symbol`, none, ...). Running the labeler first gives every CAP user the same gene-symbol experience regardless of atlas.
+
+2. When CAP returns the annotated file, `copy_cap_annotations` runs `validate_marker_genes` against `var['feature_name']`. `feature_name` must exist by that point anyway — generating it before CAP means annotator-provided marker symbols are matched against the exact same gene symbols CAP's UI showed during curation.
+
+3. It establishes a single source of truth (`feature_name`) for symbols across all atlases before any downstream tool needs to read them, avoiding per-atlas fallback logic.
+
+**Not strictly required.** CAP likely accepts files without `feature_name` (falling back to Ensembl IDs or producer-supplied `gene_symbol`), and the labeler could run after CAP return instead. The workflow placement above is a UX and consistency choice, not a schema requirement.
+
+## Goals
+
+1. Populate `var['feature_name']` + `feature_reference` / `feature_biotype` / `feature_length` / `feature_type` from the Ensembl IDs in `var.index`, using the GENCODE tables already vendored in `hca-schema-validator`.
+2. Populate obs labels (`tissue`, `cell_type`, `assay`, `disease`, `sex`, `organism`, `development_stage`, `self_reported_ethnicity`) from their `_ontology_term_id` counterparts. Stale or drifted pre-existing values MUST be replaced.
+3. Tolerate Ensembl IDs that GENCODE does not recognize — set the derived columns to NaN for those rows and continue.
+4. Run as a minimal **patch over** the vendored CELLxGENE labeler. Do not edit the vendored code; subclass `AnnDataLabelAppender` from outside `_vendored/`.
+5. Produce an HCA-clean file: do not inject CELLxGENE-only `uns` keys (`schema_version`, `schema_reference`).
+6. Be callable from `/curate-h5ad` (via the MCP wrapper) as an approval-gated mechanical fix. The labeler itself is unconditional; the approval UX lives in the caller.
+
+## Non-goals
+
+- Bumping the bundled GENCODE release or supporting overlay updates for gene tables — out of scope for v0.
+- IDTrack integration / remapping deprecated Ensembl IDs — out of scope.
+- Generating `feature_is_filtered` from matrix sparsity. Required input; already validated. Producer sets it.
+- Preserving prior values of overwritten columns in sidecar `<col>_original` columns. Dropped outright; when the labeler is invoked via the MCP wrapper, the MCP's edit-log entry captures the fact that an overwrite happened.
+
+## Functional requirements
+
+### R1. var labeling
+
+- Read `var.index` as Ensembl feature IDs.
+- For each ID:
+  - If the ID is in vendored GENCODE → populate `feature_name`, `feature_reference`, `feature_biotype`, `feature_length`, `feature_type`.
+  - If not → set all five columns to NaN for that row. No error.
+- Mirror the same five columns to `raw.var` using the raw var index (matches CELLxGENE schema convention).
+- If any of the five columns already exists: **overwrite** unconditionally.
+
+### R2. obs labeling
+
+- For each labeled field in the HCA schema (`cell_type`, `assay`, `disease`, `organism`, `sex`, `development_stage`, `self_reported_ethnicity`, `tissue`):
+  - Read `obs['<field>_ontology_term_id']` (required input).
+  - Write the human-readable label to `obs['<field>']` via `ONTOLOGY_PARSER`.
+- If `obs['<field>']` already exists: **overwrite** unconditionally.
+- If `obs['<field>_ontology_term_id']` is missing entirely, skip that label. No partial column; no error.
+- Write `obs['observation_joinid']` — a per-cell hash used for dataset deduplication at Discover ingest. Computed via `cellxgene_schema.utils.get_hash_digest_column(adata.obs)` from the vendored module (same source CELLxGENE uses). Overwrites if already present.
+
+### R3. Scope: derived fields only
+
+The labeler touches **only** the columns it derives:
+- `var['feature_name']`, `var['feature_reference']`, `var['feature_biotype']`, `var['feature_length']`, `var['feature_type']` (and their `raw.var` mirrors)
+- `obs['tissue']`, `obs['cell_type']`, `obs['assay']`, `obs['disease']`, `obs['sex']`, `obs['organism']`, `obs['development_stage']`, `obs['self_reported_ethnicity']`
+- `obs['observation_joinid']`
+- `uns['organism_ontology_term_id']` (under R4)
+
+All other columns (producer `gene_symbol`, `*_ontology_term` drift variants, custom author fields, etc.) are left untouched. Decisions about those columns belong outside this tool.
+
+### R4. uns handling
+
+- If `obs['organism_ontology_term_id']` is present and single-valued, also write the same value to `uns['organism_ontology_term_id']` (HCA canonical is obs; uns duplicate makes CELLxGENE-v7 tooling happy without harming HCA validation).
+- Do **not** write `uns['schema_version']`, `uns['schema_reference']`, or `uns['organism']` (the label-form).
+- Edit-log / provenance is **not** the labeler's responsibility — the MCP wrapper (R6) handles that when the labeler is invoked through the `label_h5ad` tool.
+
+### R5. Overwrite behavior
+
+The labeler overwrites the fields listed in R3 unconditionally. No bookkeeping, no approval hooks, no `plan_*` API — that coupling belongs in the caller, not the labeler.
+
+Any UX around surfacing overwrites (showing the wrangler "these columns are about to change") is the caller's job. `/curate-h5ad` already knows the file state and the labeler's controlled field list (from this PRD), so it can render the diff on its own before invoking the labeler.
+
+### R6. Entry points and package boundaries
+
+The labeler lives entirely in `hca-schema-validator`. `hca-anndata-tools` is not modified. The MCP server (which depends on both packages) provides the edit-snapshot + provenance-logging wrapper.
+
+| Layer | Owns | Knows about |
+|---|---|---|
+| `hca-schema-validator` | `HCALabeler` class (subclass of vendored `AnnDataLabelAppender`). Python API only. Returns a labeled `AnnData` or writes to an explicit output path. | Schema, GENCODE tables, vendored CELLxGENE labeler. Nothing about edit snapshots or `uns['provenance']`. |
+| `hca-anndata-tools` | — (unchanged) | — |
+| MCP server (`hca-anndata-mcp`) | `label_h5ad` tool: resolve latest input → call validator's labeler API → write edit snapshot (`<stem>-edit-<ts>.h5ad`) → append to `uns['provenance']['edit_history']`. | Edit-log + snapshot convention (via its existing dep on `hca-anndata-tools`). |
+
+**Python API** — in `hca_schema_validator.labeler` (module name TBD). Sketch:
+
+```python
+class HCALabeler(AnnDataLabelAppender):
+    def write_labels(self, out_path: str): ...   # overrides base; applies HCA behavior
+```
+
+No CLI. Invocation is via the MCP `label_h5ad` tool (interactive curation) or direct Python import (tests, ad-hoc scripts).
+
+Rationale: keeps the validator package free of any dep on `hca-anndata-tools` (which would be a reverse layering). All user-visible labeling happens through the MCP tool, which owns the edit-log + snapshot conventions.
+
+## Design
+
+### Patch, do not modify
+
+The vendored CELLxGENE code lives at `packages/hca-schema-validator/src/hca_schema_validator/_vendored/cellxgene_schema/`. The labeler's entry class is `AnnDataLabelAppender` in `_vendored/cellxgene_schema/write_labels.py`.
+
+Implementation strategy — subclass `AnnDataLabelAppender` from a **new** module outside `_vendored/` and override only what needs HCA behavior:
+
+| Override | Reason |
+|---|---|
+| `__init__` | Load `hca_schema_definition.yaml` instead of CELLxGENE's schema definition. |
+| `_get_mapping_dict_feature_id` | Wrap the GENCODE lookup so unknown-organism IDs yield NaN instead of raising. |
+| `_get_mapping_dict_feature_reference` / `_biotype` / `_length` / `_type` | Same NaN-on-unknown behavior. |
+| `write_labels` | Skip the CELLxGENE-only `uns['schema_version']`, `uns['schema_reference']`, `uns['organism']` writes. Add the `uns['organism_ontology_term_id']` write (R4) and `observation_joinid` write (R2). |
+
+The vendored code stays byte-identical. Future upstream bumps pull cleanly.
+
+### Schema source
+
+Use `hca_schema_definition.yaml` as-is. It already contains `add_labels` directives on the right fields (var index at lines 79, 110, and obs ontology fields at lines 203, 218, 245, 326, 467, 531, 708, 855). No YAML changes needed for v0.
+
+### Edge cases
+
+| Input state | Behavior |
+|---|---|
+| Ensembl ID in `var.index` not in GENCODE | All five `feature_*` columns NaN for that row. |
+| `obs['<field>_ontology_term_id']` absent | Skip that label; do not write a partial `obs['<field>']`. |
+| `obs['organism_ontology_term_id']` has >1 unique value | Do not write to `uns`; continue. |
+| `var['feature_is_filtered']` absent | Do not generate. Existing `feature_is_filtered` validator catches this as a downstream error. |
+| `raw.var` absent | Skip raw-var labeling. Label only `var`. |
+| Existing `var['feature_name']` populated | Overwrite. |
+
+## Open questions
+
+_(none currently)_
+
+## Success criteria
+
+Running the HCA labeler on gut-v1 myeloid (post-curate) produces a file where:
+
+- `var['feature_name']` is populated for 34,505 / 35,574 rows and NaN for the 1,069 deprecated IDs.
+- `obs` labels (`tissue`, `cell_type`, `assay`, `disease`, `sex`, `organism`, `development_stage`, `self_reported_ethnicity`) are populated from their `_ontology_term_id` inputs, overwriting the producer-drifted versions.
+- `obs['observation_joinid']` is present.
+- `uns['organism_ontology_term_id']` is set; no `uns['schema_version']`, `uns['schema_reference']`, or `uns['organism']`.
+- Producer `*_ontology_term` drift columns and custom columns like `gene_symbol` are untouched (the labeler does not drop them; that decision lives in `/curate-h5ad`).
+- `hca-schema-validator` introduces no new errors from labeling. The two pre-existing errors (`library_id` NaN, `library_preparation_batch` delimited lists) remain — they are independent Bucket C items unrelated to labeling.
+- CAP marker validation finds 54 / 56 markers in `var['feature_name']` (matching what we observed in yesterday's scratch experiment).

--- a/packages/hca-schema-validator/src/hca_schema_validator/__init__.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/__init__.py
@@ -6,6 +6,7 @@ __schema_version__ = "1.0.0"  # HCA schema version (independent from CELLxGENE)
 __schema_reference_url__ = "https://data.humancellatlas.org/metadata"  # Static URL, no version in path
 
 # Import after constants are defined
+from .labeler import HCALabeler
 from .validator import HCAValidator
 
-__all__ = ["HCAValidator"]
+__all__ = ["HCAValidator", "HCALabeler"]

--- a/packages/hca-schema-validator/src/hca_schema_validator/labeler.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/labeler.py
@@ -1,0 +1,111 @@
+"""HCA labeler - extends cellxgene AnnDataLabelAppender with HCA-specific behavior.
+
+Populates derived columns (var feature_*, obs ontology labels, observation_joinid)
+using GENCODE 48 and cellxgene-ontology-guide, while:
+  * Skipping CELLxGENE-only uns keys (schema_version, schema_reference, organism label).
+  * Tolerating Ensembl IDs not in bundled GENCODE (sets NaN instead of raising).
+  * Copying organism_ontology_term_id into uns when single-valued in obs.
+
+See packages/hca-schema-validator/PRD-hca-add-labels.md for full design.
+"""
+
+from pathlib import Path
+from typing import Dict, List
+
+import pandas as pd
+import yaml
+
+from hca_schema_validator._vendored.cellxgene_schema import gencode
+from hca_schema_validator._vendored.cellxgene_schema.gencode import get_gene_checker
+from hca_schema_validator._vendored.cellxgene_schema.utils import get_hash_digest_column
+from hca_schema_validator._vendored.cellxgene_schema.write_labels import AnnDataLabelAppender
+
+_SCHEMA_PATH = Path(__file__).parent / "schema_definitions" / "hca_schema_definition.yaml"
+
+
+class HCALabeler(AnnDataLabelAppender):
+    """HCA-flavored AnnDataLabelAppender.
+
+    Subclasses the vendored CELLxGENE labeler with three changes:
+      1. Loads hca_schema_definition.yaml as schema_def.
+      2. Overrides the 5 feature mapping methods to return NaN when the
+         Ensembl ID isn't recognized by bundled GENCODE.
+      3. Overrides write_labels to skip CELLxGENE-only uns keys and to
+         write uns['organism_ontology_term_id'] (when single-valued in
+         obs) plus obs['observation_joinid'].
+    """
+
+    def __init__(self, adata):
+        super().__init__(adata)
+        with open(_SCHEMA_PATH) as f:
+            self.schema_def = yaml.safe_load(f)
+
+    # -- NaN-tolerance overrides: each wraps the same inner GENCODE lookup as
+    # the base, but returns pd.NA when get_organism_from_feature_id yields None
+    # (the base raises ValueError on the first unknown ID).
+
+    def _get_mapping_dict_feature_id(self, ids: List[str]) -> Dict[str, object]:
+        out: Dict[str, object] = {}
+        for i in ids:
+            organism = gencode.get_organism_from_feature_id(i)
+            out[i] = pd.NA if organism is None else get_gene_checker(organism).get_symbol(i)
+        return out
+
+    def _get_mapping_dict_feature_reference(self, ids: List[str]) -> Dict[str, object]:
+        out: Dict[str, object] = {}
+        for i in ids:
+            organism = gencode.get_organism_from_feature_id(i)
+            out[i] = pd.NA if organism is None else organism.value
+        return out
+
+    def _get_mapping_dict_feature_type(self, ids: List[str]) -> Dict[str, object]:
+        out: Dict[str, object] = {}
+        for i in ids:
+            organism = gencode.get_organism_from_feature_id(i)
+            out[i] = pd.NA if organism is None else get_gene_checker(organism).get_type(i)
+        return out
+
+    def _get_mapping_dict_feature_length(self, ids: List[str]) -> Dict[str, object]:
+        out: Dict[str, object] = {}
+        for i in ids:
+            organism = gencode.get_organism_from_feature_id(i)
+            out[i] = pd.NA if organism is None else get_gene_checker(organism).get_length(i)
+        return out
+
+    def _get_mapping_dict_feature_biotype(self, ids: List[str]) -> Dict[str, object]:
+        # Base uses ERCC prefix only and never touches organism, so it can't fail.
+        # We still NaN unknown-organism IDs to keep R1 consistent: all five
+        # feature_* columns are NaN for rows the rest of the labeler can't resolve.
+        out: Dict[str, object] = {}
+        for i in ids:
+            organism = gencode.get_organism_from_feature_id(i)
+            if organism is None:
+                out[i] = pd.NA
+            elif i.startswith("ERCC"):
+                out[i] = "spike-in"
+            else:
+                out[i] = "gene"
+        return out
+
+    # -- HCA-specific write path --
+
+    def write_labels(self, output_path: str) -> None:
+        """Apply HCA labels and write a new h5ad.
+
+        Unlike the base, does NOT set uns['schema_version'] or
+        uns['schema_reference'] (CELLxGENE-only). Copies
+        organism_ontology_term_id from obs to uns when single-valued,
+        and writes obs['observation_joinid'].
+        """
+        self._add_labels()
+        self._remove_categories_with_zero_values()
+
+        organism_col = self.adata.obs.get("organism_ontology_term_id")
+        if organism_col is not None:
+            vals = organism_col.dropna().unique()
+            if len(vals) == 1:
+                self.adata.uns["organism_ontology_term_id"] = str(vals[0])
+
+        self.adata.obs["observation_joinid"] = get_hash_digest_column(self.adata.obs)
+
+        self.adata.write_h5ad(output_path, compression="gzip")

--- a/packages/hca-schema-validator/src/hca_schema_validator/labeler.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/labeler.py
@@ -13,6 +13,7 @@ from hca_schema_validator._vendored.cellxgene_schema.write_labels import AnnData
 
 _SCHEMA_PATH = Path(__file__).parent / "schema_definitions" / "hca_schema_definition.yaml"
 _ORGANISM_COL = "organism_ontology_term_id"
+_HUMAN_TAXON = "NCBITaxon:9606"
 _FORBIDDEN_UNS_KEYS = ("schema_version", "schema_reference")
 _NON_REQUIRED_LEVELS = {"optional", "strongly_recommended"}
 # Human GENCODE 48 has ~79k genes + 92 ERCC. Bound large enough to cache
@@ -66,6 +67,15 @@ class HCALabeler(AnnDataLabelAppender):
                     f"uns['{key}'] must not be present on input "
                     "(file appears to have been processed by cellxgene-schema add-labels already)"
                 )
+        if _ORGANISM_COL in self.adata.obs.columns:
+            non_human = sorted(
+                v for v in self.adata.obs[_ORGANISM_COL].dropna().unique() if v != _HUMAN_TAXON
+            )
+            if non_human:
+                issues.append(
+                    f"obs['{_ORGANISM_COL}'] contains non-human values {non_human}; "
+                    f"HCALabeler supports only {_HUMAN_TAXON}"
+                )
         if issues:
             raise ValueError("HCALabeler preflight failed:\n  - " + "\n  - ".join(issues))
 
@@ -117,12 +127,6 @@ class HCALabeler(AnnDataLabelAppender):
 
         self._add_labels()
         self._remove_categories_with_zero_values()
-
-        organism_col = self.adata.obs.get(_ORGANISM_COL)
-        if organism_col is not None:
-            vals = organism_col.dropna().unique()
-            if len(vals) == 1:
-                self.adata.uns[_ORGANISM_COL] = str(vals[0])
 
         self.adata.obs["observation_joinid"] = get_hash_digest_column(self.adata.obs)
 

--- a/packages/hca-schema-validator/src/hca_schema_validator/labeler.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/labeler.py
@@ -13,8 +13,8 @@ from hca_schema_validator._vendored.cellxgene_schema.write_labels import AnnData
 
 _SCHEMA_PATH = Path(__file__).parent / "schema_definitions" / "hca_schema_definition.yaml"
 _ORGANISM_COL = "organism_ontology_term_id"
+_OBSERVATION_JOINID_COL = "observation_joinid"
 _HUMAN_TAXON = "NCBITaxon:9606"
-_FORBIDDEN_UNS_KEYS = ("schema_version", "schema_reference")
 _NON_REQUIRED_LEVELS = {"optional", "strongly_recommended"}
 # Human GENCODE 48 has ~79k genes + 92 ERCC. Bound large enough to cache
 # several GENCODE vintages of deprecated IDs without leaking unboundedly
@@ -61,7 +61,8 @@ class HCALabeler(AnnDataLabelAppender):
                 level = str(col_def.get("requirement_level", "")).lower()
                 if level not in _NON_REQUIRED_LEVELS:
                     issues.append(f"Missing required column '{col_name}' in {component_name}")
-        for key in _FORBIDDEN_UNS_KEYS:
+        reserved_uns_keys = self.schema_def.get("components", {}).get("uns", {}).get("reserved_columns", [])
+        for key in reserved_uns_keys:
             if key in self.adata.uns:
                 issues.append(
                     f"uns['{key}'] must not be present on input "
@@ -128,6 +129,6 @@ class HCALabeler(AnnDataLabelAppender):
         self._add_labels()
         self._remove_categories_with_zero_values()
 
-        self.adata.obs["observation_joinid"] = get_hash_digest_column(self.adata.obs)
+        self.adata.obs[_OBSERVATION_JOINID_COL] = get_hash_digest_column(self.adata.obs)
 
         self.adata.write_h5ad(output_path, compression="gzip")

--- a/packages/hca-schema-validator/src/hca_schema_validator/labeler.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/labeler.py
@@ -16,14 +16,20 @@ _ORGANISM_COL = "organism_ontology_term_id"
 _FORBIDDEN_UNS_KEYS = ("schema_version", "schema_reference")
 
 
+_SUPPORTED_ORGANISMS = (SupportedOrganisms.HOMO_SAPIENS, SupportedOrganisms.ERCC)
+
+
 @functools.lru_cache(maxsize=None)
 def _organism_for_feature(feature_id: str):
-    # HCA is human-only. Probe HOMO_SAPIENS directly instead of scanning all
-    # supported organisms — the base's get_organism_from_feature_id loads
-    # every GENCODE table in turn, which wastes memory and time on files
-    # with deprecated IDs. Any new organism = code change.
-    human = SupportedOrganisms.HOMO_SAPIENS
-    return human if get_gene_checker(human).is_valid_id(feature_id) else None
+    # HCA supports human genes + ERCC spike-ins only. Probe these two tables
+    # directly instead of scanning all 16 organisms the vendored base knows
+    # about — that base loads every GENCODE table in turn, which is wasted
+    # memory/time on files with deprecated IDs. Adding a new organism is a
+    # code change.
+    for organism in _SUPPORTED_ORGANISMS:
+        if get_gene_checker(organism).is_valid_id(feature_id):
+            return organism
+    return None
 
 
 class HCALabeler(AnnDataLabelAppender):
@@ -75,10 +81,13 @@ class HCALabeler(AnnDataLabelAppender):
         return self._map_by_organism(ids, lambda i, o: get_gene_checker(o).get_length(i))
 
     def _get_mapping_dict_feature_biotype(self, ids):
-        # Base uses the ERCC prefix only and never touches organism, but we
-        # still NaN unknown-organism IDs so all five feature_* columns stay
-        # in sync — same rows NaN everywhere.
-        return self._map_by_organism(ids, lambda i, _o: "spike-in" if i.startswith("ERCC") else "gene")
+        # Use organism == ERCC rather than the base's ID-prefix check, so
+        # anything in the ERCC table is "spike-in" regardless of its literal
+        # ID shape. Unknown-organism IDs still NaN (via _map_by_organism) so
+        # all five feature_* columns stay in sync — same rows NaN everywhere.
+        return self._map_by_organism(
+            ids, lambda _i, o: "spike-in" if o == SupportedOrganisms.ERCC else "gene"
+        )
 
     def write_labels(self, output_path: str) -> None:
         self._preflight()

--- a/packages/hca-schema-validator/src/hca_schema_validator/labeler.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/labeler.py
@@ -1,4 +1,4 @@
-"""HCA labeler: NaN-tolerant AnnDataLabelAppender with HCA-flavored uns handling."""
+"""HCA labeler: NaN-tolerant AnnDataLabelAppender with HCA preflight checks."""
 
 import functools
 from pathlib import Path

--- a/packages/hca-schema-validator/src/hca_schema_validator/labeler.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/labeler.py
@@ -16,6 +16,11 @@ _ORGANISM_COL = "organism_ontology_term_id"
 _OBSERVATION_JOINID_COL = "observation_joinid"
 _HUMAN_TAXON = "NCBITaxon:9606"
 _NON_REQUIRED_LEVELS = {"optional", "strongly_recommended"}
+# Keys that signal the input has already been through cellxgene-schema
+# add-labels. `citation` (also in the schema's reserved_columns list) is
+# added at Discover publish, not by add-labels, so we don't reject on it
+# — narrower check matches the intent of R7.
+_POST_ADDLABELS_UNS_KEYS = ("schema_version", "schema_reference")
 # Human GENCODE 48 has ~79k genes + 92 ERCC. Bound large enough to cache
 # several GENCODE vintages of deprecated IDs without leaking unboundedly
 # in long-running processes (e.g. the MCP server).
@@ -61,8 +66,7 @@ class HCALabeler(AnnDataLabelAppender):
                 level = str(col_def.get("requirement_level", "")).lower()
                 if level not in _NON_REQUIRED_LEVELS:
                     issues.append(f"Missing required column '{col_name}' in {component_name}")
-        reserved_uns_keys = self.schema_def.get("components", {}).get("uns", {}).get("reserved_columns", [])
-        for key in reserved_uns_keys:
+        for key in _POST_ADDLABELS_UNS_KEYS:
             if key in self.adata.uns:
                 issues.append(
                     f"uns['{key}'] must not be present on input "

--- a/packages/hca-schema-validator/src/hca_schema_validator/labeler.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/labeler.py
@@ -14,12 +14,17 @@ from hca_schema_validator._vendored.cellxgene_schema.write_labels import AnnData
 _SCHEMA_PATH = Path(__file__).parent / "schema_definitions" / "hca_schema_definition.yaml"
 _ORGANISM_COL = "organism_ontology_term_id"
 _FORBIDDEN_UNS_KEYS = ("schema_version", "schema_reference")
+_NON_REQUIRED_LEVELS = {"optional", "strongly_recommended"}
+# Human GENCODE 48 has ~79k genes + 92 ERCC. Bound large enough to cache
+# several GENCODE vintages of deprecated IDs without leaking unboundedly
+# in long-running processes (e.g. the MCP server).
+_ORGANISM_CACHE_SIZE = 200_000
 
 
 _SUPPORTED_ORGANISMS = (SupportedOrganisms.HOMO_SAPIENS, SupportedOrganisms.ERCC)
 
 
-@functools.lru_cache(maxsize=None)
+@functools.lru_cache(maxsize=_ORGANISM_CACHE_SIZE)
 def _organism_for_feature(feature_id: str):
     # HCA supports human genes + ERCC spike-ins only. Probe these two tables
     # directly instead of scanning all 16 organisms the vendored base knows
@@ -46,7 +51,14 @@ class HCALabeler(AnnDataLabelAppender):
                 continue
             component = self.schema_def.get("components", {}).get(component_name, {})
             for col_name, col_def in component.get("columns", {}).items():
-                if "add_labels" in col_def and col_name not in df.columns:
+                if "add_labels" not in col_def or col_name in df.columns:
+                    continue
+                # Honor the schema's requirement_level: only default-required
+                # columns trigger preflight failure. Optional / strongly-
+                # recommended columns missing here just mean we skip labeling
+                # for that field — see _add_column below.
+                level = str(col_def.get("requirement_level", "")).lower()
+                if level not in _NON_REQUIRED_LEVELS:
                     issues.append(f"Missing required column '{col_name}' in {component_name}")
         for key in _FORBIDDEN_UNS_KEYS:
             if key in self.adata.uns:
@@ -56,6 +68,17 @@ class HCALabeler(AnnDataLabelAppender):
                 )
         if issues:
             raise ValueError("HCALabeler preflight failed:\n  - " + "\n  - ".join(issues))
+
+    def _add_column(self, component: str, column: str, column_definition: dict) -> None:
+        # Skip silently when the source column isn't on the target dataframe.
+        # Preflight has already rejected missing required columns, so this
+        # only fires for optional / strongly-recommended ones (e.g. the
+        # HCA schema marks cell_type_ontology_term_id optional).
+        if column != "index":
+            df = getattr_anndata(self.adata, component)
+            if df is None or column not in df.columns:
+                return
+        super()._add_column(component, column, column_definition)
 
     def _map_by_organism(
         self,

--- a/packages/hca-schema-validator/src/hca_schema_validator/labeler.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/labeler.py
@@ -1,110 +1,73 @@
-"""HCA labeler - extends cellxgene AnnDataLabelAppender with HCA-specific behavior.
+"""HCA labeler: NaN-tolerant AnnDataLabelAppender with HCA-flavored uns handling."""
 
-Populates derived columns (var feature_*, obs ontology labels, observation_joinid)
-using GENCODE 48 and cellxgene-ontology-guide, while:
-  * Skipping CELLxGENE-only uns keys (schema_version, schema_reference, organism label).
-  * Tolerating Ensembl IDs not in bundled GENCODE (sets NaN instead of raising).
-  * Copying organism_ontology_term_id into uns when single-valued in obs.
-
-See packages/hca-schema-validator/PRD-hca-add-labels.md for full design.
-"""
-
+import functools
 from pathlib import Path
-from typing import Dict, List
+from typing import Callable, Dict, List
 
 import pandas as pd
 import yaml
 
 from hca_schema_validator._vendored.cellxgene_schema import gencode
-from hca_schema_validator._vendored.cellxgene_schema.gencode import get_gene_checker
+from hca_schema_validator._vendored.cellxgene_schema.gencode import SupportedOrganisms, get_gene_checker
 from hca_schema_validator._vendored.cellxgene_schema.utils import get_hash_digest_column
 from hca_schema_validator._vendored.cellxgene_schema.write_labels import AnnDataLabelAppender
 
 _SCHEMA_PATH = Path(__file__).parent / "schema_definitions" / "hca_schema_definition.yaml"
+_ORGANISM_COL = "organism_ontology_term_id"
+
+
+@functools.lru_cache(maxsize=None)
+def _organism_for_feature(feature_id: str):
+    # Memoized because the base labeler calls us once per feature per
+    # derived column (5 columns × 35k genes on a typical HCA file), but
+    # the lookup is purely a function of the ID and the bundled GENCODE.
+    return gencode.get_organism_from_feature_id(feature_id)
 
 
 class HCALabeler(AnnDataLabelAppender):
-    """HCA-flavored AnnDataLabelAppender.
-
-    Subclasses the vendored CELLxGENE labeler with three changes:
-      1. Loads hca_schema_definition.yaml as schema_def.
-      2. Overrides the 5 feature mapping methods to return NaN when the
-         Ensembl ID isn't recognized by bundled GENCODE.
-      3. Overrides write_labels to skip CELLxGENE-only uns keys and to
-         write uns['organism_ontology_term_id'] (when single-valued in
-         obs) plus obs['observation_joinid'].
-    """
-
     def __init__(self, adata):
         super().__init__(adata)
         with open(_SCHEMA_PATH) as f:
             self.schema_def = yaml.safe_load(f)
 
-    # -- NaN-tolerance overrides: each wraps the same inner GENCODE lookup as
-    # the base, but returns pd.NA when get_organism_from_feature_id yields None
-    # (the base raises ValueError on the first unknown ID).
-
-    def _get_mapping_dict_feature_id(self, ids: List[str]) -> Dict[str, object]:
+    def _map_by_organism(
+        self,
+        ids: List[str],
+        fn: Callable[[str, SupportedOrganisms], object],
+    ) -> Dict[str, object]:
         out: Dict[str, object] = {}
         for i in ids:
-            organism = gencode.get_organism_from_feature_id(i)
-            out[i] = pd.NA if organism is None else get_gene_checker(organism).get_symbol(i)
+            organism = _organism_for_feature(i)
+            out[i] = pd.NA if organism is None else fn(i, organism)
         return out
 
-    def _get_mapping_dict_feature_reference(self, ids: List[str]) -> Dict[str, object]:
-        out: Dict[str, object] = {}
-        for i in ids:
-            organism = gencode.get_organism_from_feature_id(i)
-            out[i] = pd.NA if organism is None else organism.value
-        return out
+    def _get_mapping_dict_feature_id(self, ids):
+        return self._map_by_organism(ids, lambda i, o: get_gene_checker(o).get_symbol(i))
 
-    def _get_mapping_dict_feature_type(self, ids: List[str]) -> Dict[str, object]:
-        out: Dict[str, object] = {}
-        for i in ids:
-            organism = gencode.get_organism_from_feature_id(i)
-            out[i] = pd.NA if organism is None else get_gene_checker(organism).get_type(i)
-        return out
+    def _get_mapping_dict_feature_reference(self, ids):
+        return self._map_by_organism(ids, lambda i, o: o.value)
 
-    def _get_mapping_dict_feature_length(self, ids: List[str]) -> Dict[str, object]:
-        out: Dict[str, object] = {}
-        for i in ids:
-            organism = gencode.get_organism_from_feature_id(i)
-            out[i] = pd.NA if organism is None else get_gene_checker(organism).get_length(i)
-        return out
+    def _get_mapping_dict_feature_type(self, ids):
+        return self._map_by_organism(ids, lambda i, o: get_gene_checker(o).get_type(i))
 
-    def _get_mapping_dict_feature_biotype(self, ids: List[str]) -> Dict[str, object]:
-        # Base uses ERCC prefix only and never touches organism, so it can't fail.
-        # We still NaN unknown-organism IDs to keep R1 consistent: all five
-        # feature_* columns are NaN for rows the rest of the labeler can't resolve.
-        out: Dict[str, object] = {}
-        for i in ids:
-            organism = gencode.get_organism_from_feature_id(i)
-            if organism is None:
-                out[i] = pd.NA
-            elif i.startswith("ERCC"):
-                out[i] = "spike-in"
-            else:
-                out[i] = "gene"
-        return out
+    def _get_mapping_dict_feature_length(self, ids):
+        return self._map_by_organism(ids, lambda i, o: get_gene_checker(o).get_length(i))
 
-    # -- HCA-specific write path --
+    def _get_mapping_dict_feature_biotype(self, ids):
+        # Base uses the ERCC prefix only and never touches organism, but we
+        # still NaN unknown-organism IDs so all five feature_* columns stay
+        # in sync — same rows NaN everywhere.
+        return self._map_by_organism(ids, lambda i, _o: "spike-in" if i.startswith("ERCC") else "gene")
 
     def write_labels(self, output_path: str) -> None:
-        """Apply HCA labels and write a new h5ad.
-
-        Unlike the base, does NOT set uns['schema_version'] or
-        uns['schema_reference'] (CELLxGENE-only). Copies
-        organism_ontology_term_id from obs to uns when single-valued,
-        and writes obs['observation_joinid'].
-        """
         self._add_labels()
         self._remove_categories_with_zero_values()
 
-        organism_col = self.adata.obs.get("organism_ontology_term_id")
+        organism_col = self.adata.obs.get(_ORGANISM_COL)
         if organism_col is not None:
             vals = organism_col.dropna().unique()
             if len(vals) == 1:
-                self.adata.uns["organism_ontology_term_id"] = str(vals[0])
+                self.adata.uns[_ORGANISM_COL] = str(vals[0])
 
         self.adata.obs["observation_joinid"] = get_hash_digest_column(self.adata.obs)
 

--- a/packages/hca-schema-validator/src/hca_schema_validator/labeler.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/labeler.py
@@ -7,21 +7,23 @@ from typing import Callable, Dict, List
 import pandas as pd
 import yaml
 
-from hca_schema_validator._vendored.cellxgene_schema import gencode
 from hca_schema_validator._vendored.cellxgene_schema.gencode import SupportedOrganisms, get_gene_checker
-from hca_schema_validator._vendored.cellxgene_schema.utils import get_hash_digest_column
+from hca_schema_validator._vendored.cellxgene_schema.utils import get_hash_digest_column, getattr_anndata
 from hca_schema_validator._vendored.cellxgene_schema.write_labels import AnnDataLabelAppender
 
 _SCHEMA_PATH = Path(__file__).parent / "schema_definitions" / "hca_schema_definition.yaml"
 _ORGANISM_COL = "organism_ontology_term_id"
+_FORBIDDEN_UNS_KEYS = ("schema_version", "schema_reference")
 
 
 @functools.lru_cache(maxsize=None)
 def _organism_for_feature(feature_id: str):
-    # Memoized because the base labeler calls us once per feature per
-    # derived column (5 columns × 35k genes on a typical HCA file), but
-    # the lookup is purely a function of the ID and the bundled GENCODE.
-    return gencode.get_organism_from_feature_id(feature_id)
+    # HCA is human-only. Probe HOMO_SAPIENS directly instead of scanning all
+    # supported organisms — the base's get_organism_from_feature_id loads
+    # every GENCODE table in turn, which wastes memory and time on files
+    # with deprecated IDs. Any new organism = code change.
+    human = SupportedOrganisms.HOMO_SAPIENS
+    return human if get_gene_checker(human).is_valid_id(feature_id) else None
 
 
 class HCALabeler(AnnDataLabelAppender):
@@ -29,6 +31,25 @@ class HCALabeler(AnnDataLabelAppender):
         super().__init__(adata)
         with open(_SCHEMA_PATH) as f:
             self.schema_def = yaml.safe_load(f)
+
+    def _preflight(self) -> None:
+        issues: List[str] = []
+        for component_name in ("obs", "var", "raw.var"):
+            df = getattr_anndata(self.adata, component_name)
+            if df is None:
+                continue
+            component = self.schema_def.get("components", {}).get(component_name, {})
+            for col_name, col_def in component.get("columns", {}).items():
+                if "add_labels" in col_def and col_name not in df.columns:
+                    issues.append(f"Missing required column '{col_name}' in {component_name}")
+        for key in _FORBIDDEN_UNS_KEYS:
+            if key in self.adata.uns:
+                issues.append(
+                    f"uns['{key}'] must not be present on input "
+                    "(file appears to have been processed by cellxgene-schema add-labels already)"
+                )
+        if issues:
+            raise ValueError("HCALabeler preflight failed:\n  - " + "\n  - ".join(issues))
 
     def _map_by_organism(
         self,
@@ -60,6 +81,8 @@ class HCALabeler(AnnDataLabelAppender):
         return self._map_by_organism(ids, lambda i, _o: "spike-in" if i.startswith("ERCC") else "gene")
 
     def write_labels(self, output_path: str) -> None:
+        self._preflight()
+
         self._add_labels()
         self._remove_categories_with_zero_values()
 

--- a/packages/hca-schema-validator/tests/test_labeler.py
+++ b/packages/hca-schema-validator/tests/test_labeler.py
@@ -30,6 +30,20 @@ def _label(adata, tmp_path):
     return anndata.read_h5ad(str(out_path))
 
 
+def _replace_first_feature_id(adata, new_id):
+    """Swap the first var/raw.var index entry for `new_id` and return it.
+
+    Both indexes are updated together so they stay aligned (otherwise the
+    labeler's raw.var mirror would target a different gene).
+    """
+    new_ids = [new_id] + list(adata.var.index[1:])
+    adata.var.index = pd.Index(new_ids)
+    raw = adata.raw.to_adata()
+    raw.var.index = pd.Index(new_ids)
+    adata.raw = raw
+    return new_id
+
+
 def test_feature_name_populated_from_ensembl(labeled):
     expected = {
         "ENSG00000127603": "MACF1",
@@ -45,13 +59,7 @@ def test_feature_name_populated_from_ensembl(labeled):
 
 
 def test_unknown_ensembl_yields_nan(base_adata, tmp_path):
-    known_ids = list(base_adata.var.index)
-    fake_id = "ENSG99999999999"
-    new_ids = [fake_id] + known_ids[1:]
-    base_adata.var.index = pd.Index(new_ids)
-    raw = base_adata.raw.to_adata()
-    raw.var.index = pd.Index(new_ids)
-    base_adata.raw = raw
+    fake_id = _replace_first_feature_id(base_adata, "ENSG99999999999")
 
     labeled = _label(base_adata, tmp_path)
     raw_var = labeled.raw.to_adata().var
@@ -127,13 +135,7 @@ def test_preflight_fails_when_cellxgene_schema_keys_present(base_adata, tmp_path
 
 
 def test_ercc_spike_in_labeled(base_adata, tmp_path):
-    known_ids = list(base_adata.var.index)
-    ercc_id = "ERCC-00002"
-    new_ids = [ercc_id] + known_ids[1:]
-    base_adata.var.index = pd.Index(new_ids)
-    raw = base_adata.raw.to_adata()
-    raw.var.index = pd.Index(new_ids)
-    base_adata.raw = raw
+    ercc_id = _replace_first_feature_id(base_adata, "ERCC-00002")
 
     labeled = _label(base_adata, tmp_path)
 

--- a/packages/hca-schema-validator/tests/test_labeler.py
+++ b/packages/hca-schema-validator/tests/test_labeler.py
@@ -84,17 +84,13 @@ def test_existing_obs_label_overwritten(base_adata, tmp_path):
     assert "STALE_VALUE" not in labeled.obs["tissue"].astype(str).unique()
 
 
-def test_organism_copied_to_uns_when_single_valued(labeled):
-    assert labeled.uns.get("organism_ontology_term_id") == "NCBITaxon:9606"
-
-
-def test_organism_not_copied_when_multivalued(base_adata, tmp_path):
+def test_preflight_fails_on_non_human_organism(base_adata, tmp_path):
     base_adata.obs["organism_ontology_term_id"] = base_adata.obs["organism_ontology_term_id"].astype(str)
     first_label = base_adata.obs.index[0]
     base_adata.obs.loc[first_label, "organism_ontology_term_id"] = "NCBITaxon:10090"
 
-    labeled = _label(base_adata, tmp_path)
-    assert "organism_ontology_term_id" not in labeled.uns
+    with pytest.raises(ValueError, match="NCBITaxon:10090"):
+        _label(base_adata, tmp_path)
 
 
 def test_cellxgene_only_uns_keys_absent(labeled):

--- a/packages/hca-schema-validator/tests/test_labeler.py
+++ b/packages/hca-schema-validator/tests/test_labeler.py
@@ -109,10 +109,19 @@ def test_observation_joinid_written(labeled, base_adata):
     assert labeled.obs["observation_joinid"].notna().all()
 
 
-def test_preflight_fails_on_missing_ontology_term_id_column(base_adata, tmp_path):
-    del base_adata.obs["cell_type_ontology_term_id"]
-    with pytest.raises(ValueError, match="cell_type_ontology_term_id"):
+def test_preflight_fails_on_missing_required_ontology_term_id_column(base_adata, tmp_path):
+    del base_adata.obs["organism_ontology_term_id"]
+    with pytest.raises(ValueError, match="organism_ontology_term_id"):
         _label(base_adata, tmp_path)
+
+
+def test_optional_cell_type_column_missing_is_skipped(base_adata, tmp_path):
+    # cell_type_ontology_term_id is marked requirement_level: optional in the
+    # HCA schema; labeler should succeed without writing obs['cell_type'].
+    del base_adata.obs["cell_type_ontology_term_id"]
+    labeled = _label(base_adata, tmp_path)
+    assert "cell_type" not in labeled.obs.columns
+    assert "tissue" in labeled.obs.columns  # other labels still written
 
 
 def test_preflight_fails_when_cellxgene_schema_keys_present(base_adata, tmp_path):

--- a/packages/hca-schema-validator/tests/test_labeler.py
+++ b/packages/hca-schema-validator/tests/test_labeler.py
@@ -1,0 +1,121 @@
+"""Tests for HCALabeler."""
+
+import copy
+import tempfile
+from pathlib import Path
+
+import anndata
+import pandas as pd
+import pytest
+
+from hca_schema_validator import HCALabeler
+
+from .fixtures import hca_fixtures
+
+
+def _label_to_temp(adata):
+    """Label adata and read the written file back. Returns the re-loaded adata."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out_path = Path(tmpdir) / "labeled.h5ad"
+        HCALabeler(adata).write_labels(str(out_path))
+        return anndata.read_h5ad(str(out_path))
+
+
+@pytest.fixture
+def base_adata():
+    """Fresh, unlabeled copy of the canonical HCA-valid fixture."""
+    return copy.deepcopy(hca_fixtures.adata)
+
+
+def test_feature_name_populated_from_ensembl(base_adata):
+    """var['feature_name'] is populated with GENCODE symbols for known Ensembl IDs."""
+    labeled = _label_to_temp(base_adata)
+    expected = {
+        "ENSG00000127603": "MACF1",
+        "ENSG00000141510": "TP53",
+        "ENSG00000012048": "BRCA1",
+        "ENSG00000139618": "BRCA2",
+        "ENSG00000002330": "BAD",
+        "ENSG00000000005": "TNMD",
+        "ENSG00000000419": "DPM1",
+    }
+    for ens_id, symbol in expected.items():
+        assert labeled.var.loc[ens_id, "feature_name"] == symbol
+
+
+def test_unknown_ensembl_yields_nan(base_adata):
+    """Unknown Ensembl IDs get NaN across all five feature_* columns; real rows unaffected."""
+    # Replace one known ID with a fake one. Patch both .var and .raw.var so their
+    # indexes stay aligned.
+    known_ids = list(base_adata.var.index)
+    fake_id = "ENSG99999999999"
+    new_ids = [fake_id] + known_ids[1:]
+    base_adata.var.index = pd.Index(new_ids)
+    raw = base_adata.raw.to_adata()
+    raw.var.index = pd.Index(new_ids)
+    base_adata.raw = raw
+
+    labeled = _label_to_temp(base_adata)
+
+    # Fake row: all five derived columns are NaN
+    for col in ("feature_name", "feature_reference", "feature_biotype", "feature_length", "feature_type"):
+        assert pd.isna(labeled.var.loc[fake_id, col]), f"{col} should be NaN for unknown ID"
+
+    # Real row still resolves
+    assert labeled.var.loc["ENSG00000141510", "feature_name"] == "TP53"
+
+
+def test_obs_labels_populated_from_term_id(base_adata):
+    """obs['tissue'], obs['cell_type'], obs['assay'], obs['disease'] are written."""
+    labeled = _label_to_temp(base_adata)
+    for col in ("tissue", "cell_type", "assay", "disease"):
+        assert col in labeled.obs.columns, f"{col} should be added by labeler"
+        assert labeled.obs[col].notna().all(), f"{col} should be fully populated"
+
+
+def test_existing_obs_label_overwritten(base_adata):
+    """Pre-existing obs label is replaced with the canonical value."""
+    base_adata.obs["tissue"] = "STALE_VALUE"
+    labeled = _label_to_temp(base_adata)
+    assert "STALE_VALUE" not in labeled.obs["tissue"].astype(str).unique()
+
+
+def test_organism_copied_to_uns_when_single_valued(base_adata):
+    """Single-valued obs organism is also written to uns."""
+    labeled = _label_to_temp(base_adata)
+    assert labeled.uns.get("organism_ontology_term_id") == "NCBITaxon:9606"
+
+
+def test_organism_not_copied_when_multivalued(base_adata):
+    """Multi-valued organism in obs is not copied to uns."""
+    # Introduce a second organism value on one cell
+    base_adata.obs["organism_ontology_term_id"] = base_adata.obs["organism_ontology_term_id"].astype(str)
+    base_adata.obs.iloc[0, base_adata.obs.columns.get_loc("organism_ontology_term_id")] = "NCBITaxon:10090"
+
+    labeled = _label_to_temp(base_adata)
+    assert "organism_ontology_term_id" not in labeled.uns
+
+
+def test_cellxgene_only_uns_keys_absent(base_adata):
+    """schema_version, schema_reference, and the label-form 'organism' are not written."""
+    labeled = _label_to_temp(base_adata)
+    assert "schema_version" not in labeled.uns
+    assert "schema_reference" not in labeled.uns
+    assert "organism" not in labeled.uns
+
+
+def test_observation_joinid_written(base_adata):
+    """obs['observation_joinid'] is written with one value per cell."""
+    labeled = _label_to_temp(base_adata)
+    assert "observation_joinid" in labeled.obs.columns
+    assert len(labeled.obs["observation_joinid"]) == base_adata.n_obs
+    assert labeled.obs["observation_joinid"].notna().all()
+
+
+def test_producer_columns_preserved(base_adata):
+    """Custom producer columns outside the labeler's controlled set are untouched."""
+    base_adata.obs["author_cell_type"] = "custom_label"
+    base_adata.var["gene_symbol"] = "CUSTOM_SYMBOL"
+    labeled = _label_to_temp(base_adata)
+    assert (labeled.obs["author_cell_type"].astype(str) == "custom_label").all()
+    assert (labeled.var["gene_symbol"].astype(str) == "CUSTOM_SYMBOL").all()

--- a/packages/hca-schema-validator/tests/test_labeler.py
+++ b/packages/hca-schema-validator/tests/test_labeler.py
@@ -1,8 +1,6 @@
 """Tests for HCALabeler."""
 
 import copy
-import tempfile
-from pathlib import Path
 
 import anndata
 import pandas as pd
@@ -10,26 +8,29 @@ import pytest
 
 from hca_schema_validator import HCALabeler
 
-from .fixtures import hca_fixtures
-
-
-def _label_to_temp(adata):
-    """Label adata and read the written file back. Returns the re-loaded adata."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        out_path = Path(tmpdir) / "labeled.h5ad"
-        HCALabeler(adata).write_labels(str(out_path))
-        return anndata.read_h5ad(str(out_path))
+from .fixtures.hca_fixtures import adata as valid_adata
 
 
 @pytest.fixture
 def base_adata():
-    """Fresh, unlabeled copy of the canonical HCA-valid fixture."""
-    return copy.deepcopy(hca_fixtures.adata)
+    # Deepcopy the module-level fixture so tests don't mutate each other's state.
+    return copy.deepcopy(valid_adata)
 
 
-def test_feature_name_populated_from_ensembl(base_adata):
-    """var['feature_name'] is populated with GENCODE symbols for known Ensembl IDs."""
-    labeled = _label_to_temp(base_adata)
+@pytest.fixture
+def labeled(base_adata, tmp_path):
+    out_path = tmp_path / "labeled.h5ad"
+    HCALabeler(base_adata).write_labels(str(out_path))
+    return anndata.read_h5ad(str(out_path))
+
+
+def _label(adata, tmp_path):
+    out_path = tmp_path / "labeled.h5ad"
+    HCALabeler(adata).write_labels(str(out_path))
+    return anndata.read_h5ad(str(out_path))
+
+
+def test_feature_name_populated_from_ensembl(labeled):
     expected = {
         "ENSG00000127603": "MACF1",
         "ENSG00000141510": "TP53",
@@ -43,10 +44,7 @@ def test_feature_name_populated_from_ensembl(base_adata):
         assert labeled.var.loc[ens_id, "feature_name"] == symbol
 
 
-def test_unknown_ensembl_yields_nan(base_adata):
-    """Unknown Ensembl IDs get NaN across all five feature_* columns; real rows unaffected."""
-    # Replace one known ID with a fake one. Patch both .var and .raw.var so their
-    # indexes stay aligned.
+def test_unknown_ensembl_yields_nan(base_adata, tmp_path):
     known_ids = list(base_adata.var.index)
     fake_id = "ENSG99999999999"
     new_ids = [fake_id] + known_ids[1:]
@@ -55,67 +53,53 @@ def test_unknown_ensembl_yields_nan(base_adata):
     raw.var.index = pd.Index(new_ids)
     base_adata.raw = raw
 
-    labeled = _label_to_temp(base_adata)
+    labeled = _label(base_adata, tmp_path)
 
-    # Fake row: all five derived columns are NaN
     for col in ("feature_name", "feature_reference", "feature_biotype", "feature_length", "feature_type"):
         assert pd.isna(labeled.var.loc[fake_id, col]), f"{col} should be NaN for unknown ID"
-
-    # Real row still resolves
     assert labeled.var.loc["ENSG00000141510", "feature_name"] == "TP53"
 
 
-def test_obs_labels_populated_from_term_id(base_adata):
-    """obs['tissue'], obs['cell_type'], obs['assay'], obs['disease'] are written."""
-    labeled = _label_to_temp(base_adata)
+def test_obs_labels_populated_from_term_id(labeled):
     for col in ("tissue", "cell_type", "assay", "disease"):
-        assert col in labeled.obs.columns, f"{col} should be added by labeler"
-        assert labeled.obs[col].notna().all(), f"{col} should be fully populated"
+        assert col in labeled.obs.columns
+        assert labeled.obs[col].notna().all()
 
 
-def test_existing_obs_label_overwritten(base_adata):
-    """Pre-existing obs label is replaced with the canonical value."""
+def test_existing_obs_label_overwritten(base_adata, tmp_path):
     base_adata.obs["tissue"] = "STALE_VALUE"
-    labeled = _label_to_temp(base_adata)
+    labeled = _label(base_adata, tmp_path)
     assert "STALE_VALUE" not in labeled.obs["tissue"].astype(str).unique()
 
 
-def test_organism_copied_to_uns_when_single_valued(base_adata):
-    """Single-valued obs organism is also written to uns."""
-    labeled = _label_to_temp(base_adata)
+def test_organism_copied_to_uns_when_single_valued(labeled):
     assert labeled.uns.get("organism_ontology_term_id") == "NCBITaxon:9606"
 
 
-def test_organism_not_copied_when_multivalued(base_adata):
-    """Multi-valued organism in obs is not copied to uns."""
-    # Introduce a second organism value on one cell
+def test_organism_not_copied_when_multivalued(base_adata, tmp_path):
     base_adata.obs["organism_ontology_term_id"] = base_adata.obs["organism_ontology_term_id"].astype(str)
-    base_adata.obs.iloc[0, base_adata.obs.columns.get_loc("organism_ontology_term_id")] = "NCBITaxon:10090"
+    first_label = base_adata.obs.index[0]
+    base_adata.obs.loc[first_label, "organism_ontology_term_id"] = "NCBITaxon:10090"
 
-    labeled = _label_to_temp(base_adata)
+    labeled = _label(base_adata, tmp_path)
     assert "organism_ontology_term_id" not in labeled.uns
 
 
-def test_cellxgene_only_uns_keys_absent(base_adata):
-    """schema_version, schema_reference, and the label-form 'organism' are not written."""
-    labeled = _label_to_temp(base_adata)
+def test_cellxgene_only_uns_keys_absent(labeled):
     assert "schema_version" not in labeled.uns
     assert "schema_reference" not in labeled.uns
     assert "organism" not in labeled.uns
 
 
-def test_observation_joinid_written(base_adata):
-    """obs['observation_joinid'] is written with one value per cell."""
-    labeled = _label_to_temp(base_adata)
+def test_observation_joinid_written(labeled, base_adata):
     assert "observation_joinid" in labeled.obs.columns
     assert len(labeled.obs["observation_joinid"]) == base_adata.n_obs
     assert labeled.obs["observation_joinid"].notna().all()
 
 
-def test_producer_columns_preserved(base_adata):
-    """Custom producer columns outside the labeler's controlled set are untouched."""
+def test_producer_columns_preserved(base_adata, tmp_path):
     base_adata.obs["author_cell_type"] = "custom_label"
     base_adata.var["gene_symbol"] = "CUSTOM_SYMBOL"
-    labeled = _label_to_temp(base_adata)
+    labeled = _label(base_adata, tmp_path)
     assert (labeled.obs["author_cell_type"].astype(str) == "custom_label").all()
     assert (labeled.var["gene_symbol"].astype(str) == "CUSTOM_SYMBOL").all()

--- a/packages/hca-schema-validator/tests/test_labeler.py
+++ b/packages/hca-schema-validator/tests/test_labeler.py
@@ -121,6 +121,24 @@ def test_preflight_fails_when_cellxgene_schema_keys_present(base_adata, tmp_path
         _label(base_adata, tmp_path)
 
 
+def test_ercc_spike_in_labeled(base_adata, tmp_path):
+    known_ids = list(base_adata.var.index)
+    ercc_id = "ERCC-00002"
+    new_ids = [ercc_id] + known_ids[1:]
+    base_adata.var.index = pd.Index(new_ids)
+    raw = base_adata.raw.to_adata()
+    raw.var.index = pd.Index(new_ids)
+    base_adata.raw = raw
+
+    labeled = _label(base_adata, tmp_path)
+
+    row = labeled.var.loc[ercc_id]
+    assert row["feature_biotype"] == "spike-in"
+    assert row["feature_reference"] == "NCBITaxon:32630"
+    assert row["feature_type"] == "synthetic"
+    assert "spike-in control" in str(row["feature_name"])
+
+
 def test_producer_columns_preserved(base_adata, tmp_path):
     base_adata.obs["author_cell_type"] = "custom_label"
     base_adata.var["gene_symbol"] = "CUSTOM_SYMBOL"

--- a/packages/hca-schema-validator/tests/test_labeler.py
+++ b/packages/hca-schema-validator/tests/test_labeler.py
@@ -54,16 +54,28 @@ def test_unknown_ensembl_yields_nan(base_adata, tmp_path):
     base_adata.raw = raw
 
     labeled = _label(base_adata, tmp_path)
+    raw_var = labeled.raw.to_adata().var
 
     for col in ("feature_name", "feature_reference", "feature_biotype", "feature_length", "feature_type"):
-        assert pd.isna(labeled.var.loc[fake_id, col]), f"{col} should be NaN for unknown ID"
+        assert pd.isna(labeled.var.loc[fake_id, col]), f"var.{col} should be NaN for unknown ID"
+        assert pd.isna(raw_var.loc[fake_id, col]), f"raw.var.{col} should be NaN for unknown ID"
     assert labeled.var.loc["ENSG00000141510", "feature_name"] == "TP53"
+    assert raw_var.loc["ENSG00000141510", "feature_name"] == "TP53"
 
 
 def test_obs_labels_populated_from_term_id(labeled):
-    for col in ("tissue", "cell_type", "assay", "disease"):
-        assert col in labeled.obs.columns
-        assert labeled.obs[col].notna().all()
+    for col in (
+        "tissue",
+        "cell_type",
+        "assay",
+        "disease",
+        "sex",
+        "organism",
+        "development_stage",
+        "self_reported_ethnicity",
+    ):
+        assert col in labeled.obs.columns, f"{col} should be added by labeler"
+        assert labeled.obs[col].notna().all(), f"{col} should be fully populated"
 
 
 def test_existing_obs_label_overwritten(base_adata, tmp_path):
@@ -95,6 +107,18 @@ def test_observation_joinid_written(labeled, base_adata):
     assert "observation_joinid" in labeled.obs.columns
     assert len(labeled.obs["observation_joinid"]) == base_adata.n_obs
     assert labeled.obs["observation_joinid"].notna().all()
+
+
+def test_preflight_fails_on_missing_ontology_term_id_column(base_adata, tmp_path):
+    del base_adata.obs["cell_type_ontology_term_id"]
+    with pytest.raises(ValueError, match="cell_type_ontology_term_id"):
+        _label(base_adata, tmp_path)
+
+
+def test_preflight_fails_when_cellxgene_schema_keys_present(base_adata, tmp_path):
+    base_adata.uns["schema_version"] = "5.0.0"
+    with pytest.raises(ValueError, match="schema_version"):
+        _label(base_adata, tmp_path)
 
 
 def test_producer_columns_preserved(base_adata, tmp_path):


### PR DESCRIPTION
## Summary

- Adds `HCALabeler`: a subclass of the vendored CELLxGENE `AnnDataLabelAppender` that populates HCA-canonical derived columns (`var.feature_*`, 8 obs ontology labels, `observation_joinid`) using GENCODE 48 and `cellxgene-ontology-guide`, while leaving producer-custom columns and `uns` entirely untouched.
- Tolerates Ensembl IDs the bundled GENCODE doesn't recognize — sets NaN across all five `feature_*` columns for affected rows instead of raising. Unblocks files with deprecated IDs (~3% of gut-v1 myeloid).
- Supports ERCC spike-ins via a second supported organism probe; non-human / non-ERCC IDs NaN out.
- Preflight rejects files that have already been through cellxgene-schema add-labels (`uns['schema_version']` or `uns['schema_reference']` present) and files with non-human organism values in obs.
- Honors `requirement_level` on obs columns: required fields missing → preflight fails; optional/strongly-recommended missing → skip silently (currently only `cell_type_ontology_term_id` is marked optional).
- No CLI. Python API only. The MCP server (follow-up ticket) will wrap this with edit-snapshot + provenance logging.
- Vendored code stays byte-identical — subclass + override pattern matches existing `HCAValidator(Validator)`.

See `packages/hca-schema-validator/PRD-hca-add-labels.md` for full design.

Closes #351
Progresses #352

## Test plan

- [x] Unit tests: `poetry run pytest packages/hca-schema-validator/tests/test_labeler.py -v` (12 tests).
- [x] Full validator test suite still passes: `poetry run pytest packages/hca-schema-validator/tests/ -q` (58 tests).
- [x] End-to-end on gut-v1 myeloid integrated object:
  - 34,505 / 35,574 `feature_name` populated; 1,069 NaN (matches known deprecated-ID count).
  - All 50,296 cells labeled with `tissue` / `cell_type` / `assay` / `disease` / etc.
  - `observation_joinid` present for all cells.
  - `uns` unchanged by the labeler.
  - Producer columns (`gene_symbol`, `mt`, `ribo`, `hb`, `gene_id`) untouched.
  - `hca-schema-validator` on the labeled file: same 2 pre-existing errors (`library_id` NaN, `library_preparation_batch` delimited) — no new errors introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)