### PR TITLE
fix: rewrite hca-schema-validator path dep for hca-anndata-mcp publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -113,8 +113,11 @@ jobs:
       - name: Swap path deps to version pins for PyPI
         run: |
           cd packages/hca-anndata-mcp
-          sed -i 's|hca-anndata-tools = {path = "../hca-anndata-tools", develop = true}|hca-anndata-tools = ">=0.1.0,<1"|' pyproject.toml
-          sed -i 's|hca-schema-validator = {path = "../hca-schema-validator", develop = true}|hca-schema-validator = ">=0.10.0,<1"|' pyproject.toml
+          # Match by dependency key so whitespace / key-order changes in the
+          # {path = ..., develop = true} dict don't silently turn the sed
+          # into a no-op. Guard below catches multi-line dicts.
+          sed -i -E 's|^hca-anndata-tools\s*=.*$|hca-anndata-tools = ">=0.1.0,<1"|' pyproject.toml
+          sed -i -E 's|^hca-schema-validator\s*=.*$|hca-schema-validator = ">=0.10.0,<1"|' pyproject.toml
           if grep -q 'path = "../hca-anndata-tools"' pyproject.toml || grep -q 'path = "../hca-schema-validator"' pyproject.toml; then
             echo "ERROR: path dependency still present after sed replacement"
             cat pyproject.toml

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -88,7 +88,7 @@ jobs:
           packages-dir: packages/hca-anndata-tools/dist/
 
   publish-hca-anndata-mcp:
-    needs: [release-please, publish-hca-anndata-tools]
+    needs: [release-please, publish-hca-anndata-tools, publish-hca-schema-validator]
     if: |
       !failure() && !cancelled() &&
       (needs.release-please.outputs.hca_anndata_mcp_release == 'true' || github.event_name == 'workflow_dispatch')

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -115,10 +115,11 @@ jobs:
           cd packages/hca-anndata-mcp
           # Match by dependency key so whitespace / key-order changes in the
           # {path = ..., develop = true} dict don't silently turn the sed
-          # into a no-op. Guard below catches multi-line dicts.
-          sed -i -E 's|^hca-anndata-tools\s*=.*$|hca-anndata-tools = ">=0.1.0,<1"|' pyproject.toml
-          sed -i -E 's|^hca-schema-validator\s*=.*$|hca-schema-validator = ">=0.10.0,<1"|' pyproject.toml
-          if grep -q 'path = "../hca-anndata-tools"' pyproject.toml || grep -q 'path = "../hca-schema-validator"' pyproject.toml; then
+          # into a no-op. POSIX [[:space:]] class (GNU sed -E doesn't treat
+          # \s as whitespace). Guard below catches multi-line dicts.
+          sed -i -E 's|^[[:space:]]*hca-anndata-tools[[:space:]]*=.*$|hca-anndata-tools = ">=0.1.0,<1"|' pyproject.toml
+          sed -i -E 's|^[[:space:]]*hca-schema-validator[[:space:]]*=.*$|hca-schema-validator = ">=0.10.0,<1"|' pyproject.toml
+          if grep -Eq 'path[[:space:]]*=[[:space:]]*"\.\./hca-anndata-tools"' pyproject.toml || grep -Eq 'path[[:space:]]*=[[:space:]]*"\.\./hca-schema-validator"' pyproject.toml; then
             echo "ERROR: path dependency still present after sed replacement"
             cat pyproject.toml
             exit 1

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,7 +25,7 @@ jobs:
     needs: release-please
     if: |
       !failure() && !cancelled() &&
-      (needs.release-please.outputs.hca_schema_validator_release == 'true' || github.event_name == 'workflow_dispatch')
+      (needs['release-please'].outputs.hca_schema_validator_release == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -58,7 +58,7 @@ jobs:
     needs: release-please
     if: |
       !failure() && !cancelled() &&
-      (needs.release-please.outputs.hca_anndata_tools_release == 'true' || github.event_name == 'workflow_dispatch')
+      (needs['release-please'].outputs.hca_anndata_tools_release == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -95,9 +95,9 @@ jobs:
     # propagate skipped-dep state to downstream jobs.
     if: |
       always() && !cancelled() &&
-      (needs.release-please.outputs.hca_anndata_mcp_release == 'true' || github.event_name == 'workflow_dispatch') &&
-      (needs.publish-hca-anndata-tools.result == 'success' || needs.publish-hca-anndata-tools.result == 'skipped') &&
-      (needs.publish-hca-schema-validator.result == 'success' || needs.publish-hca-schema-validator.result == 'skipped')
+      (needs['release-please'].outputs.hca_anndata_mcp_release == 'true' || github.event_name == 'workflow_dispatch') &&
+      (needs['publish-hca-anndata-tools'].result == 'success' || needs['publish-hca-anndata-tools'].result == 'skipped') &&
+      (needs['publish-hca-schema-validator'].result == 'success' || needs['publish-hca-schema-validator'].result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -89,9 +89,15 @@ jobs:
 
   publish-hca-anndata-mcp:
     needs: [release-please, publish-hca-anndata-tools, publish-hca-schema-validator]
+    # Use always() + explicit result checks so mcp still publishes when
+    # sibling publish jobs are intentionally skipped (e.g. only mcp is in
+    # this release). !failure() alone is unreliable: GitHub Actions can
+    # propagate skipped-dep state to downstream jobs.
     if: |
-      !failure() && !cancelled() &&
-      (needs.release-please.outputs.hca_anndata_mcp_release == 'true' || github.event_name == 'workflow_dispatch')
+      always() && !cancelled() &&
+      (needs.release-please.outputs.hca_anndata_mcp_release == 'true' || github.event_name == 'workflow_dispatch') &&
+      (needs.publish-hca-anndata-tools.result == 'success' || needs.publish-hca-anndata-tools.result == 'skipped') &&
+      (needs.publish-hca-schema-validator.result == 'success' || needs.publish-hca-schema-validator.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -110,11 +110,12 @@ jobs:
           curl -sSL https://install.python-poetry.org | python3 -
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-      - name: Swap path dep to version pin for PyPI
+      - name: Swap path deps to version pins for PyPI
         run: |
           cd packages/hca-anndata-mcp
           sed -i 's|hca-anndata-tools = {path = "../hca-anndata-tools", develop = true}|hca-anndata-tools = ">=0.1.0,<1"|' pyproject.toml
-          if grep -q 'path = "../hca-anndata-tools"' pyproject.toml; then
+          sed -i 's|hca-schema-validator = {path = "../hca-schema-validator", develop = true}|hca-schema-validator = ">=0.10.0,<1"|' pyproject.toml
+          if grep -q 'path = "../hca-anndata-tools"' pyproject.toml || grep -q 'path = "../hca-schema-validator"' pyproject.toml; then
             echo "ERROR: path dependency still present after sed replacement"
             cat pyproject.toml
             exit 1

--- a/packages/hca-anndata-mcp/pyproject.toml
+++ b/packages/hca-anndata-mcp/pyproject.toml
@@ -11,6 +11,9 @@ packages = [{include = "hca_anndata_mcp", from = "src"}]
 [tool.poetry.dependencies]
 python = "^3.10"
 fastmcp = ">=2,<3"
+# Path deps below are rewritten to PyPI version pins at publish time by
+# .github/workflows/release-please.yml. Keep both entries covered by the
+# sed rewrite there if you add or rename sibling packages.
 hca-anndata-tools = {path = "../hca-anndata-tools", develop = true}
 hca-schema-validator = {path = "../hca-schema-validator", develop = true}
 


### PR DESCRIPTION
## Summary

- The `publish-hca-anndata-mcp` job failed on 0.4.0 with `400 Bad Request: Can't have direct dependency` from PyPI.
- Root cause: the release-please workflow's path-dep sed rewrite only covered `hca-anndata-tools`. PR #342 added `hca-schema-validator` as a second path dep without updating the sed, so the built wheel shipped a `file:///.../packages/hca-schema-validator` reference that PyPI rejected.

## Changes

1. **`.github/workflows/release-please.yml`** — add a second `sed` for `hca-schema-validator`, extend the guard check to verify both path deps are rewritten. Pin is `>=0.10.0,<1`, mirroring the `hca-anndata-tools` pattern.
2. **`packages/hca-anndata-mcp/pyproject.toml`** — add a comment above the path deps noting they're rewritten at publish time. Dual purpose: warns future maintainers adding a new sibling dep, and registers a change against the `hca-anndata-mcp` package so release-please will cut a patch release (0.4.1) and trigger the publish again.

## Expected outcome

After merge:
- release-please PR updates to include `hca-anndata-mcp: 0.4.1`.
- Merging that release PR triggers `publish-hca-anndata-mcp` which will now succeed (both path deps rewritten).
- `hca-anndata-mcp 0.4.1` lands on PyPI, carrying all the features that should have been in 0.4.0.

## Test plan

- [x] Diff verified — both sed lines present, guard covers both deps.
- [ ] CI passes on this PR.
- [ ] After merge: release-please cuts 0.4.1.
- [ ] After release PR merge: `publish-hca-anndata-mcp` workflow succeeds.
- [ ] Verify `hca-anndata-mcp 0.4.1` appears on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)