### PR TITLE
fix(cell-annotation-validator): drop bogus per-set title requirement

### DIFF
--- a/packages/hca-schema-validator/src/hca_schema_validator/cell_annotation_validator.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/cell_annotation_validator.py
@@ -6,7 +6,10 @@ Phase 1 (see issue #362) performs four structural checks:
    is a non-empty dict).
 2. ``uns['cellannotation_schema_version']`` is present and well-formed.
 3. ``uns['cellannotation_metadata']`` is a dict and each per-set value is a
-   dict with a ``title`` key.
+   dict. The CAP AnnData schema's per-set required fields (``description``,
+   ``annotation_method``, ``algorithm_name``, ``algorithm_version``,
+   ``algorithm_repo_url``) are left to the upstream CAP-side validator; this
+   check only enforces structural shape.
 4. Each annotation set has the CAP-required per-set obs columns.
 
 Marker-gene coverage (Phase 2) and CL-term validity (Phase 3) are out of
@@ -35,9 +38,6 @@ _REQUIRED_OBS_SUFFIXES = (
     "rationale",
     "marker_gene_evidence",
 )
-
-# CAP per-set metadata keys required in uns['cellannotation_metadata'][<set>].
-_REQUIRED_SET_METADATA_KEYS = ("title",)
 
 NO_SETS_ERROR = (
     "No CAP annotation sets present. At least one annotation set conforming "
@@ -139,12 +139,6 @@ class HCACellAnnotationValidator:
                     f"dict; got {type(set_meta).__name__}."
                 )
                 continue
-            missing_keys = [k for k in _REQUIRED_SET_METADATA_KEYS if k not in set_meta]
-            if missing_keys:
-                self._error(
-                    f"uns['cellannotation_metadata']['{set_name}'] is missing "
-                    f"required keys: {missing_keys}."
-                )
             annotation_sets.append(set_name)
         return annotation_sets
 

--- a/packages/hca-schema-validator/tests/test_cell_annotation_validator.py
+++ b/packages/hca-schema-validator/tests/test_cell_annotation_validator.py
@@ -79,16 +79,6 @@ def test_malformed_schema_version_errors(cap_h5ad):
     assert any("semver" in e for e in v.errors)
 
 
-def test_set_missing_title_errors(cap_h5ad):
-    def mutate(adata):
-        adata.uns["cellannotation_metadata"] = {"author_annotation": {}}
-    _rewrite(cap_h5ad, mutate)
-
-    v = HCACellAnnotationValidator()
-    assert v.validate_adata(str(cap_h5ad)) is False
-    assert any("author_annotation" in e and "title" in e for e in v.errors)
-
-
 def test_set_metadata_wrong_type_errors(cap_h5ad):
     def mutate(adata):
         adata.uns["cellannotation_metadata"] = {"author_annotation": "not-a-dict"}


### PR DESCRIPTION
Closes #422.

## Summary

- `_REQUIRED_SET_METADATA_KEYS = ("title",)` was added in #366 as a "backstop for corrupted CAP structures." In practice no upstream CAP source emits a per-set `title`, so the check fires on **every real CAP-annotated HCA file** — flagging every spec-compliant file as invalid via the dataset-validator service's `hcaCellAnnotation` dot.
- Neither spec requires it. The [HCA Cell Annotation schema page](https://data.humancellatlas.org/metadata/cell-annotation) does not enumerate `title` at the per-set level, and the [upstream CAP AnnData schema](https://github.com/cellannotation/cell-annotation-schema/blob/main/docs/cap_anndata_schema.md) defines per-set required fields as `description`, `annotation_method`, `algorithm_name`, `algorithm_version`, `algorithm_repo_url` only. `title` lives only at the dataset level (`uns['title']`), not per-set.
- Real CAP exports tested (project-557 / ocular-outflow-segment-v1, optic-nerve-v1, ocular-surface-v1 — 11 files across two bionetworks and three CAP-curator teams) include all 5 per-set required fields and are spec-compliant; they only fail this one over-strict check.

## Changes

- **Delete `_REQUIRED_SET_METADATA_KEYS`** and the missing-keys check loop in `_check_metadata`. The per-set "must be a dict" type check stays — that's the legitimate structural backstop.
- **Update the module docstring** (check #3) to reflect the narrower structural-only contract and point at the upstream CAP-side validator (which runs separately in the dataset-validator service, the `cap` dot in the tracker) for the actual per-set required-field enforcement.
- **Drop the now-orphaned `test_set_missing_title_errors` test** (10 of 11 prior tests stay; happy path still passes via the fixture).

## Verification

- Package tests: **96 passing** in `hca-schema-validator` (10 in `test_cell_annotation_validator.py`).
- Service tests: **7 passing** in `services/hca-schema-validator/tests/test_cell_annotation.py` (subprocess wiring + log capture).
- `make typecheck`: **clean** across all 4 venvs.
- End-to-end: ran `HCACellAnnotationValidator().validate_adata()` on a previously-failing file (`ocular-outflow-segment-v1` scRNA, the one that surfaced this in the tracker) — now returns `is_valid: True` with no errors/warnings.

## Audit notes

- No external imports of the removed constant (it was private — `_` prefix).
- The "missing required keys" grep hit in `hca-anndata-tools/write.py` is unrelated (edit-log entry validation, different feature).
- One minor follow-up worth knowing about: the test fixture `testing.py:create_cap_annotated_h5ad` still writes `{"title": "..."}` as per-set metadata — a leftover from the buggy era. It still passes the structural check (it's a dict) so the fixture works, but it's no longer realistic vs real CAP exports (which have 5 required fields). Deliberately out of scope here to keep the PR small.

## Deploy chain

Per CLAUDE.md "Updating hca-schema-validator in the Batch Service":

1. Merge → release-please publishes a new `hca-schema-validator` patch version to PyPI.
2. Follow-up PR bumps `services/hca-schema-validator/pyproject.toml` version pin + regenerates `poetry.lock`.
3. `make batch-publish-container ENV=prod` refreshes the AWS Batch image.

Until step 3 ships, every CAP-sourced file in the tracker will continue to show this red dot.

## Related

- Originating PR: #366
- Sibling issue: #423 (wire `HCACellAnnotationValidator` into `/curate-h5ad` and `/evaluate-h5ad` skills so this class of issue is visible during curation, not just post-upload — depends on this PR landing first)
- Parallel discovery from the same curation session: #421 (`label_h5ad` no-op mode for CellxGENE-sourced files)

## Test plan

- [x] Package tests pass (96)
- [x] Service tests pass (7)
- [x] `make typecheck` clean
- [x] Previously-failing real file (`eye/ocular-outflow-segment-v1`) re-validated locally and passes
- [ ] Reviewer: spot-check the docstring wording for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)