### PR TITLE
chore(batch-service): bump hca-schema-validator to 0.12.1 (#403)

### DIFF
--- a/services/hca-schema-validator/poetry.lock
+++ b/services/hca-schema-validator/poetry.lock
@@ -509,14 +509,14 @@ numpy = ">=1.21.2"
 
 [[package]]
 name = "hca-schema-validator"
-version = "0.12.0"
+version = "0.12.1"
 description = "HCA schema validation for single-cell datasets"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "hca_schema_validator-0.12.0-py3-none-any.whl", hash = "sha256:e26db3996c899a3d057098fe99766c3ed85397ea1542c4d6fa3a6485a6b82942"},
-    {file = "hca_schema_validator-0.12.0.tar.gz", hash = "sha256:3d358db9f59beec972edd8d2c3c167e659980a578caefa8b1565c2b4d6d90fd2"},
+    {file = "hca_schema_validator-0.12.1-py3-none-any.whl", hash = "sha256:e2856e256808a54222c3c0f9c3976f335fe3ce9048f045febf634fde2a0eb883"},
+    {file = "hca_schema_validator-0.12.1.tar.gz", hash = "sha256:7993d7cf74b0648cfbd8e654cf042440ad4ee517453358d7355457ab2e7f003e"},
 ]
 
 [package.dependencies]
@@ -2099,4 +2099,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "~=3.11"
-content-hash = "86cc191057923822994acbb7cd2cc429dccb97ead9a47c0f795f4ccf379e5904"
+content-hash = "4671dc1492d55e87076b4458a1b717467cf335e3584420ac2cc343b424649fd7"

--- a/services/hca-schema-validator/pyproject.toml
+++ b/services/hca-schema-validator/pyproject.toml
@@ -3,7 +3,7 @@ name = "hca-schema-validator-service"
 version = "0.1.0"
 requires-python = "~=3.11"
 dependencies = [
-    "hca-schema-validator (>=0.12.0,<0.13.0)"
+    "hca-schema-validator (>=0.12.1,<0.13.0)"
 ]
 
 [tool.poetry]


### PR DESCRIPTION
Closes #403.

## Summary

Picks up the \`_validate_dataframe\` per-column sanity-loop gating from #400 (released as \`hca-schema-validator-v0.12.1\` via release-please #394) into the batch dataset-validator service.

The version constraint already accepted 0.12.1, but the lockfile pinned 0.12.0 and the Dockerfile uses \`poetry export --without-hashes\` which respects the lock — so container builds were still installing 0.12.0.

Per CLAUDE.md "Updating hca-schema-validator in the Batch Service":

\`\`\`
services/hca-schema-validator/pyproject.toml      | 2 +-   (>=0.12.0 → >=0.12.1)
services/hca-schema-validator/poetry.lock         | 8 ++++----   (regenerated)
\`\`\`

## Deploy plan after merge

\`\`\`bash
make batch-publish-container ENV=dev    # smoke-test
make batch-publish-container ENV=prod   # roll out
\`\`\`

Each does build → push to ECR → register new Batch JD revision. Next \`submit-job\` automatically uses the latest revision.

## Verification

After redeploy, a validation of a previously-noisy file (e.g. one of the heart/heart-v1 source datasets) should produce a claim-check payload \<1 MB instead of ~240 MB. Pre/post comparison plan:

- Watch validator + tracker logs (\`/aws/batch/{env}/hca-atlas-tracker/validator-batch\` and the App Runner log group).
- List the bucket post-validate; large payloads should be gone.

## Related

- #400 / PR #402 — the fix landed in \`packages/hca-schema-validator/\`.
- #394 — release-please tag + PyPI publish of v0.12.1.
- #401 — sibling override that collapses remaining schema-column zero-obs warnings (independent; not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)