### PR TITLE
chore: bump hca-schema-validator to 0.11.x in batch service

### DIFF
--- a/services/hca-schema-validator/poetry.lock
+++ b/services/hca-schema-validator/poetry.lock
@@ -509,14 +509,14 @@ numpy = ">=1.21.2"
 
 [[package]]
 name = "hca-schema-validator"
-version = "0.10.2"
+version = "0.11.0"
 description = "HCA schema validation for single-cell datasets"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "hca_schema_validator-0.10.2-py3-none-any.whl", hash = "sha256:4ff8da98c96d79833931192427cbd6b84b44a4bd1c32ac38214b30dc8e7fdbe4"},
-    {file = "hca_schema_validator-0.10.2.tar.gz", hash = "sha256:0af3fb37555ce850c9e31a5e3c491c64f1f102a65b0960ecac2638823acd1c9b"},
+    {file = "hca_schema_validator-0.11.0-py3-none-any.whl", hash = "sha256:c834f3d39168a87e89ddcd42b2181f1d6bbab3244025ea2b87f5b7a3f8b56cc5"},
+    {file = "hca_schema_validator-0.11.0.tar.gz", hash = "sha256:0f2704d4792cacbfcaa9c8598ba0c6e4b5f7469eaa1b2f386ea49385e6facb81"},
 ]
 
 [package.dependencies]
@@ -2099,4 +2099,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "~=3.11"
-content-hash = "eaa16bdcec391b831d94552edef4dd94aaec06677b1ad961e18741b863dc1539"
+content-hash = "c6db6302d2e7475eefcd34f2da690b33ebe1f937daa9a5541f941b1f8d2e0fcd"

--- a/services/hca-schema-validator/pyproject.toml
+++ b/services/hca-schema-validator/pyproject.toml
@@ -3,7 +3,7 @@ name = "hca-schema-validator-service"
 version = "0.1.0"
 requires-python = "~=3.11"
 dependencies = [
-    "hca-schema-validator (>=0.10.0,<0.11.0)"
+    "hca-schema-validator (>=0.11.0,<0.12.0)"
 ]
 
 [tool.poetry]


### PR DESCRIPTION
Closes the release-coordination gap flagged in #366.

## Summary

- Bumps the `hca-schema-validator` pin in `services/hca-schema-validator/pyproject.toml` from `>=0.10.0,<0.11.0` to `>=0.11.0,<0.12.0`.
- Regenerates `services/hca-schema-validator/poetry.lock` — resolved to 0.11.0.
- Brings `HCACellAnnotationValidator` (from #362 Phase 1) into the batch service venv, so the Docker container's `cell_annotation.py` entrypoint can actually import the new class.

## Verification

- Locally: `poetry install` picked up 0.11.0, `from hca_schema_validator import HCACellAnnotationValidator` succeeds.
- Service test suite (11 tests) passes against the installed 0.11.0.

## Deploy sequence (context)

1. ✅ Merge #366 (Phase 1)
2. ✅ Merge #309 (release-please, bumps package → 0.11.0 on PyPI)
3. ✅ Merge #367 (unrelated workflow fix for mcp publish)
4. **This PR** (service-pin bump)
5. After merge: `make batch-publish-container ENV=dev`, submit a test job, verify SNS payload has the fourth `hcaCellAnnotation` key, then `ENV=prod`.

## Test plan

- [x] Poetry lock resolves to 0.11.0.
- [x] `HCACellAnnotationValidator` importable from the pinned venv.
- [x] Service test suite (11 tests) green against 0.11.0.
- [ ] CI passes on this PR.
- [ ] Post-merge: rebuild Docker, `cell_annotation.py` runs cleanly inside the container (previously returned ImportError because 0.10.2 didn't have the class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)