### PR TITLE
chore(batch-service): bump hca-schema-validator to 0.13.0 (#417)

### DIFF
--- a/services/hca-schema-validator/poetry.lock
+++ b/services/hca-schema-validator/poetry.lock
@@ -509,14 +509,14 @@ numpy = ">=1.21.2"
 
 [[package]]
 name = "hca-schema-validator"
-version = "0.12.1"
+version = "0.13.0"
 description = "HCA schema validation for single-cell datasets"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "hca_schema_validator-0.12.1-py3-none-any.whl", hash = "sha256:e2856e256808a54222c3c0f9c3976f335fe3ce9048f045febf634fde2a0eb883"},
-    {file = "hca_schema_validator-0.12.1.tar.gz", hash = "sha256:7993d7cf74b0648cfbd8e654cf042440ad4ee517453358d7355457ab2e7f003e"},
+    {file = "hca_schema_validator-0.13.0-py3-none-any.whl", hash = "sha256:35a5e04faa8e12040e10ae52e866d88f27f5e1c3c265ac2a1a8e9046011001c4"},
+    {file = "hca_schema_validator-0.13.0.tar.gz", hash = "sha256:593ba47c0d613dd0fd91042bddfe0b9248bea3f80dbacd890cf35252cb231243"},
 ]
 
 [package.dependencies]
@@ -2099,4 +2099,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "~=3.11"
-content-hash = "4671dc1492d55e87076b4458a1b717467cf335e3584420ac2cc343b424649fd7"
+content-hash = "9d7da8a00b3bd0b1086d7645837280a6e97ef664feee2ced82bd26a4c4beafd7"

--- a/services/hca-schema-validator/pyproject.toml
+++ b/services/hca-schema-validator/pyproject.toml
@@ -3,7 +3,7 @@ name = "hca-schema-validator-service"
 version = "0.1.0"
 requires-python = "~=3.11"
 dependencies = [
-    "hca-schema-validator (>=0.12.1,<0.13.0)"
+    "hca-schema-validator (>=0.13.0,<0.14.0)"
 ]
 
 [tool.poetry]


### PR DESCRIPTION
Closes #417

## What

Bumps the batch service's `hca-schema-validator` pin to the freshly-published `0.13.0` (which carries the SRE-forbidden change from #370 / #409) and regenerates `poetry.lock`.

```diff
- "hca-schema-validator (>=0.12.1,<0.13.0)"
+ "hca-schema-validator (>=0.13.0,<0.14.0)"
```

The matching `poetry.lock` update resolves `hca-schema-validator` from `0.12.0` (previously pinned) to `0.13.0` (PyPI).

## Why this is its own PR

Per `CLAUDE.md` "Updating hca-schema-validator in the Batch Service" — every release of `hca-schema-validator` requires a manual pin + lockfile bump before the batch Docker image can be rebuilt. This PR isolates that step so reviewers can see exactly what version moved and exercise the lock file before any deploy work begins.

## Verification

Locally (in the `services/hca-schema-validator` poetry venv):

- `poetry lock` → writes lock file with `hca-schema-validator 0.13.0`
- `poetry install` → 1 package updated (`0.12.0 → 0.13.0`)
- `poetry run python -c 'import hca_schema_validator; print(hca_schema_validator.__version__)'` → `0.13.0`
- `poetry run pytest tests/` → **11 passed**

## Deploy sequence

This is step 5 of the SRE-forbidden deploy plan:

```
✅ 1. #409 merged                            (SRE forbidden mechanism)
✅ 2. #415 merged                            (release-please bump-minor/patch-pre-major)
✅ 3. PR #413 refreshed to 0.13.0 / 0.6.0
✅ 4. #413 merged → 0.13.0 + 0.6.0 on PyPI
⏳ 5. This PR — service pin bump  ← you are here
⏳ 6. #410 — converter strips SRE  (must land before batch rebuild)
⏳ 7. Wrangler heads-up
⏳ 8. Rebuild batch Docker → deploy dev → verify → prod
⏳ 9. Revalidation sweep
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
