### PR TITLE
chore: bump hca-schema-validator to 0.12.x in batch service

### DIFF
--- a/services/hca-schema-validator/poetry.lock
+++ b/services/hca-schema-validator/poetry.lock
@@ -509,14 +509,14 @@ numpy = ">=1.21.2"
 
 [[package]]
 name = "hca-schema-validator"
-version = "0.11.0"
+version = "0.12.0"
 description = "HCA schema validation for single-cell datasets"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "hca_schema_validator-0.11.0-py3-none-any.whl", hash = "sha256:c834f3d39168a87e89ddcd42b2181f1d6bbab3244025ea2b87f5b7a3f8b56cc5"},
-    {file = "hca_schema_validator-0.11.0.tar.gz", hash = "sha256:0f2704d4792cacbfcaa9c8598ba0c6e4b5f7469eaa1b2f386ea49385e6facb81"},
+    {file = "hca_schema_validator-0.12.0-py3-none-any.whl", hash = "sha256:e26db3996c899a3d057098fe99766c3ed85397ea1542c4d6fa3a6485a6b82942"},
+    {file = "hca_schema_validator-0.12.0.tar.gz", hash = "sha256:3d358db9f59beec972edd8d2c3c167e659980a578caefa8b1565c2b4d6d90fd2"},
 ]
 
 [package.dependencies]
@@ -2099,4 +2099,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "~=3.11"
-content-hash = "c6db6302d2e7475eefcd34f2da690b33ebe1f937daa9a5541f941b1f8d2e0fcd"
+content-hash = "86cc191057923822994acbb7cd2cc429dccb97ead9a47c0f795f4ccf379e5904"

--- a/services/hca-schema-validator/pyproject.toml
+++ b/services/hca-schema-validator/pyproject.toml
@@ -3,7 +3,7 @@ name = "hca-schema-validator-service"
 version = "0.1.0"
 requires-python = "~=3.11"
 dependencies = [
-    "hca-schema-validator (>=0.11.0,<0.12.0)"
+    "hca-schema-validator (>=0.12.0,<0.13.0)"
 ]
 
 [tool.poetry]


### PR DESCRIPTION
## Summary
- Bumps `hca-schema-validator` pin from `>=0.11.0,<0.12.0` to `>=0.12.0,<0.13.0` in `services/hca-schema-validator/pyproject.toml`.
- Regenerates `poetry.lock` so the Docker build picks up the new constraint cleanly.
- Picks up the new producer-cosmetic-column check (#377) and HCALabeler reserved-column preflight (#374) in the AWS Batch validator.

After merge:
1. `make batch-publish-container ENV=dev` to build, push to ECR, and register the new job def.
2. Smoke test against the gut myeloid producer file — expected to surface 4 cosmetic-column-present warnings + 16 ID/label mismatch errors.
3. Once dev verifies, deploy to prod with `ENV=prod`.

Closes #379

## Test plan
- [x] `poetry lock` regenerated cleanly with `hca-schema-validator 0.12.0` pinned.
- [x] `poetry install` + `poetry run pytest` — 11/11 service tests pass.
- [ ] Post-merge: `make batch-publish-container ENV=dev` succeeds.
- [ ] Post-merge: dev batch job against gut myeloid surfaces the new warnings + errors.
- [ ] Prod deploy after dev smoke test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)