### PR TITLE
chore(mcp/label): drop vestigial obs_label_cols_overwritten / var_feature_name_overwritten

### DIFF
--- a/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/label.py
+++ b/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/label.py
@@ -6,8 +6,6 @@ from hca_anndata_tools._io import open_h5ad
 from hca_anndata_tools.write import make_edit_entry, resolve_latest, write_h5ad
 from hca_schema_validator import HCA_DERIVED_OBS_LABELS, HCALabeler
 
-_FEATURE_NAME_COL = "feature_name"
-
 
 def label_h5ad(path: str) -> dict:
     """Populate derived HCA labels in var (feature_*) and obs from `_ontology_term_id` columns.
@@ -55,12 +53,7 @@ def label_h5ad(path: str) -> dict:
 
     Returns:
         On success: dict with ``output_path``, ``n_obs``, ``n_vars``,
-        ``feature_name_labeled``, ``feature_name_nan``, ``obs_labels_written``,
-        ``obs_label_cols_overwritten``, ``var_feature_name_overwritten``.
-        ``obs_label_cols_overwritten`` is always ``[]`` and
-        ``var_feature_name_overwritten`` is always ``False`` on success
-        (preflight rejects the file otherwise) — retained for caller
-        compatibility.
+        ``feature_name_labeled``, ``feature_name_nan``, ``obs_labels_written``.
         On failure: ``{"error": ...}``.
     """
     try:
@@ -76,14 +69,10 @@ def label_h5ad(path: str) -> dict:
             n_obs = int(adata.n_obs)
             n_vars = int(adata.n_vars)
 
-            pre_feature_name_set = _FEATURE_NAME_COL in adata.var.columns
-            pre_obs_label_cols = {
-                c for c in HCA_DERIVED_OBS_LABELS if c in adata.obs.columns
-            }
             # cell_type_ontology_term_id is optional per schema — a producer
             # `cell_type` column without a source means the labeler skips the
             # write, so we track source presence to avoid reporting phantom
-            # writes/overwrites.
+            # writes.
             labels_with_source = {
                 c for c in HCA_DERIVED_OBS_LABELS
                 if f"{c}_ontology_term_id" in adata.obs.columns
@@ -104,10 +93,9 @@ def label_h5ad(path: str) -> dict:
                 # tell which one fired.
                 return {"error": f"label_h5ad failed during labeling: {ve}"}
 
-            feature_name_nan = int(adata.var[_FEATURE_NAME_COL].isna().sum())
+            feature_name_nan = int(adata.var["feature_name"].isna().sum())
             feature_name_labeled = n_vars - feature_name_nan
             obs_labels_written = sorted(labels_with_source)
-            obs_label_cols_overwritten = sorted(pre_obs_label_cols & labels_with_source)
 
             entry = make_edit_entry(
                 operation="label_h5ad",
@@ -123,8 +111,6 @@ def label_h5ad(path: str) -> dict:
                     "feature_name_nan": feature_name_nan,
                     "raw_var_mirrored": raw_var_mirrored,
                     "obs_labels_written": obs_labels_written,
-                    "obs_label_cols_overwritten": obs_label_cols_overwritten,
-                    "var_feature_name_overwritten": pre_feature_name_set,
                     "observation_joinid_written": True,
                 },
             )
@@ -141,8 +127,6 @@ def label_h5ad(path: str) -> dict:
             "feature_name_labeled": feature_name_labeled,
             "feature_name_nan": feature_name_nan,
             "obs_labels_written": obs_labels_written,
-            "obs_label_cols_overwritten": obs_label_cols_overwritten,
-            "var_feature_name_overwritten": pre_feature_name_set,
         }
     except Exception as e:
         return {"error": str(e)}

--- a/packages/hca-anndata-mcp/tests/test_label.py
+++ b/packages/hca-anndata-mcp/tests/test_label.py
@@ -24,9 +24,6 @@ def test_label_h5ad_happy_path(labelable_path):
     # All seven fixture Ensembl IDs are GENCODE-resolvable.
     assert result["feature_name_labeled"] == 7
     assert result["feature_name_nan"] == 0
-    # Fixture ships with no bare-label columns pre-populated.
-    assert result["obs_label_cols_overwritten"] == []
-    assert result["var_feature_name_overwritten"] is False
     # cell_type is optional but present in the fixture, so all 8 labels written.
     assert set(result["obs_labels_written"]) == {
         "tissue", "cell_type", "assay", "disease",
@@ -54,8 +51,6 @@ def test_label_h5ad_writes_edit_log_entry(labelable_path):
     assert details["feature_name_nan"] == 0
     assert details["raw_var_mirrored"] is True
     assert details["observation_joinid_written"] is True
-    assert details["var_feature_name_overwritten"] is False
-    assert details["obs_label_cols_overwritten"] == []
     assert set(details["obs_labels_written"]) == {
         "tissue", "cell_type", "assay", "disease",
         "sex", "organism", "development_stage", "self_reported_ethnicity",


### PR DESCRIPTION
## Summary

Drops two fields from `label_h5ad`'s return dict and edit-log entry that have been vestigial since #374 / #375 made `HCALabeler` reject any input where the controlled label columns are pre-populated:

- `obs_label_cols_overwritten` — always `[]` on success.
- `var_feature_name_overwritten` — always `False` on success.

Both never reach the return path on failure (preflight short-circuits). The wrapper's docstring already flagged them as "retained for caller compatibility"; no skills, tests, or downstream code read them.

### Diff
- `packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/label.py` — drop the `pre_feature_name_set` / `pre_obs_label_cols` locals, the `obs_label_cols_overwritten = sorted(...)` computation, both fields from the edit-log details and success return, and trim the docstring's Returns section. Inlined the now-single-use `_FEATURE_NAME_COL = "feature_name"` constant per /simplify quality review.
- `packages/hca-anndata-mcp/tests/test_label.py` — drop the four assertions on the removed fields.

### Edit-log compatibility
Files already on disk with these keys in historical edit-log entries are unaffected — the change only stops emitting them for new `label_h5ad` runs. Consumers like `/evaluate-h5ad` and `/curate-h5ad` already tolerate their absence.

Closes #393

## Test plan
- [x] `poetry run pytest packages/hca-anndata-mcp/tests/` — 32 tests pass.
- [x] `make typecheck` — pyright clean across all four venvs.
- [x] Repo-wide grep confirms no remaining references to either field name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)