### PR TITLE
feat(skills): add Atlas line + drop empty bionetwork row (#432)

### DIFF
--- a/.claude/skills/curate-h5ad/SKILL.md
+++ b/.claude/skills/curate-h5ad/SKILL.md
@@ -114,6 +114,8 @@ Then add an **Outstanding issues** bullet list pulled from Buckets B1, B2, and C
 ### Header
 One short paragraph or bullet block with: final file path, shape (`n_obs × n_vars`), `title` from `uns`, schema type (include version only when schema is CellxGENE — HCA is unversioned), X verdict + `raw.X` presence, compression status, `obsm` keys present. Add a **Provenance** line: `N donors · M samples · K libraries` from `get_descriptive_stats.columns[<col>].unique` for each column. Skip any metric whose column wasn't returned or whose `unique` is 0.
 
+If the final file lives under `/Users/dave/hca-tracker-upload/prod/<bionetwork>/<atlas-slug>/...`, lead the bullet block with an **Atlas** line rendered as `` `<bionetwork> / <atlas-slug>` (HCA Tracker upload location) ``. Extracted purely from the path — no `atlas` field exists on the file itself, so the upload-tracker directory convention is the source of truth. Omit the bullet when the file isn't under that tree.
+
 ### Mechanical fixes applied
 
 | # | Operation | Effect |

--- a/.claude/skills/evaluate-h5ad/SKILL.md
+++ b/.claude/skills/evaluate-h5ad/SKILL.md
@@ -32,6 +32,7 @@ Then synthesize the results into a report with these sections in order. Use mark
 
 ## 1. File overview
 One compact block (bullets or a short table) with:
+- **Atlas** (when the input lives under `/Users/dave/hca-tracker-upload/prod/<bionetwork>/<atlas-slug>/...`): render as `` `<bionetwork> / <atlas-slug>` (HCA Tracker upload location) ``. Extracted purely from the path — there is no `atlas` field on the file itself, so the upload-tracker directory convention is the source of truth. Omit this bullet if the file isn't under that tree.
 - Input path (`$ARGUMENTS`). If the tools auto-resolved to a newer snapshot, add the resolved basename on a second line — read it from any tool that returns a `filename` field (e.g. `check_schema_type.filename`). Skip the second line when input and resolved agree.
 - Shape: `n_obs × n_vars`, file size (MB)
 - `title` from `uns`
@@ -45,10 +46,9 @@ One compact block (bullets or a short table) with:
 | Category | Missing |
 |---|---|
 | Required (schema-wide) | list the `missing_required` field names |
-| Required (bionetwork) | list the `missing_required_bionetwork` field names |
 | Extra uns keys (not in schema) | list any `extra_uns_keys` |
 
-If nothing is missing, say so in a single line instead of an empty table.
+Do not render a `Required (bionetwork)` row. `missing_required_bionetwork` is union-aggregated across modelled bionetwork subclasses (adipose / gut / MSK) and not routed per file, so its value is uninformative — empty isn't a green light, and a hit could be a false positive against the wrong bionetwork. If nothing is missing across the whole table, say so in a single line instead of rendering it.
 
 ## 3. Storage & compression
 


### PR DESCRIPTION
Closes #432.

## Summary

Two small skill-template polish items discovered during the eye-bionetwork curation session (9 files across `ocular-outflow-segment-v1`, `optic-nerve-v1`, `ocular-surface-v1`). Distinct scope from #396 / #431 (Summary + Edit history).

### Change 1 — Atlas line in both Header sections

Files under \`/Users/dave/hca-tracker-upload/prod/<bionetwork>/<atlas-slug>/...\` now get an **Atlas** bullet in the report Header derived from the path. The atlas/bionetwork identity has no field on the file itself — the upload-tracker directory convention is the source of truth.

Verified on all 9 saved curation reports from this session: each correctly renders e.g. \`Atlas: eye / optic-nerve-v1\` at the top of the Header.

### Change 2 — Drop the `Required (bionetwork)` row from `/evaluate-h5ad` Section 2

The row sources from \`list_uns_fields.missing_required_bionetwork\`, which is **union-aggregated across the modelled bionetwork subclasses** (adipose / gut / MSK) — not routed per file. So on an eye atlas (no \`EyeDataset\` modelled) the row was always empty, but that's *not* a green light, just uninformative; a hit would be a false positive against the wrong bionetwork. Removed the row entirely and added a brief explanatory line in the prose so a future reader knows why bionetwork-required isn't checked.

## Changes

- \`.claude/skills/curate-h5ad/SKILL.md\` (+2 / -0) — Atlas line in Step 5 Header section
- \`.claude/skills/evaluate-h5ad/SKILL.md\` (+2 / -2) — Atlas line in Section 1; bionetwork row dropped from Section 2 table

## Verification

- Real session: 9 saved curation reports + 1 evaluation report all render correctly with the Atlas line at top of Header.
- No tests touched — skill templates are markdown only.

## Sequencing

Independent of #431 (PR for #396). Both branched from the same main tip, neither blocks the other.

## Test plan

- [x] Real session validated the changes (all 9 curation reports + 1 eval)
- [ ] Reviewer: confirm the Atlas line's path convention assumption matches your team's upload layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)