### PR TITLE
feat: save validation results to s3 (#386)

### DIFF
--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -27,6 +27,9 @@ import pandas as pd
 
 # Somewhat less than the actual value of 256KiB, to make room for small unforeseen deviations
 MAX_SNS_MESSAGE_LENGTH = 250_000
+# S3 prefix under which full validation results are written as a "claim check"
+# the tracker can fall back to when the SNS message has been truncated.
+S3_VALIDATION_METADATA_PREFIX = "validation-metadata"
 # Prefix for the truncation placeholder string. The full marker also embeds
 # the retained-vs-total counts so curators see how many messages were dropped
 # even when binary-search collapses to zero retained — see _truncated_marker.
@@ -292,6 +295,45 @@ def publish_validation_result(message: ValidationMessage, sns_topic_arn: str) ->
         
     except Exception as e:
         logger.error("Unexpected error publishing to SNS: %s", str(e))
+        return False
+
+
+def write_validation_results_to_s3(
+    message: ValidationMessage,
+    bucket: str,
+    file_id: str,
+    batch_job_id: str,
+) -> bool:
+    """
+    Write the full validation message JSON to S3 as a claim check.
+
+    The tracker reads this object when the inline SNS message has been
+    truncated to fit the SNS 256 KiB limit. Failures here are logged but
+    never raise — the SNS publish is the authoritative pipeline step.
+
+    Args:
+        message: ValidationMessage to serialize (untruncated)
+        bucket: S3 bucket (reuses the data bucket the input file came from)
+        file_id: Tracker file UUID, used in the key
+        batch_job_id: AWS Batch job ID, used in the key so each run gets a
+            distinct object
+
+    Returns:
+        True if the write succeeded, False otherwise.
+    """
+    key = f"{S3_VALIDATION_METADATA_PREFIX}/{file_id}/{batch_job_id}.json"
+    try:
+        s3_client = boto3.client('s3')
+        s3_client.put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=message.to_json().encode('utf-8'),
+            ContentType='application/json',
+        )
+        logger.info("S3 claim check write succeeded for file %s", file_id)
+        return True
+    except Exception as e:
+        logger.error("S3 claim check write failed for file %s: %s", file_id, e)
         return False
 
 
@@ -924,6 +966,23 @@ def main() -> int:
     finally:
         # Clean up work directory (includes downloaded files)
         cleanup_files(work_dir)
+
+        # Attempt to write full results to S3 as a claim check before SNS.
+        # Skipped in local mode (no real bucket) and when env validation
+        # never resolved a real bucket/file_id/batch_job_id (early-exit path).
+        s3_bucket = env_vars.get('bucket')
+        s3_file_id = env_vars.get('file_id')
+        s3_batch_job_id = env_vars.get('batch_job_id')
+        if (
+            validation_message
+            and not local_mode
+            and s3_bucket and s3_bucket != "unknown"
+            and s3_file_id and s3_file_id != "unknown"
+            and s3_batch_job_id and s3_batch_job_id != "unknown"
+        ):
+            write_validation_results_to_s3(
+                validation_message, s3_bucket, s3_file_id, s3_batch_job_id
+            )
 
         # Publish or print results
         sns_topic_arn = env_vars.get('sns_topic_arn')

--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -847,6 +847,7 @@ def main() -> int:
         bucket = env_vars['bucket']
         key = env_vars['key']
         batch_job_id = env_vars['batch_job_id']
+        # TODO: this check is redundant; see issue 399
         if file_id is None or bucket is None or key is None or batch_job_id is None:
             raise RuntimeError("Required env vars unexpectedly None after missing_vars check")
 

--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -308,9 +308,10 @@ def write_validation_results_to_s3(
     """
     Write the full validation message JSON to S3 as a claim check.
 
-    The tracker reads this object when the inline SNS message has been
-    truncated to fit the SNS 256 KiB limit. Failures here are logged but
-    never raise — the SNS publish is the authoritative pipeline step.
+    The tracker reads this object when possible to avoid using an inline
+    SNS message that may have been truncated to fit the SNS 256 KiB limit.
+    Failures here are logged but never raise — the SNS publish is the
+    authoritative pipeline step.
 
     Args:
         message: ValidationMessage to serialize (untruncated)

--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -48,6 +48,7 @@ def _truncated_marker(retained: int, total: int) -> str:
 # Batch job variables
 S3_BUCKET = 'S3_BUCKET'
 S3_KEY = 'S3_KEY'
+VALIDATION_RESULTS_BUCKET = 'VALIDATION_RESULTS_BUCKET'
 LOG_LEVEL = 'LOG_LEVEL'
 FILE_ID = 'FILE_ID'
 SNS_TOPIC_ARN = 'SNS_TOPIC_ARN'
@@ -745,6 +746,7 @@ def validate_environment() -> tuple[dict[str, str | None], list[str]]:
         'local_file': local_file,
         'bucket': os.environ.get(S3_BUCKET) or ("local" if local_file else None),
         'key': os.environ.get(S3_KEY) or (local_file if local_file else None),
+        'validation_results_bucket': os.environ.get(VALIDATION_RESULTS_BUCKET),
         'file_id': os.environ.get(FILE_ID) or ("local" if local_file else None),
         'sns_topic_arn': os.environ.get(SNS_TOPIC_ARN),
         'batch_job_id': os.environ.get(AWS_BATCH_JOB_ID) or ("local" if local_file else None),
@@ -970,7 +972,7 @@ def main() -> int:
         # Attempt to write full results to S3 as a claim check before SNS.
         # Skipped in local mode (no real bucket) and when env validation
         # never resolved a real bucket/file_id/batch_job_id (early-exit path).
-        s3_bucket = env_vars.get('bucket')
+        s3_bucket = env_vars.get('validation_results_bucket')
         s3_file_id = env_vars.get('file_id')
         s3_batch_job_id = env_vars.get('batch_job_id')
         if (

--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -976,13 +976,7 @@ def main() -> int:
         s3_bucket = env_vars.get('validation_results_bucket')
         s3_file_id = env_vars.get('file_id')
         s3_batch_job_id = env_vars.get('batch_job_id')
-        if (
-            validation_message
-            and not local_mode
-            and s3_bucket and s3_bucket != "unknown"
-            and s3_file_id and s3_file_id != "unknown"
-            and s3_batch_job_id and s3_batch_job_id != "unknown"
-        ):
+        if validation_message and not local_mode and s3_bucket and s3_file_id and s3_batch_job_id:
             write_validation_results_to_s3(
                 validation_message, s3_bucket, s3_file_id, s3_batch_job_id
             )

--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -28,7 +28,7 @@ import pandas as pd
 # Somewhat less than the actual value of 256KiB, to make room for small unforeseen deviations
 MAX_SNS_MESSAGE_LENGTH = 250_000
 # S3 prefix under which full validation results are written as a "claim check"
-# the tracker can fall back to when the SNS message has been truncated.
+# the tracker can read from to avoid using a truncated SNS message.
 S3_VALIDATION_METADATA_PREFIX = "validation-metadata"
 # Prefix for the truncation placeholder string. The full marker also embeds
 # the retained-vs-total counts so curators see how many messages were dropped

--- a/services/dataset-validator/tests/test_dataset_validator.py
+++ b/services/dataset-validator/tests/test_dataset_validator.py
@@ -206,22 +206,40 @@ class TestDatasetValidator:
 def test_missing_sns_topic_logs_error_and_exits(caplog, env_manager, base_env_vars):
     """Test that missing SNS_TOPIC_ARN logs error and exits with code 1."""
     from dataset_validator.main import main
-    
+
     # Set up environment with missing SNS_TOPIC_ARN
     test_env = base_env_vars.copy()
     del test_env['SNS_TOPIC_ARN']  # Remove SNS topic to test missing variable
     env_manager['set'](test_env)
-    
+
     # Capture logs from the specific logger
     with caplog.at_level(logging.ERROR, logger="dataset_validator.main"):
         result = main()
-    
+
     # Should exit with code 1
     assert result == 1
-    
+
     # Should log the missing environment variable error
     assert "Missing required environment variables" in caplog.text
     assert "SNS_TOPIC_ARN=None" in caplog.text
+
+
+def test_missing_bucket_skips_s3_claim_check(caplog, env_manager, base_env_vars):
+    """When env validation fails before resolving a bucket, no S3 write is attempted."""
+    from dataset_validator.main import main
+
+    test_env = base_env_vars.copy()
+    del test_env['S3_BUCKET']
+    env_manager['set'](test_env)
+    env_manager['clear'](['S3_BUCKET'])
+
+    with caplog.at_level(logging.INFO, logger="dataset_validator.main"):
+        result = main()
+
+    assert result == 1
+    assert "Missing required environment variables" in caplog.text
+    # The S3 claim-check write must be skipped — there's no actionable bucket.
+    assert "S3 claim check write" not in caplog.text
 
 
 @pytest.mark.parametrize("test_case", [
@@ -524,6 +542,119 @@ def test_publish_validation_result_scenarios(caplog, mock_aws, test_case):
         assert parsed_message == test_case["message_data"]
 
 
+def _build_message(**overrides) -> "object":
+    """Helper to build a ValidationMessage for claim-check tests."""
+    from dataset_validator.main import ValidationMessage
+    base = {
+        'file_id': 'test-file-uuid',
+        'status': 'success',
+        'timestamp': '2024-01-01T12:00:00Z',
+        'bucket': 'test-bucket',
+        'key': 'datasets/test.h5ad',
+        'batch_job_id': 'job-abc',
+        'batch_job_name': 'test-job',
+        'downloaded_sha256': 'abc123',
+        'source_sha256': 'abc123',
+        'integrity_status': 'valid',
+        'metadata_summary': None,
+        'tool_reports': None,
+        'error_message': None,
+    }
+    base.update(overrides)
+    return ValidationMessage(**base)
+
+
+def test_write_validation_results_to_s3_success(caplog, mock_aws):
+    """Successful claim-check write places a JSON object at the expected key."""
+    from dataset_validator.main import write_validation_results_to_s3, configure_logging
+    configure_logging()
+
+    message = _build_message(file_id='file-1', batch_job_id='job-1')
+
+    with caplog.at_level(logging.INFO, logger="dataset_validator.main"):
+        result = write_validation_results_to_s3(
+            message, mock_aws['bucket_name'], 'file-1', 'job-1'
+        )
+
+    assert result is True
+    assert "S3 claim check write succeeded for file file-1" in caplog.text
+
+    obj = mock_aws['s3_client'].get_object(
+        Bucket=mock_aws['bucket_name'],
+        Key='validation-metadata/file-1/job-1.json',
+    )
+    body = obj['Body'].read().decode('utf-8')
+    assert json.loads(body) == json.loads(message.to_json())
+    assert obj['ContentType'] == 'application/json'
+
+
+def test_write_validation_results_to_s3_failure(caplog, mock_aws):
+    """Write to a nonexistent bucket logs the error and returns False without raising."""
+    from dataset_validator.main import write_validation_results_to_s3, configure_logging
+    configure_logging()
+
+    message = _build_message(file_id='file-2', batch_job_id='job-2')
+
+    with caplog.at_level(logging.ERROR, logger="dataset_validator.main"):
+        result = write_validation_results_to_s3(
+            message, 'nonexistent-bucket', 'file-2', 'job-2'
+        )
+
+    assert result is False
+    assert "S3 claim check write failed for file file-2" in caplog.text
+
+
+def test_write_validation_results_to_s3_writes_full_untruncated_json(mock_aws):
+    """The body written to S3 is the full to_json() output, not the SNS-truncated form."""
+    from dataset_validator.main import (
+        write_validation_results_to_s3,
+        ValidationToolReport,
+        MAX_SNS_MESSAGE_LENGTH,
+    )
+
+    # Build a message whose SNS-bound JSON would be truncated.
+    huge_errors = [f"error-{i}" for i in range(20000)]
+    tool_reports = {
+        "cap": ValidationToolReport(
+            valid=False, errors=huge_errors, warnings=[],
+            started_at='2024-01-01T12:00:00Z', finished_at='2024-01-01T12:00:01Z',
+        ),
+        "cellxgene": ValidationToolReport(
+            valid=True, errors=[], warnings=[],
+            started_at='2024-01-01T12:00:00Z', finished_at='2024-01-01T12:00:01Z',
+        ),
+        "hcaSchema": ValidationToolReport(
+            valid=True, errors=[], warnings=[],
+            started_at='2024-01-01T12:00:00Z', finished_at='2024-01-01T12:00:01Z',
+        ),
+        "hcaCellAnnotation": ValidationToolReport(
+            valid=True, errors=[], warnings=[],
+            started_at='2024-01-01T12:00:00Z', finished_at='2024-01-01T12:00:01Z',
+        ),
+    }
+    message = _build_message(
+        file_id='file-3', batch_job_id='job-3', tool_reports=tool_reports
+    )
+
+    # Sanity: this message must actually trigger SNS truncation, otherwise
+    # the test wouldn't be meaningfully exercising the claim-check use case.
+    full_json = message.to_json()
+    truncated_json = message.to_length_limited_json()
+    assert len(full_json) > MAX_SNS_MESSAGE_LENGTH
+    assert truncated_json != full_json
+
+    assert write_validation_results_to_s3(
+        message, mock_aws['bucket_name'], 'file-3', 'job-3'
+    ) is True
+
+    obj = mock_aws['s3_client'].get_object(
+        Bucket=mock_aws['bucket_name'],
+        Key='validation-metadata/file-3/job-3.json',
+    )
+    body = obj['Body'].read().decode('utf-8')
+    assert body == full_json
+
+
 @pytest.mark.parametrize("test_case", [
     {
         "name": "success",
@@ -547,6 +678,7 @@ def test_publish_validation_result_scenarios(caplog, mock_aws, test_case):
             "Starting download:",
             "Verifying file integrity",
             "Publishing validation result to SNS",
+            "S3 claim check write",
         ],
         "expected_stdout": {
             "status": "success",
@@ -922,16 +1054,31 @@ def test_end_to_end_validation_scenarios(mock_read_h5ad, caplog, mock_aws, env_m
     # Run main function
     with caplog.at_level(logging.INFO, logger="dataset_validator.main"):
         result = main()
-    
+
     # Verify exit code
     assert result == test_case["expected_exit_code"]
-    
+
     # Verify expected log messages
     for expected_log in test_case["expected_logs"]:
         assert expected_log in caplog.text
-    
+
     # Verify SNS message content
     _validate_sns_message(mock_aws, caplog, test_case["expected_sns_message"])
+
+    # Verify the S3 claim-check object was written for this run, regardless of
+    # whether the validation itself succeeded or failed — failures still get
+    # recorded so the tracker can read the full result if SNS was truncated.
+    expected_key = (
+        f"validation-metadata/{test_case['file_id']}/{test_case['batch_job_id']}.json"
+    )
+    claim_obj = mock_aws['s3_client'].get_object(
+        Bucket=mock_aws['bucket_name'], Key=expected_key
+    )
+    claim_body = json.loads(claim_obj['Body'].read().decode('utf-8'))
+    assert claim_body['file_id'] == test_case['expected_sns_message']['file_id']
+    assert claim_body['batch_job_id'] == test_case['expected_sns_message']['batch_job_id']
+    assert claim_body['status'] == test_case['expected_sns_message']['status']
+    assert "S3 claim check write succeeded" in caplog.text
 
 
 def _get_last_sns_message(sns_backend, topic_arn):

--- a/services/dataset-validator/tests/test_dataset_validator.py
+++ b/services/dataset-validator/tests/test_dataset_validator.py
@@ -40,20 +40,22 @@ def mock_aws():
     
     try:
         with mock_s3(), mock_sns():
-            # Create S3 client and bucket
+            # Create S3 client and buckets
             s3_client = boto3.client('s3', region_name='us-east-1')
             s3_client.create_bucket(Bucket='test-bucket')
-            
+            s3_client.create_bucket(Bucket='test-results-bucket')
+
             # Create SNS client and topic
             sns_client = boto3.client('sns', region_name='us-east-1')
             topic_response = sns_client.create_topic(Name='test-topic')
             topic_arn = topic_response['TopicArn']
-            
+
             yield {
                 's3_client': s3_client,
                 'sns_client': sns_client,
                 'topic_arn': topic_arn,
-                'bucket_name': 'test-bucket'
+                'bucket_name': 'test-bucket',
+                'validation_results_bucket_name': 'test-results-bucket',
             }
     finally:
         # Restore original region
@@ -1024,6 +1026,7 @@ def test_end_to_end_validation_scenarios(mock_read_h5ad, caplog, mock_aws, env_m
     test_env = {
         'S3_BUCKET': mock_aws['bucket_name'],
         'S3_KEY': test_case["s3_key"],
+        'VALIDATION_RESULTS_BUCKET': mock_aws['validation_results_bucket_name'],
         'FILE_ID': test_case["file_id"],
         'SNS_TOPIC_ARN': mock_aws['topic_arn'],
         'AWS_BATCH_JOB_ID': test_case["batch_job_id"],
@@ -1072,13 +1075,55 @@ def test_end_to_end_validation_scenarios(mock_read_h5ad, caplog, mock_aws, env_m
         f"validation-metadata/{test_case['file_id']}/{test_case['batch_job_id']}.json"
     )
     claim_obj = mock_aws['s3_client'].get_object(
-        Bucket=mock_aws['bucket_name'], Key=expected_key
+        Bucket=mock_aws['validation_results_bucket_name'], Key=expected_key
     )
     claim_body = json.loads(claim_obj['Body'].read().decode('utf-8'))
     assert claim_body['file_id'] == test_case['expected_sns_message']['file_id']
     assert claim_body['batch_job_id'] == test_case['expected_sns_message']['batch_job_id']
     assert claim_body['status'] == test_case['expected_sns_message']['status']
     assert "S3 claim check write succeeded" in caplog.text
+
+
+@patch("anndata.io.read_h5ad")
+def test_unset_validation_results_bucket_skips_s3_claim_check(
+    mock_read_h5ad, caplog, mock_aws, env_manager
+):
+    """VALIDATION_RESULTS_BUCKET is optional: when unset, validation still
+    completes successfully but no S3 claim-check write is attempted."""
+    from dataset_validator.main import main
+
+    s3_key = "datasets/test.h5ad"
+    _setup_valid_s3_file(mock_aws['s3_client'], mock_aws['bucket_name'], s3_key)
+
+    env_manager['set']({
+        'S3_BUCKET': mock_aws['bucket_name'],
+        'S3_KEY': s3_key,
+        'FILE_ID': 'test-file-no-results-bucket',
+        'SNS_TOPIC_ARN': mock_aws['topic_arn'],
+        'AWS_BATCH_JOB_ID': 'job-no-results-bucket',
+        **external_validator_path_vars,
+    })
+    env_manager['clear'](['VALIDATION_RESULTS_BUCKET', 'CAP_MOCK_ERROR'])
+
+    mock_adata = MagicMock()
+    mock_read_h5ad.return_value = mock_adata
+    mock_adata.obs = pd.DataFrame({
+        "assay": ["assay-a"],
+        "suspension_type": ["cell"],
+        "tissue": ["lung"],
+        "disease": ["normal"],
+    })
+    mock_adata.uns = {"title": "test"}
+    mock_adata.n_obs = 1
+    mock_adata.n_vars = 10
+
+    with caplog.at_level(logging.INFO, logger="dataset_validator.main"):
+        result = main()
+
+    assert result == 0
+    assert "Validation completed successfully" in caplog.text
+    # Claim-check write must be skipped entirely — no success or failure log.
+    assert "S3 claim check write" not in caplog.text
 
 
 def _get_last_sns_message(sns_backend, topic_arn):


### PR DESCRIPTION
Closes #386

Contrary to the implementation in #397, this always tries to write to S3 as long as the necessary information to determine the file location is present