### PR TITLE
docs: surface CAP marker-gene validation in skill reports

### DIFF
--- a/.claude/skills/curate-h5ad/SKILL.md
+++ b/.claude/skills/curate-h5ad/SKILL.md
@@ -143,10 +143,12 @@ Pull from the latest `import_cap_annotations` entry's `details`:
 
 Source the numbers from the `copy_cap_annotations` tool result's `marker_gene_validation` field if it ran this session. If only a prior `import_cap_annotations` entry exists, call `validate_marker_genes` on the final file to get fresh numbers — a marker list that matched against `var.index` before `label_h5ad` populated `var['feature_name']` will look very different now.
 
+Marker symbols are resolved against the target's var gene-name source: `var['feature_name']` is preferred, else `var['gene_name']`, else `var.index` (the Ensembl IDs) as a last resort. Post-`label_h5ad` files always have `feature_name`; files that skipped labeling fall back to whatever the producer shipped.
+
 | Metric | Value |
 |---|---|
 | Total unique markers | … |
-| Found in `var['feature_name']` | … |
+| Found in var gene-name source | … |
 | Missing | … |
 
 For each missing marker, list it with its classification — `not_in_gencode` (marker symbol doesn't resolve to any GENCODE entry — typo, glob pattern, or deprecated rename), `missing_from_var` (valid symbol but not present in this file's gene set), or a known rename surfaced by the tool:

--- a/.claude/skills/curate-h5ad/SKILL.md
+++ b/.claude/skills/curate-h5ad/SKILL.md
@@ -139,6 +139,24 @@ Pull from the latest `import_cap_annotations` entry's `details`:
 | `match_fraction_of_source` | as % |
 | `match_fraction_of_target` | as % |
 
+### CAP marker validation (only if `copy_cap_annotations` ran this session, or a prior `import_cap_annotations` entry is in the edit log)
+
+Source the numbers from the `copy_cap_annotations` tool result's `marker_gene_validation` field if it ran this session. If only a prior `import_cap_annotations` entry exists, call `validate_marker_genes` on the final file to get fresh numbers — a marker list that matched against `var.index` before `label_h5ad` populated `var['feature_name']` will look very different now.
+
+| Metric | Value |
+|---|---|
+| Total unique markers | … |
+| Found in `var['feature_name']` | … |
+| Missing | … |
+
+For each missing marker, list it with its classification — `not_in_gencode` (marker symbol doesn't resolve to any GENCODE entry — typo, glob pattern, or deprecated rename), `missing_from_var` (valid symbol but not present in this file's gene set), or a known rename surfaced by the tool:
+
+| Marker | Classification |
+|---|---|
+| … | … |
+
+If all markers hit, say so in one line instead of an empty table. Any `not_in_gencode` entries point at CAP-side fixes (ask the CAP curator); `missing_from_var` points at target-side gaps (different gene set than the one CAP was authored against).
+
 ### Still to do
 
 **Bucket B1 — blocking (validator errors or unset `required: true` fields)**

--- a/.claude/skills/curate-h5ad/SKILL.md
+++ b/.claude/skills/curate-h5ad/SKILL.md
@@ -151,13 +151,13 @@ Marker symbols are resolved against the target's var gene-name source: `var['fea
 | Found in var gene-name source | … |
 | Missing | … |
 
-For each missing marker, list it with its classification — `not_in_gencode` (marker symbol doesn't resolve to any GENCODE entry — typo, glob pattern, or deprecated rename), `missing_from_var` (valid symbol but not present in this file's gene set), or a known rename surfaced by the tool:
+For each missing marker, list it with its classification exactly as returned by the tool — `not_in_gencode` (marker symbol doesn't resolve to any GENCODE entry — typo, glob pattern, or deprecated rename), `missing_from_var` (valid symbol but not present in this file's gene set), or `known_rename` (submitted marker is a deprecated symbol; the tool provides the current target in `var_name`, plus `ensembl_id` when available):
 
-| Marker | Classification |
-|---|---|
-| … | … |
+| Marker | Classification | Var name | Ensembl ID |
+|---|---|---|---|
+| … | … | … | … |
 
-If all markers hit, say so in one line instead of an empty table. Any `not_in_gencode` entries point at CAP-side fixes (ask the CAP curator); `missing_from_var` points at target-side gaps (different gene set than the one CAP was authored against).
+Leave `Var name` / `Ensembl ID` blank for `not_in_gencode` and `missing_from_var` rows — those fields are only populated on `known_rename`. If all markers hit, say so in one line instead of an empty table. `not_in_gencode` entries point at CAP-side fixes (ask the CAP curator); `missing_from_var` points at target-side gaps (different gene set than the one CAP was authored against); `known_rename` entries should report the rename target from `var_name` so the mismatch is explicit.
 
 ### Still to do
 

--- a/.claude/skills/evaluate-h5ad/SKILL.md
+++ b/.claude/skills/evaluate-h5ad/SKILL.md
@@ -20,7 +20,7 @@ Run all of the following MCP tool calls in parallel to gather data:
 6. **get_cap_annotations** — CAP cell annotation sets, if present
 7. **view_edit_log** — read `uns/provenance/edit_history` so edit history is already in hand when synthesizing the report
 
-Then, only if `get_cap_annotations` reports `has_cap_annotations: true`, call **validate_marker_genes** — CAP marker-gene coverage against the target's var gene-name source (`var['feature_name']` preferred, else `var['gene_name']`, else `var.index`). Skipping on non-CAP files avoids an unnecessary O(n_obs) organism scan and a guaranteed error on CellxGENE-layout inputs.
+Then, only if `get_cap_annotations` reports `has_cap_annotations: true`, call **validate_marker_genes** — CAP marker-gene coverage against the target's var gene-name source (`var['feature_name']` preferred, else `var['gene_name']`, else `var.index`). The `has_cap_annotations` gate already implies HCA-layout, so the tool has what it needs; skipping on non-CAP files avoids a redundant call.
 
 Then synthesize the results into a report with these sections in order. Use markdown tables wherever multiple items share the same shape; keep prose tight.
 
@@ -75,7 +75,7 @@ Flag any uncompressed dataset in a >100 MB file as an issue.
 | `match_fraction_of_source` | as % |
 | `match_fraction_of_target` | as % |
 
-- If `validate_marker_genes` ran (CAP present), render its result:
+- If `validate_marker_genes` ran (CAP present), render its result. If the tool returned `{error: ...}` (e.g. `organism_ontology_term_id` missing or non-human), report the error as a single line and skip the tables below.
 
 | Metric | Value |
 |---|---|
@@ -83,11 +83,11 @@ Flag any uncompressed dataset in a >100 MB file as an issue.
 | Found in var gene-name source | … |
 | Missing | … |
 
-| Marker | Classification |
-|---|---|
-| … | … |
+| Marker | Classification | Var name | Ensembl ID |
+|---|---|---|---|
+| … | … | … | … |
 
-See `/curate-h5ad` Step 5 for classification meanings (`not_in_gencode` / `missing_from_var` / known rename), the `feature_name` → `gene_name` → `var.index` fallback order, and where each miss kind points for remediation.
+See `/curate-h5ad` Step 5 for classification meanings (`not_in_gencode` / `missing_from_var` / `known_rename`), the `feature_name` → `gene_name` → `var.index` fallback order, and where each miss kind points for remediation.
 
 ## 6. Edit history
 Summarize entries as a table: `timestamp`, `operation`, one-line `description`. If absent, note that the file hasn't been edited through `hca-anndata-tools`.

--- a/.claude/skills/evaluate-h5ad/SKILL.md
+++ b/.claude/skills/evaluate-h5ad/SKILL.md
@@ -19,6 +19,7 @@ Run all of the following MCP tool calls in parallel to gather data:
 5. **list_uns_fields** — HCA schema field completeness (required vs set vs missing)
 6. **get_cap_annotations** — CAP cell annotation sets, if present
 7. **view_edit_log** — read `uns/provenance/edit_history` so edit history is already in hand when synthesizing the report
+8. **validate_marker_genes** — CAP marker-gene coverage against `var['feature_name']` (falls back to `var.index` when `feature_name` isn't populated). The tool errors on CellxGENE-layout or non-human files and returns an empty result on HCA files without CAP marker lists — both cases are ignored by the Section 5 renderer, which only surfaces this check when `has_cap_annotations: true`. Catches cases where CAP was imported before `label_h5ad` populated `feature_name`, or where the target's gene set has drifted since CAP was authored.
 
 Then synthesize the results into a report with these sections in order. Use markdown tables wherever multiple items share the same shape; keep prose tight.
 
@@ -72,6 +73,20 @@ Flag any uncompressed dataset in a >100 MB file as an issue.
 | `matched_n_obs` | … |
 | `match_fraction_of_source` | as % |
 | `match_fraction_of_target` | as % |
+
+- If CAP annotations are present, render the `validate_marker_genes` result (ordered total → found → missing). Include a second table listing each missing marker with its classification — `not_in_gencode`, `missing_from_var`, or a known rename:
+
+| Metric | Value |
+|---|---|
+| Total unique markers | … |
+| Found in `var['feature_name']` | … |
+| Missing | … |
+
+| Marker | Classification |
+|---|---|
+| … | … |
+
+If all markers hit, say so in one line instead of rendering the second table. `not_in_gencode` misses point at the CAP source (typo / glob / deprecated rename); `missing_from_var` misses point at the target's gene set.
 
 ## 6. Edit history
 Summarize entries as a table: `timestamp`, `operation`, one-line `description`. If absent, note that the file hasn't been edited through `hca-anndata-tools`.

--- a/.claude/skills/evaluate-h5ad/SKILL.md
+++ b/.claude/skills/evaluate-h5ad/SKILL.md
@@ -20,7 +20,7 @@ Run all of the following MCP tool calls in parallel to gather data:
 6. **get_cap_annotations** — CAP cell annotation sets, if present
 7. **view_edit_log** — read `uns/provenance/edit_history` so edit history is already in hand when synthesizing the report
 
-Then, only if `get_cap_annotations` reports `has_cap_annotations: true`, call **validate_marker_genes** — CAP marker-gene coverage against `var['feature_name']` (falls back to `var.index`). Skipping on non-CAP files avoids an unnecessary O(n_obs) organism scan and a guaranteed error on CellxGENE-layout inputs.
+Then, only if `get_cap_annotations` reports `has_cap_annotations: true`, call **validate_marker_genes** — CAP marker-gene coverage against the target's var gene-name source (`var['feature_name']` preferred, else `var['gene_name']`, else `var.index`). Skipping on non-CAP files avoids an unnecessary O(n_obs) organism scan and a guaranteed error on CellxGENE-layout inputs.
 
 Then synthesize the results into a report with these sections in order. Use markdown tables wherever multiple items share the same shape; keep prose tight.
 
@@ -80,14 +80,14 @@ Flag any uncompressed dataset in a >100 MB file as an issue.
 | Metric | Value |
 |---|---|
 | Total unique markers | … |
-| Found in `var['feature_name']` | … |
+| Found in var gene-name source | … |
 | Missing | … |
 
 | Marker | Classification |
 |---|---|
 | … | … |
 
-See `/curate-h5ad` Step 5 for classification meanings (`not_in_gencode` / `missing_from_var` / known rename) and where each kind points for remediation.
+See `/curate-h5ad` Step 5 for classification meanings (`not_in_gencode` / `missing_from_var` / known rename), the `feature_name` → `gene_name` → `var.index` fallback order, and where each miss kind points for remediation.
 
 ## 6. Edit history
 Summarize entries as a table: `timestamp`, `operation`, one-line `description`. If absent, note that the file hasn't been edited through `hca-anndata-tools`.

--- a/.claude/skills/evaluate-h5ad/SKILL.md
+++ b/.claude/skills/evaluate-h5ad/SKILL.md
@@ -19,7 +19,8 @@ Run all of the following MCP tool calls in parallel to gather data:
 5. **list_uns_fields** — HCA schema field completeness (required vs set vs missing)
 6. **get_cap_annotations** — CAP cell annotation sets, if present
 7. **view_edit_log** — read `uns/provenance/edit_history` so edit history is already in hand when synthesizing the report
-8. **validate_marker_genes** — CAP marker-gene coverage against `var['feature_name']` (falls back to `var.index` when `feature_name` isn't populated). The tool errors on CellxGENE-layout or non-human files and returns an empty result on HCA files without CAP marker lists — both cases are ignored by the Section 5 renderer, which only surfaces this check when `has_cap_annotations: true`. Catches cases where CAP was imported before `label_h5ad` populated `feature_name`, or where the target's gene set has drifted since CAP was authored.
+
+Then, only if `get_cap_annotations` reports `has_cap_annotations: true`, call **validate_marker_genes** — CAP marker-gene coverage against `var['feature_name']` (falls back to `var.index`). Skipping on non-CAP files avoids an unnecessary O(n_obs) organism scan and a guaranteed error on CellxGENE-layout inputs.
 
 Then synthesize the results into a report with these sections in order. Use markdown tables wherever multiple items share the same shape; keep prose tight.
 
@@ -74,7 +75,7 @@ Flag any uncompressed dataset in a >100 MB file as an issue.
 | `match_fraction_of_source` | as % |
 | `match_fraction_of_target` | as % |
 
-- If CAP annotations are present, render the `validate_marker_genes` result (ordered total → found → missing). Include a second table listing each missing marker with its classification — `not_in_gencode`, `missing_from_var`, or a known rename:
+- If `validate_marker_genes` ran (CAP present), render its result:
 
 | Metric | Value |
 |---|---|
@@ -86,7 +87,7 @@ Flag any uncompressed dataset in a >100 MB file as an issue.
 |---|---|
 | … | … |
 
-If all markers hit, say so in one line instead of rendering the second table. `not_in_gencode` misses point at the CAP source (typo / glob / deprecated rename); `missing_from_var` misses point at the target's gene set.
+See `/curate-h5ad` Step 5 for classification meanings (`not_in_gencode` / `missing_from_var` / known rename) and where each kind points for remediation.
 
 ## 6. Edit history
 Summarize entries as a table: `timestamp`, `operation`, one-line `description`. If absent, note that the file hasn't been edited through `hca-anndata-tools`.


### PR DESCRIPTION
Closes #358.

## Summary

- **`/curate-h5ad` Step 5**: adds a "CAP marker validation" section between "CAP overlap" and "Still to do". Previously the 54/56 marker match number + missing marker names were buried inside a single table cell of the Mechanical-fixes row. Template renders total / found / missing counts plus a per-miss classification table (`not_in_gencode` vs `missing_from_var` vs known-rename).
- **`/evaluate-h5ad`**: adds `validate_marker_genes` to the parallel tool burst, and extends Section 5 (CAP annotations) to render the same metric table + missing-marker breakdown when CAP is present. This catches files where CAP was imported before `label_h5ad` populated `feature_name`, or where the target's gene set has drifted since CAP was authored.

Behavior on inapplicable files is explicit: `validate_marker_genes` errors on CellxGENE-layout / non-human and returns empty on HCA-without-CAP — both are ignored by the Section 5 renderer, which only surfaces the check when `has_cap_annotations: true`.

## Test plan

- [ ] Run `/curate-h5ad` on a file without CAP — confirm the new marker-validation section is omitted
- [ ] Run `/curate-h5ad` on the gut-v1 myeloid file — confirm the marker table renders with 54/56 hit, 2 `not_in_gencode` misses (`H2*`, `STMN`)
- [ ] Run `/evaluate-h5ad` on a CellxGENE file — confirm Section 5 doesn't try to render the marker tables
- [ ] Run `/evaluate-h5ad` on a post-CAP HCA file — confirm marker tables render

🤖 Generated with [Claude Code](https://claude.com/claude-code)