### PR TITLE
chore(batch-service): bump hca-schema-validator to 0.13.1 (#426)

### DIFF
--- a/services/hca-schema-validator/poetry.lock
+++ b/services/hca-schema-validator/poetry.lock
@@ -509,14 +509,14 @@ numpy = ">=1.21.2"
 
 [[package]]
 name = "hca-schema-validator"
-version = "0.13.0"
+version = "0.13.1"
 description = "HCA schema validation for single-cell datasets"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "hca_schema_validator-0.13.0-py3-none-any.whl", hash = "sha256:35a5e04faa8e12040e10ae52e866d88f27f5e1c3c265ac2a1a8e9046011001c4"},
-    {file = "hca_schema_validator-0.13.0.tar.gz", hash = "sha256:593ba47c0d613dd0fd91042bddfe0b9248bea3f80dbacd890cf35252cb231243"},
+    {file = "hca_schema_validator-0.13.1-py3-none-any.whl", hash = "sha256:a4af8d01ef8b85f699d400740bdb99b3a1bb08665d8aead15a9bb7edd8cbc4ac"},
+    {file = "hca_schema_validator-0.13.1.tar.gz", hash = "sha256:1552cd462693f56d0c61db20dc972d49da4c3b3e89d2de6824716ac69ba04011"},
 ]
 
 [package.dependencies]
@@ -2099,4 +2099,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "~=3.11"
-content-hash = "9d7da8a00b3bd0b1086d7645837280a6e97ef664feee2ced82bd26a4c4beafd7"
+content-hash = "d1ecba8693fc452aa41db522c2c413d466b21e18eb76d587171fd9b613fb24f1"

--- a/services/hca-schema-validator/pyproject.toml
+++ b/services/hca-schema-validator/pyproject.toml
@@ -3,7 +3,7 @@ name = "hca-schema-validator-service"
 version = "0.1.0"
 requires-python = "~=3.11"
 dependencies = [
-    "hca-schema-validator (>=0.13.0,<0.14.0)"
+    "hca-schema-validator (>=0.13.1,<0.14.0)"
 ]
 
 [tool.poetry]


### PR DESCRIPTION
Closes #426.

## Summary

- Bumps `hca-schema-validator` pin in `services/hca-schema-validator/pyproject.toml` from `>=0.13.0,<0.14.0` to `>=0.13.1,<0.14.0`.
- Regenerates `services/hca-schema-validator/poetry.lock` — only the `hca-schema-validator` package version + wheel/tarball SHA-256 hashes change; no other dependency drift.

## Why

Picks up the title-requirement fix from #424 (closed by release-please publish in #425) so the dataset-validator service's `hcaCellAnnotation` dot stops flagging spec-compliant CAP-sourced HCA files. Until this lands and the batch container is rebuilt, every CAP-sourced file in the tracker continues to show the red dot for the now-fixed bogus check.

## Verification

- Service tests: **11/11 passing** against the new package version.
- `poetry.lock` regenerated cleanly with `poetry lock` after pin bump.

## Deploy

After merge: `make batch-publish-container ENV=prod` refreshes the AWS Batch image. Tracker `hcaCellAnnotation` dot clears on next file re-validation.

## Related

- #422 (originating bug)
- #424 (the fix)
- #425 (release-please publish to PyPI)
- #423 (follow-up: wire the validator into `/curate-h5ad` + `/evaluate-h5ad` skills so this class of issue is visible during curation, not just post-upload)

## Test plan

- [x] Service tests pass
- [x] Lock file regen is minimal (only hca-schema-validator entry changes)
- [ ] Reviewer: confirm pin range looks right (`>=0.13.1,<0.14.0`)
- [ ] After merge + PyPI confirms: `make batch-publish-container ENV=prod`

🤖 Generated with [Claude Code](https://claude.com/claude-code)