### PR TITLE
feat: validate producer cosmetic obs columns vs ontology_term_id

### DIFF
--- a/packages/hca-anndata-mcp/src/hca_anndata_mcp/server.py
+++ b/packages/hca-anndata-mcp/src/hca_anndata_mcp/server.py
@@ -21,6 +21,7 @@ from hca_anndata_tools import (
     view_edit_log,
 )
 
+from hca_anndata_mcp.tools.check_cosmetic import check_cosmetic_labels_h5ad
 from hca_anndata_mcp.tools.label import label_h5ad
 from hca_anndata_mcp.tools.plot import plot_embedding_mcp
 from hca_anndata_mcp.tools.validate import validate_schema
@@ -46,6 +47,9 @@ mcp = FastMCP(
         "check_x_normalization to classify X as raw-counts / normalized / indeterminate, "
         "check_schema_type to identify CellxGENE vs HCA layout and report the schema version, "
         "validate_schema to run the HCA schema validator and report is_valid / errors / warnings, "
+        "check_cosmetic_labels_h5ad as a fast targeted alternative — checks only that "
+        "producer-supplied obs label columns (tissue, cell_type, ...) match their "
+        "*_ontology_term_id values, without the full schema validation cost, "
         "label_h5ad to populate var['feature_name'] (+ feature_reference/biotype/length/type) and "
         "obs ontology labels (tissue, cell_type, ...) from *_ontology_term_id columns — run before "
         "copy_cap_annotations so marker-gene validation has canonical gene symbols to match against, "
@@ -72,4 +76,5 @@ mcp.tool()(view_edit_log)
 mcp.tool()(check_x_normalization)
 mcp.tool()(check_schema_type)
 mcp.tool()(validate_schema)
+mcp.tool()(check_cosmetic_labels_h5ad)
 mcp.tool()(label_h5ad)

--- a/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/check_cosmetic.py
+++ b/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/check_cosmetic.py
@@ -1,0 +1,51 @@
+"""MCP wrapper for hca_schema_validator.check_cosmetic_labels."""
+
+import os
+
+from hca_anndata_tools._io import open_h5ad
+from hca_anndata_tools.write import resolve_latest
+from hca_schema_validator import check_cosmetic_labels
+
+
+def check_cosmetic_labels_h5ad(path: str) -> dict:
+    """Check producer-supplied obs label columns against their `*_ontology_term_id` siblings.
+
+    Targeted alternative to :func:`validate_schema` — runs only the producer-
+    cosmetic-column check (issue #377), skipping the full schema/raw/feature
+    validation pipeline. Useful when a curator wants quick feedback on
+    label/ID drift without paying for a full validate run.
+
+    For each of the eight controlled HCA obs label columns
+    (:data:`hca_schema_validator.HCA_DERIVED_OBS_LABELS`):
+
+    * column present → warning ("delete the column")
+    * column present + source `*_ontology_term_id` present → row-level checks:
+        - cosmetic value with NaN term ID → error
+        - cosmetic value disagrees with canonical ontology label → error
+
+    Args:
+        path: Path to an .h5ad file. Auto-resolves to the latest timestamped
+            edit snapshot before reading.
+
+    Returns:
+        Dict with ``filename``, ``warning_count``, ``error_count``,
+        ``warnings`` (list of str), ``errors`` (list of str), and ``is_clean``
+        (True iff both lists are empty). On failure, ``error`` is returned
+        instead.
+    """
+    try:
+        path = resolve_latest(path)
+        if not os.path.isfile(path):
+            return {"error": f"File not found: {path}"}
+        with open_h5ad(path, backed="r") as adata:
+            warnings, errors = check_cosmetic_labels(adata)
+        return {
+            "filename": os.path.basename(path),
+            "warning_count": len(warnings),
+            "error_count": len(errors),
+            "warnings": warnings,
+            "errors": errors,
+            "is_clean": not warnings and not errors,
+        }
+    except Exception as e:
+        return {"error": str(e)}

--- a/packages/hca-anndata-mcp/tests/test_check_cosmetic.py
+++ b/packages/hca-anndata-mcp/tests/test_check_cosmetic.py
@@ -1,0 +1,61 @@
+"""Unit tests for the check_cosmetic_labels_h5ad MCP wrapper (#377)."""
+
+import anndata as ad
+import numpy as np
+import pandas as pd
+from hca_anndata_mcp.tools.check_cosmetic import check_cosmetic_labels_h5ad
+from hca_schema_validator.testing import create_labelable_h5ad
+
+
+def test_clean_file_is_clean(tmp_path):
+    path = create_labelable_h5ad(tmp_path / "clean.h5ad")
+    result = check_cosmetic_labels_h5ad(str(path))
+    assert "error" not in result, result
+    assert result["is_clean"] is True
+    assert result["warning_count"] == 0
+    assert result["error_count"] == 0
+
+
+def test_warning_when_cosmetic_present_and_matches(tmp_path):
+    path = create_labelable_h5ad(tmp_path / "matches.h5ad")
+    adata = ad.read_h5ad(path)
+    adata.obs["tissue"] = "lung"  # canonical for UBERON:0002048
+    adata.write_h5ad(path)
+
+    result = check_cosmetic_labels_h5ad(str(path))
+    assert "error" not in result, result
+    assert result["is_clean"] is False
+    assert result["warning_count"] == 1
+    assert "obs['tissue']" in result["warnings"][0]
+    assert result["error_count"] == 0
+
+
+def test_error_on_mismatch(tmp_path):
+    path = create_labelable_h5ad(tmp_path / "mismatch.h5ad")
+    adata = ad.read_h5ad(path)
+    adata.obs["tissue"] = "WRONG"
+    adata.write_h5ad(path)
+
+    result = check_cosmetic_labels_h5ad(str(path))
+    assert any("'WRONG'" in e and "UBERON:0002048" in e for e in result["errors"])
+    assert any("Either delete the cosmetic column" in e for e in result["errors"])
+
+
+def test_error_on_value_with_nan_term_id(tmp_path):
+    path = create_labelable_h5ad(tmp_path / "nan_id.h5ad")
+    adata = ad.read_h5ad(path)
+    adata.obs["cell_type"] = pd.Series(["PRODUCER_LABEL"] * adata.n_obs, index=adata.obs.index)
+    adata.obs["cell_type_ontology_term_id"] = adata.obs["cell_type_ontology_term_id"].astype(object)
+    adata.obs.loc[adata.obs.index[0], "cell_type_ontology_term_id"] = np.nan
+    adata.write_h5ad(path)
+
+    result = check_cosmetic_labels_h5ad(str(path))
+    assert any(
+        "have NaN in cell_type_ontology_term_id" in e and "PRODUCER_LABEL" in e
+        for e in result["errors"]
+    )
+
+
+def test_missing_file():
+    result = check_cosmetic_labels_h5ad("/nonexistent/file.h5ad")
+    assert "error" in result

--- a/packages/hca-anndata-mcp/tests/test_validate.py
+++ b/packages/hca-anndata-mcp/tests/test_validate.py
@@ -3,6 +3,7 @@
 import anndata as ad
 from hca_anndata_mcp.tools.validate import validate_schema
 from hca_anndata_tools.testing import create_sample_h5ad
+from hca_schema_validator.testing import create_labelable_h5ad
 
 
 def test_validate_schema_shape(sample_h5ad):
@@ -18,6 +19,30 @@ def test_validate_schema_shape(sample_h5ad):
 def test_validate_schema_missing_file():
     result = validate_schema("/nonexistent/file.h5ad")
     assert "error" in result
+
+
+def test_validate_schema_surfaces_cosmetic_check(tmp_path):
+    """Confirm the new producer-cosmetic-column check (issue #377) surfaces
+    through the MCP wrapper. The wrapper just returns the validator's
+    warnings/errors, so this test exercises the integration boundary
+    rather than re-testing the underlying logic.
+    """
+    path = create_labelable_h5ad(tmp_path / "cosmetic.h5ad")
+    adata = ad.read_h5ad(path)
+    adata.obs["tissue"] = "WRONG_TISSUE_LABEL"
+    adata.write_h5ad(path)
+
+    result = validate_schema(str(path))
+
+    assert any(
+        "obs['tissue']" in w and "should not be populated by producers" in w
+        for w in result["warnings"]
+    ), result["warnings"]
+    assert any(
+        "'WRONG_TISSUE_LABEL'" in e and "Either delete the cosmetic column" in e
+        for e in result["errors"]
+    ), result["errors"]
+    assert result["is_valid"] is False
 
 
 def test_validate_schema_resolves_latest(tmp_path):

--- a/packages/hca-schema-validator/src/hca_schema_validator/__init__.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/__init__.py
@@ -8,11 +8,12 @@ __schema_reference_url__ = "https://data.humancellatlas.org/metadata"  # Static 
 # Import after constants are defined
 from .cell_annotation_validator import HCACellAnnotationValidator
 from .labeler import HCA_DERIVED_OBS_LABELS, HCALabeler
-from .validator import HCAValidator
+from .validator import HCAValidator, check_cosmetic_labels
 
 __all__ = [
     "HCAValidator",
     "HCACellAnnotationValidator",
     "HCALabeler",
     "HCA_DERIVED_OBS_LABELS",
+    "check_cosmetic_labels",
 ]

--- a/packages/hca-schema-validator/src/hca_schema_validator/validator.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/validator.py
@@ -1,5 +1,6 @@
 """HCA Validator - extends cellxgene Validator with HCA-specific rules."""
 
+import functools
 import re
 from pathlib import Path
 
@@ -13,6 +14,7 @@ from hca_schema_validator._vendored.cellxgene_schema.utils import getattr_anndat
 from hca_schema_validator._vendored.cellxgene_schema.validate import Validator
 
 from . import __schema_version__ as HCA_SCHEMA_VERSION
+from .labeler import HCA_DERIVED_OBS_LABELS
 
 # GENCODE version info (loaded once at module level)
 _GENE_INFO_PATH = Path(__file__).parent / "_vendored" / "cellxgene_schema" / "gencode_files" / "gene_info.yml"
@@ -71,6 +73,11 @@ class HCAValidator(Validator):
         self.warnings = other + feature_id
         return result
 
+    def _check_cosmetic_label_columns(self):
+        warnings, errors = check_cosmetic_labels(self.adata, self.schema_def)
+        self.warnings.extend(warnings)
+        self.errors.extend(errors)
+
     def _deep_check(self):
         """
         The base class skips raw validation when *any* errors exist, but raw
@@ -92,6 +99,8 @@ class HCAValidator(Validator):
             for w in raw_skip_warnings:
                 self.warnings.remove(w)
             self._validate_raw()
+
+        self._check_cosmetic_label_columns()
 
     def _validate_list(self, list_name, current_list, element_type):
         """
@@ -305,3 +314,118 @@ class HCAValidator(Validator):
                             f"Column '{column_name}' in dataframe '{df_name}' contains a value "
                             f"'{value}' that does not match the required pattern '{column_def['pattern']}'."
                         )
+
+
+def check_cosmetic_labels(adata, schema_def=None):
+    """Run the producer-cosmetic-column check and return (warnings, errors).
+
+    The HCA labeler populates the eight controlled obs label columns from their
+    `*_ontology_term_id` counterparts. Producers shouldn't ship the cosmetic
+    columns at all; if they do, every populated row needs a term ID and the
+    cosmetic value must agree with the canonical ontology label.
+
+    Per-column rules (each fires independently and aggregates):
+
+    * column present → warning ("delete the column")
+    * column present + source present → row-level checks:
+        - cosmetic value, source NaN → error ("add term ID, delete the label,
+          or delete the column")
+        - both populated, file label != canonical → error ("delete the column
+          or fix the term ID")
+        - unresolvable term ID → silently skipped (the curie validator flags
+          bad IDs through its own pathway)
+
+    Args:
+        adata: An AnnData object.
+        schema_def: Loaded HCA schema definition dict. If omitted, the bundled
+            HCA schema is loaded — pass an explicit value when reusing this
+            check from a context that already has the schema in hand.
+
+    Returns:
+        ``(warnings, errors)`` — two lists of strings, ready for the caller to
+        append to its own report. Issue #377.
+    """
+    if schema_def is None:
+        schema_def = _load_default_schema_def()
+
+    warnings: list[str] = []
+    errors: list[str] = []
+
+    obs = getattr_anndata(adata, "obs")
+    if obs is None:
+        return warnings, errors
+
+    obs_components = schema_def.get("components", {}).get("obs", {}).get("columns", {})
+    for cosmetic_col in HCA_DERIVED_OBS_LABELS:
+        if cosmetic_col not in obs.columns:
+            continue
+        source_col = f"{cosmetic_col}_ontology_term_id"
+        warnings.append(
+            f"obs['{cosmetic_col}'] should not be populated by producers — "
+            f"the HCA labeler populates this column from {source_col}. "
+            f"Delete the column."
+        )
+        if source_col not in obs.columns:
+            continue
+        exceptions = set(
+            obs_components.get(source_col, {})
+            .get("curie_constraints", {})
+            .get("exceptions", [])
+        )
+        errors.extend(_compare_cosmetic_to_term_ids(obs, cosmetic_col, source_col, exceptions))
+
+    return warnings, errors
+
+
+@functools.lru_cache(maxsize=1)
+def _load_default_schema_def():
+    schema_path = Path(__file__).parent / SCHEMA_DIR / SCHEMA_FILENAME
+    with open(schema_path) as fp:
+        return yaml.safe_load(fp)
+
+
+def _compare_cosmetic_to_term_ids(obs, cosmetic_col, source_col, exceptions):
+    pair_counts = (
+        obs[[source_col, cosmetic_col]]
+        .astype(object)
+        .groupby([source_col, cosmetic_col], dropna=False)
+        .size()
+    )
+    canonical_cache: dict[str, str | None] = {}
+    errors: list[str] = []
+    for (term_id, file_label), n in pair_counts.items():
+        file_label_str = None if pd.isna(file_label) else str(file_label)
+        if pd.isna(term_id):
+            if file_label_str is not None:
+                errors.append(
+                    f"obs['{cosmetic_col}']: {n} rows labeled '{file_label_str}' "
+                    f"have NaN in {source_col}. Either add the term ID, "
+                    f"delete the label, or delete the cosmetic column."
+                )
+            continue
+        if file_label_str is None:
+            continue
+        term_id_str = str(term_id)
+        if term_id_str not in canonical_cache:
+            canonical_cache[term_id_str] = _lookup_canonical_label(term_id_str, exceptions)
+        canonical = canonical_cache[term_id_str]
+        if canonical is None or canonical == file_label_str:
+            continue
+        errors.append(
+            f"obs['{cosmetic_col}']: {n} rows labeled '{file_label_str}' but "
+            f"{source_col} is '{term_id_str}' (canonical label: '{canonical}'). "
+            f"Either delete the cosmetic column, or fix {source_col} so it "
+            f"matches the label."
+        )
+    return errors
+
+
+def _lookup_canonical_label(term_id, exceptions):
+    # Sentinels (e.g. 'unknown', 'na') are their own canonical label
+    # — matches cellxgene labeler behavior.
+    if term_id in exceptions:
+        return term_id
+    try:
+        return ONTOLOGY_PARSER.get_term_label(term_id)
+    except (KeyError, ValueError):
+        return None

--- a/packages/hca-schema-validator/src/hca_schema_validator/validator.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/validator.py
@@ -367,14 +367,21 @@ def check_cosmetic_labels(adata, schema_def=None):
         )
         if source_col not in obs.columns:
             continue
-        exceptions = set(
-            obs_components.get(source_col, {})
-            .get("curie_constraints", {})
-            .get("exceptions", [])
-        )
+        exceptions = _collect_curie_exceptions(obs_components.get(source_col, {}))
         errors.extend(_compare_cosmetic_to_term_ids(obs, cosmetic_col, source_col, exceptions))
 
     return warnings, errors
+
+
+def _collect_curie_exceptions(source_def):
+    # `exceptions` (e.g. 'unknown', 'na') can live at the top-level
+    # `curie_constraints` and/or inside per-rule `dependencies` blocks.
+    # Union both so sentinel-vs-mismatch errors fire for any column that
+    # only declares its sentinels conditionally.
+    exceptions = set(source_def.get("curie_constraints", {}).get("exceptions", []))
+    for dep in source_def.get("dependencies", []):
+        exceptions.update(dep.get("curie_constraints", {}).get("exceptions", []))
+    return exceptions
 
 
 @functools.lru_cache(maxsize=1)

--- a/packages/hca-schema-validator/tests/test_validator.py
+++ b/packages/hca-schema-validator/tests/test_validator.py
@@ -150,6 +150,152 @@ def test_valid_adata_passes():
     assert is_valid is True, f"Validation failed with errors: {validator.errors}"
 
 
+def _cosmetic_check_messages(validator):
+    """Filter validator messages to those produced by the cosmetic-label check (#377)."""
+    warnings = [w for w in validator.warnings if "should not be populated by producers" in w]
+    errors = [e for e in validator.errors if "Either delete the cosmetic column" in e or "Either add the term ID" in e]
+    return warnings, errors
+
+
+def test_cosmetic_check_silent_when_columns_absent():
+    from .fixtures.hca_fixtures import adata
+
+    _, validator = _validate_from_fixture(adata)
+    warnings, errors = _cosmetic_check_messages(validator)
+    assert warnings == []
+    assert errors == []
+
+
+def test_cosmetic_check_warning_only_when_values_match():
+    from .fixtures.hca_fixtures import adata
+
+    modified = adata.copy()
+    modified.obs["tissue"] = "lung"  # canonical label for UBERON:0002048
+    _, validator = _validate_from_fixture(modified)
+    warnings, errors = _cosmetic_check_messages(validator)
+    assert len(warnings) == 1
+    assert "obs['tissue']" in warnings[0]
+    assert errors == []
+
+
+def test_cosmetic_check_error_on_mismatch():
+    from .fixtures.hca_fixtures import adata
+
+    modified = adata.copy()
+    modified.obs["tissue"] = "WRONG_LABEL"
+    _, validator = _validate_from_fixture(modified)
+    warnings, errors = _cosmetic_check_messages(validator)
+    assert len(warnings) == 1
+    assert any(
+        "'WRONG_LABEL'" in e and "UBERON:0002048" in e and "'lung'" in e
+        for e in errors
+    ), errors
+
+
+def test_cosmetic_check_aggregates_across_columns():
+    from .fixtures.hca_fixtures import adata
+
+    modified = adata.copy()
+    modified.obs["tissue"] = "WRONG_TISSUE"
+    modified.obs["assay"] = "WRONG_ASSAY"
+    _, validator = _validate_from_fixture(modified)
+    warnings, errors = _cosmetic_check_messages(validator)
+    assert len(warnings) == 2
+    assert sum("'WRONG_TISSUE'" in e for e in errors) == 1
+    assert sum("'WRONG_ASSAY'" in e for e in errors) == 1
+
+
+def test_cosmetic_check_handles_optional_cell_type_with_source_present():
+    # cell_type is the only optional column in HCA_DERIVED_OBS_LABELS — verify
+    # it gets the same warning + mismatch-error treatment as the required
+    # columns when the source cell_type_ontology_term_id is present.
+    from .fixtures.hca_fixtures import adata
+
+    modified = adata.copy()
+    modified.obs["cell_type"] = "WRONG_CELL_TYPE"
+    _, validator = _validate_from_fixture(modified)
+    warnings, errors = _cosmetic_check_messages(validator)
+    assert any("obs['cell_type']" in w for w in warnings)
+    assert any(
+        "'WRONG_CELL_TYPE'" in e and "CL:0000066" in e and "'epithelial cell'" in e
+        for e in errors
+    ), errors
+
+
+def test_cosmetic_check_warning_only_when_source_column_absent():
+    from .fixtures.hca_fixtures import adata
+
+    modified = adata.copy()
+    modified.obs["cell_type"] = "PRODUCER_CELL_TYPE"
+    del modified.obs["cell_type_ontology_term_id"]  # cell_type is optional, can be removed
+    _, validator = _validate_from_fixture(modified)
+    warnings, errors = _cosmetic_check_messages(validator)
+    assert len(warnings) == 1
+    assert "obs['cell_type']" in warnings[0]
+    assert errors == []  # no source → no row-level check
+
+
+def test_cosmetic_check_error_on_value_with_nan_term_id():
+    from .fixtures.hca_fixtures import adata
+
+    modified = adata.copy()
+    modified.obs["cell_type"] = pd.Series(["PRODUCER_LABEL", "PRODUCER_LABEL"], index=modified.obs.index)
+    # Source column exists but one row has NaN.
+    modified.obs["cell_type_ontology_term_id"] = modified.obs["cell_type_ontology_term_id"].astype(object)
+    modified.obs.loc[modified.obs.index[0], "cell_type_ontology_term_id"] = np.nan
+    _, validator = _validate_from_fixture(modified)
+    warnings, errors = _cosmetic_check_messages(validator)
+    assert len(warnings) == 1
+    assert any(
+        "have NaN in cell_type_ontology_term_id" in e and "1 rows labeled 'PRODUCER_LABEL'" in e
+        for e in errors
+    ), errors
+
+
+def test_cosmetic_check_skips_unresolvable_term_ids():
+    from .fixtures.hca_fixtures import adata
+
+    modified = adata.copy()
+    modified.obs["tissue"] = "anything"
+    modified.obs["tissue_ontology_term_id"] = modified.obs["tissue_ontology_term_id"].astype(object)
+    modified.obs.loc[:, "tissue_ontology_term_id"] = "UBERON:9999999"  # nonexistent
+    _, validator = _validate_from_fixture(modified)
+    warnings, errors = _cosmetic_check_messages(validator)
+    assert len(warnings) == 1
+    # No mismatch error — unresolvable IDs are silently skipped here (the
+    # curie validator surfaces the bad ID via its own pathway).
+    assert errors == []
+
+
+def test_cosmetic_check_sentinel_values_match():
+    from .fixtures.hca_fixtures import adata
+
+    modified = adata.copy()
+    modified.obs["self_reported_ethnicity"] = "unknown"
+    modified.obs["self_reported_ethnicity_ontology_term_id"] = "unknown"
+    _, validator = _validate_from_fixture(modified)
+    warnings, errors = _cosmetic_check_messages(validator)
+    assert len(warnings) == 1
+    assert errors == []
+
+
+def test_cosmetic_check_fires_with_ignore_labels_false():
+    from .fixtures.hca_fixtures import adata
+
+    modified = adata.copy()
+    modified.obs["tissue"] = "WRONG"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir) / "test.h5ad"
+        modified.write_h5ad(str(tmp_path))
+        validator = HCAValidator(ignore_labels=False)
+        validator.validate_adata(str(tmp_path))
+
+    warnings, errors = _cosmetic_check_messages(validator)
+    assert len(warnings) == 1
+    assert any("'WRONG'" in e for e in errors)
+
+
 def test_study_pi_missing():
     """Test that removing study_pi from uns produces an error."""
     from .fixtures.hca_fixtures import adata

--- a/packages/hca-schema-validator/tests/test_validator.py
+++ b/packages/hca-schema-validator/tests/test_validator.py
@@ -279,6 +279,27 @@ def test_cosmetic_check_sentinel_values_match():
     assert errors == []
 
 
+def test_cosmetic_check_sentinel_values_mismatch_errors():
+    # Guards against a regression where sentinel term IDs ('unknown', 'na')
+    # are silently treated as unresolvable. self_reported_ethnicity declares
+    # its 'unknown' exception only inside a dependencies block, so this
+    # exercises the union-with-dependencies path in _collect_curie_exceptions.
+    from .fixtures.hca_fixtures import adata
+
+    modified = adata.copy()
+    modified.obs["self_reported_ethnicity"] = "PRODUCER_LABEL"
+    modified.obs["self_reported_ethnicity_ontology_term_id"] = "unknown"
+    _, validator = _validate_from_fixture(modified)
+    warnings, errors = _cosmetic_check_messages(validator)
+    assert len(warnings) == 1
+    assert any(
+        "self_reported_ethnicity_ontology_term_id" in e
+        and "'PRODUCER_LABEL'" in e
+        and "'unknown'" in e
+        for e in errors
+    ), errors
+
+
 def test_cosmetic_check_fires_with_ignore_labels_false():
     from .fixtures.hca_fixtures import adata
 


### PR DESCRIPTION
## Summary
- New producer-cosmetic-column check in `HCAValidator`: warns when any of the eight controlled obs label columns is present (informational — producers shouldn't ship them; CXG exports legitimately do); errors when a cosmetic value disagrees with the canonical ontology label of its row's term ID, or when the cosmetic column has a value but the term ID row is NaN.
- Two-tier severity is the resolution to the #267 tension: clean CXG exports validate (warnings only), CXG/HCA files with curation drift correctly fail.
- Independent of `ignore_labels`. Sentinel values (`unknown`, `na`) are their own canonical label per `curie_constraints.exceptions`. Unresolvable IDs are silently skipped (the curie validator surfaces those via its own pathway).
- Exposed as a free function `check_cosmetic_labels(adata, schema_def=None)` for callers who want the targeted check without the full validation pipeline.
- New MCP tool `check_cosmetic_labels_h5ad(path)` for fast, targeted feedback — read-only, just opens obs in backed mode.
- Existing `validate_schema` MCP tool picks up the new warnings/errors automatically (same `HCAValidator`).

End-to-end verification on `gut-v1/myeloid-r1-wip-10.h5ad` (the original producer submission):

```
4 warnings: tissue, assay, disease, organism (columns present)
16 errors:
  - tissue: 9 (8 underscore-vs-space + 1 ascending_colon vs parent UBERON:0001155 = 1,225 cells)
  - assay:  5 (case-only "10X" vs canonical "10x")
  - disease: 2 (HPO-style phrasing on MONDO ID; concatenated parent labels on enteritis)
```

The 1,225-cell `ascending_colon` case is the biologically meaningful one — without this check, add-labels would silently demote those cells to `colon`.

Closes #377

## Test plan
- [x] `packages/hca-schema-validator` — full suite passes (88 tests). 10 new in `test_validator.py`: clean fixture; cosmetic + match (warning only); mismatch error; multi-column aggregation; cell_type with source present (the optional column case the user asked about); source absent (warning only); value with NaN term ID; unresolvable IDs (skipped); sentinel match; both `ignore_labels` modes.
- [x] `packages/hca-anndata-mcp` — full suite passes (32 tests). 5 new in `test_check_cosmetic.py` covering the new MCP tool's clean/match/mismatch/NaN-id/missing-file paths, plus an integration test in `test_validate.py` confirming the existing `validate_schema` tool surfaces the new warnings/errors.
- [x] `make typecheck` — clean across all four pyright passes.
- [x] Manual MCP run (post-restart) on the original gut myeloid file → 4 warnings + 16 errors as listed above.
- [x] Manual MCP run on the 2026-04-21 edited gut myeloid → 8 warnings, 0 errors (cosmetic columns still present but values match — the prior curation pass fixed the IDs but didn't strip the columns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)