### PR TITLE
fix(hca-schema-validator): gate _validate_dataframe per-column sanity loop to schema-defined obs columns (#400)

### DIFF
--- a/packages/hca-schema-validator/src/hca_schema_validator/validator.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/validator.py
@@ -134,18 +134,18 @@ class HCAValidator(Validator):
         Missing optional columns produce no warning or error.
 
         For obs, the base class's per-column sanity loop is restricted to
-        schema-defined columns by temporarily filtering ``self.adata.obs``
-        before delegating. Curator-added extras (e.g. ``barcode``,
-        ``original_cell_type``) and HCA fields whose only definition is in
-        the LinkML entity schemas are skipped, preventing zero-observation
-        warnings and other type checks from amplifying on columns the h5ad
-        validator has no rules for. The original obs is restored in
-        ``finally``.
+        schema-defined columns. Curator-added extras (e.g. ``barcode``,
+        ``original_cell_type``) and HCA fields defined only in the LinkML
+        entity schemas are skipped, preventing zero-observation warnings
+        and other type checks from amplifying on columns the h5ad validator
+        has no rules for.
         """
         df_definition = self.schema_def["components"].get(df_name, {})
         if "columns" not in df_definition:
             return super()._validate_dataframe(df_name)
 
+        # Capture the full schema column set before requirement_level
+        # extraction below strips optional / strongly_recommended entries.
         schema_columns = set(df_definition["columns"].keys())
 
         # Extract optional and strongly_recommended columns before base class sees them
@@ -161,14 +161,14 @@ class HCAValidator(Validator):
                 sr_columns[col_name] = col_def
                 del df_definition["columns"][col_name]
 
-        # For obs, replace the dataframe with a schema-columns-only view so
-        # the vendored per-column sanity loop ignores curator extras /
-        # non-schema fields. ``original_obs`` doubles as the "did we mutate?"
-        # sentinel and the saved value for restoration in ``finally``.
+        # For obs, filter to schema columns so the vendored per-column
+        # sanity loop ignores curator extras. ``original_obs`` is both the
+        # restore value and the "did we mutate?" sentinel; only set when
+        # the obs actually has non-schema columns to drop.
         original_obs = None
         if df_name == "obs":
             current_obs = getattr_anndata(self.adata, "obs")
-            if current_obs is not None and not set(current_obs.columns).issubset(schema_columns):
+            if current_obs is not None and set(current_obs.columns) - schema_columns:
                 original_obs = current_obs
 
         # Base class validates only required columns

--- a/packages/hca-schema-validator/src/hca_schema_validator/validator.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/validator.py
@@ -122,7 +122,8 @@ class HCAValidator(Validator):
 
     def _validate_dataframe(self, df_name):
         """
-        Extends base dataframe validation with requirement_level support.
+        Extends base dataframe validation with requirement_level support and
+        scopes per-column sanity checks to schema-defined columns.
 
         Columns with requirement_level: strongly_recommended are removed from
         the schema before the base class runs (so it won't error on missing),
@@ -131,10 +132,21 @@ class HCAValidator(Validator):
         Columns with requirement_level: optional are also removed before the
         base class runs, then validated with full validation only if present.
         Missing optional columns produce no warning or error.
+
+        For obs, the base class's per-column sanity loop is restricted to
+        schema-defined columns by temporarily filtering ``self.adata.obs``
+        before delegating. Curator-added extras (e.g. ``barcode``,
+        ``original_cell_type``) and HCA fields whose only definition is in
+        the LinkML entity schemas are skipped, preventing zero-observation
+        warnings and other type checks from amplifying on columns the h5ad
+        validator has no rules for. The original obs is restored in
+        ``finally``.
         """
         df_definition = self.schema_def["components"].get(df_name, {})
         if "columns" not in df_definition:
             return super()._validate_dataframe(df_name)
+
+        schema_columns = set(df_definition["columns"].keys())
 
         # Extract optional and strongly_recommended columns before base class sees them
         optional_columns = {}
@@ -149,13 +161,29 @@ class HCAValidator(Validator):
                 sr_columns[col_name] = col_def
                 del df_definition["columns"][col_name]
 
+        # For obs, replace the dataframe with a schema-columns-only view so
+        # the vendored per-column sanity loop ignores curator extras /
+        # non-schema fields. ``original_obs`` doubles as the "did we mutate?"
+        # sentinel and the saved value for restoration in ``finally``.
+        original_obs = None
+        if df_name == "obs":
+            current_obs = getattr_anndata(self.adata, "obs")
+            if current_obs is not None and not set(current_obs.columns).issubset(schema_columns):
+                original_obs = current_obs
+
         # Base class validates only required columns
         try:
+            if original_obs is not None:
+                kept = [c for c in original_obs.columns if c in schema_columns]
+                self.adata.obs = original_obs[kept]
             super()._validate_dataframe(df_name)
         finally:
             # Restore schema def even if super() raises
             df_definition["columns"].update(sr_columns)
             df_definition["columns"].update(optional_columns)
+            # Restore the full obs so downstream checks see all columns
+            if original_obs is not None:
+                self.adata.obs = original_obs
 
         df = getattr_anndata(self.adata, df_name)
         if df is not None:

--- a/packages/hca-schema-validator/tests/test_validator.py
+++ b/packages/hca-schema-validator/tests/test_validator.py
@@ -891,6 +891,60 @@ def test_raw_validation_runs_despite_unrelated_errors():
     )
 
 
+def test_non_schema_obs_column_with_unused_categories_is_skipped():
+    """Non-schema obs columns are excluded from the vendored per-column sanity
+    loop. A curator-extra column with many unused Categorical levels would
+    otherwise generate one warning per unused level (#400).
+    """
+    from .fixtures.hca_fixtures import adata
+
+    modified = adata.copy()
+    # Curator-added column carrying unused Categorical levels. If the gating
+    # is not in effect the vendored loop emits one "zero observations"
+    # warning per unused category; with #400 the column is skipped entirely.
+    modified.obs["barcode"] = pd.Categorical(
+        ["AAAA"] * modified.n_obs,
+        categories=["AAAA"] + [f"UNUSED_{i}" for i in range(100)],
+    )
+
+    _, validator = _validate_from_fixture(modified)
+
+    barcode_messages = [
+        m for m in (validator.warnings + validator.errors) if "barcode" in m
+    ]
+    assert barcode_messages == [], (
+        f"Expected no validator messages about non-schema 'barcode' column; got: {barcode_messages}"
+    )
+
+
+def test_schema_obs_column_with_unused_categories_still_warns():
+    """Schema-defined obs columns are still subject to the vendored per-column
+    sanity loop. Regression check that #400 didn't accidentally suppress
+    warnings on legitimate schema columns.
+    """
+    from .fixtures.hca_fixtures import adata
+
+    modified = adata.copy()
+    # sample_id is a schema-defined obs column. Replace it with a Categorical
+    # carrying a real value plus several unused levels.
+    real_values = list(modified.obs["sample_id"])
+    modified.obs["sample_id"] = pd.Categorical(
+        real_values,
+        categories=list(set(real_values)) + [f"UNUSED_SAMPLE_{i}" for i in range(3)],
+    )
+
+    _, validator = _validate_from_fixture(modified)
+
+    sample_id_zero_obs = [
+        w for w in validator.warnings
+        if "sample_id" in w and "zero observations" in w
+    ]
+    assert len(sample_id_zero_obs) >= 1, (
+        f"Expected at least one zero-observation warning for schema column 'sample_id'; "
+        f"got warnings: {validator.warnings}"
+    )
+
+
 class TestCLOntologyOverlay:
     """Tests that the CL ontology overlay includes newer salivary gland cell types."""
 


### PR DESCRIPTION
Closes #400.

## Summary

The vendored CellxGene \`Validator._validate_dataframe()\` runs mixed-type, zero-observation, and illegal-categorical sanity checks against **every** column in \`obs\` (\`_vendored/cellxgene_schema/validate.py:1052-1085\`), regardless of whether the column is part of the HCA schema. On real-world h5ad files where curators carry extra columns inherited from upstream tooling (e.g. \`barcode\` set as a Pandas Categorical with a huge whitelist), each unused category becomes its own warning with no actionable content. A single hocker2021 validation produced a **230 MB** validation-results JSON dominated by **1.34 million** warnings from \`barcode\` alone (99.83% of the total).

This PR layers obs-filtering on top of the existing requirement_level override in \`HCAValidator._validate_dataframe()\`: before calling \`super()\`, temporarily replace \`self.adata.obs\` with a slice containing only schema-defined columns; restore in \`finally\`. The vendored per-column loop then iterates only schema columns, so non-schema columns generate no spurious warnings/errors and the type-iteration cost is avoided entirely.

**Vendored code is unchanged.** All HCA-specific behavior remains in \`hca_schema_validator/validator.py\` per existing pattern.

Schema content validation (the schema-driven loop on \`df_definition['columns']\` at \`validate.py:1086-1105\`) is unaffected — schema columns are preserved in the filtered obs.

## What changes

\`packages/hca-schema-validator/src/hca_schema_validator/validator.py\`:

\`\`\`python
# For obs, replace the dataframe with a schema-columns-only view so
# the vendored per-column sanity loop ignores curator extras /
# non-schema fields. \`original_obs\` doubles as the "did we mutate?"
# sentinel and the saved value for restoration in \`finally\`.
original_obs = None
if df_name == "obs":
    current_obs = getattr_anndata(self.adata, "obs")
    if current_obs is not None and not set(current_obs.columns).issubset(schema_columns):
        original_obs = current_obs

try:
    if original_obs is not None:
        kept = [c for c in original_obs.columns if c in schema_columns]
        self.adata.obs = original_obs[kept]
    super()._validate_dataframe(df_name)
finally:
    df_definition["columns"].update(sr_columns)
    df_definition["columns"].update(optional_columns)
    if original_obs is not None:
        self.adata.obs = original_obs
\`\`\`

\`packages/hca-schema-validator/tests/test_validator.py\` — two new tests:

- \`test_non_schema_obs_column_with_unused_categories_is_skipped\` — adds a \`barcode\` Categorical with 100 unused levels; asserts the validator emits zero warnings/errors mentioning \`barcode\`.
- \`test_schema_obs_column_with_unused_categories_still_warns\` — regression test: replaces \`sample_id\` (a schema column) with a Categorical carrying extra unused levels; asserts the zero-observation warning is still produced (so the gate didn't accidentally silence schema columns).

## Test results

\`\`\`
$ poetry run pytest tests/ -q
91 passed, 71 warnings in 20.38s
\`\`\`

(89 → 91; pre-existing 89 still green.)

## Expected real-world effect

On the hocker2021 payload that motivated this fix:

| | Before | After |
|---|---:|---:|
| Total warnings | ~1,337,733 | ~1,842 (schema columns only) |
| \`barcode\` warnings | 1,335,539 | 0 |
| validation_info JSONB write size | ~230 MB | ~250 KB |

The remaining 1,842 warnings are on schema-defined columns (\`sample_id\`: 469, \`library_id\`: 414, \`donor_id\`: 289, …) — those will be collapsed further by the sibling ticket #401.

## Out of scope

- **Collapsing per-category zero-observation warnings into one summary per column** — tracked in #401, independent override.
- **Schema cross-drift cleanup** (3 requirement-level mismatches between LinkML and h5ad obs validator: \`library_preparation_batch\`, \`library_sequencing_run\`, \`is_primary_data\`) — separate cleanup.
- **Bionetwork-scoped slots** (\`ambient_count_correction\`, \`doublet_detection\`) — only required for Adipose / Gut / Musculoskeletal; the h5ad validator is bionetwork-agnostic; addressing this is a larger architectural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)