### PR TITLE
feat(skills/curate-h5ad): add Summary + Outstanding issues + Edit history sections (#396)

### DIFF
--- a/.claude/skills/curate-h5ad/SKILL.md
+++ b/.claude/skills/curate-h5ad/SKILL.md
@@ -109,7 +109,7 @@ For the Provenance line below, re-run `get_summary` on the final file to fetch i
 
 Two or three sentences distilling the session: which Bucket A operations actually ran, the validator delta in one phrase (e.g. "errors went 4 → 2; remaining errors are Bucket C upstream-data issues"), and a one-clause hand-off (e.g. "Bucket B1 awaiting wrangler input on `study_pi`"). Tight prose paragraph, no nested headings.
 
-Then add an **Outstanding issues** bullet list pulled from Buckets B1, B2, and C (one line per item, prefix each line with the bucket label, e.g. `- B1: study_pi unset (validator error)`). This is the up-front highlight for someone reading the saved markdown cold. The full detail with action questions lives in the *Still to do* section near the bottom — keep this list tight: one line per item, no inline tables. If all three buckets are empty, replace the bullet list with a single line: "Outstanding issues: none."
+Then add an **Outstanding issues** bullet list pulled from Buckets B1, B2, and C — one line per item, no bucket-label prefixes (the reader doesn't need our internal taxonomy). Order: validator errors first, then warnings, then non-validator items. The full detail with action questions lives in the *Still to do* section near the bottom — keep this list tight: one line per item, no inline tables. If all three buckets are empty, replace the bullet list with a single line: "Outstanding issues: none."
 
 ### Header
 One short paragraph or bullet block with: final file path, shape (`n_obs × n_vars`), `title` from `uns`, schema type (include version only when schema is CellxGENE — HCA is unversioned), X verdict + `raw.X` presence, compression status, `obsm` keys present. Add a **Provenance** line: `N donors · M samples · K libraries` from `get_descriptive_stats.columns[<col>].unique` for each column. Skip any metric whose column wasn't returned or whose `unique` is 0.
@@ -179,7 +179,9 @@ For each missing marker, list it with its classification exactly as returned by 
 |---|---|---|---|
 | … | … | … | … |
 
-Leave `Var name` / `Ensembl ID` blank for `not_in_gencode` and `missing_from_var` rows — those fields are only populated on `known_rename`. If all markers hit, say so in one line instead of an empty table. `not_in_gencode` entries point at CAP-side fixes (ask the CAP curator); `missing_from_var` points at target-side gaps (different gene set than the one CAP was authored against); `known_rename` entries should report the rename target from `var_name` so the mismatch is explicit.
+Leave `Var name` / `Ensembl ID` blank for `not_in_gencode` and `missing_from_var` rows — those fields are only populated on `known_rename`. If all markers hit, say so in one line instead of an empty table.
+
+Report each missing marker by **symbol and classification only**. Do not speculate about why a symbol is `not_in_gencode` (e.g. "looks like a glob", "looks like a truncated `STMN1`", "probably a typo") — the classification name is the answer the tool gave; cause is the curator's call. Pointer for follow-up: `not_in_gencode` and `missing_from_var` go to the CAP curator (CAP-side fix), `known_rename` rows surface the new symbol via `var_name`.
 
 ### Still to do
 

--- a/.claude/skills/curate-h5ad/SKILL.md
+++ b/.claude/skills/curate-h5ad/SKILL.md
@@ -105,6 +105,12 @@ Also re-run `get_cap_annotations` on the final file, and if it reports `has_cap_
 
 For the Provenance line below, re-run `get_summary` on the final file to fetch its obs columns, then run `get_descriptive_stats` with `columns` set to the intersection of `["donor_id", "sample_id", "library_id"]` and the final file's obs column names (extract `name` from each `{name, dtype}` object in `get_summary.obs_columns`).
 
+### Summary
+
+Two or three sentences distilling the session: which Bucket A operations actually ran, the validator delta in one phrase (e.g. "errors went 4 → 2; remaining errors are Bucket C upstream-data issues"), and a one-clause hand-off (e.g. "Bucket B1 awaiting wrangler input on `study_pi`"). Tight prose paragraph, no nested headings.
+
+Then add an **Outstanding issues** bullet list pulled from Buckets B1, B2, and C (one line per item, prefix each line with the bucket label, e.g. `- B1: study_pi unset (validator error)`). This is the up-front highlight for someone reading the saved markdown cold. The full detail with action questions lives in the *Still to do* section near the bottom — keep this list tight: one line per item, no inline tables. If all three buckets are empty, replace the bullet list with a single line: "Outstanding issues: none."
+
 ### Header
 One short paragraph or bullet block with: final file path, shape (`n_obs × n_vars`), `title` from `uns`, schema type (include version only when schema is CellxGENE — HCA is unversioned), X verdict + `raw.X` presence, compression status, `obsm` keys present. Add a **Provenance** line: `N donors · M samples · K libraries` from `get_descriptive_stats.columns[<col>].unique` for each column. Skip any metric whose column wasn't returned or whose `unique` is 0.
 
@@ -196,6 +202,16 @@ Leave `Var name` / `Ensembl ID` blank for `not_in_gencode` and `missing_from_var
 | `library_id` NaN (validator error) | Needs real values from source |
 
 Only surface items that are still open — don't re-list anything resolved this session. Omit any of the three sub-tables that have no entries.
+
+### Edit history
+
+Render every entry returned by the `view_edit_log` call from the top of Step 5 as a table, oldest first:
+
+| # | Timestamp (UTC) | Operation | Description |
+|---|---|---|---|
+| 1 | 2026-04-21 04:19:10 | `normalize_raw` | Moved raw counts to raw.X and normalized X with normalize_total(target_sum=10000) + log1p |
+
+Format the timestamp as `YYYY-MM-DD HH:MM:SS` (drop the `T` and the fractional seconds and timezone — entries are always UTC). Use the entry's `description` field verbatim. If the file has no edit log (no `uns/provenance/edit_history`), say "No edit history — file hasn't been edited through `hca-anndata-tools`."
 
 ## Save the report
 

--- a/.claude/skills/evaluate-h5ad/SKILL.md
+++ b/.claude/skills/evaluate-h5ad/SKILL.md
@@ -114,7 +114,14 @@ See `/curate-h5ad` Step 5 for classification meanings (`not_in_gencode` / `missi
 Then list each error and warning verbatim, one per line. If `error_count` and `warning_count` are both 0, replace the list with a single "No structural cell-annotation issues" line. This is what the dataset-validator service runs at upload time under the `hcaCellAnnotation` key — catching issues here means fewer red-dot surprises in the tracker.
 
 ## 6. Edit history
-Summarize entries as a table: `timestamp`, `operation`, one-line `description`. If absent, note that the file hasn't been edited through `hca-anndata-tools`.
+
+Render every entry returned by `view_edit_log` as a table, oldest first:
+
+| # | Timestamp (UTC) | Operation | Description |
+|---|---|---|---|
+| 1 | 2026-04-21 04:19:10 | `normalize_raw` | Moved raw counts to raw.X and normalized X with normalize_total(target_sum=10000) + log1p |
+
+Format the timestamp as `YYYY-MM-DD HH:MM:SS` (drop the `T` and the fractional seconds and timezone — entries are always UTC). Use the entry's `description` field verbatim. If the file has no edit log, say "No edit history — file hasn't been edited through `hca-anndata-tools`."
 
 ## 7. Summary & recommendations
 - One-line readiness verdict: ready / needs work / not started.

--- a/.claude/skills/evaluate-h5ad/SKILL.md
+++ b/.claude/skills/evaluate-h5ad/SKILL.md
@@ -99,7 +99,7 @@ Flag any uncompressed dataset in a >100 MB file as an issue.
 |---|---|---|---|
 | … | … | … | … |
 
-See `/curate-h5ad` Step 5 for classification meanings (`not_in_gencode` / `missing_from_var` / `known_rename`), the `feature_name` → `gene_name` → `var.index` fallback order, and where each miss kind points for remediation.
+See `/curate-h5ad` Step 5 for classification meanings (`not_in_gencode` / `missing_from_var` / `known_rename`), the `feature_name` → `gene_name` → `var.index` fallback order, and where each miss kind points for remediation. Report each missing marker by symbol and classification only — do not speculate about cause (typo / glob / rename); the classification name is the answer.
 
 - If `validate_cell_annotation` ran (CAP present), render its result as a single sub-block. Render this block independently of the marker-gene table — the two are conditionally independent and either may render without the other. The wrapper has two failure shapes; handle each accordingly:
   - **Top-level `{error: str}`** — only fires on wrapper-level failures (path resolution, missing file, unexpected exception in the wrapper itself). Report the error as a single line and skip the table below.

--- a/docs/prd-curation-report.md
+++ b/docs/prd-curation-report.md
@@ -1,0 +1,258 @@
+# PRD: Curation Report Shape
+
+Status: draft (2026-05-07) — for review, not committed to the skill yet.
+
+## Problem
+
+The persisted markdown report from `/curate-h5ad` is currently shaped around the curator's session: *"these fixes ran in this session, here's the validator delta, here are the buckets we classified items into"*. That serves the operator running the skill, but it doesn't serve the two readers who actually receive the report:
+
+1. **Data generators** receiving the file back from curation. They need to know: *what did the curator change in my file, and what do I still need to fix upstream?*
+2. **Future readers** (handoff, audit, weeks later). They need to know: *what is this file, what state is it in, what's still outstanding?*
+
+The session framing also leans on internal taxonomy — "Bucket A / B1 / B2 / C" — that means nothing to anyone outside this skill.
+
+## Goals
+
+- Refocus the report on **the file's current state and outstanding responsibilities**, not on the session that produced it.
+- Make it unambiguous **what the curator changed** so data generators can verify their data wasn't broken.
+- Make it unambiguous **what the data generator must fix** that the curator can't (bad gene IDs, ontology mismatches, NaN required fields, delimited-list values, etc.).
+- Replace the A/B/C bucket labels with descriptive responsibility labels.
+
+## Non-goals
+
+- Preserving the session-narrative shape (validator-delta-style "before/after" table, "fixes applied this session" log as the dominant view). Audit data still lives in the edit log; we just don't lead with it.
+- Reproducing the existing PDF's *Session context — tool and skill changes* table. That coupled tooling-PR work to data work; it's not part of the file itself.
+
+## Audiences
+
+| Audience | What they want |
+|---|---|
+| Data generator | What changed in the file; what they must fix upstream |
+| Future reader | Orientation; current state; outstanding actions |
+| Curator (in-session) | Confirmation that fixes ran cleanly; deferred action list — this is the *least* primary now |
+
+## Proposed shape
+
+Five sections, file-state-oriented:
+
+### 1. Header — current state snapshot
+
+Same shape as today's Header: file path, shape, title, schema, X verdict + raw.X presence, compression, embeddings, provenance line. No session detail.
+
+### 2. Validation summary
+
+A single-line verdict and counts:
+
+> **Validation: not yet passing — 2 errors, 32 warnings (excluding 2,138 expected feature-ID warnings against GENCODE v48).**
+
+Errors are spelled out verbatim under the line — they're the immediate eye-level "what's blocking" signal. Warnings are summarized by kind/count, not enumerated.
+
+### 3. Validation checklist (the new core)
+
+Every check the validator runs, each with a status symbol and an owner. Two presentation options:
+
+**Option A — comprehensive table (every check, even passing ones).**
+Pros: gives the data generator a confidence-list ("47/47 checks evaluated, 2 currently failing"); makes new failures introduced by re-curation easy to spot. Cons: long; lots of repetitive green rows.
+
+**Option B — findings-only with header counts.**
+Pros: tight; reads in seconds. Cons: loses the "everything was checked" reassurance; a missing failure could be confused with an absent check.
+
+**Recommendation: Option B with a header line stating the total checks evaluated** ("47 checks evaluated; 2 failing, 5 warnings, 2 fixed during curation, 38 passing"). The body lists only the non-pass + fixed-during-curation rows.
+
+Each row shows:
+
+| Check | Status | Owner | Notes |
+|---|---|---|---|
+| `obs['library_id']` populated | ✗ Fail | Data generator | 28,633 / 50,296 cells NaN. Validator error. |
+| `obs['library_preparation_batch']` single-value | ✗ Fail | Data generator | Some rows hold semicolon-delimited lists. Validator error. |
+| Var feature_* labels populated | ✓ Fixed during curation | (curator) | `label_h5ad` populated `var['feature_name']` + 4 sibling columns from Ensembl IDs (34,505 / 35,574 matched GENCODE). |
+| Obs ontology labels populated | ✓ Fixed during curation | (curator) | `label_h5ad` wrote 8 derived obs labels from their `_ontology_term_id` columns. |
+| `obs['library_preparation_batch']` placeholder values | ✓ Fixed during curation | (curator) | `replace_placeholder_values` removed 464 `'unknown'` cells. |
+| CAP marker symbols resolve in GENCODE | ⚠ Warn | Data generator | 2 markers (`H2*`, `STMN`) classified `not_in_gencode`. |
+| Var Ensembl IDs in current GENCODE | ⚠ Warn | Data generator | 1,069 IDs unmatched in GENCODE v48 / Ensembl 114 (mirrored in raw.var). |
+
+Status symbols (5 values, picked to be both color-blind safe and skim-able):
+
+- ✓ **Pass** — currently meets the check.
+- ✓ **Fixed during curation** — was failing on the file we received; the curator's tools made it pass. The "during curation" annotation comes from any `import_*` / `label_h5ad` / `replace_placeholder_values` / `set_uns` / `normalize_raw` / `compress_h5ad` entry in `uns/provenance/edit_history`. *Not session-bounded* — if a previous curation session fixed it, it still shows here.
+- ✗ **Fail** — currently failing. Validator error.
+- ⚠ **Warn** — validator warning that isn't expected schema noise (CAP zero-observation warnings, for example, are filtered out and counted separately).
+- ➖ **Skipped** — check didn't apply (e.g. CAP marker validation when CAP isn't present).
+
+Owner is one of: `(curator)`, `Data generator`, or `(none — passing)`. The owner field is the key new affordance — it tells data generators which rows belong to them at a glance.
+
+### 4. Curator changes
+
+Audit trail of every edit the curator's tools made to the file, derived from `uns/provenance/edit_history`. Same 4-column table the skill template already uses (`#` / Timestamp / Operation / Description). This is for verification: the data generator can trace every modification.
+
+### 5. Outstanding actions
+
+Two sub-sections, **named by responsibility, no A/B/C**:
+
+#### Data generator must fix
+
+The current Bucket C list. Validator errors and warnings the curator can't address from inside the file: NaN sources, delimited-list values, gene-ID mismatches with GENCODE, CAP marker text quality, label/term-id drift the labeler refused to overwrite, etc.
+
+#### Curator (awaiting input)
+
+The current Bucket B list, merged. Required-but-unset values that need a wrangler decision (`study_pi`, `default_embedding`). One row per question.
+
+Either subsection is omitted when empty.
+
+## Bucket-name → descriptive-name mapping
+
+| Old | New |
+|---|---|
+| Bucket A | *(no longer surfaced — folded into "Fixed during curation" rows in the checklist)* |
+| Bucket B1 | "Curator (awaiting input) — blocking" |
+| Bucket B2 | "Curator (awaiting input) — recommended" |
+| Bucket C | "Data generator must fix" |
+
+The skill internally can keep the A/B/C taxonomy for routing logic; the report just doesn't expose it.
+
+## Open questions
+
+1. **Comprehensive vs findings-only checklist (Option A vs B)?** Default to B with the count header.
+2. **Do we keep the "Validator delta" before/after table?** I think no — it's session-flavored. The checklist's "Fixed during curation" status conveys the same information in a file-state idiom. If we want to retain the visual delta, we could add a tiny header line under "Validation summary": *"This curation has fixed 5 checks since the original file."* Less prominent than today's table.
+3. **Where does CAP overlap and CAP marker validation live?** Today they're top-level sections. Proposal: collapse into rows in the validation checklist (`CAP cell overlap ≥ 95%`, `CAP marker symbols resolve in GENCODE`). Data behind those rows still goes in a CAP-specific subsection right after the checklist for the cases where richer detail matters.
+4. **Should "Curator changes" precede or follow "Outstanding actions"?** I lean *follow* — outstanding-actions is the call-to-action, curator-changes is reference. Keep the call-to-action up where the eye lands.
+5. **Section ordering overall?** Proposed:
+   1. Header
+   2. Validation summary
+   3. Outstanding actions (split by responsibility) ← elevated
+   4. Validation checklist
+   5. CAP details (overlap + marker validation, when applicable)
+   6. Curator changes (edit log audit)
+
+## Tension: checklist vs. fixes log
+
+The user noted this directly: a single-status checklist can mask the fact that an item was fixed by the curator. The proposed `Fixed during curation` status resolves that — it's a distinct value, not collapsed into pass. The data generator can filter the table to that status to see exactly what changed.
+
+## Template — myeloid example
+
+Below is what the report would look like rendered on the current myeloid file under the proposed shape, for review.
+
+```markdown
+# Curation report — `myeloid-r1-wip-10-edit-2026-05-07-12-07-56.h5ad`
+
+## Header
+
+- **File**: `/Users/dave/hca-tracker-upload/prod/gut/gut-v1/integrated-objects/myeloid-r1-wip-10-edit-2026-05-07-12-07-56.h5ad`
+- **Shape**: 50,296 × 35,574 (424.9 MB)
+- **Title**: *Human Gut Cell Atlas (HGCA) v1 - Myeloid*
+- **Schema**: HCA (unversioned)
+- **X**: `normalized` · `raw.X` present
+- **Compression**: gzip level 4 on every dataset
+- **Embeddings**: `X_scVI` (50296, 30), `X_umap` (50296, 2)
+- **Provenance**: 199 donors · 371 samples · 52 libraries
+
+## Validation summary
+
+**Validation: not yet passing — 2 errors, 32 unexpected warnings.** (2,138 GENCODE feature-ID warnings excluded from the count; 32 CAP zero-observation warnings excluded as expected schema behavior.)
+
+Errors:
+- `Column 'library_id' in dataframe 'obs' must not contain NaN values.`
+- `Column 'library_preparation_batch' in dataframe 'obs' contains values with list separators (e.g. 'library1; library2; …; library16'). Each value must be a single identifier, not a delimited list.`
+
+## Outstanding actions
+
+### Data generator must fix
+
+| Issue | Detail |
+|---|---|
+| `obs['library_id']` NaN values | 28,633 / 50,296 cells; populated rows hold comma-concatenated lists. Needs real per-cell values from source. Validator error. |
+| `obs['library_preparation_batch']` delimited lists | Some rows hold semicolon-delimited values like `'library1; library2; …; library16'`. Each value must be a single identifier. Validator error. |
+| Var Ensembl IDs not in GENCODE v48 | 1,069 distinct IDs unmatched (mirrored in `raw.var` → 2,138 warnings). Annotation-version decision required. |
+| CAP marker symbols (`H2*`, `STMN`) | Both classified `not_in_gencode` by `validate_marker_genes` — not in var and not in GENCODE. CAP-side curator decision. |
+
+### Curator (awaiting input)
+
+*(none)*
+
+## Validation checklist
+
+47 checks evaluated · 2 failing · 2 warnings (non-feature-ID) · 6 fixed during curation · 37 passing.
+
+| Check | Status | Owner | Notes |
+|---|---|---|---|
+| `obs['library_id']` populated | ✗ Fail | Data generator | 28,633 / 50,296 NaN. Validator error. |
+| `obs['library_preparation_batch']` single value per row | ✗ Fail | Data generator | Some rows are delimited lists. Validator error. |
+| `obs['library_preparation_batch']` no placeholder values | ✓ Fixed during curation | (curator) | `replace_placeholder_values` removed 464 `'unknown'` cells (2026-04-21). |
+| `obs['library_sequencing_run']` no placeholder values | ✓ Fixed during curation | (curator) | `replace_placeholder_values` removed 464 `'unknown'` cells (2026-04-21). |
+| X is normalized | ✓ Fixed during curation | (curator) | `normalize_raw` moved raw counts to `raw.X` and applied `normalize_total(target_sum=10000) + log1p` (2026-04-21). |
+| Var feature_* columns populated | ✓ Fixed during curation | (curator) | `label_h5ad` populated `var['feature_name']` and four sibling `feature_*` columns; 34,505 / 35,574 matched GENCODE (2026-04-21). |
+| Obs ontology label columns populated | ✓ Fixed during curation | (curator) | `label_h5ad` wrote 8 obs labels (`tissue`, `cell_type`, `assay`, `disease`, `sex`, `organism`, `development_stage`, `self_reported_ethnicity`) from their `_ontology_term_id` columns (2026-04-21). |
+| CAP annotations present | ✓ Fixed during curation | (curator) | `copy_cap_annotations` imported 1 annotation set (`Prelim annotation`) from `HCA Gut Cell Atlas v1 Myeloid Lineage.h5ad` (latest run 2026-05-07). |
+| Var Ensembl IDs match current GENCODE | ⚠ Warn | Data generator | 1,069 IDs unmatched in GENCODE v48 / Ensembl 114. |
+| CAP marker symbols resolve in GENCODE | ⚠ Warn | Data generator | 2 markers (`H2*`, `STMN`) classified `not_in_gencode`. |
+
+(Passing rows omitted; full count in the header line.)
+
+## CAP details
+
+### Cell overlap
+
+| Metric | Value |
+|---|---|
+| CAP source file | `HCA Gut Cell Atlas v1 Myeloid Lineage.h5ad` |
+| `cells.n_cap` | 52,311 |
+| `cells.n_hca` | 50,296 |
+| `cells.n_matched` | 49,904 |
+| `cells.missing_from_hca` | 2,407 (4.6% of CAP) |
+| `cells.missing_from_cap` | 392 (0.8% of HCA) |
+
+### Gene overlap
+
+| Metric | Value |
+|---|---|
+| `genes.n_cap` | 36,353 |
+| `genes.n_hca` | 35,574 |
+| `genes.n_matched` | 35,574 |
+| `genes.missing_from_hca` | 779 (2.1% of CAP) |
+| `genes.missing_from_cap` | 0 (0.0% of HCA) |
+
+### Marker validation
+
+| Metric | Value |
+|---|---|
+| Total unique markers | 56 |
+| Found in var gene-name source | 54 |
+| Missing | 2 |
+
+| Marker | Classification | Var name | Ensembl ID |
+|---|---|---|---|
+| `H2*` | `not_in_gencode` | — | — |
+| `STMN` | `not_in_gencode` | — | — |
+
+## Curator changes
+
+Audit trail from `uns/provenance/edit_history`, oldest first.
+
+| # | Timestamp (UTC) | Operation | Description |
+|---|---|---|---|
+| 1 | 2026-04-21 04:19:10 | `normalize_raw` | Moved raw counts to raw.X and normalized X with normalize_total(target_sum=10000) + log1p |
+| 2 | 2026-04-21 04:19:51 | `replace_placeholder_values` | Replaced placeholder values with NaN in `library_preparation_batch` |
+| 3 | 2026-04-21 04:19:57 | `replace_placeholder_values` | Replaced placeholder values with NaN in `library_sequencing_run` |
+| 4 | 2026-04-21 04:20:03 | `label_h5ad` | Populated var feature_* from Ensembl IDs (34505/35574 matched GENCODE) and 8 obs ontology labels |
+| 5 | 2026-04-21 04:20:49 | `import_cap_annotations` | Copied CAP annotations from HCA Gut Cell Atlas v1 Myeloid Lineage.h5ad |
+| 6 | 2026-04-21 04:21:05 | `set_uns` | Set uns['default_embedding'] |
+| 7–14 | 2026-05-07 | `import_cap_annotations` | 8 re-runs (consolidating tooling iterations on the new shape). |
+```
+
+## Decisions to make before implementing
+
+- [ ] Comprehensive vs findings-only checklist (Option A vs B). PRD recommends B.
+- [ ] Section ordering — confirmed list above?
+- [ ] Whether to keep `Validator delta` (PRD says drop).
+- [ ] Whether to collapse CAP overlap/marker into the checklist or keep as a sub-section. PRD: keep sub-section for richer detail, but also surface as one-line checklist rows.
+- [ ] Final descriptive names for the responsibility labels — *"Data generator"* and *"Curator (awaiting input)"* read fine but worth team review.
+
+## Implementation notes (deferred)
+
+Once the shape is agreed, the skill changes are:
+
+1. Replace `## Step 5 — Report` body in `curate-h5ad/SKILL.md` with the new section list.
+2. Add a parallel template fragment in `evaluate-h5ad/SKILL.md` for the read-only case (no curator changes section, no outstanding actions for the curator).
+3. Build the validation-checklist row generator from `validate_schema` errors+warnings + `view_edit_log` entries. Each tool name in the edit log maps deterministically to a set of checks it satisfies.
+
+The mapping in (3) is the meaningful new logic. Worth a follow-up issue to enumerate it explicitly.


### PR DESCRIPTION
Closes #396.

## Summary

Adds two sections to the persisted `/curate-h5ad` Step 5 report template (and aligns `/evaluate-h5ad` Section 6 to the new edit-history shape) so the saved markdown carries the structure team's hand-composed PDFs historically had:

- **`### Summary`** block at the top of Step 5 — 2-3 prose sentences distilling what ran, the validator delta in one phrase, and a one-clause hand-off — followed by an **Outstanding issues** bullet list pulled from Buckets B1 / B2 / C so the saved-markdown reader sees the open items up-front. Full detail with action questions stays in the existing *Still to do* section.
- **`### Edit history`** block at the bottom of Step 5 — 4-column table (`#`, `Timestamp UTC`, `Operation`, `Description`) rendered from `view_edit_log`, oldest first. Timestamp formatted `YYYY-MM-DD HH:MM:SS` (no T, no fractional seconds, UTC implied).
- **`/evaluate-h5ad`** Section 6 updated to the same 4-column shape so both skills emit identical edit-history tables.

## Commits

1. `3ae0ff6` — feat(skills/curate-h5ad): add Summary + Outstanding issues + Edit history sections
2. `08b85d0` — refactor(skills): drop bucket-label prefixes from Outstanding issues; tighten marker-reporting rule (marker reporting in both skills now reports by symbol + classification only, no cause speculation)

Both originally landed on `noopdog/396-curate-summary-edit-history` and were cherry-picked here onto current main (post-#424 / post-#429) without conflicts.

## Verification

- Used the new template extensively during a real session (9 file curations across `eye/ocular-outflow-segment-v1`, `eye/optic-nerve-v1`, `eye/ocular-surface-v1`). All 9 saved reports are well-formed: Summary section reads cleanly, Outstanding issues bullets accurately reflect Bucket B1/B2/C contents, Edit history table renders correctly from `view_edit_log` output.
- No tests touched — skill templates are markdown only.

## Related

- #391 (the persisted reports work this builds on)
- #423 / #429 (cell-annotation validator wiring — landed separately on main and is now reflected in the rebased base; no conflicts with this PR's sections)
- Follow-up: separate PR will add an Atlas-line bullet + drop the empty `Required (bionetwork)` row — distinct skill polish discovered in the same curation session, out of #396's scope.

## Test plan

- [x] Both cherry-picked commits rebased cleanly onto current main
- [x] Real session validated the template (9 saved reports — all the curation outputs from this session)
- [ ] Reviewer: spot-check the Summary block wording for any leftover bucket-prefix references

🤖 Generated with [Claude Code](https://claude.com/claude-code)