### PR TITLE
feat(batch-validator): write full validation results to S3 (claim-check) — #386

### DIFF
--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -981,8 +981,8 @@ def main() -> int:
         # (tool_reports populated). Crash-failure messages without tool_reports
         # are small, fit inline in SNS, and don't benefit from claim-check;
         # writing one with placeholder IDs ("local"/"unknown") would also
-        # collide on a shared key. Local mode never writes — runs print to
-        # stdout instead.
+        # collide on a shared key. Local mode skips the claim-check write
+        # regardless of whether SNS is configured.
         validation_results_bucket = os.environ.get(VALIDATION_RESULTS_BUCKET)
         if (
             validation_message

--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -989,8 +989,12 @@ def main() -> int:
         # Clean up work directory (includes downloaded files)
         cleanup_files(work_dir)
 
+        # Skip claim-check writes for local runs even when FILE_ID /
+        # AWS_BATCH_JOB_ID are explicitly set — local mode is documented as
+        # not interacting with S3. The in-function placeholder guard catches
+        # the default-ID case; this skips the real-ID case too.
         validation_results_bucket = os.environ.get(VALIDATION_RESULTS_BUCKET)
-        if validation_message and validation_results_bucket:
+        if validation_message and validation_results_bucket and not local_mode:
             write_validation_result_to_s3(validation_message, validation_results_bucket)
 
         # Publish or print results

--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -74,12 +74,6 @@ INTEGRITY_ERROR = 'error'
 # Cross-repo claim-check contract: tracker reads from this same key shape.
 VALIDATION_METADATA_KEY_PREFIX = 'validation-metadata'
 
-# Placeholder identifiers that must NOT appear in a claim-check key — they
-# come from local mode (validate_environment) or env-validation failures
-# (create_failure_message) and would cause unrelated jobs to overwrite a
-# shared key.
-CLAIM_CHECK_PLACEHOLDER_IDS = frozenset({'local', 'unknown'})
-
 
 class JobContextFilter(logging.Filter):
     """Inject AWS Batch job context into each log record.
@@ -271,6 +265,10 @@ def write_validation_result_to_s3(message: ValidationMessage, bucket: str) -> bo
     object. The tracker fetches this object instead of trusting the size-limited
     SNS payload.
 
+    The caller is responsible for ensuring this is only invoked for messages
+    representing a completed validation (tool_reports populated) with real
+    identifiers — the function trusts those inputs.
+
     Failure is logged and swallowed; the caller publishes the inline SNS message
     regardless, degrading to inline-only mode rather than failing the job.
 
@@ -279,19 +277,9 @@ def write_validation_result_to_s3(message: ValidationMessage, bucket: str) -> bo
         bucket: Destination S3 bucket (from VALIDATION_RESULTS_BUCKET env).
 
     Returns:
-        True on success, False on any failure or skip (informational only —
-        the caller continues either way).
+        True on success, False on any failure (informational only — the caller
+        continues either way).
     """
-    if (
-        message.file_id in CLAIM_CHECK_PLACEHOLDER_IDS
-        or message.batch_job_id in CLAIM_CHECK_PLACEHOLDER_IDS
-    ):
-        logger.info(
-            "Skipping S3 claim check write: placeholder identifiers "
-            "(file_id=%s, batch_job_id=%s)",
-            message.file_id, message.batch_job_id,
-        )
-        return False
     key = f"{VALIDATION_METADATA_KEY_PREFIX}/{message.file_id}/{message.batch_job_id}.json"
     try:
         # Let boto3 resolve region from the environment/metadata
@@ -989,12 +977,19 @@ def main() -> int:
         # Clean up work directory (includes downloaded files)
         cleanup_files(work_dir)
 
-        # Skip claim-check writes for local runs even when FILE_ID /
-        # AWS_BATCH_JOB_ID are explicitly set — local mode is documented as
-        # not interacting with S3. The in-function placeholder guard catches
-        # the default-ID case; this skips the real-ID case too.
+        # Claim-check only when the validation process actually completed
+        # (tool_reports populated). Crash-failure messages without tool_reports
+        # are small, fit inline in SNS, and don't benefit from claim-check;
+        # writing one with placeholder IDs ("local"/"unknown") would also
+        # collide on a shared key. Local mode never writes — runs print to
+        # stdout instead.
         validation_results_bucket = os.environ.get(VALIDATION_RESULTS_BUCKET)
-        if validation_message and validation_results_bucket and not local_mode:
+        if (
+            validation_message
+            and validation_message.tool_reports is not None
+            and validation_results_bucket
+            and not local_mode
+        ):
             write_validation_result_to_s3(validation_message, validation_results_bucket)
 
         # Publish or print results

--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -74,6 +74,12 @@ INTEGRITY_ERROR = 'error'
 # Cross-repo claim-check contract: tracker reads from this same key shape.
 VALIDATION_METADATA_KEY_PREFIX = 'validation-metadata'
 
+# Placeholder identifiers that must NOT appear in a claim-check key — they
+# come from local mode (validate_environment) or env-validation failures
+# (create_failure_message) and would cause unrelated jobs to overwrite a
+# shared key.
+CLAIM_CHECK_PLACEHOLDER_IDS = frozenset({'local', 'unknown'})
+
 
 class JobContextFilter(logging.Filter):
     """Inject AWS Batch job context into each log record.
@@ -273,9 +279,19 @@ def write_validation_result_to_s3(message: ValidationMessage, bucket: str) -> bo
         bucket: Destination S3 bucket (from VALIDATION_RESULTS_BUCKET env).
 
     Returns:
-        True on success, False on any failure (informational only — the caller
-        continues either way).
+        True on success, False on any failure or skip (informational only —
+        the caller continues either way).
     """
+    if (
+        message.file_id in CLAIM_CHECK_PLACEHOLDER_IDS
+        or message.batch_job_id in CLAIM_CHECK_PLACEHOLDER_IDS
+    ):
+        logger.info(
+            "Skipping S3 claim check write: placeholder identifiers "
+            "(file_id=%s, batch_job_id=%s)",
+            message.file_id, message.batch_job_id,
+        )
+        return False
     key = f"{VALIDATION_METADATA_KEY_PREFIX}/{message.file_id}/{message.batch_job_id}.json"
     try:
         # Let boto3 resolve region from the environment/metadata
@@ -973,10 +989,8 @@ def main() -> int:
         # Clean up work directory (includes downloaded files)
         cleanup_files(work_dir)
 
-        # Local mode uses placeholder file_id/batch_job_id ("local"); writing
-        # those would collide on a shared key and overwrite real results.
         validation_results_bucket = os.environ.get(VALIDATION_RESULTS_BUCKET)
-        if validation_message and validation_results_bucket and not local_mode:
+        if validation_message and validation_results_bucket:
             write_validation_result_to_s3(validation_message, validation_results_bucket)
 
         # Publish or print results

--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -48,6 +48,11 @@ S3_KEY = 'S3_KEY'
 LOG_LEVEL = 'LOG_LEVEL'
 FILE_ID = 'FILE_ID'
 SNS_TOPIC_ARN = 'SNS_TOPIC_ARN'
+# Optional: when set, the validator writes the full results JSON as a
+# claim-check object to this bucket before publishing SNS. Missing or
+# write-failure → log + skip; SNS publish still runs as today (graceful
+# fallback consistent with the tracker side, hca-atlas-tracker#1254 / #1255).
+VALIDATION_RESULTS_BUCKET = 'VALIDATION_RESULTS_BUCKET'
 AWS_BATCH_JOB_ID = 'AWS_BATCH_JOB_ID'
 AWS_BATCH_JOB_NAME = 'AWS_BATCH_JOB_NAME'
 AWS_DEFAULT_REGION = 'AWS_DEFAULT_REGION'
@@ -253,6 +258,53 @@ def log_memory_usage(label: str) -> None:
     divisor = 1024 * 1024 if sys.platform == "darwin" else 1024
     peak_mb = ru.ru_maxrss / divisor
     logger.info("Memory [%s]: peak RSS = %.1f MB", label, peak_mb)
+
+
+def write_validation_result_to_s3(message: ValidationMessage, bucket: str) -> bool:
+    """
+    Write the full (un-truncated) validation result JSON to S3 as a claim-check
+    object. The tracker fetches this object instead of trusting the size-limited
+    SNS payload — see the claim-check PRD in hca-atlas-tracker.
+
+    Failure (boto3 ClientError, network glitch, anything else) is logged and
+    swallowed. The caller proceeds to publish the inline SNS message regardless,
+    so a write failure here degrades the system to inline-only mode rather than
+    failing the validation job. Same graceful-fallback semantics as the tracker
+    side (hca-atlas-tracker#1254 / #1255).
+
+    Args:
+        message: ValidationMessage with the full results to persist.
+        bucket: Destination S3 bucket (from VALIDATION_RESULTS_BUCKET env).
+
+    Returns:
+        True on success, False on any failure (informational only — the caller
+        continues either way).
+    """
+    key = f"validation-metadata/{message.file_id}/{message.batch_job_id}.json"
+    try:
+        # Let boto3 resolve region from the environment/metadata
+        s3_client = boto3.client('s3')
+        s3_client.put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=message.to_json().encode('utf-8'),
+            ContentType='application/json',
+        )
+        logger.info("S3 claim check write succeeded for file %s", message.file_id)
+        return True
+    except ClientError as e:
+        error_code = e.response.get('Error', {}).get('Code', 'Unknown')
+        error_message = e.response.get('Error', {}).get('Message', str(e))
+        logger.error(
+            "S3 claim check write failed for file %s [%s]: %s",
+            message.file_id, error_code, error_message,
+        )
+        return False
+    except Exception as e:
+        logger.error(
+            "S3 claim check write failed for file %s: %s", message.file_id, str(e),
+        )
+        return False
 
 
 def publish_validation_result(message: ValidationMessage, sns_topic_arn: str) -> bool:
@@ -924,6 +976,14 @@ def main() -> int:
     finally:
         # Clean up work directory (includes downloaded files)
         cleanup_files(work_dir)
+
+        # Optional claim-check write to S3. When VALIDATION_RESULTS_BUCKET is
+        # unset or the write fails, fall through to inline-only SNS — the
+        # tracker side falls back correspondingly (hca-atlas-tracker#1254 /
+        # #1255).
+        validation_results_bucket = os.environ.get(VALIDATION_RESULTS_BUCKET)
+        if validation_message and validation_results_bucket:
+            write_validation_result_to_s3(validation_message, validation_results_bucket)
 
         # Publish or print results
         sns_topic_arn = env_vars.get('sns_topic_arn')

--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -48,10 +48,6 @@ S3_KEY = 'S3_KEY'
 LOG_LEVEL = 'LOG_LEVEL'
 FILE_ID = 'FILE_ID'
 SNS_TOPIC_ARN = 'SNS_TOPIC_ARN'
-# Optional: when set, the validator writes the full results JSON as a
-# claim-check object to this bucket before publishing SNS. Missing or
-# write-failure → log + skip; SNS publish still runs as today (graceful
-# fallback consistent with the tracker side, hca-atlas-tracker#1254 / #1255).
 VALIDATION_RESULTS_BUCKET = 'VALIDATION_RESULTS_BUCKET'
 AWS_BATCH_JOB_ID = 'AWS_BATCH_JOB_ID'
 AWS_BATCH_JOB_NAME = 'AWS_BATCH_JOB_NAME'
@@ -74,6 +70,9 @@ STATUS_FAILURE = 'failure'
 INTEGRITY_VALID = 'valid'
 INTEGRITY_INVALID = 'invalid'
 INTEGRITY_ERROR = 'error'
+
+# Cross-repo claim-check contract: tracker reads from this same key shape.
+VALIDATION_METADATA_KEY_PREFIX = 'validation-metadata'
 
 
 class JobContextFilter(logging.Filter):
@@ -264,13 +263,10 @@ def write_validation_result_to_s3(message: ValidationMessage, bucket: str) -> bo
     """
     Write the full (un-truncated) validation result JSON to S3 as a claim-check
     object. The tracker fetches this object instead of trusting the size-limited
-    SNS payload — see the claim-check PRD in hca-atlas-tracker.
+    SNS payload.
 
-    Failure (boto3 ClientError, network glitch, anything else) is logged and
-    swallowed. The caller proceeds to publish the inline SNS message regardless,
-    so a write failure here degrades the system to inline-only mode rather than
-    failing the validation job. Same graceful-fallback semantics as the tracker
-    side (hca-atlas-tracker#1254 / #1255).
+    Failure is logged and swallowed; the caller publishes the inline SNS message
+    regardless, degrading to inline-only mode rather than failing the job.
 
     Args:
         message: ValidationMessage with the full results to persist.
@@ -280,7 +276,7 @@ def write_validation_result_to_s3(message: ValidationMessage, bucket: str) -> bo
         True on success, False on any failure (informational only — the caller
         continues either way).
     """
-    key = f"validation-metadata/{message.file_id}/{message.batch_job_id}.json"
+    key = f"{VALIDATION_METADATA_KEY_PREFIX}/{message.file_id}/{message.batch_job_id}.json"
     try:
         # Let boto3 resolve region from the environment/metadata
         s3_client = boto3.client('s3')
@@ -977,10 +973,6 @@ def main() -> int:
         # Clean up work directory (includes downloaded files)
         cleanup_files(work_dir)
 
-        # Optional claim-check write to S3. When VALIDATION_RESULTS_BUCKET is
-        # unset or the write fails, fall through to inline-only SNS — the
-        # tracker side falls back correspondingly (hca-atlas-tracker#1254 /
-        # #1255).
         validation_results_bucket = os.environ.get(VALIDATION_RESULTS_BUCKET)
         if validation_message and validation_results_bucket:
             write_validation_result_to_s3(validation_message, validation_results_bucket)

--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -973,8 +973,10 @@ def main() -> int:
         # Clean up work directory (includes downloaded files)
         cleanup_files(work_dir)
 
+        # Local mode uses placeholder file_id/batch_job_id ("local"); writing
+        # those would collide on a shared key and overwrite real results.
         validation_results_bucket = os.environ.get(VALIDATION_RESULTS_BUCKET)
-        if validation_message and validation_results_bucket:
+        if validation_message and validation_results_bucket and not local_mode:
             write_validation_result_to_s3(validation_message, validation_results_bucket)
 
         # Publish or print results

--- a/services/dataset-validator/tests/test_dataset_validator.py
+++ b/services/dataset-validator/tests/test_dataset_validator.py
@@ -624,6 +624,53 @@ def test_write_validation_result_to_s3_swallows_non_client_error(caplog):
     assert "simulated network failure" in caplog.text
 
 
+@pytest.mark.parametrize("placeholder_field", ["file_id", "batch_job_id"])
+def test_write_validation_result_to_s3_skips_placeholder_ids(
+    caplog, mock_aws, placeholder_field
+):
+    """Refuse to write when file_id or batch_job_id is a placeholder
+    ("unknown" from env-validation failures, "local" from local mode) —
+    multiple jobs would collide on the same key."""
+    from dataset_validator.main import (
+        write_validation_result_to_s3,
+        ValidationMessage,
+        configure_logging,
+    )
+
+    configure_logging()
+
+    fields = {
+        "file_id": "real-file",
+        "batch_job_id": "real-job",
+    }
+    fields[placeholder_field] = "unknown"
+
+    message = ValidationMessage(
+        file_id=fields["file_id"],
+        status="failure",
+        timestamp="2024-01-01T12:00:00Z",
+        bucket="unknown",
+        key="unknown",
+        batch_job_id=fields["batch_job_id"],
+        batch_job_name=None,
+    )
+
+    with caplog.at_level(logging.INFO, logger="dataset_validator.main"):
+        result = write_validation_result_to_s3(message, mock_aws["bucket_name"])
+
+    assert result is False
+    assert "Skipping S3 claim check write: placeholder identifiers" in caplog.text
+
+    # Nothing was written — the canonical "unknown/unknown" key must not exist.
+    from botocore.exceptions import ClientError
+    from dataset_validator.main import VALIDATION_METADATA_KEY_PREFIX
+    with pytest.raises(ClientError):
+        mock_aws["s3_client"].get_object(
+            Bucket=mock_aws["bucket_name"],
+            Key=f"{VALIDATION_METADATA_KEY_PREFIX}/{message.file_id}/{message.batch_job_id}.json",
+        )
+
+
 @pytest.mark.parametrize("test_case", [
     {
         "name": "success",
@@ -1141,7 +1188,8 @@ def test_local_mode_skips_claim_check_write(
         exit_code = main()
 
     assert exit_code == 0
-    assert "S3 claim check write" not in caplog.text
+    assert "S3 claim check write succeeded" not in caplog.text
+    assert "Skipping S3 claim check write: placeholder identifiers" in caplog.text
     from botocore.exceptions import ClientError
     with pytest.raises(ClientError):
         mock_aws["s3_client"].get_object(

--- a/services/dataset-validator/tests/test_dataset_validator.py
+++ b/services/dataset-validator/tests/test_dataset_validator.py
@@ -624,53 +624,6 @@ def test_write_validation_result_to_s3_swallows_non_client_error(caplog):
     assert "simulated network failure" in caplog.text
 
 
-@pytest.mark.parametrize("placeholder_value", ["unknown", "local"])
-@pytest.mark.parametrize("placeholder_field", ["file_id", "batch_job_id"])
-def test_write_validation_result_to_s3_skips_placeholder_ids(
-    caplog, mock_aws, placeholder_field, placeholder_value
-):
-    """Refuse to write when file_id or batch_job_id is a placeholder
-    ("unknown" from env-validation failures, "local" from local mode) —
-    multiple jobs would collide on the same key."""
-    from dataset_validator.main import (
-        write_validation_result_to_s3,
-        ValidationMessage,
-        configure_logging,
-    )
-
-    configure_logging()
-
-    fields = {
-        "file_id": "real-file",
-        "batch_job_id": "real-job",
-    }
-    fields[placeholder_field] = placeholder_value
-
-    message = ValidationMessage(
-        file_id=fields["file_id"],
-        status="failure",
-        timestamp="2024-01-01T12:00:00Z",
-        bucket="unknown",
-        key="unknown",
-        batch_job_id=fields["batch_job_id"],
-        batch_job_name=None,
-    )
-
-    with caplog.at_level(logging.INFO, logger="dataset_validator.main"):
-        result = write_validation_result_to_s3(message, mock_aws["bucket_name"])
-
-    assert result is False
-    assert "Skipping S3 claim check write: placeholder identifiers" in caplog.text
-
-    # Nothing was written: the key built from the placeholder-bearing message
-    # (e.g. "unknown/real-job" or "real-file/unknown") must not exist in S3.
-    from botocore.exceptions import ClientError
-    from dataset_validator.main import VALIDATION_METADATA_KEY_PREFIX
-    with pytest.raises(ClientError):
-        mock_aws["s3_client"].get_object(
-            Bucket=mock_aws["bucket_name"],
-            Key=f"{VALIDATION_METADATA_KEY_PREFIX}/{message.file_id}/{message.batch_job_id}.json",
-        )
 
 
 @pytest.mark.parametrize("test_case", [
@@ -1153,6 +1106,46 @@ def test_main_wires_claim_check_and_falls_back_gracefully(
             mock_aws["s3_client"].get_object(
                 Bucket=mock_aws["bucket_name"], Key=expected_key
             )
+
+
+def test_main_skips_claim_check_when_validation_crashed(caplog, mock_aws, env_manager):
+    """When the process crashes before the validators run (e.g. S3 download
+    fails), the resulting message has tool_reports=None and is small enough
+    to fit inline in SNS. The claim-check write should be skipped — it
+    would add no value and require placeholder data we don't have."""
+    from dataset_validator.main import main, VALIDATION_METADATA_KEY_PREFIX
+
+    file_id = "test-file-crash"
+    batch_job_id = "job-crash"
+
+    env_manager["set"]({
+        "S3_BUCKET": mock_aws["bucket_name"],
+        "S3_KEY": "datasets/does-not-exist.h5ad",  # forces download failure
+        "FILE_ID": file_id,
+        "SNS_TOPIC_ARN": mock_aws["topic_arn"],
+        "AWS_BATCH_JOB_ID": batch_job_id,
+        "BATCH_JOB_NAME": "crash-test",
+        "VALIDATION_RESULTS_BUCKET": mock_aws["bucket_name"],
+        **external_validator_path_vars,
+    })
+    env_manager["clear"](["CAP_MOCK_ERROR"])
+
+    with caplog.at_level(logging.INFO, logger="dataset_validator.main"):
+        exit_code = main()
+
+    assert exit_code == 1
+    assert "S3 download failed" in caplog.text
+    # SNS message still published (graceful crash path).
+    assert "Successfully published SNS message" in caplog.text
+    # No claim-check write attempted.
+    assert "S3 claim check write" not in caplog.text
+
+    from botocore.exceptions import ClientError
+    with pytest.raises(ClientError):
+        mock_aws["s3_client"].get_object(
+            Bucket=mock_aws["bucket_name"],
+            Key=f"{VALIDATION_METADATA_KEY_PREFIX}/{file_id}/{batch_job_id}.json",
+        )
 
 
 @pytest.mark.parametrize("set_real_ids", [

--- a/services/dataset-validator/tests/test_dataset_validator.py
+++ b/services/dataset-validator/tests/test_dataset_validator.py
@@ -527,6 +527,72 @@ def test_publish_validation_result_scenarios(caplog, mock_aws, test_case):
 @pytest.mark.parametrize("test_case", [
     {
         "name": "success",
+        "description": "S3 claim-check write succeeds and stores the full message body",
+        "use_valid_bucket": True,
+        "expected_result": True,
+        "log_level": logging.INFO,
+        "expected_logs": ["S3 claim check write succeeded for file test-file-123"],
+        "verify_object": True,
+    },
+    {
+        "name": "missing_bucket",
+        "description": "S3 claim-check write fails when the bucket does not exist; SNS publish must still proceed",
+        "use_valid_bucket": False,
+        "expected_result": False,
+        "log_level": logging.ERROR,
+        "expected_logs": ["S3 claim check write failed for file test-file-123"],
+        "verify_object": False,
+    },
+], ids=lambda x: x["name"])
+def test_write_validation_result_to_s3_scenarios(caplog, mock_aws, test_case):
+    """Parameterized test for claim-check S3 write scenarios."""
+    from dataset_validator.main import (
+        write_validation_result_to_s3,
+        ValidationMessage,
+        configure_logging,
+    )
+
+    configure_logging()
+
+    message = ValidationMessage(
+        file_id="test-file-123",
+        status="success",
+        timestamp="2024-01-01T12:00:00Z",
+        bucket="test-bucket",
+        key="test/file.h5ad",
+        batch_job_id="job-123",
+        batch_job_name="test-job",
+        downloaded_sha256="abc123",
+        source_sha256="abc123",
+        integrity_status="valid",
+    )
+
+    bucket = (
+        mock_aws["bucket_name"]
+        if test_case["use_valid_bucket"]
+        else "nonexistent-claim-check-bucket"
+    )
+
+    with caplog.at_level(test_case["log_level"], logger="dataset_validator.main"):
+        result = write_validation_result_to_s3(message, bucket)
+
+    assert result is test_case["expected_result"]
+    for expected_log in test_case["expected_logs"]:
+        assert expected_log in caplog.text
+
+    if test_case["verify_object"]:
+        expected_key = f"validation-metadata/{message.file_id}/{message.batch_job_id}.json"
+        response = mock_aws["s3_client"].get_object(Bucket=bucket, Key=expected_key)
+        body = response["Body"].read().decode("utf-8")
+        # The S3 object holds the full (un-truncated) JSON.
+        assert json.loads(body) == json.loads(message.to_json())
+        # Content-Type is set so any downstream tooling that inspects HEAD knows the shape.
+        assert response.get("ContentType") == "application/json"
+
+
+@pytest.mark.parametrize("test_case", [
+    {
+        "name": "success",
         "description": "Local file mode completes validation, skips S3 and prints JSON to stdout",
         "adata": {
             "obs": {

--- a/services/dataset-validator/tests/test_dataset_validator.py
+++ b/services/dataset-validator/tests/test_dataset_validator.py
@@ -589,6 +589,41 @@ def test_write_validation_result_to_s3_scenarios(caplog, mock_aws, test_case):
         assert response.get("ContentType") == "application/json"
 
 
+def test_write_validation_result_to_s3_swallows_non_client_error(caplog):
+    """Non-ClientError exceptions (network glitch, etc.) must not propagate."""
+    from dataset_validator.main import (
+        write_validation_result_to_s3,
+        ValidationMessage,
+        configure_logging,
+    )
+
+    configure_logging()
+
+    message = ValidationMessage(
+        file_id="test-file-999",
+        status="success",
+        timestamp="2024-01-01T12:00:00Z",
+        bucket="test-bucket",
+        key="test/file.h5ad",
+        batch_job_id="job-999",
+        batch_job_name="test-job",
+        downloaded_sha256="abc",
+        source_sha256="abc",
+        integrity_status="valid",
+    )
+
+    fake_s3 = MagicMock()
+    fake_s3.put_object.side_effect = ConnectionError("simulated network failure")
+
+    with patch("dataset_validator.main.boto3.client", return_value=fake_s3):
+        with caplog.at_level(logging.ERROR, logger="dataset_validator.main"):
+            result = write_validation_result_to_s3(message, "any-bucket")
+
+    assert result is False
+    assert "S3 claim check write failed for file test-file-999" in caplog.text
+    assert "simulated network failure" in caplog.text
+
+
 @pytest.mark.parametrize("test_case", [
     {
         "name": "success",
@@ -997,6 +1032,123 @@ def test_end_to_end_validation_scenarios(mock_read_h5ad, caplog, mock_aws, env_m
     
     # Verify SNS message content
     _validate_sns_message(mock_aws, caplog, test_case["expected_sns_message"])
+
+
+@pytest.mark.parametrize("test_case", [
+    {
+        "name": "valid_bucket_writes_and_publishes",
+        "description": "main() writes claim-check to S3 AND publishes SNS",
+        "claim_check_bucket": "test-bucket",  # same as mock_aws bucket
+        "expect_s3_write": True,
+        "expect_claim_check_log": "S3 claim check write succeeded",
+    },
+    {
+        "name": "write_failure_still_publishes",
+        "description": "main() with a bad VALIDATION_RESULTS_BUCKET still publishes SNS (graceful fallback)",
+        "claim_check_bucket": "nonexistent-claim-check-bucket",
+        "expect_s3_write": False,
+        "expect_claim_check_log": "S3 claim check write failed",
+    },
+], ids=lambda x: x["name"])
+@patch("anndata.io.read_h5ad")
+def test_main_wires_claim_check_and_falls_back_gracefully(
+    mock_read_h5ad, caplog, mock_aws, env_manager, test_case
+):
+    """End-to-end: VALIDATION_RESULTS_BUCKET triggers the write in main()'s
+    finally block, and a write failure does NOT block SNS publish."""
+    from dataset_validator.main import main, VALIDATION_METADATA_KEY_PREFIX
+
+    s3_key = "datasets/test.h5ad"
+    file_id = "test-file-claimcheck"
+    batch_job_id = "job-claimcheck"
+    _setup_valid_s3_file(mock_aws["s3_client"], mock_aws["bucket_name"], s3_key)
+
+    env_manager["set"]({
+        "S3_BUCKET": mock_aws["bucket_name"],
+        "S3_KEY": s3_key,
+        "FILE_ID": file_id,
+        "SNS_TOPIC_ARN": mock_aws["topic_arn"],
+        "AWS_BATCH_JOB_ID": batch_job_id,
+        "BATCH_JOB_NAME": "claim-check-test",
+        "VALIDATION_RESULTS_BUCKET": test_case["claim_check_bucket"],
+        **external_validator_path_vars,
+    })
+    env_manager["clear"](["CAP_MOCK_ERROR"])
+
+    mock_adata = MagicMock()
+    mock_read_h5ad.return_value = mock_adata
+    mock_adata.obs = pd.DataFrame({
+        "assay": ["a"], "suspension_type": ["s"],
+        "tissue": ["t"], "disease": ["d"],
+    })
+    mock_adata.uns = {"title": "test"}
+    mock_adata.n_obs = 1
+    mock_adata.n_vars = 1
+
+    with caplog.at_level(logging.INFO, logger="dataset_validator.main"):
+        exit_code = main()
+
+    assert exit_code == 0
+    assert test_case["expect_claim_check_log"] in caplog.text
+    assert "Successfully published SNS message" in caplog.text
+
+    expected_key = f"{VALIDATION_METADATA_KEY_PREFIX}/{file_id}/{batch_job_id}.json"
+    if test_case["expect_s3_write"]:
+        response = mock_aws["s3_client"].get_object(
+            Bucket=mock_aws["bucket_name"], Key=expected_key
+        )
+        assert json.loads(response["Body"].read())["file_id"] == file_id
+    else:
+        from botocore.exceptions import ClientError
+        with pytest.raises(ClientError):
+            mock_aws["s3_client"].get_object(
+                Bucket=mock_aws["bucket_name"], Key=expected_key
+            )
+
+
+@patch("anndata.io.read_h5ad")
+def test_local_mode_skips_claim_check_write(
+    mock_read_h5ad, caplog, mock_aws, env_manager, tmp_path, capsys
+):
+    """Local mode must not write to S3 even when VALIDATION_RESULTS_BUCKET
+    is set — file_id/batch_job_id default to "local" and would collide on
+    a shared key."""
+    from dataset_validator.main import main, VALIDATION_METADATA_KEY_PREFIX
+
+    local_file = str(tmp_path / "test.h5ad")
+    Path(local_file).touch()
+
+    env_manager["set"]({
+        "LOCAL_FILE": local_file,
+        "VALIDATION_RESULTS_BUCKET": mock_aws["bucket_name"],
+        **external_validator_path_vars,
+    })
+    env_manager["clear"](
+        ["S3_BUCKET", "S3_KEY", "FILE_ID", "SNS_TOPIC_ARN", "AWS_BATCH_JOB_ID"]
+    )
+
+    mock_adata = MagicMock()
+    mock_read_h5ad.return_value = mock_adata
+    mock_adata.obs = pd.DataFrame({
+        "assay": ["a"], "suspension_type": ["s"],
+        "tissue": ["t"], "disease": ["d"],
+    })
+    mock_adata.uns = {"title": "test"}
+    mock_adata.n_obs = 1
+    mock_adata.n_vars = 1
+
+    with caplog.at_level(logging.INFO, logger="dataset_validator.main"):
+        exit_code = main()
+
+    assert exit_code == 0
+    assert "S3 claim check write" not in caplog.text
+    from botocore.exceptions import ClientError
+    with pytest.raises(ClientError):
+        mock_aws["s3_client"].get_object(
+            Bucket=mock_aws["bucket_name"],
+            Key=f"{VALIDATION_METADATA_KEY_PREFIX}/local/local.json",
+        )
+    capsys.readouterr()  # drain stdout JSON dump
 
 
 def _get_last_sns_message(sns_backend, topic_arn):

--- a/services/dataset-validator/tests/test_dataset_validator.py
+++ b/services/dataset-validator/tests/test_dataset_validator.py
@@ -661,7 +661,8 @@ def test_write_validation_result_to_s3_skips_placeholder_ids(
     assert result is False
     assert "Skipping S3 claim check write: placeholder identifiers" in caplog.text
 
-    # Nothing was written — the canonical "unknown/unknown" key must not exist.
+    # Nothing was written: the key built from the placeholder-bearing message
+    # (e.g. "unknown/real-job" or "real-file/unknown") must not exist in S3.
     from botocore.exceptions import ClientError
     from dataset_validator.main import VALIDATION_METADATA_KEY_PREFIX
     with pytest.raises(ClientError):
@@ -1153,26 +1154,39 @@ def test_main_wires_claim_check_and_falls_back_gracefully(
             )
 
 
+@pytest.mark.parametrize("set_real_ids", [
+    pytest.param(False, id="default_placeholder_ids"),
+    pytest.param(True, id="real_ids_from_env"),
+])
 @patch("anndata.io.read_h5ad")
 def test_local_mode_skips_claim_check_write(
-    mock_read_h5ad, caplog, mock_aws, env_manager, tmp_path, capsys
+    mock_read_h5ad, caplog, mock_aws, env_manager, tmp_path, capsys, set_real_ids
 ):
     """Local mode must not write to S3 even when VALIDATION_RESULTS_BUCKET
-    is set — file_id/batch_job_id default to "local" and would collide on
-    a shared key."""
+    is set — whether IDs default to the "local" placeholder OR are
+    explicitly provided via FILE_ID / AWS_BATCH_JOB_ID. Local runs are
+    documented as skipping all S3 interactions."""
     from dataset_validator.main import main, VALIDATION_METADATA_KEY_PREFIX
 
     local_file = str(tmp_path / "test.h5ad")
     Path(local_file).touch()
 
-    env_manager["set"]({
+    env_to_set = {
         "LOCAL_FILE": local_file,
         "VALIDATION_RESULTS_BUCKET": mock_aws["bucket_name"],
         **external_validator_path_vars,
-    })
-    env_manager["clear"](
-        ["S3_BUCKET", "S3_KEY", "FILE_ID", "SNS_TOPIC_ARN", "AWS_BATCH_JOB_ID"]
-    )
+    }
+    real_file_id = "real-local-file-id"
+    real_batch_job_id = "real-local-batch-job-id"
+    if set_real_ids:
+        env_to_set["FILE_ID"] = real_file_id
+        env_to_set["AWS_BATCH_JOB_ID"] = real_batch_job_id
+
+    env_manager["set"](env_to_set)
+    vars_to_clear = ["S3_BUCKET", "S3_KEY", "SNS_TOPIC_ARN"]
+    if not set_real_ids:
+        vars_to_clear += ["FILE_ID", "AWS_BATCH_JOB_ID"]
+    env_manager["clear"](vars_to_clear)
 
     mock_adata = MagicMock()
     mock_read_h5ad.return_value = mock_adata
@@ -1188,14 +1202,20 @@ def test_local_mode_skips_claim_check_write(
         exit_code = main()
 
     assert exit_code == 0
-    assert "S3 claim check write succeeded" not in caplog.text
-    assert "Skipping S3 claim check write: placeholder identifiers" in caplog.text
+    # main()'s `not local_mode` gate skips the call entirely in both
+    # variants, so neither the success log nor the in-function placeholder
+    # log fires.
+    assert "S3 claim check write" not in caplog.text
+    assert "Skipping S3 claim check write" not in caplog.text
+
     from botocore.exceptions import ClientError
-    with pytest.raises(ClientError):
-        mock_aws["s3_client"].get_object(
-            Bucket=mock_aws["bucket_name"],
-            Key=f"{VALIDATION_METADATA_KEY_PREFIX}/local/local.json",
-        )
+    candidate_keys = [
+        f"{VALIDATION_METADATA_KEY_PREFIX}/local/local.json",
+        f"{VALIDATION_METADATA_KEY_PREFIX}/{real_file_id}/{real_batch_job_id}.json",
+    ]
+    for key in candidate_keys:
+        with pytest.raises(ClientError):
+            mock_aws["s3_client"].get_object(Bucket=mock_aws["bucket_name"], Key=key)
     capsys.readouterr()  # drain stdout JSON dump
 
 

--- a/services/dataset-validator/tests/test_dataset_validator.py
+++ b/services/dataset-validator/tests/test_dataset_validator.py
@@ -581,12 +581,11 @@ def test_write_validation_result_to_s3_scenarios(caplog, mock_aws, test_case):
         assert expected_log in caplog.text
 
     if test_case["verify_object"]:
-        expected_key = f"validation-metadata/{message.file_id}/{message.batch_job_id}.json"
+        from dataset_validator.main import VALIDATION_METADATA_KEY_PREFIX
+        expected_key = f"{VALIDATION_METADATA_KEY_PREFIX}/{message.file_id}/{message.batch_job_id}.json"
         response = mock_aws["s3_client"].get_object(Bucket=bucket, Key=expected_key)
         body = response["Body"].read().decode("utf-8")
-        # The S3 object holds the full (un-truncated) JSON.
         assert json.loads(body) == json.loads(message.to_json())
-        # Content-Type is set so any downstream tooling that inspects HEAD knows the shape.
         assert response.get("ContentType") == "application/json"
 
 

--- a/services/dataset-validator/tests/test_dataset_validator.py
+++ b/services/dataset-validator/tests/test_dataset_validator.py
@@ -624,9 +624,10 @@ def test_write_validation_result_to_s3_swallows_non_client_error(caplog):
     assert "simulated network failure" in caplog.text
 
 
+@pytest.mark.parametrize("placeholder_value", ["unknown", "local"])
 @pytest.mark.parametrize("placeholder_field", ["file_id", "batch_job_id"])
 def test_write_validation_result_to_s3_skips_placeholder_ids(
-    caplog, mock_aws, placeholder_field
+    caplog, mock_aws, placeholder_field, placeholder_value
 ):
     """Refuse to write when file_id or batch_job_id is a placeholder
     ("unknown" from env-validation failures, "local" from local mode) —
@@ -643,7 +644,7 @@ def test_write_validation_result_to_s3_skips_placeholder_ids(
         "file_id": "real-file",
         "batch_job_id": "real-job",
     }
-    fields[placeholder_field] = "unknown"
+    fields[placeholder_field] = placeholder_value
 
     message = ValidationMessage(
         file_id=fields["file_id"],


### PR DESCRIPTION
## Design decision: graceful fallback + completed-validation gate

`VALIDATION_RESULTS_BUCKET` is **optional**. The claim-check write only fires when:

1. The env var is set, AND
2. The validation process actually **completed** (`validation_message.tool_reports is not None`), AND
3. We're not in local mode

If the env var is unset, or the validation crashed before the validators ran (S3 download failed, integrity check failed, metadata read crashed, env validation failed), or we're in local mode → skip the S3 write. SNS still publishes inline as today. If the S3 write fails for AWS reasons (ClientError, network glitch) → log and swallow, SNS still publishes.

Rationale for the completed-validation gate: claim-check exists to deliver payloads at risk of SNS truncation. Crash-failure messages carry only `status` + `error_message` + IDs — well under SNS's 256 KB limit, so claim-check adds no value. Plus the env-validation-failure path has `"unknown"` placeholder IDs that would collide on a shared key. Local mode uses `"local"` placeholders and prints to stdout instead of touching S3.

## Summary

- Adds `VALIDATION_RESULTS_BUCKET` env var constant and `VALIDATION_METADATA_KEY_PREFIX = 'validation-metadata'`
- Adds `write_validation_result_to_s3()` helper — writes the full JSON to `validation-metadata/<file_id>/<batch_job_id>.json`, ContentType `application/json`, ClientError + bare Exception both logged and swallowed
- Gates the write in `main()`'s finally block: `tool_reports is not None AND bucket is set AND not local_mode`

## How this fits the claim-check chain

| Stage | Repo | PR | Behavior |
|---|---|---|---|
| Tracker submits Batch job with `VALIDATION_RESULTS_BUCKET` | hca-atlas-tracker | #1260 | Optional — only forwarded when set and in the allowlist |
| **Validator writes full JSON to S3 then publishes SNS** | **this repo** | **this PR** | **Optional, completed-validation only; write failure → log + swallow** |
| Tracker `/api/sns` reads S3 object, falls back to inline data on failure | hca-atlas-tracker | #1261 | Graceful fallback on any S3 read failure |

End-to-end: every link in the chain falls back to inline-only SNS on misconfiguration or transient failure. A bucket has to be configured everywhere for the claim-check to take effect — but partial deployment never breaks validation.

## Test plan

- [x] `pytest tests/test_dataset_validator.py` — 30 tests pass:
  - 3 unit tests for `write_validation_result_to_s3` (success, ClientError, non-ClientError)
  - 2 `main()`-wiring tests (valid bucket → S3 object written + SNS; bad bucket → write fails + SNS still publishes)
  - 1 crash-path test (download failure → no S3 write + SNS still publishes)
  - 2 local-mode tests (default placeholder IDs vs real IDs — both skip S3)
- [x] `pyright src/dataset_validator/main.py` — 0 errors
- [ ] After merge: rebuild validator container image and bump the Batch job definition so the new `VALIDATION_RESULTS_BUCKET` env var is honored at runtime

## Out of scope

- AWS Batch retry-attempt-aware keys — Copilot flagged that `<file_id>/<batch_job_id>.json` isn't unique across retries. **Won't fix:** the validator-batch JD is registered without `--retry-strategy`, so default `attempts: 1` applies and no retry can overwrite a prior attempt's object. Any future retry-enablement would need a coordinated cross-repo change to include `AWS_BATCH_JOB_ATTEMPT` in the key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)