### PR TITLE
docs: surface CAP overlap stats in evaluate-h5ad report

### DIFF
--- a/.claude/skills/curate-h5ad/SKILL.md
+++ b/.claude/skills/curate-h5ad/SKILL.md
@@ -95,7 +95,7 @@ Each tool writes a new timestamped file. For most subsequent calls, passing eith
 Re-run `view_edit_log` and the validator on the final file, then produce a structured report with these sections in order. Use markdown tables; skip any section with no content.
 
 ### Header
-One short paragraph or bullet block with: final file path, shape (`n_obs × n_vars`), `title` from `uns`, schema type + version, X verdict + `raw.X` presence, compression status, `obsm` keys present.
+One short paragraph or bullet block with: final file path, shape (`n_obs × n_vars`), `title` from `uns`, schema type (include version only when schema is CellxGENE — HCA is unversioned), X verdict + `raw.X` presence, compression status, `obsm` keys present.
 
 ### Mechanical fixes applied
 

--- a/.claude/skills/curate-h5ad/SKILL.md
+++ b/.claude/skills/curate-h5ad/SKILL.md
@@ -45,7 +45,7 @@ Only these are in Bucket A. Nothing else. A row belongs in A only when its preco
 
 ### Bucket B — Needs wrangler input (todo — stop and ask)
 
-Split these into two classes so the wrangler sees which items actually block validation vs. which are recommended-but-optional. Ground the split in `list_uns_fields` output: `required: true` fields that are unset are blocking; `required: false` fields that are unset are recommended at most.
+Split these into two classes so the wrangler sees which items actually block validation vs. which are recommended-but-optional. The primary blocking signal is `validate_schema` — any error it reports (on `obs`, `var`, or `uns`) blocks. Use `list_uns_fields` as a secondary signal for missing `uns` fields specifically: `required: true` fields that are unset are blocking; `required: false` fields that are unset are recommended at most.
 
 For each item, write a concrete question — not a suggested answer.
 
@@ -57,7 +57,7 @@ For each item, write a concrete question — not a suggested answer.
 
 **B2 — Recommended (optional fields the wrangler may want to set)**
 
-Only the fields explicitly named below belong in B2. Do **not** scan `list_uns_fields` for other unset optional fields and invent questions about them — a field being optional-and-unset is not itself a reason to ask. The skill's scope is the explicit tool list (`convert_cellxgene_to_hca`, `normalize_raw`, `replace_placeholder_values`, `copy_cap_annotations`, `compress_h5ad`) plus the named fields here; everything else is the wrangler's call, unprompted.
+Only the fields explicitly named below belong in B2. Do **not** scan `list_uns_fields` for other unset optional fields and invent questions about them — a field being optional-and-unset is not itself a reason to ask. The skill's scope is the explicit tool list (`convert_cellxgene_to_hca`, `normalize_raw`, `replace_placeholder_values`, `copy_cap_annotations`, `set_uns` on the named fields here, `compress_h5ad`); everything else is the wrangler's call, unprompted.
 
 - `default_embedding` — list the obsm keys and ask which one. Optional per schema, but a file shipped without it will display in CELLxGENE Explorer with no default scatter. Must name a 2D embedding to actually plot; 30D latents (e.g. `X_scVI`) are valid per schema but won't display. If only one 2D embedding exists, surface that — the wrangler will almost certainly pick it.
 
@@ -141,7 +141,7 @@ Pull from the latest `import_cap_annotations` entry's `details`:
 
 | Field | Question |
 |---|---|
-| `ambient_count_correction` | which value from the allowed set? |
+| `study_pi` | who are the PI(s)? e.g. `["Teichmann,Sarah,A."]` |
 
 **Bucket B2 — recommended (optional)**
 

--- a/.claude/skills/curate-h5ad/SKILL.md
+++ b/.claude/skills/curate-h5ad/SKILL.md
@@ -45,12 +45,20 @@ Only these are in Bucket A. Nothing else.
 
 ### Bucket B — Needs wrangler input (todo — stop and ask)
 
-For each of these, write a concrete question, not a suggested answer:
+Split these into two classes so the wrangler sees which items actually block validation vs. which are recommended-but-optional. Ground the split in `list_uns_fields` output: `required: true` fields that are unset are blocking; `required: false` fields that are unset are recommended at most.
+
+For each item, write a concrete question — not a suggested answer.
+
+**B1 — Blocking (validator errors or unset `required: true` fields)**
 
 - Missing required `uns` fields (e.g. `study_pi`) — ask for the value(s).
-- `default_embedding` — list the obsm keys and ask which one.
 - **No CAP annotation set present** — the file must ship with at least one CAP annotation set (see the [HCA Cell Annotation schema](https://data.humancellatlas.org/metadata/cell-annotation)). Ask the wrangler to provide a local path to a CAP-exported version of this file (same cells, with CAP annotation sets populated) — `copy_cap_annotations` reads the source via AnnData/h5py so a URL must be downloaded locally first. If supplied, `copy_cap_annotations` becomes a mechanical fix for Step 4.
 - Any other `uns` field the validator flags as missing.
+
+**B2 — Recommended (optional fields the wrangler may want to set)**
+
+- `default_embedding` — list the obsm keys and ask which one. Optional per schema, but a file shipped without it will display in CELLxGENE Explorer with no default scatter. Must name a 2D embedding to actually plot; 30D latents (e.g. `X_scVI`) are valid per schema but won't display. If only one 2D embedding exists, surface that — the wrangler will almost certainly pick it.
+- Any other field where `list_uns_fields` reports `required: false` and `is_set: false` — mention only if there's a reason the wrangler might care; otherwise omit.
 
 If the wrangler answers during the session, those answers become additional mechanical fixes (`set_uns ...`, `copy_cap_annotations`, ...) to run in Step 4.
 
@@ -68,9 +76,9 @@ Report these but don't attempt to fix:
 
 ## Step 3 — Present the punch list
 
-Show three sections: **A (will run)**, **B (needs your answer)**, **C (still to do, out of scope)**. Then stop and wait for explicit approval before running anything.
+Show these sections: **A (will run)**, **B1 (blocking — needs your answer)**, **B2 (recommended — optional)**, **C (still to do, out of scope)**. Then stop and wait for explicit approval before running anything.
 
-If the wrangler answers any Bucket B items, promote those to Bucket A as `set_uns` calls.
+If the wrangler answers any Bucket B items (B1 or B2), promote those to Bucket A as `set_uns` calls.
 
 ## Step 4 — Run the mechanical fixes
 
@@ -84,9 +92,66 @@ Each tool writes a new timestamped file. For most subsequent calls, passing eith
 
 ## Step 5 — Report
 
-- Call `view_edit_log` on the final file; list the entries added this session.
-- Re-run the validator; report error/warning deltas vs. Step 1.
-- If `copy_cap_annotations` ran, surface its cell-overlap stats as their own line: `source_n_obs`, `target_n_obs`, `matched_n_obs`, `match_fraction_of_source`, `match_fraction_of_target`. These come back in the tool result and also live in the edit-log entry's `details`.
-- Summarize:
-  - **Fixed this session** — each Bucket A action that ran, with the resulting validator change.
-  - **Still to do** — every Bucket B question the wrangler didn't answer, plus every Bucket C item.
+Re-run `view_edit_log` and the validator on the final file, then produce a structured report with these sections in order. Use markdown tables; skip any section with no content.
+
+### Header
+One short paragraph or bullet block with: final file path, shape (`n_obs × n_vars`), `title` from `uns`, schema type + version, X verdict + `raw.X` presence, compression status, `obsm` keys present.
+
+### Mechanical fixes applied
+
+| # | Operation | Effect |
+|---|---|---|
+| 1 | `normalize_raw` | e.g. "Moved raw counts → raw.X; normalized X with `normalize_total(target_sum=10000)` + log1p" |
+| 2 | `replace_placeholder_values` (`library_preparation_batch`) | e.g. "N cells: `'unknown'` → NaN" |
+| 3 | `copy_cap_annotations` | name the CAP source file |
+| 4 | `compress_h5ad` | e.g. "Skipped — already gzipped" or "Rewrote X with gzip level 4" |
+
+Only include the rows for tools that actually ran this session.
+
+### Validator delta
+
+|  | Before | After |
+|---|---|---|
+| Errors | N | M |
+| Non-feature-ID warnings | N | M |
+| CAP zero-observation warnings | N | M |
+| Named warnings resolved | — | e.g. "raw.X absent", "`unknown` placeholder in `library_preparation_batch`" |
+
+Count **CAP "zero observations" warnings** (text: `contains a category '...' with zero observations`) separately from other warnings. These are *expected* after `copy_cap_annotations`: CAP declares a closed vocabulary per annotation set that spans all lineages, and a per-lineage file only realizes a subset — unused vocabulary terms are intentional schema information, not a defect. Report the count and move on; don't prune them. The validator's `--add-labels` remediation note comes from vendored CellxGENE code and does not apply to HCA.
+
+Also list the specific error/warning kinds that disappeared or newly appeared, one line each.
+
+### CAP overlap (only if `copy_cap_annotations` ran this session, or a prior `import_cap_annotations` entry is in the edit log)
+
+Pull from the latest `import_cap_annotations` entry's `details`:
+
+| Metric | Value |
+|---|---|
+| CAP source file | `cap_source_file` |
+| `source_n_obs` | … |
+| `target_n_obs` | … |
+| `matched_n_obs` | … |
+| `match_fraction_of_source` | as % |
+| `match_fraction_of_target` | as % |
+
+### Still to do
+
+**Bucket B1 — blocking (validator errors or unset `required: true` fields)**
+
+| Field | Question |
+|---|---|
+| `ambient_count_correction` | which value from the allowed set? |
+
+**Bucket B2 — recommended (optional)**
+
+| Field | Question |
+|---|---|
+| `default_embedding` | `X_umap` (only 2D option) — confirm? |
+
+**Bucket C — upstream / curator**
+
+| Issue | Detail |
+|---|---|
+| `library_id` NaN (validator error) | Needs real values from source |
+
+Only surface items that are still open — don't re-list anything resolved this session. Omit any of the three sub-tables that have no entries.

--- a/.claude/skills/curate-h5ad/SKILL.md
+++ b/.claude/skills/curate-h5ad/SKILL.md
@@ -34,7 +34,7 @@ Start with the evaluator, then gate the HCA validator on the schema it reports:
 
 ### Bucket A — Mechanical (safe to run after approval)
 
-Only these are in Bucket A. Nothing else.
+Only these are in Bucket A. Nothing else. A row belongs in A only when its preconditions are **already satisfied** at punch-list time — don't pre-list rows whose inputs depend on an unanswered B question (e.g. `set_uns('default_embedding', …)` belongs in B2 until the wrangler picks a value, then gets promoted to A per Step 3).
 
 - **`convert_cellxgene_to_hca`** — when `check_schema_type` reports `schema: "cellxgene"`. Must run **first**: it reshapes the file into HCA layout before any other fix makes sense, and the other tools (including `validate_schema`) assume HCA layout. After conversion, re-enter Step 1 on the converted file to get an accurate Bucket A/B/C list.
 - **`normalize_raw`** — when `check_x_normalization` reports `verdict: "raw_counts"` and `has_raw_x: false`. Deterministic: moves X→raw.X, normalizes X with `normalize_total(target_sum=10000) + log1p`.
@@ -57,10 +57,11 @@ For each item, write a concrete question — not a suggested answer.
 
 **B2 — Recommended (optional fields the wrangler may want to set)**
 
-- `default_embedding` — list the obsm keys and ask which one. Optional per schema, but a file shipped without it will display in CELLxGENE Explorer with no default scatter. Must name a 2D embedding to actually plot; 30D latents (e.g. `X_scVI`) are valid per schema but won't display. If only one 2D embedding exists, surface that — the wrangler will almost certainly pick it.
-- Any other field where `list_uns_fields` reports `required: false` and `is_set: false` — mention only if there's a reason the wrangler might care; otherwise omit.
+Only the fields explicitly named below belong in B2. Do **not** scan `list_uns_fields` for other unset optional fields and invent questions about them — a field being optional-and-unset is not itself a reason to ask. The skill's scope is the explicit tool list (`convert_cellxgene_to_hca`, `normalize_raw`, `replace_placeholder_values`, `copy_cap_annotations`, `compress_h5ad`) plus the named fields here; everything else is the wrangler's call, unprompted.
 
-If the wrangler answers during the session, those answers become additional mechanical fixes (`set_uns ...`, `copy_cap_annotations`, ...) to run in Step 4.
+- `default_embedding` — list the obsm keys and ask which one. Optional per schema, but a file shipped without it will display in CELLxGENE Explorer with no default scatter. Must name a 2D embedding to actually plot; 30D latents (e.g. `X_scVI`) are valid per schema but won't display. If only one 2D embedding exists, surface that — the wrangler will almost certainly pick it.
+
+If the wrangler answers a B2 item during the session, that answer becomes a `set_uns` mechanical fix (promoted to Bucket A) for Step 4.
 
 ### Bucket C — Upstream / curator judgment (out of scope for this skill)
 

--- a/.claude/skills/curate-h5ad/SKILL.md
+++ b/.claude/skills/curate-h5ad/SKILL.md
@@ -47,7 +47,7 @@ Only these are in Bucket A. Nothing else. A row belongs in A only when its preco
 
 Split these into two classes so the wrangler sees which items actually block validation vs. which are recommended-but-optional. The primary blocking signal is `validate_schema` — any error it reports (on `obs`, `var`, or `uns`) blocks. Use `list_uns_fields` as a secondary signal for missing `uns` fields specifically: `required: true` fields that are unset are blocking; `required: false` fields that are unset are recommended at most.
 
-For each item, write a concrete question — not a suggested answer.
+For each item, write a concrete question. For **B1** items, do not include a suggested answer — ask only for the missing required value. For **B2** items, if there's an obvious single valid option (e.g. only one 2D embedding exists), you may phrase it as a confirmation question ("`X_umap` — confirm?") rather than silently deciding.
 
 **B1 — Blocking (validator errors or unset `required: true` fields)**
 
@@ -79,7 +79,7 @@ Report these but don't attempt to fix:
 
 Show these sections: **A (will run)**, **B1 (blocking — needs your answer)**, **B2 (recommended — optional)**, **C (still to do, out of scope)**. Then stop and wait for explicit approval before running anything.
 
-If the wrangler answers any Bucket B items (B1 or B2), promote those to Bucket A as `set_uns` calls.
+If the wrangler answers any Bucket B items (B1 or B2), promote those to Bucket A as the appropriate mechanical action: `set_uns` for answered `uns` values (e.g. `default_embedding`, `study_pi`), `copy_cap_annotations` when the answer is a CAP source file path.
 
 ## Step 4 — Run the mechanical fixes
 
@@ -93,7 +93,7 @@ Each tool writes a new timestamped file. For most subsequent calls, passing eith
 
 ## Step 5 — Report
 
-Re-run `view_edit_log` and the validator on the final file, then produce a structured report with these sections in order. Use markdown tables; skip any section with no content.
+Re-run `view_edit_log` on the final file, then produce a structured report with these sections in order. Also re-run `validate_schema` — but only if `check_schema_type` reports `hca` on the final file. If the file is still CellxGENE (e.g. conversion wasn't approved), skip the validator rerun and note why under "Validator delta" instead of pasting a misleading error list. Use markdown tables; skip any section with no content.
 
 ### Header
 One short paragraph or bullet block with: final file path, shape (`n_obs × n_vars`), `title` from `uns`, schema type (include version only when schema is CellxGENE — HCA is unversioned), X verdict + `raw.X` presence, compression status, `obsm` keys present.

--- a/.claude/skills/evaluate-h5ad/SKILL.md
+++ b/.claude/skills/evaluate-h5ad/SKILL.md
@@ -46,7 +46,7 @@ Render one row per dataset that `get_storage_info` actually returns — the shap
 
 - **Dense X**: one row, `X` (no `data`/`indices`/`indptr` sub-datasets).
 - **Sparse X** (csr/csc): three rows — `X.data`, `X.indices`, `X.indptr`.
-- Same pattern for `raw/X` when present.
+- Same pattern for `raw/X` when present — note that `get_storage_info` returns this under the result key `raw_X` (underscore), but label the rendered rows as `raw/X` / `raw/X.data` / etc. to match the HDF5 path.
 - Include a row for each populated `layers/<name>` if any.
 
 | Dataset | Codec | Level | Chunks |

--- a/.claude/skills/evaluate-h5ad/SKILL.md
+++ b/.claude/skills/evaluate-h5ad/SKILL.md
@@ -20,41 +20,56 @@ Run all of the following MCP tool calls in parallel to gather data:
 6. **get_cap_annotations** — CAP cell annotation sets, if present
 7. **view_edit_log** — read `uns/provenance/edit_history` so edit history is already in hand when synthesizing the report
 
-Then synthesize the results into a report covering:
+Then synthesize the results into a report with these sections in order. Use markdown tables wherever multiple items share the same shape; keep prose tight.
 
-## 1. File Overview
-- Cell count, gene count, file size
-- Title (from `list_uns_fields`)
-- Schema type + version (from `check_schema_type`: CellxGENE or HCA)
-- X matrix verdict (from `check_x_normalization`: raw_counts / normalized / indeterminate, and whether raw.X is present)
+## 1. File overview
+One compact block (bullets or a short table) with:
+- Final file path (resolved snapshot, not the input path if they differ)
+- Shape: `n_obs × n_vars`, file size (MB)
+- `title` from `uns`
+- Schema type + version (from `check_schema_type`)
+- X verdict (from `check_x_normalization`: `raw_counts` / `normalized` / `indeterminate`) + whether `raw.X` is present
 
-## 2. HCA Metadata Readiness
-- How many required HCA uns fields are set vs missing?
-- List each missing required field by name
-- Note any bionetwork-only fields that are missing
-- Flag any extra uns keys not in the HCA schema
+## 2. HCA metadata readiness
 
-## 3. Storage & Compression
-- Is X compressed? What codec and compression level?
-- Is raw/X present and compressed?
-- Are chunks reasonable for the matrix dimensions?
-- Flag any uncompressed datasets in a large file
+| Category | Missing |
+|---|---|
+| Required (schema-wide) | list the `missing_required` field names |
+| Required (bionetwork) | list the `missing_required_bionetwork` field names |
+| Extra uns keys (not in schema) | list any `extra_uns_keys` |
+
+If nothing is missing, say so in a single line instead of an empty table.
+
+## 3. Storage & compression
+
+| Dataset | Codec | Level | Chunks |
+|---|---|---|---|
+| X.data | gzip / — | 4 / — | … |
+| raw/X.data | gzip / — | 4 / — | … |
+
+Flag any uncompressed dataset in a >100 MB file as an issue.
 
 ## 4. Embeddings
-- Which obsm keys exist (UMAP, PCA, scVI, etc.)?
-- Is `default_embedding` set in uns? Does it match an obsm key?
+- List each `obsm` key with its shape.
+- Does `uns['default_embedding']` exist? Does it name a real `obsm` key?
 
-## 5. CAP Annotations
-- Are CAP annotation sets present?
-- If yes: how many sets, how many cell labels, do they have ontology mappings?
-- If no: note that CAP annotations are missing
+## 5. CAP annotations
+- Are CAP annotation sets present? If yes, name them and give the cell-label count per set. If no, state that CAP is missing.
+- If `view_edit_log` contains any `import_cap_annotations` entries, render the latest entry's overlap stats as a table (this shows how faithfully CAP aligns to the current cells):
 
-## 6. Edit History
-- Use the `view_edit_log` result fetched in Step 1.
-- If entries are present: summarize recent edits (who/what/when)
-- If absent: note that no edit history exists (file hasn't been edited through hca-anndata-tools)
+| Metric | Value |
+|---|---|
+| CAP source file | `cap_source_file` |
+| `source_n_obs` | … |
+| `target_n_obs` | … |
+| `matched_n_obs` | … |
+| `match_fraction_of_source` | as % |
+| `match_fraction_of_target` | as % |
 
-## 7. Summary & Recommendations
-- Overall HCA readiness: ready / needs work / not started
-- Prioritized list of what to fix, most important first
-- If `check_schema_type` reported `cellxgene`, recommend `convert_cellxgene_to_hca` as the first fix.
+## 6. Edit history
+Summarize entries as a table: `timestamp`, `operation`, one-line `description`. If absent, note that the file hasn't been edited through `hca-anndata-tools`.
+
+## 7. Summary & recommendations
+- One-line readiness verdict: ready / needs work / not started.
+- Prioritized list of next actions, most important first.
+- If `check_schema_type` reported `cellxgene`, the first action is `convert_cellxgene_to_hca`.

--- a/.claude/skills/evaluate-h5ad/SKILL.md
+++ b/.claude/skills/evaluate-h5ad/SKILL.md
@@ -24,7 +24,7 @@ Then synthesize the results into a report with these sections in order. Use mark
 
 ## 1. File overview
 One compact block (bullets or a short table) with:
-- Final file path (resolved snapshot, not the input path if they differ)
+- Input path (`$ARGUMENTS`). If the tools auto-resolved to a newer snapshot, add the resolved basename on a second line — read it from any tool that returns a `filename` field (e.g. `check_schema_type.filename`). Skip the second line when input and resolved agree.
 - Shape: `n_obs × n_vars`, file size (MB)
 - `title` from `uns`
 - Schema type (from `check_schema_type`) — include the version only when schema is CellxGENE (HCA is unversioned)
@@ -42,10 +42,16 @@ If nothing is missing, say so in a single line instead of an empty table.
 
 ## 3. Storage & compression
 
+Render one row per dataset that `get_storage_info` actually returns — the shape depends on the matrix format:
+
+- **Dense X**: one row, `X` (no `data`/`indices`/`indptr` sub-datasets).
+- **Sparse X** (csr/csc): three rows — `X.data`, `X.indices`, `X.indptr`.
+- Same pattern for `raw/X` when present.
+- Include a row for each populated `layers/<name>` if any.
+
 | Dataset | Codec | Level | Chunks |
 |---|---|---|---|
-| X.data | gzip / — | 4 / — | … |
-| raw/X.data | gzip / — | 4 / — | … |
+| … | gzip / — | 4 / — | … |
 
 Flag any uncompressed dataset in a >100 MB file as an issue.
 

--- a/.claude/skills/evaluate-h5ad/SKILL.md
+++ b/.claude/skills/evaluate-h5ad/SKILL.md
@@ -14,7 +14,7 @@ Run all of the following MCP tool calls in parallel to gather data:
 
 1. **get_summary** — cell/gene counts, obs/var columns, uns keys, layers, obsm
 2. **get_storage_info** — compression, chunking, sparse format, file size
-3. **check_schema_type** — report CellxGENE vs HCA layout and schema version
+3. **check_schema_type** — report CellxGENE vs HCA layout (CellxGENE carries a schema version; HCA is not versioned so skip the version for HCA files)
 4. **check_x_normalization** — classify X as raw_counts / normalized / indeterminate
 5. **list_uns_fields** — HCA schema field completeness (required vs set vs missing)
 6. **get_cap_annotations** — CAP cell annotation sets, if present
@@ -27,7 +27,7 @@ One compact block (bullets or a short table) with:
 - Final file path (resolved snapshot, not the input path if they differ)
 - Shape: `n_obs × n_vars`, file size (MB)
 - `title` from `uns`
-- Schema type + version (from `check_schema_type`)
+- Schema type (from `check_schema_type`) — include the version only when schema is CellxGENE (HCA is unversioned)
 - X verdict (from `check_x_normalization`: `raw_counts` / `normalized` / `indeterminate`) + whether `raw.X` is present
 
 ## 2. HCA metadata readiness


### PR DESCRIPTION
Closes #346.

## Summary
- Restructured `evaluate-h5ad` report into tables and added a CAP overlap stats block that reads the latest `import_cap_annotations` edit-log entry (`source_n_obs`, `target_n_obs`, `matched_n_obs`, `match_fraction_of_source`, `match_fraction_of_target`, `cap_source_file`).
- Clarified schema-version handling across both skills: HCA is unversioned, only CellxGENE carries a version.
- Tightened `curate-h5ad` Bucket A (no pre-listing rows whose inputs depend on unanswered B questions) and Bucket B2 (restricted to explicitly named fields — currently just `default_embedding` — instead of scanning every optional unset uns field).

## Test plan
- [x] Ran `/curate-h5ad` on `gut-v1/integrated-objects/myeloid-r1-wip-10.h5ad` end to end (normalize_raw → replace_placeholder_values ×2 → copy_cap_annotations → set_uns → compress) and confirmed the final report renders the CAP overlap table correctly (source 95.4%, target 99.2%).
- [ ] Run the updated `/evaluate-h5ad` on the stroma integrated object once it's back in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)