### PR TITLE
chore(release-please): keep 0.x packages at sub-1.0 on breaking changes (#414)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,22 @@ make batch-publish-container ENV=prod   # Same for production
 make batch-submit-job ENV=dev
 ```
 
+## Release Policy
+
+All three publishable packages (`hca-schema-validator`, `hca-anndata-tools`, `hca-anndata-mcp`) are pre-1.0 and treated as still iterating. Two flags in `release-please-config.json` shape the bump behavior:
+
+- **`bump-minor-pre-major: true`** — on a 0.x package, `feat!` (BREAKING CHANGE) produces a minor bump (`0.12.1` → `0.13.0`), not release-please's default `0.x` → `1.0.0` promotion.
+- **`bump-patch-for-minor-pre-major: true`** — non-breaking `feat:` commits produce a patch bump (`0.12.1` → `0.12.2`), not the default minor. This keeps the minor bump as the explicit "breaking change" signal at 0.x.
+
+Net effect on 0.x packages: `fix:` → patch, `feat:` → patch, `feat!:` → minor. The minor digit is the only signal that a release contains a breaking change; consumers pinning `>=0.12,<0.13` get automatic patches but block on minors.
+
+**Cutting 1.0.0 is a deliberate manual act.** When a package is API-stable enough to graduate:
+
+1. Land a commit with `Release-As: 1.0.0` in the footer (release-please will honor it), OR
+2. Hand-edit `.release-please-manifest.json` to set the target version.
+
+Before doing either, update `.github/workflows/release-please.yml` — the MCP publish step has sed substitutions that hard-cap sibling packages at `<1`. Those caps must be relaxed (e.g., `<2`) or the post-1.0 MCP wheel on PyPI will refuse to install. (Tracked in a follow-up issue.)
+
 ## Updating hca-schema-validator in the Batch Service
 
 When a new version of `hca-schema-validator` is released (via release-please → PyPI):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,12 +76,17 @@ All three publishable packages (`hca-schema-validator`, `hca-anndata-tools`, `hc
 
 Net effect on 0.x packages: `fix:` → patch, `feat:` → patch, `feat!:` → minor. The minor digit is the only signal that a release contains a breaking change; consumers pinning `>=0.12,<0.13` get automatic patches but block on minors.
 
-**Cutting 1.0.0 is a deliberate manual act.** When a package is API-stable enough to graduate:
+**Cutting 1.0.0 is a deliberate manual act.** When a package is API-stable enough to graduate, land a commit with `Release-As: 1.0.0` in the footer:
 
-1. Land a commit with `Release-As: 1.0.0` in the footer (release-please will honor it), OR
-2. Hand-edit `.release-please-manifest.json` to set the target version.
+```
+chore(<package>): graduate to 1.0.0
 
-Before doing either, update `.github/workflows/release-please.yml` — the MCP publish step has sed substitutions that hard-cap sibling packages at `<1`. Those caps must be relaxed (e.g., `<2`) or the post-1.0 MCP wheel on PyPI will refuse to install. (Tracked in a follow-up issue.)
+Release-As: 1.0.0
+```
+
+This is release-please's supported override mechanism — it overrides the auto-computed bump for the package whose path the commit touches. Don't hand-edit `.release-please-manifest.json`: that file is a back-reference to the last released version per path and editing it doesn't reliably cut a release; it can also desync from the git tags release-please uses for compare links.
+
+Before tagging 1.0.0, update `.github/workflows/release-please.yml` — the MCP publish step has sed substitutions that hard-cap sibling packages at `<1`. Those caps must be relaxed (e.g., `<2`) or the post-1.0 MCP wheel on PyPI will refuse to install. (Tracked in [#416](https://github.com/clevercanary/hca-validation-tools/issues/416).)
 
 ## Updating hca-schema-validator in the Batch Service
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,4 +1,5 @@
 {
+  "bump-minor-pre-major": true,
   "packages": {
     "packages/hca-schema-validator": {
       "release-type": "python",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
   "packages": {
     "packages/hca-schema-validator": {
       "release-type": "python",


### PR DESCRIPTION
Closes #414

## Why

PR #413 (the release-please-cut release PR following [#370 / #409](https://github.com/clevercanary/hca-validation-tools/pull/409)) currently proposes:

- `hca-schema-validator`: `0.12.1` → **`1.0.0`**
- `hca-anndata-mcp`: `0.5.1` → **`1.0.0`**

Release-please's default is to promote 0.x → 1.0 on any `feat!` (BREAKING CHANGE). For packages still iterating below 1.0 — which all three of ours are — the more useful convention is to treat breaking changes as minor bumps and reserve 1.0.0 for an explicit stability milestone.

## What this PR contains

Two flags in `release-please-config.json` plus a release-policy doc section.

### `release-please-config.json` (2 new top-level flags)

```diff
 {
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
   "packages": { ... }
 }
```

- **`bump-minor-pre-major: true`** — on 0.x packages, `feat!` (BREAKING CHANGE) → minor bump (`0.12.1` → `0.13.0`) instead of release-please's default `0.x` → `1.0.0` promotion.
- **`bump-patch-for-minor-pre-major: true`** — on 0.x packages, non-breaking `feat:` → patch bump (`0.12.1` → `0.12.2`) instead of the default minor.

Together these keep the **minor digit as the explicit "breaking change" signal** at 0.x. The rule on 0.x packages becomes:

| Commit type | Bump |
|---|---|
| `fix:` | patch |
| `feat:` | patch |
| `feat!:` | **minor** |

Without the second flag, `feat:` and `feat!:` would both produce a minor bump and the version number alone wouldn't signal whether a release contains breaking changes. The second flag was added in the second commit after code review surfaced that gap (see [code-review trace](#) in the conversation).

### `CLAUDE.md` — new "Release Policy" section

Documents both flags and the supported way to deliberately cut 1.0.0 when an API milestone is reached:

```
chore(<package>): graduate to 1.0.0

Release-As: 1.0.0
```

Also calls out the MCP `<1` sed caps in the publish workflow that must be relaxed before any package crosses 1.0 (tracked in [#416](https://github.com/clevercanary/hca-validation-tools/issues/416)).

## Effect after merge

Release-please re-runs on every push to main. After this PR merges:

1. Release-please re-evaluates all commits since the last release.
2. The SRE `feat!` from #409 becomes a minor bump under the new rule.
3. **PR #413 refreshes in place** with corrected bumps:
   - `hca-schema-validator`: `0.12.1` → `0.13.0`
   - `hca-anndata-mcp`: `0.5.1` → `0.6.0`

No manual edits to #413, no closing/reopening.

## Follow-up issue filed

- [#416](https://github.com/clevercanary/hca-validation-tools/issues/416) — relax MCP publish sed `<1` caps before any package crosses 1.0.0 (latent, action required only at 1.0 promotion).

## Reference

https://github.com/googleapis/release-please/blob/main/docs/customizing.md#bump-minor-pre-major

🤖 Generated with [Claude Code](https://claude.com/claude-code)
