### PR TITLE
fix(batch-validator): SNS truncation no longer hides warnings

### DIFF
--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -27,10 +27,18 @@ import pandas as pd
 
 # Somewhat less than the actual value of 256KiB, to make room for small unforeseen deviations
 MAX_SNS_MESSAGE_LENGTH = 250_000
-TRUNCATED_MESSAGES_MESSAGE = "Messages truncated"
+# Prefix for the truncation placeholder string. The full marker also embeds
+# the retained-vs-total counts so curators see how many messages were dropped
+# even when binary-search collapses to zero retained — see _truncated_marker.
+TRUNCATED_MESSAGES_PREFIX = "Messages truncated"
 # When truncating to fit SNS limits, error lists from higher-priority tools are preserved longer.
 # Unknown tools default to priority 0 (truncated first among errors).
 TOOL_ERROR_PRIORITY = {"cellxgene": 0, "cap": 1, "hcaSchema": 2, "hcaCellAnnotation": 3}
+
+
+def _truncated_marker(retained: int, total: int) -> str:
+    """Format the truncation placeholder so the curator sees the original count."""
+    return f"{TRUNCATED_MESSAGES_PREFIX} ({retained} of {total} shown)"
 
 
 # Environment variable constants
@@ -147,13 +155,16 @@ class ValidationMessage:
         full_message = self.to_json()
         if self.tool_reports is None or len(full_message) < max_length:
             return full_message
-        
-        # Create a list of message arrays from tool_reports, represented as
-        # (key in tool_reports, attribute in tool report object) pairs
+
+        # Create a list of (tool_key, message_type) pairs to consider for truncation.
+        # Empty lists are excluded so they keep their `[]` serialization — stamping
+        # them with a placeholder would inflate warningCount/errorCount and trip
+        # false PartiallyValidIcon indicators in the tracker UI (#382).
         list_paths = [
             (key, message_type)
             for key in self.tool_reports.keys()
             for message_type in ["errors", "warnings"]
+            if self._get_report_message_list(key, message_type)
         ]
         # Truncation priority: warnings first, then cellxgene errors, then cap errors,
         # then hcaSchema errors, then hcaCellAnnotation errors (preserved longest)
@@ -168,16 +179,17 @@ class ValidationMessage:
         # Truncate entire lists until the message JSON is small enough, and note which list was the last to be truncated
         threshold_path = None
         for p in list_paths:
-            truncated_message._set_report_message_list(*p, [TRUNCATED_MESSAGES_MESSAGE])
+            original_total = len(self._get_report_message_list(*p))
+            truncated_message._set_report_message_list(*p, [_truncated_marker(0, original_total)])
             if len(truncated_message.to_json()) < max_length:
                 threshold_path = p
                 break
-        
+
         # If all lists have been truncated and somehow none have made the message small enough,
         # give up and try using it anyway
         if threshold_path is None:
             return truncated_message.to_json()
-        
+
         # Get the original value of the list that was the threshold for making the message small enough
         message_list = self._get_report_message_list(*threshold_path)
 
@@ -190,14 +202,14 @@ class ValidationMessage:
             middle_length = int((max_valid_length + min_invalid_length)/2)
             truncated_message._set_report_message_list(
                 *threshold_path,
-                [*message_list[:middle_length], TRUNCATED_MESSAGES_MESSAGE],
+                [*message_list[:middle_length], _truncated_marker(middle_length, len(message_list))],
             )
             if len(truncated_message.to_json()) < max_length:
                 max_valid_length = middle_length
             else:
                 min_invalid_length = middle_length
                 truncated_message._set_report_message_list(*threshold_path, truncated_list_before)
-        
+
         # Return the truncated message JSON
         return truncated_message.to_json()
 
@@ -566,6 +578,12 @@ def apply_cellxgene_validator(file_path: Path) -> ValidationToolReport:
     """
     Apply the CELLxGENE validator to the given file and create a validation report.
 
+    .. note::
+       Currently unreferenced — the batch flow stubs the cellxgene slot
+       rather than running this validator, since the tracker UI hides
+       cellxgene results. See #382. Kept so the integration can be
+       re-enabled without rewriting the wiring.
+
     Args:
         file_path: Path of the file to validate
 
@@ -856,10 +874,17 @@ def main() -> int:
         log_memory_usage("after CAP validator")
         gc.collect()
 
-        # Call CELLxGENE validator
-        cellxgene_validation_report = apply_cellxgene_validator(local_file)
-        log_memory_usage("after CELLxGENE validator")
-        gc.collect()
+        # cellxgene-schema is intentionally not run: the tracker UI hides
+        # the cellxgene tab unconditionally (see shouldShowValidator), so its
+        # results are dead-letter and crowd out visible warnings under SNS
+        # truncation. We send a stub report so the SNS payload schema (which
+        # requires the cellxgene field) stays satisfied. Re-enable by wiring
+        # apply_cellxgene_validator back in. See #382.
+        now_iso = datetime.now(timezone.utc).isoformat()
+        cellxgene_validation_report = ValidationToolReport(
+            valid=True, errors=[], warnings=[],
+            started_at=now_iso, finished_at=now_iso,
+        )
 
         # Call HCA schema validator
         hca_schema_validation_report = apply_hca_schema_validator(local_file)

--- a/services/dataset-validator/tests/test_dataset_validator.py
+++ b/services/dataset-validator/tests/test_dataset_validator.py
@@ -691,10 +691,13 @@ def test_local_file_mode(mock_read_h5ad, caplog, env_manager, tmp_path, test_cas
                     "errors": [],
                     "warnings": []
                 },
+                # cellxgene is stubbed in main.py (apply_cellxgene_validator
+                # is no longer called) — see #382. Expected output reflects
+                # the empty stub, not the mock script's "ERROR: test" output.
                 "cellxgene": {
-                    "valid": False,
-                    "errors": ["ERROR: test"],
-                    "warnings": ["WARNING: test"]
+                    "valid": True,
+                    "errors": [],
+                    "warnings": []
                 },
                 "hcaSchema": {
                     "valid": False,
@@ -857,10 +860,11 @@ def test_local_file_mode(mock_read_h5ad, caplog, env_manager, tmp_path, test_cas
                     "errors": ["Encountered an unexpected error while calling CAP validator: Error in CAP validator"],
                     "warnings": []
                 },
+                # cellxgene stubbed in main.py — see #382.
                 "cellxgene": {
-                    "valid": False,
-                    "errors": ["ERROR: test"],
-                    "warnings": ["WARNING: test"]
+                    "valid": True,
+                    "errors": [],
+                    "warnings": []
                 },
                 "hcaSchema": {
                     "valid": False,

--- a/services/dataset-validator/tests/test_validation_message.py
+++ b/services/dataset-validator/tests/test_validation_message.py
@@ -1,11 +1,12 @@
 import json
+import re
 import sys
 from pathlib import Path
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
-from dataset_validator.main import ValidationToolReport, ValidationMessage, TRUNCATED_MESSAGES_MESSAGE
+from dataset_validator.main import ValidationToolReport, ValidationMessage, TRUNCATED_MESSAGES_PREFIX
 
 @pytest.mark.parametrize("test_case", [
     {
@@ -161,15 +162,97 @@ def test_length_limited_json_scenarios(test_case):
   assert test_case["expected_min_length"] <= len(message_json)
   assert len(message_json) <= test_case["expected_max_length"]
   if "expected_truncated_count" in test_case:
-    assert message_json.count(f'"{TRUNCATED_MESSAGES_MESSAGE}"') == test_case["expected_truncated_count"]
+    assert message_json.count(TRUNCATED_MESSAGES_PREFIX) == test_case["expected_truncated_count"]
   parsed = json.loads(message_json)
+
+  def _has_truncation_marker(items):
+    return any(isinstance(s, str) and s.startswith(TRUNCATED_MESSAGES_PREFIX) for s in items)
+
   if test_case.get("expect_errors_preserved"):
     for tool_report in parsed["tool_reports"].values():
-      assert TRUNCATED_MESSAGES_MESSAGE not in tool_report["errors"], (
+      assert not _has_truncation_marker(tool_report["errors"]), (
         "Errors should not be truncated when warnings can be truncated instead"
       )
   if test_case.get("expect_tool_errors_preserved"):
     for tool_key in test_case["expect_tool_errors_preserved"]:
-      assert TRUNCATED_MESSAGES_MESSAGE not in parsed["tool_reports"][tool_key]["errors"], (
+      assert not _has_truncation_marker(parsed["tool_reports"][tool_key]["errors"]), (
         f"{tool_key} errors should not be truncated"
       )
+
+
+def _build_message(tool_reports):
+  ts = "2025-10-18T04:42:04.963Z"
+  return ValidationMessage(
+    file_id="test-file-id", status="success", timestamp=ts,
+    bucket="test-bucket", key="test-key", batch_job_id="test-job-id",
+    tool_reports={
+      tool_key: ValidationToolReport(
+        valid=not r["errors"], errors=r["errors"], warnings=r["warnings"],
+        started_at=ts, finished_at=ts,
+      )
+      for tool_key, r in tool_reports.items()
+    },
+  )
+
+
+def test_empty_lists_serialize_as_empty():
+  """Empty error/warning lists keep their `[]` serialization rather than getting
+  the truncation placeholder. Without this, the tracker UI inflates warningCount
+  to 1 and shows a false PartiallyValidIcon for tools that had nothing to say.
+  See #382."""
+  large = "x" * 100
+  message = _build_message({
+    "cap": {"errors": [], "warnings": []},  # empty
+    "cellxgene": {"errors": [], "warnings": []},  # empty
+    "hcaSchema": {"errors": [], "warnings": [large] * 5000},  # overflows
+    "hcaCellAnnotation": {"errors": [], "warnings": []},  # empty
+  })
+  parsed = json.loads(message.to_length_limited_json())
+  for tool in ("cap", "cellxgene", "hcaCellAnnotation"):
+    assert parsed["tool_reports"][tool]["errors"] == [], (
+      f"{tool}.errors should be [] but got {parsed['tool_reports'][tool]['errors']}"
+    )
+    assert parsed["tool_reports"][tool]["warnings"] == [], (
+      f"{tool}.warnings should be [] but got {parsed['tool_reports'][tool]['warnings']}"
+    )
+
+
+def test_placeholder_includes_counts():
+  """Truncation placeholder embeds (retained of total shown) so curators see
+  how many messages were dropped even when binary search retains a fraction."""
+  large = "x" * 100
+  message = _build_message({
+    "cap": {"errors": [], "warnings": []},
+    "cellxgene": {"errors": [], "warnings": []},
+    "hcaSchema": {"errors": [], "warnings": [large] * 5000},
+    "hcaCellAnnotation": {"errors": [], "warnings": []},
+  })
+  parsed = json.loads(message.to_length_limited_json())
+  warnings = parsed["tool_reports"]["hcaSchema"]["warnings"]
+  marker = warnings[-1]
+  match = re.fullmatch(rf"{re.escape(TRUNCATED_MESSAGES_PREFIX)} \((\d+) of (\d+) shown\)", marker)
+  assert match, f"placeholder should match count format, got: {marker!r}"
+  retained, total = int(match.group(1)), int(match.group(2))
+  assert total == 5000, f"original count should be preserved, got {total}"
+  assert retained == len(warnings) - 1, f"retained count {retained} should match list length {len(warnings)-1}"
+
+
+def test_collapsed_to_zero_still_reports_original_count():
+  """When higher-priority lists fill the budget, the threshold list collapses to
+  zero retained — the placeholder must still report the original count so the
+  curator knows there's something hidden. Mirrors the Cohen scenario where
+  hcaSchema warnings collapse because the budget is consumed by other tools.
+  See #382."""
+  big = "x" * 250
+  message = _build_message({
+    "cap": {"errors": [], "warnings": []},
+    "cellxgene": {"errors": [], "warnings": []},
+    "hcaSchema": {"errors": [], "warnings": [big] * 50},  # small but truncated first
+    "hcaCellAnnotation": {"errors": [big] * 1100, "warnings": []},  # fills budget
+  })
+  parsed = json.loads(message.to_length_limited_json())
+  warnings = parsed["tool_reports"]["hcaSchema"]["warnings"]
+  assert len(warnings) == 1, f"expected collapse to placeholder only, got {len(warnings)} entries"
+  assert warnings[0] == f"{TRUNCATED_MESSAGES_PREFIX} (0 of 50 shown)", (
+    f"unexpected placeholder: {warnings[0]!r}"
+  )


### PR DESCRIPTION
## Summary
- Stop running cellxgene-schema in the batch — its results are dead-letter (tracker UI hides the cellxgene tab unconditionally) yet on Cohen-class files they consumed ~600 KB of SNS budget and squeezed visible hcaSchema warnings to zero. Slot is stubbed with `valid=True, errors=[], warnings=[]`.
- Skip empty lists in the truncation pass so empty `errors`/`warnings` no longer get the misleading `["Messages truncated"]` placeholder (which was inflating `warningCount` to 1 and tripping false `PartiallyValidIcon` in the tracker UI).
- Embed `(retained of total shown)` counts in the placeholder string so curators see `"Messages truncated (0 of 7897 shown)"` instead of a bare `"Messages truncated"` when the binary search collapses.

## Empirical impact on Cohen_25

Verified by running each sub-validator locally and feeding the real outputs through `to_length_limited_json`:

| Metric | Before | After |
|---|---|---|
| hcaSchema warnings retained (of 7,897) | 0 | 2,797 (~35%) |
| CAP Upload UI indicator | False yellow check | Clean green check |
| HCA Cell Annotation warnings UI indicator | False yellow check | Clean (errors only) |
| HCA Tier-1 placeholder visible to curator | bare `"Messages truncated"` | `"Messages truncated (0 of 7897 shown)"` if collapsed, else partial list + count marker |

cellxgene-schema also no longer runs as a subprocess on every batch job, saving meaningful CPU + a full H5AD re-read in a separate venv.

Closes #382

## Test plan
- [x] `services/dataset-validator` — full suite passes (42 tests). 9 tests in `test_validation_message.py`: 6 existing (priority preserved) + 3 new (`test_empty_lists_serialize_as_empty`, `test_placeholder_includes_counts`, `test_collapsed_to_zero_still_reports_original_count`).
- [x] Two existing end-to-end fixtures in `test_dataset_validator.py` (`success`, `cap_failure`) updated to expect the empty cellxgene stub. Inline comments at each site point to #382.
- [x] `make typecheck` — clean across all four pyright passes.
- [ ] Post-merge: `make batch-publish-container ENV=dev` succeeds.
- [ ] Post-merge: re-run dev batch validator on `Cohen_25-r1-wip-5.h5ad` (path `/Users/dave/hca-tracker-upload/prod/msk/source-datasets/`); verify HCA Tier-1 tab shows actual warnings + count marker (not just the placeholder), CAP Upload shows a clean green check, and HCA Cell Annotation indicator reflects only its errors.
- [ ] Prod deploy after dev verification.

## Notes for reviewers
- **Dead-code retention**: `apply_cellxgene_validator` and the `CELLXGENE_VALIDATOR_*` env constants are retained even though unreferenced from the main flow. The function's docstring explicitly says it's intentionally unused (with #382 reference). Defensible deferred cleanup — removing now would create churn if cellxgene needs to be re-enabled. Happy to strip in a follow-up if preferred.
- **Why `valid=True` for the cellxgene stub**: `validationSummary.overallValid` is `&&`-folded across tools. Today cellxgene-schema returns `valid=false` for nearly any file with off-vintage Ensembl IDs, marking the file invalid for a reason the curator can't see. With cellxgene hidden in the UI, `valid=True` for that slot is the honest answer ("we didn't validate against this schema, so we can't say it's invalid against it").

🤖 Generated with [Claude Code](https://claude.com/claude-code)