### PR TITLE
fix(dataset-validator): read metadata via read_elem, not backed read_h5ad (#447)

### DIFF
--- a/services/dataset-validator/poetry.lock
+++ b/services/dataset-validator/poetry.lock
@@ -779,8 +779,8 @@ files = [
 google-auth = ">=2.14.1,<3.0.0"
 googleapis-common-protos = ">=1.63.2,<2.0.0"
 proto-plus = [
-    {version = ">=1.22.3,<2.0.0"},
     {version = ">=1.25.0,<2.0.0", markers = "python_version >= \"3.13\""},
+    {version = ">=1.22.3,<2.0.0", markers = "python_version < \"3.13\""},
 ]
 protobuf = ">=4.25.8,<8.0.0"
 requests = ">=2.20.0,<3.0.0"
@@ -1060,6 +1060,7 @@ develop = true
 [package.dependencies]
 google-api-python-client = "^2.171.0"
 gspread = "^6.2.0"
+h5py = {version = "^3.8", optional = true}
 linkml = "1.9.2"
 linkml-runtime = "^1.9.1"
 linkml-validator = "^0.4.5"
@@ -1071,6 +1072,9 @@ python-dotenv = "^1.1.0"
 pyyaml = "^6.0"
 requests = "^2.32.3"
 urllib3 = "^2.5.0"
+
+[package.extras]
+h5ad = ["h5py (>=3.8,<4.0)"]
 
 [package.source]
 type = "directory"
@@ -1781,8 +1785,8 @@ files = [
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.23.2", markers = "python_version == \"3.11\""},
     {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
+    {version = ">=1.23.2", markers = "python_version == \"3.11\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -3508,4 +3512,4 @@ test = ["coverage (>=7.10)", "hypothesis", "mypy", "packaging", "pytest (<8.4)",
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "f3051e9f067ed86c5dcdbab67c463413972d59b57e6418003081da5bd5a4950f"
+content-hash = "fa8423cee2d5d241664b97a13e7f072a3caa5abd952e3ced9ab97339c0204009"

--- a/services/dataset-validator/pyproject.toml
+++ b/services/dataset-validator/pyproject.toml
@@ -11,7 +11,7 @@ python = "^3.11"
 boto3 = "^1.34.0"
 # Minimal dependencies for Batch environment - add back as needed
 # python-dotenv = "^1.1.0"
-hca-validation-shared = {path = "../../shared", develop = true}
+hca-validation-shared = {path = "../../shared", develop = true, extras = ["h5ad"]}
 anndata = "^0.12.2"
 cap-upload-validator = "^1.5.1"
 

--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -18,14 +18,18 @@ import subprocess
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Callable, List, Optional, Tuple
+from types import SimpleNamespace
+from typing import Callable, List, Optional, Tuple, cast
 
 import boto3
 from botocore.exceptions import ClientError
 import anndata
+from anndata.io import read_elem
+import h5py
 import pandas as pd
 
 from hca_validation.metadata_coverage import compute_metadata_coverage
+from hca_validation.h5ad_storage import get_matrix_storage
 from hca_validation.schema_utils import load_schemaview
 
 
@@ -138,6 +142,7 @@ class ValidationMessage:
         dict[str, ValidationToolReport]
     ] = None
     metadata_coverage: Optional[dict] = None             # Per-field completeness summary (#405)
+    matrix_storage: Optional[dict] = None                # Per-matrix/layer shape + size, from HDF5 header (#447)
     error_message: Optional[str] = None                  # Human-readable error description
 
     def to_json(self) -> str:
@@ -471,30 +476,74 @@ def _get_schemaview():
     return load_schemaview()
 
 
-def read_file_metadata(file_path: Path) -> Tuple[MetadataSummary, Optional[dict]]:
-    """Open an h5ad once and return (metadata_summary, metadata_coverage).
+def _read_shape(f: h5py.File, obs: pd.DataFrame) -> Tuple[int, int]:
+    """Derive (n_obs, n_vars) from the X header, falling back to obs/var length.
 
-    Coverage failures are non-fatal — they're returned as None so the
-    caller can still publish a summary. Reading the file at all is fatal
-    (raised through), since downstream validators depend on it.
+    X carries a ``shape`` attr when sparse; when dense it's a 2-D dataset.
     """
-    adata = None
+    if "X" in f:
+        x = f["X"]
+        shape = x.attrs.get("shape")
+        if shape is not None and len(shape) == 2:
+            return int(shape[0]), int(shape[1])
+        if isinstance(x, h5py.Dataset) and len(x.shape) == 2:
+            return int(x.shape[0]), int(x.shape[1])
+    n_vars = 0
+    if "var" in f:
+        var = f["var"]
+        n_vars = int(var[var.attrs["_index"]].shape[0])
+    return int(len(obs)), n_vars
+
+
+def _read_metadata_inputs(file_path: Path) -> Tuple[pd.DataFrame, dict, int, int]:
+    """Read (obs, uns, n_obs, n_vars) from an h5ad without loading matrices.
+
+    Uses targeted ``read_elem`` of obs/uns plus the X header for shape — never
+    opens X/raw/layers. This replaces ``read_h5ad(path, backed="r")``, whose
+    backed mode is X-only and eagerly materializes ``layers`` + ``raw`` (15–24+ GB
+    on large files). See hca-validation-tools#447.
+    """
+    with h5py.File(file_path, "r") as f:
+        # read_elem returns a broad RWAble type; obs/uns are concretely a
+        # DataFrame and a dict for an h5ad.
+        obs = cast(pd.DataFrame, read_elem(f["obs"]))
+        uns = cast(dict, read_elem(f["uns"])) if "uns" in f else {}
+        n_obs, n_vars = _read_shape(f, obs)
+    return obs, uns, n_obs, n_vars
+
+
+def read_file_metadata(
+    file_path: Path,
+) -> Tuple[MetadataSummary, Optional[dict], Optional[dict]]:
+    """Read metadata once and return (summary, coverage, matrix_storage).
+
+    Only obs + uns (+ matrix headers) are read — never the matrices themselves —
+    so this stays bounded (~1 GB) even on files whose X/raw/layers hold billions
+    of nonzeros. Coverage and matrix-storage failures are non-fatal (returned as
+    None); a failure to read obs/uns is fatal (raised through).
+    """
     try:
-        try:
-            adata = anndata.io.read_h5ad(file_path, backed="r")
-            summary = _extract_metadata_summary(adata)
-        except Exception as e:
-            logger.error("Error reading metadata: %s", e)
-            raise
-        try:
-            coverage = compute_metadata_coverage(adata, _get_schemaview())
-        except Exception as e:
-            logger.warning("metadata_coverage computation failed: %s", e)
-            coverage = None
-        return summary, coverage
-    finally:
-        if adata is not None:
-            adata.file.close()
+        obs, uns, n_obs, n_vars = _read_metadata_inputs(file_path)
+    except Exception as e:
+        logger.error("Error reading metadata: %s", e)
+        raise
+
+    adata_like = SimpleNamespace(obs=obs, uns=uns, n_obs=n_obs, n_vars=n_vars)
+    summary = _extract_metadata_summary(adata_like)
+
+    try:
+        coverage = compute_metadata_coverage(adata_like, _get_schemaview())
+    except Exception as e:
+        logger.warning("metadata_coverage computation failed: %s", e)
+        coverage = None
+
+    try:
+        matrix_storage = get_matrix_storage(str(file_path))
+    except Exception as e:
+        logger.warning("matrix_storage computation failed: %s", e)
+        matrix_storage = None
+
+    return summary, coverage, matrix_storage
 
 
 def get_default_cap_validator_script_path() -> Path:
@@ -950,10 +999,13 @@ def main() -> int:
 
             validation_message.integrity_status = INTEGRITY_VALID
 
-        # Read metadata summary + per-field coverage (#405) in one h5ad open.
-        validation_message.metadata_summary, validation_message.metadata_coverage = (
-            read_file_metadata(local_file)
-        )
+        # Read metadata summary + per-field coverage (#405) + per-matrix storage
+        # (#447) without loading any matrix data.
+        (
+            validation_message.metadata_summary,
+            validation_message.metadata_coverage,
+            validation_message.matrix_storage,
+        ) = read_file_metadata(local_file)
         log_memory_usage("after metadata read")
         gc.collect()
 

--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -173,10 +173,13 @@ class ValidationMessage:
         """
 
         # The inline SNS message never carries matrix_storage; serialize/truncate a
-        # view of self with it stripped. (No copy in the common case where it's None.)
+        # view of self with it stripped. A shallow copy suffices — only the
+        # matrix_storage field is reassigned, and the truncation path below
+        # deep-copies before mutating tool_reports lists, so the original (and
+        # its possibly-large matrix_storage) is never copied or mutated here.
         base = self
         if self.matrix_storage is not None:
-            base = copy.deepcopy(self)
+            base = copy.copy(self)
             base.matrix_storage = None
 
         # If there are no reports to truncate or the full message is short enough, use the full message
@@ -512,7 +515,9 @@ def _read_shape(f: h5py.File, obs: pd.DataFrame) -> Tuple[int, int]:
         if isinstance(index_name, bytes):
             index_name = index_name.decode()
         if index_name is not None and index_name in var:
-            n_vars = int(var[index_name].shape[0])
+            node = var[index_name]
+            if isinstance(node, h5py.Dataset):
+                n_vars = int(node.shape[0])
     return int(len(obs)), n_vars
 
 

--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -163,11 +163,25 @@ class ValidationMessage:
         return len(json.dumps(self._get_report_message_list(report_key, message_type)))
 
     def to_length_limited_json(self, max_length=MAX_SNS_MESSAGE_LENGTH) -> str:
-        """Convert to a JSON string with message lists truncated to ensure that the JSON is below a given length."""
+        """Convert to a JSON string with message lists truncated to ensure that the JSON is below a given length.
+
+        ``matrix_storage`` (#447) is omitted entirely from the inline SNS payload:
+        it can be large (a file with many layers) and is always available in full
+        from the S3 claim-check (write_validation_results_to_s3), which the tracker
+        reads preferentially. Keeping it out keeps the SNS message shape identical
+        to the pre-#447 payload.
+        """
+
+        # The inline SNS message never carries matrix_storage; serialize/truncate a
+        # view of self with it stripped. (No copy in the common case where it's None.)
+        base = self
+        if self.matrix_storage is not None:
+            base = copy.deepcopy(self)
+            base.matrix_storage = None
 
         # If there are no reports to truncate or the full message is short enough, use the full message
-        full_message = self.to_json()
-        if self.tool_reports is None or len(full_message) < max_length:
+        full_message = base.to_json()
+        if base.tool_reports is None or len(full_message) < max_length:
             return full_message
 
         # Create a list of (tool_key, message_type) pairs to consider for truncation.
@@ -176,24 +190,24 @@ class ValidationMessage:
         # false PartiallyValidIcon indicators in the tracker UI (#382).
         list_paths = [
             (key, message_type)
-            for key in self.tool_reports.keys()
+            for key in base.tool_reports.keys()
             for message_type in ["errors", "warnings"]
-            if self._get_report_message_list(key, message_type)
+            if base._get_report_message_list(key, message_type)
         ]
         # Truncation priority: warnings first, then cellxgene errors, then cap errors,
         # then hcaSchema errors, then hcaCellAnnotation errors (preserved longest)
         list_paths.sort(key=lambda p: (
             0 if p[1] == "warnings" else 1 + TOOL_ERROR_PRIORITY.get(p[0], 0),
-            -self._json_length_of_report_list(*p),
+            -base._json_length_of_report_list(*p),
         ))
 
         # Create a copy of the validation message to truncate lists in
-        truncated_message = copy.deepcopy(self)
+        truncated_message = copy.deepcopy(base)
 
         # Truncate entire lists until the message JSON is small enough, and note which list was the last to be truncated
         threshold_path = None
         for p in list_paths:
-            original_total = len(self._get_report_message_list(*p))
+            original_total = len(base._get_report_message_list(*p))
             truncated_message._set_report_message_list(*p, [_truncated_marker(0, original_total)])
             if len(truncated_message.to_json()) < max_length:
                 threshold_path = p
@@ -205,7 +219,7 @@ class ValidationMessage:
             return truncated_message.to_json()
 
         # Get the original value of the list that was the threshold for making the message small enough
-        message_list = self._get_report_message_list(*threshold_path)
+        message_list = base._get_report_message_list(*threshold_path)
 
         # Do a binary search to determine how much of the list can be retained,
         # ensuring that the truncated message remains at a valid length
@@ -511,10 +525,11 @@ def _read_metadata_inputs(file_path: Path) -> Tuple[pd.DataFrame, dict, int, int
     on large files). See hca-validation-tools#447.
     """
     with h5py.File(file_path, "r") as f:
-        # read_elem returns a broad RWAble type; obs/uns are concretely a
-        # DataFrame and a dict for an h5ad.
-        obs = cast(pd.DataFrame, read_elem(f["obs"]))
-        uns = cast(dict, read_elem(f["uns"])) if "uns" in f else {}
+        # obs/uns are always HDF5 groups in an h5ad; cast so read_elem accepts
+        # them (f[...] is typed Group | Dataset | Datatype). read_elem returns a
+        # broad RWAble type; obs/uns are concretely a DataFrame and a dict.
+        obs = cast(pd.DataFrame, read_elem(cast(h5py.Group, f["obs"])))
+        uns = cast(dict, read_elem(cast(h5py.Group, f["uns"]))) if "uns" in f else {}
         n_obs, n_vars = _read_shape(f, obs)
     return obs, uns, n_obs, n_vars
 

--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -23,7 +23,6 @@ from typing import Callable, List, Optional, Tuple, cast
 
 import boto3
 from botocore.exceptions import ClientError
-import anndata
 from anndata.io import read_elem
 import h5py
 import pandas as pd
@@ -441,45 +440,6 @@ def get_column_unique_values_if_present(df: pd.DataFrame, name: str, map_value=s
     return list(df[name].map(map_value).unique()) if name in df else []
 
 
-def read_metadata(file_path: Path) -> MetadataSummary:
-    """
-    Read metadata from an H5AD file and extract key biological annotations.
-    
-    This function opens an H5AD (AnnData) file in backed mode and extracts unique values
-    from key observation columns to create a metadata summary. The file is automatically
-    closed after reading to prevent resource leaks.
-    
-    Args:
-        file_path: Path to the H5AD file to read metadata from
-        
-    Returns:
-        MetadataSummary: A summary containing:
-            - title: Title of the individual dataset
-            - assay: List of unique assay types in the dataset
-            - suspension_type: List of unique suspension types
-            - tissue: List of unique tissue types
-            - disease: List of unique disease conditions
-            - cell_count: Total number of cells/observations in the dataset
-            
-    Raises:
-        Exception: If the H5AD file cannot be read or required columns are missing
-        
-    Note:
-        The file is opened in backed mode ('r') for memory efficiency and automatically
-        closed in the finally block to ensure proper resource cleanup.
-    """
-    adata = None
-    try:
-        adata = anndata.io.read_h5ad(file_path, backed="r")
-        return _extract_metadata_summary(adata)
-    except Exception as e:
-        logger.error("Error reading metadata: %s", e)
-        raise
-    finally:
-        if adata is not None:
-            adata.file.close()
-
-
 def _extract_metadata_summary(adata) -> MetadataSummary:
     title = adata.uns.get("title")
     # anndata.obs is typed DataFrame | Dataset2D (backed vs in-memory); runtime is DataFrame here
@@ -508,7 +468,9 @@ def _read_shape(f: h5py.File, obs: pd.DataFrame) -> Tuple[int, int]:
     if "X" in f:
         x = f["X"]
         shape = x.attrs.get("shape")
-        if shape is not None and len(shape) == 2:
+        # Guard against a non-sequence shape attr (malformed file) so we fall
+        # through to the var/obs fallback instead of raising on len().
+        if shape is not None and hasattr(shape, "__len__") and len(shape) == 2:
             return int(shape[0]), int(shape[1])
         if isinstance(x, h5py.Dataset) and len(x.shape) == 2:
             return int(x.shape[0]), int(x.shape[1])

--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -491,7 +491,14 @@ def _read_shape(f: h5py.File, obs: pd.DataFrame) -> Tuple[int, int]:
     n_vars = 0
     if "var" in f:
         var = f["var"]
-        n_vars = int(var[var.attrs["_index"]].shape[0])
+        # Defensive: this fallback only runs for files where X lacks a shape
+        # attr (not produced by anndata). Degrade to 0 rather than raising a
+        # cryptic h5py error if the var index is missing/malformed.
+        index_name = var.attrs.get("_index")
+        if isinstance(index_name, bytes):
+            index_name = index_name.decode()
+        if index_name is not None and index_name in var:
+            n_vars = int(var[index_name].shape[0])
     return int(len(obs)), n_vars
 
 

--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -162,29 +162,27 @@ class ValidationMessage:
     def _json_length_of_report_list(self, report_key: str, message_type: str) -> int:
         return len(json.dumps(self._get_report_message_list(report_key, message_type)))
 
-    def to_length_limited_json(self, max_length=MAX_SNS_MESSAGE_LENGTH) -> str:
-        """Convert to a JSON string with message lists truncated to ensure that the JSON is below a given length.
+    def _to_sns_json(self) -> str:
+        """Serialize for the inline SNS payload, omitting ``matrix_storage``.
 
-        ``matrix_storage`` (#447) is omitted entirely from the inline SNS payload:
-        it can be large (a file with many layers) and is always available in full
-        from the S3 claim-check (write_validation_results_to_s3), which the tracker
-        reads preferentially. Keeping it out keeps the SNS message shape identical
-        to the pre-#447 payload.
+        ``matrix_storage`` (#447) can be large (a file with many layers) and is
+        always available in full from the S3 claim-check
+        (write_validation_results_to_s3), which the tracker reads preferentially.
+        Dropping the key keeps the SNS message shape identical to the pre-#447
+        payload.
         """
+        data = asdict(self)
+        data.pop("matrix_storage", None)
+        return json.dumps(data, separators=(',', ':'))
 
-        # The inline SNS message never carries matrix_storage; serialize/truncate a
-        # view of self with it stripped. A shallow copy suffices — only the
-        # matrix_storage field is reassigned, and the truncation path below
-        # deep-copies before mutating tool_reports lists, so the original (and
-        # its possibly-large matrix_storage) is never copied or mutated here.
-        base = self
-        if self.matrix_storage is not None:
-            base = copy.copy(self)
-            base.matrix_storage = None
+    def to_length_limited_json(self, max_length=MAX_SNS_MESSAGE_LENGTH) -> str:
+        """Convert to a length-limited SNS JSON string, truncating message lists
+        to stay below ``max_length``. Excludes ``matrix_storage`` (see
+        :meth:`_to_sns_json`)."""
 
-        # If there are no reports to truncate or the full message is short enough, use the full message
-        full_message = base.to_json()
-        if base.tool_reports is None or len(full_message) < max_length:
+        # If there are no reports to truncate or the message is short enough, use it as-is.
+        full_message = self._to_sns_json()
+        if self.tool_reports is None or len(full_message) < max_length:
             return full_message
 
         # Create a list of (tool_key, message_type) pairs to consider for truncation.
@@ -193,36 +191,39 @@ class ValidationMessage:
         # false PartiallyValidIcon indicators in the tracker UI (#382).
         list_paths = [
             (key, message_type)
-            for key in base.tool_reports.keys()
+            for key in self.tool_reports.keys()
             for message_type in ["errors", "warnings"]
-            if base._get_report_message_list(key, message_type)
+            if self._get_report_message_list(key, message_type)
         ]
         # Truncation priority: warnings first, then cellxgene errors, then cap errors,
         # then hcaSchema errors, then hcaCellAnnotation errors (preserved longest)
         list_paths.sort(key=lambda p: (
             0 if p[1] == "warnings" else 1 + TOOL_ERROR_PRIORITY.get(p[0], 0),
-            -base._json_length_of_report_list(*p),
+            -self._json_length_of_report_list(*p),
         ))
 
-        # Create a copy of the validation message to truncate lists in
-        truncated_message = copy.deepcopy(base)
+        # Truncate lists in a copy. Strip matrix_storage before the deep copy so
+        # the (possibly large) field is neither copied nor serialized.
+        truncated_message = copy.copy(self)
+        truncated_message.matrix_storage = None
+        truncated_message = copy.deepcopy(truncated_message)
 
         # Truncate entire lists until the message JSON is small enough, and note which list was the last to be truncated
         threshold_path = None
         for p in list_paths:
-            original_total = len(base._get_report_message_list(*p))
+            original_total = len(self._get_report_message_list(*p))
             truncated_message._set_report_message_list(*p, [_truncated_marker(0, original_total)])
-            if len(truncated_message.to_json()) < max_length:
+            if len(truncated_message._to_sns_json()) < max_length:
                 threshold_path = p
                 break
 
         # If all lists have been truncated and somehow none have made the message small enough,
         # give up and try using it anyway
         if threshold_path is None:
-            return truncated_message.to_json()
+            return truncated_message._to_sns_json()
 
         # Get the original value of the list that was the threshold for making the message small enough
-        message_list = base._get_report_message_list(*threshold_path)
+        message_list = self._get_report_message_list(*threshold_path)
 
         # Do a binary search to determine how much of the list can be retained,
         # ensuring that the truncated message remains at a valid length
@@ -235,7 +236,7 @@ class ValidationMessage:
                 *threshold_path,
                 [*message_list[:middle_length], _truncated_marker(middle_length, len(message_list))],
             )
-            if len(truncated_message.to_json()) < max_length:
+            if len(truncated_message._to_sns_json()) < max_length:
                 max_valid_length = middle_length
             else:
                 min_invalid_length = middle_length

--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -171,7 +171,13 @@ class ValidationMessage:
         Dropping the key keeps the SNS message shape identical to the pre-#447
         payload.
         """
-        data = asdict(self)
+        # Null matrix_storage on a shallow copy before asdict so its (possibly
+        # large) payload is never recursively copied just to be discarded.
+        src = self
+        if self.matrix_storage is not None:
+            src = copy.copy(self)
+            src.matrix_storage = None
+        data = asdict(src)
         data.pop("matrix_storage", None)
         return json.dumps(data, separators=(',', ':'))
 
@@ -511,14 +517,15 @@ def _read_shape(f: h5py.File, obs: pd.DataFrame) -> Tuple[int, int]:
         var = f["var"]
         # Defensive: this fallback only runs for files where X lacks a shape
         # attr (not produced by anndata). Degrade to 0 rather than raising a
-        # cryptic h5py error if the var index is missing/malformed.
-        index_name = var.attrs.get("_index")
-        if isinstance(index_name, bytes):
-            index_name = index_name.decode()
-        if index_name is not None and index_name in var:
-            node = var[index_name]
-            if isinstance(node, h5py.Dataset):
-                n_vars = int(node.shape[0])
+        # cryptic h5py error if var isn't a group or its index is missing/malformed.
+        if isinstance(var, h5py.Group):
+            index_name = var.attrs.get("_index")
+            if isinstance(index_name, bytes):
+                index_name = index_name.decode()
+            if index_name is not None and index_name in var:
+                node = var[index_name]
+                if isinstance(node, h5py.Dataset):
+                    n_vars = int(node.shape[0])
     return int(len(obs)), n_vars
 
 

--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -242,8 +242,8 @@ class ValidationMessage:
                 min_invalid_length = middle_length
                 truncated_message._set_report_message_list(*threshold_path, truncated_list_before)
 
-        # Return the truncated message JSON
-        return truncated_message.to_json()
+        # Return the truncated message JSON (matrix_storage omitted, see _to_sns_json)
+        return truncated_message._to_sns_json()
 
 
 def configure_logging() -> logging.Logger:

--- a/services/dataset-validator/tests/test_dataset_validator.py
+++ b/services/dataset-validator/tests/test_dataset_validator.py
@@ -469,6 +469,35 @@ def test_matrix_storage_excluded_from_sns_message():
     assert len(sns) < MAX_SNS_MESSAGE_LENGTH
 
 
+def test_sns_omits_matrix_storage_on_truncation_path():
+    """Even when tool-report lists force the binary-search truncation path, the
+    final SNS payload omits matrix_storage and stays under the limit."""
+    from dataset_validator.main import (
+        ValidationMessage, ValidationToolReport, MAX_SNS_MESSAGE_LENGTH,
+    )
+
+    # Huge error list → forces truncation through to the binary-search return.
+    huge_errors = [f"ERROR {i}: " + "x" * 60 for i in range(10000)]
+    reports = {
+        "hcaSchema": ValidationToolReport(
+            valid=False, errors=huge_errors, warnings=[],
+            started_at="2024-01-01T00:00:00Z", finished_at="2024-01-01T00:00:01Z",
+        ),
+    }
+    msg = ValidationMessage(
+        file_id="f", status="failure", timestamp="2024-01-01T00:00:00Z",
+        bucket="b", key="k", batch_job_id="j",
+        tool_reports=reports,
+        matrix_storage={"X": {"format": "csr_matrix"}, "raw_X": None, "layers": None},
+    )
+    assert len(msg.to_json()) > MAX_SNS_MESSAGE_LENGTH  # forces truncation
+
+    sns = msg.to_length_limited_json()
+    parsed = json.loads(sns)
+    assert "matrix_storage" not in parsed          # omitted on the truncation path too
+    assert len(sns) < MAX_SNS_MESSAGE_LENGTH        # actually under the measured limit
+
+
 @pytest.mark.parametrize("test_case", [
     {
         "name": "success",

--- a/services/dataset-validator/tests/test_dataset_validator.py
+++ b/services/dataset-validator/tests/test_dataset_validator.py
@@ -425,6 +425,16 @@ def test_read_shape_var_fallback_is_robust(tmp_path):
         n_obs, n_vars = _read_shape(f, obs)
     assert (n_obs, n_vars) == (3, 7)
 
+    # var._index points at a group (not a dataset) → degrade, don't raise.
+    path3 = tmp_path / "weird3.h5ad"
+    with h5py.File(path3, "w") as f:
+        f.create_dataset("X", data=np.zeros(3, dtype=np.float32))
+        var = f.create_group("var")
+        var.attrs["_index"] = "idx"
+        var.create_group("idx")
+        n_obs, n_vars = _read_shape(f, obs)
+    assert (n_obs, n_vars) == (3, 0)
+
 
 def test_matrix_storage_excluded_from_sns_message():
     """matrix_storage is kept in the full claim-check JSON but omitted from the

--- a/services/dataset-validator/tests/test_dataset_validator.py
+++ b/services/dataset-validator/tests/test_dataset_validator.py
@@ -5,6 +5,7 @@ import logging
 import os
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Dict, Any, List
 from unittest.mock import MagicMock, patch
 import sys
@@ -338,21 +339,20 @@ def test_missing_bucket_skips_s3_claim_check(caplog, env_manager, base_env_vars)
         }
     }
 ], ids=lambda x: x["name"])
-@patch("anndata.io.read_h5ad")
-def test_read_metadata_scenarios(mock_read_h5ad, test_case):
-    """Parameterized test for metadata reading scenarios."""
-    from dataset_validator.main import read_metadata, MetadataSummary
-    
-    # Set up anndata mock
-    mock_adata = MagicMock()
-    mock_read_h5ad.return_value = mock_adata
-    mock_adata.obs = pd.DataFrame(test_case["adata"]["obs"])
-    mock_adata.uns = test_case["adata"]["uns"]
-    mock_adata.n_obs = mock_adata.obs.shape[0]
-    mock_adata.n_vars = test_case["adata"]["n_vars"]
+def test_extract_metadata_summary_scenarios(test_case):
+    """Parameterized test for the metadata summary extraction (obs/uns -> MetadataSummary)."""
+    from dataset_validator.main import _extract_metadata_summary, MetadataSummary
 
-    # Test reading metadata
-    metadata_summary = read_metadata(Path("test-file.h5ad"))
+    # _extract_metadata_summary only reads .obs/.uns/.n_obs/.n_vars
+    obs = pd.DataFrame(test_case["adata"]["obs"])
+    adata_like = SimpleNamespace(
+        obs=obs,
+        uns=test_case["adata"]["uns"],
+        n_obs=obs.shape[0],
+        n_vars=test_case["adata"]["n_vars"],
+    )
+
+    metadata_summary = _extract_metadata_summary(adata_like)
 
     assert metadata_summary == MetadataSummary(**test_case["expected_result"])
 
@@ -434,6 +434,18 @@ def test_read_shape_var_fallback_is_robust(tmp_path):
         var.create_group("idx")
         n_obs, n_vars = _read_shape(f, obs)
     assert (n_obs, n_vars) == (3, 0)
+
+    # X has a scalar (non-sequence) shape attr → fall through to the var index
+    # rather than raising on len(shape).
+    path4 = tmp_path / "weird4.h5ad"
+    with h5py.File(path4, "w") as f:
+        x = f.create_group("X")
+        x.attrs["shape"] = np.int64(5)            # scalar, not a 2-tuple
+        var = f.create_group("var")
+        var.attrs["_index"] = "gene_id"
+        var.create_dataset("gene_id", data=np.arange(7))
+        n_obs, n_vars = _read_shape(f, obs)
+    assert (n_obs, n_vars) == (3, 7)
 
 
 def test_matrix_storage_excluded_from_sns_message():

--- a/services/dataset-validator/tests/test_dataset_validator.py
+++ b/services/dataset-validator/tests/test_dataset_validator.py
@@ -19,6 +19,28 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 from dataset_validator.main import get_poetry_venv_path_from
 
 
+def _setup_metadata_mocks(mock_read_inputs, mock_matrix_storage, test_adata):
+    """Configure the read_file_metadata seam mocks from a test ``adata`` spec.
+
+    ``read_file_metadata`` reads obs/uns/shape via ``_read_metadata_inputs`` and
+    per-matrix storage via ``get_matrix_storage`` (no full h5ad open), so tests
+    drive those two seams instead of mocking ``anndata.read_h5ad``.
+    """
+    if test_adata is None:
+        return
+    if "exception" in test_adata:
+        mock_read_inputs.side_effect = test_adata["exception"]
+        return
+    obs_df = pd.DataFrame(test_adata["obs"])
+    mock_read_inputs.return_value = (
+        obs_df,
+        test_adata["uns"],
+        obs_df.shape[0],
+        test_adata["n_vars"],
+    )
+    mock_matrix_storage.return_value = test_adata.get("matrix_storage")
+
+
 dataset_validator_venv_path = get_poetry_venv_path_from(Path(__file__).parent.parent)
 mock_modules_path = Path(__file__).parent / "mock-modules"
 external_validator_path_vars = {
@@ -335,6 +357,48 @@ def test_read_metadata_scenarios(mock_read_h5ad, test_case):
     assert metadata_summary == MetadataSummary(**test_case["expected_result"])
 
 
+def test_read_file_metadata_real_h5ad(tmp_path):
+    """read_file_metadata reads obs/uns/shape + matrix_storage from a real h5ad
+    without loading matrices (the #447 fix path: no read_h5ad(backed="r"))."""
+    import anndata as ad
+    import scipy.sparse as sp
+    from dataset_validator.main import read_file_metadata
+
+    n_obs, n_vars = 5, 8
+    X = sp.random(n_obs, n_vars, density=0.5, format="csr", dtype=np.float32)
+    obs = pd.DataFrame({
+        "assay": ["a", "a", "b", "b", "a"],
+        "suspension_type": ["cell"] * 5,
+        "tissue": ["lung"] * 5,
+        "disease": ["normal"] * 5,
+        "donor_id": ["d1", "d1", "d2", "d2", "d2"],
+    }, index=[f"cell{i}" for i in range(n_obs)])
+    adata = ad.AnnData(X=X, obs=obs)
+    adata.uns["title"] = "tiny"
+    adata.raw = adata
+    adata.layers["denoised"] = X.copy()
+    path = tmp_path / "tiny.h5ad"
+    adata.write_h5ad(path)
+
+    summary, coverage, storage = read_file_metadata(path)
+
+    # Summary read straight from obs/uns (not the matrices)
+    assert summary.title == "tiny"
+    assert summary.cell_count == n_obs
+    assert summary.gene_count == n_vars
+    assert set(summary.assay) == {"a", "b"}
+
+    # Coverage still computed from the same obs/uns
+    assert coverage is not None
+    assert isinstance(coverage["field_coverage"], list)
+
+    # Matrix storage captured from the HDF5 header for X, raw.X and the layer
+    assert storage["X"]["format"] == "csr_matrix"
+    assert (storage["X"]["n_obs"], storage["X"]["n_vars"]) == (n_obs, n_vars)
+    assert storage["raw_X"] is not None
+    assert "denoised" in storage["layers"]
+
+
 @pytest.mark.parametrize("test_case", [
     {
         "name": "success",
@@ -481,6 +545,7 @@ def test_cap_validator_script_scenarios(mock_upload_validator, test_case):
             'metadata_summary': None,
             'tool_reports': None,
             'metadata_coverage': None,
+            'matrix_storage': None,
             'error_message': None
         },
         "use_valid_topic": True,
@@ -714,8 +779,9 @@ def test_write_validation_results_to_s3_writes_full_untruncated_json(mock_aws):
         "expected_stdout": None
     }
 ], ids=lambda x: x["name"])
-@patch("anndata.io.read_h5ad")
-def test_local_file_mode(mock_read_h5ad, caplog, env_manager, tmp_path, test_case, capsys):
+@patch("dataset_validator.main.get_matrix_storage")
+@patch("dataset_validator.main._read_metadata_inputs")
+def test_local_file_mode(mock_read_inputs, mock_matrix_storage, caplog, env_manager, tmp_path, test_case, capsys):
     """Test LOCAL_FILE mode skips S3/integrity, prints JSON when no SNS."""
     from dataset_validator.main import main
 
@@ -733,15 +799,8 @@ def test_local_file_mode(mock_read_h5ad, caplog, env_manager, tmp_path, test_cas
     # Ensure S3/SNS vars are not set
     env_manager['clear'](['S3_BUCKET', 'S3_KEY', 'FILE_ID', 'SNS_TOPIC_ARN', 'AWS_BATCH_JOB_ID'])
 
-    # Set up anndata mock
-    test_adata = test_case["adata"]
-    if test_adata is not None:
-        mock_adata = MagicMock()
-        mock_read_h5ad.return_value = mock_adata
-        mock_adata.obs = pd.DataFrame(test_adata["obs"])
-        mock_adata.uns = test_adata["uns"]
-        mock_adata.n_obs = mock_adata.obs.shape[0]
-        mock_adata.n_vars = test_adata["n_vars"]
+    # Drive the metadata read seam (obs/uns/shape + matrix storage)
+    _setup_metadata_mocks(mock_read_inputs, mock_matrix_storage, test_case["adata"])
 
     with caplog.at_level(logging.INFO, logger="dataset_validator.main"):
         result = main()
@@ -1015,8 +1074,9 @@ def test_local_file_mode(mock_read_h5ad, caplog, env_manager, tmp_path, test_cas
         }
     }
 ], ids=lambda x: x["name"])
-@patch("anndata.io.read_h5ad")
-def test_end_to_end_validation_scenarios(mock_read_h5ad, caplog, mock_aws, env_manager, test_case):
+@patch("dataset_validator.main.get_matrix_storage")
+@patch("dataset_validator.main._read_metadata_inputs")
+def test_end_to_end_validation_scenarios(mock_read_inputs, mock_matrix_storage, caplog, mock_aws, env_manager, test_case):
     """Parameterized test for end-to-end validation scenarios."""
     from dataset_validator.main import main
 
@@ -1042,18 +1102,8 @@ def test_end_to_end_validation_scenarios(mock_read_h5ad, caplog, mock_aws, env_m
     else:
         env_manager['clear'](['CAP_MOCK_ERROR'])
 
-    # Set up anndata mock
-    test_adata = test_case["adata"]
-    if test_adata is not None:
-        if "exception" in test_adata:
-            mock_read_h5ad.side_effect = test_adata["exception"]
-        else:
-            mock_adata = MagicMock()
-            mock_read_h5ad.return_value = mock_adata
-            mock_adata.obs = pd.DataFrame(test_adata["obs"])
-            mock_adata.uns = test_adata["uns"]
-            mock_adata.n_obs = mock_adata.obs.shape[0]
-            mock_adata.n_vars = test_adata["n_vars"]
+    # Drive the metadata read seam (obs/uns/shape + matrix storage)
+    _setup_metadata_mocks(mock_read_inputs, mock_matrix_storage, test_case["adata"])
 
     # Run main function
     with caplog.at_level(logging.INFO, logger="dataset_validator.main"):
@@ -1085,9 +1135,10 @@ def test_end_to_end_validation_scenarios(mock_read_h5ad, caplog, mock_aws, env_m
     assert "S3 claim check write succeeded" in caplog.text
 
 
-@patch("anndata.io.read_h5ad")
+@patch("dataset_validator.main.get_matrix_storage")
+@patch("dataset_validator.main._read_metadata_inputs")
 def test_unset_validation_results_bucket_skips_s3_claim_check(
-    mock_read_h5ad, caplog, mock_aws, env_manager
+    mock_read_inputs, mock_matrix_storage, caplog, mock_aws, env_manager
 ):
     """VALIDATION_RESULTS_BUCKET is optional: when unset, validation still
     completes successfully but no S3 claim-check write is attempted."""
@@ -1106,17 +1157,16 @@ def test_unset_validation_results_bucket_skips_s3_claim_check(
     })
     env_manager['clear'](['VALIDATION_RESULTS_BUCKET', 'CAP_MOCK_ERROR'])
 
-    mock_adata = MagicMock()
-    mock_read_h5ad.return_value = mock_adata
-    mock_adata.obs = pd.DataFrame({
-        "assay": ["assay-a"],
-        "suspension_type": ["cell"],
-        "tissue": ["lung"],
-        "disease": ["normal"],
+    _setup_metadata_mocks(mock_read_inputs, mock_matrix_storage, {
+        "obs": {
+            "assay": ["assay-a"],
+            "suspension_type": ["cell"],
+            "tissue": ["lung"],
+            "disease": ["normal"],
+        },
+        "uns": {"title": "test"},
+        "n_vars": 10,
     })
-    mock_adata.uns = {"title": "test"}
-    mock_adata.n_obs = 1
-    mock_adata.n_vars = 10
 
     with caplog.at_level(logging.INFO, logger="dataset_validator.main"):
         result = main()

--- a/services/dataset-validator/tests/test_dataset_validator.py
+++ b/services/dataset-validator/tests/test_dataset_validator.py
@@ -426,6 +426,38 @@ def test_read_shape_var_fallback_is_robust(tmp_path):
     assert (n_obs, n_vars) == (3, 7)
 
 
+def test_matrix_storage_excluded_from_sns_message():
+    """matrix_storage is kept in the full claim-check JSON but omitted from the
+    inline SNS payload, so a large matrix_storage can't push SNS over the limit."""
+    from dataset_validator.main import ValidationMessage, MAX_SNS_MESSAGE_LENGTH
+
+    # A pathologically large matrix_storage (thousands of layers) with empty
+    # tool reports — the case that previously slipped past the length limiter.
+    big_layers = {
+        f"layer_{i}": {
+            "format": "csr_matrix", "n_obs": 1, "n_vars": 1, "nnz": 0,
+            "data_dtype": "float32", "index_dtype": "int64",
+            "on_disk_bytes": 0, "resident_bytes": 0,
+        }
+        for i in range(5000)
+    }
+    msg = ValidationMessage(
+        file_id="f", status="success", timestamp="2024-01-01T00:00:00Z",
+        bucket="b", key="k", batch_job_id="j",
+        matrix_storage={"X": None, "raw_X": None, "layers": big_layers},
+    )
+
+    # Full claim-check payload retains matrix_storage...
+    full = json.loads(msg.to_json())
+    assert len(full["matrix_storage"]["layers"]) == 5000
+    assert len(msg.to_json()) > MAX_SNS_MESSAGE_LENGTH  # would be oversized inline
+
+    # ...but the inline SNS payload drops it and stays under the limit.
+    sns = msg.to_length_limited_json()
+    assert json.loads(sns)["matrix_storage"] is None
+    assert len(sns) < MAX_SNS_MESSAGE_LENGTH
+
+
 @pytest.mark.parametrize("test_case", [
     {
         "name": "success",

--- a/services/dataset-validator/tests/test_dataset_validator.py
+++ b/services/dataset-validator/tests/test_dataset_validator.py
@@ -399,6 +399,33 @@ def test_read_file_metadata_real_h5ad(tmp_path):
     assert "denoised" in storage["layers"]
 
 
+def test_read_shape_var_fallback_is_robust(tmp_path):
+    """When X has no shape header, _read_shape falls back to var — and must
+    degrade (n_vars=0) rather than raise on a missing/malformed var index."""
+    import h5py
+    from dataset_validator.main import _read_shape
+
+    obs = pd.DataFrame({"a": [1, 2, 3]})
+
+    # X is a 1-D dataset (no usable 2-D shape) and var lacks an "_index" attr.
+    path = tmp_path / "weird.h5ad"
+    with h5py.File(path, "w") as f:
+        f.create_dataset("X", data=np.zeros(3, dtype=np.float32))
+        f.create_group("var")
+        n_obs, n_vars = _read_shape(f, obs)
+    assert (n_obs, n_vars) == (3, 0)
+
+    # var with a valid (bytes) _index pointing at a real dataset → counted.
+    path2 = tmp_path / "weird2.h5ad"
+    with h5py.File(path2, "w") as f:
+        f.create_dataset("X", data=np.zeros(3, dtype=np.float32))
+        var = f.create_group("var")
+        var.attrs["_index"] = b"gene_id"
+        var.create_dataset("gene_id", data=np.arange(7))
+        n_obs, n_vars = _read_shape(f, obs)
+    assert (n_obs, n_vars) == (3, 7)
+
+
 @pytest.mark.parametrize("test_case", [
     {
         "name": "success",

--- a/services/dataset-validator/tests/test_dataset_validator.py
+++ b/services/dataset-validator/tests/test_dataset_validator.py
@@ -462,9 +462,10 @@ def test_matrix_storage_excluded_from_sns_message():
     assert len(full["matrix_storage"]["layers"]) == 5000
     assert len(msg.to_json()) > MAX_SNS_MESSAGE_LENGTH  # would be oversized inline
 
-    # ...but the inline SNS payload drops it and stays under the limit.
+    # ...but the inline SNS payload omits the key entirely (shape identical to
+    # the pre-matrix_storage payload) and stays under the limit.
     sns = msg.to_length_limited_json()
-    assert json.loads(sns)["matrix_storage"] is None
+    assert "matrix_storage" not in json.loads(sns)
     assert len(sns) < MAX_SNS_MESSAGE_LENGTH
 
 

--- a/shared/poetry.lock
+++ b/shared/poetry.lock
@@ -516,6 +516,8 @@ files = [
     {file = "greenlet-3.2.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c2ca18a03a8cfb5b25bc1cbe20f3d9a4c80d8c3b13ba3df49ac3961af0b1018d"},
     {file = "greenlet-3.2.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:9fe0a28a7b952a21e2c062cd5756d34354117796c6d9215a87f55e38d15402c5"},
     {file = "greenlet-3.2.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8854167e06950ca75b898b104b63cc646573aa5fef1353d4508ecdd1ee76254f"},
+    {file = "greenlet-3.2.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f47617f698838ba98f4ff4189aef02e7343952df3a615f847bb575c3feb177a7"},
+    {file = "greenlet-3.2.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:af41be48a4f60429d5cad9d22175217805098a9ef7c40bfef44f7669fb9d74d8"},
     {file = "greenlet-3.2.4-cp310-cp310-win_amd64.whl", hash = "sha256:73f49b5368b5359d04e18d15828eecc1806033db5233397748f4ca813ff1056c"},
     {file = "greenlet-3.2.4-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:96378df1de302bc38e99c3a9aa311967b7dc80ced1dcc6f171e99842987882a2"},
     {file = "greenlet-3.2.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1ee8fae0519a337f2329cb78bd7a8e128ec0f881073d43f023c7b8d4831d5246"},
@@ -525,6 +527,8 @@ files = [
     {file = "greenlet-3.2.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2523e5246274f54fdadbce8494458a2ebdcdbc7b802318466ac5606d3cded1f8"},
     {file = "greenlet-3.2.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1987de92fec508535687fb807a5cea1560f6196285a4cde35c100b8cd632cc52"},
     {file = "greenlet-3.2.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:55e9c5affaa6775e2c6b67659f3a71684de4c549b3dd9afca3bc773533d284fa"},
+    {file = "greenlet-3.2.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c9c6de1940a7d828635fbd254d69db79e54619f165ee7ce32fda763a9cb6a58c"},
+    {file = "greenlet-3.2.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:03c5136e7be905045160b1b9fdca93dd6727b180feeafda6818e6496434ed8c5"},
     {file = "greenlet-3.2.4-cp311-cp311-win_amd64.whl", hash = "sha256:9c40adce87eaa9ddb593ccb0fa6a07caf34015a29bf8d344811665b573138db9"},
     {file = "greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd"},
     {file = "greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb"},
@@ -534,6 +538,8 @@ files = [
     {file = "greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0"},
     {file = "greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0"},
     {file = "greenlet-3.2.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:20fb936b4652b6e307b8f347665e2c615540d4b42b3b4c8a321d8286da7e520f"},
+    {file = "greenlet-3.2.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ee7a6ec486883397d70eec05059353b8e83eca9168b9f3f9a361971e77e0bcd0"},
+    {file = "greenlet-3.2.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:326d234cbf337c9c3def0676412eb7040a35a768efc92504b947b3e9cfc7543d"},
     {file = "greenlet-3.2.4-cp312-cp312-win_amd64.whl", hash = "sha256:a7d4e128405eea3814a12cc2605e0e6aedb4035bf32697f72deca74de4105e02"},
     {file = "greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31"},
     {file = "greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945"},
@@ -543,6 +549,8 @@ files = [
     {file = "greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671"},
     {file = "greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b"},
     {file = "greenlet-3.2.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:d25c5091190f2dc0eaa3f950252122edbbadbb682aa7b1ef2f8af0f8c0afefae"},
+    {file = "greenlet-3.2.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6e343822feb58ac4d0a1211bd9399de2b3a04963ddeec21530fc426cc121f19b"},
+    {file = "greenlet-3.2.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ca7f6f1f2649b89ce02f6f229d7c19f680a6238af656f61e0115b24857917929"},
     {file = "greenlet-3.2.4-cp313-cp313-win_amd64.whl", hash = "sha256:554b03b6e73aaabec3745364d6239e9e012d64c68ccd0b8430c64ccc14939a8b"},
     {file = "greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0"},
     {file = "greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f"},
@@ -550,6 +558,8 @@ files = [
     {file = "greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1"},
     {file = "greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735"},
     {file = "greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337"},
+    {file = "greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269"},
+    {file = "greenlet-3.2.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:015d48959d4add5d6c9f6c5210ee3803a830dce46356e3bc326d6776bde54681"},
     {file = "greenlet-3.2.4-cp314-cp314-win_amd64.whl", hash = "sha256:e37ab26028f12dbb0ff65f29a8d3d44a765c61e729647bf2ddfbbed621726f01"},
     {file = "greenlet-3.2.4-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:b6a7c19cf0d2742d0809a4c05975db036fdff50cd294a93632d6a310bf9ac02c"},
     {file = "greenlet-3.2.4-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:27890167f55d2387576d1f41d9487ef171849ea0359ce1510ca6e06c8bece11d"},
@@ -559,6 +569,8 @@ files = [
     {file = "greenlet-3.2.4-cp39-cp39-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c9913f1a30e4526f432991f89ae263459b1c64d1608c0d22a5c79c287b3c70df"},
     {file = "greenlet-3.2.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:b90654e092f928f110e0007f572007c9727b5265f7632c2fa7415b4689351594"},
     {file = "greenlet-3.2.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:81701fd84f26330f0d5f4944d4e92e61afe6319dcd9775e39396e39d7c3e5f98"},
+    {file = "greenlet-3.2.4-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:28a3c6b7cd72a96f61b0e4b2a36f681025b60ae4779cc73c1535eb5f29560b10"},
+    {file = "greenlet-3.2.4-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:52206cd642670b0b320a1fd1cbfd95bca0e043179c1d8a045f2c6109dfe973be"},
     {file = "greenlet-3.2.4-cp39-cp39-win32.whl", hash = "sha256:65458b409c1ed459ea899e939f0e1cdb14f58dbc803f2f93c5eab5694d32671b"},
     {file = "greenlet-3.2.4-cp39-cp39-win_amd64.whl", hash = "sha256:d2e685ade4dafd447ede19c31277a224a239a0a1a4eca4e6390efedf20260cfb"},
     {file = "greenlet-3.2.4.tar.gz", hash = "sha256:0dca0d95ff849f9a364385f36ab49f50065d76964944638be9691e1832e9f86d"},
@@ -583,6 +595,67 @@ files = [
 [package.dependencies]
 google-auth = ">=1.12.0"
 google-auth-oauthlib = ">=0.4.1"
+
+[[package]]
+name = "h5py"
+version = "3.16.0"
+description = "Read and write HDF5 files from Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["main", "dev"]
+files = [
+    {file = "h5py-3.16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e06f864bedb2c8e7c1358e6c73af48519e317457c444d6f3d332bb4e8fa6d7d9"},
+    {file = "h5py-3.16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ec86d4fffd87a0f4cb3d5796ceb5a50123a2a6d99b43e616e5504e66a953eca3"},
+    {file = "h5py-3.16.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:86385ea895508220b8a7e45efa428aeafaa586bd737c7af9ee04661d8d84a10d"},
+    {file = "h5py-3.16.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:8975273c2c5921c25700193b408e28d6bdd0111c37468b2d4e25dcec4cd1d84d"},
+    {file = "h5py-3.16.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:1677ad48b703f44efc9ea0c3ab284527f81bc4f318386aaaebc5fede6bbae56f"},
+    {file = "h5py-3.16.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7c4dd4cf5f0a4e36083f73172f6cfc25a5710789269547f132a20975bfe2434c"},
+    {file = "h5py-3.16.0-cp310-cp310-win_amd64.whl", hash = "sha256:bdef06507725b455fccba9c16529121a5e1fbf56aa375f7d9713d9e8ff42454d"},
+    {file = "h5py-3.16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:719439d14b83f74eeb080e9650a6c7aa6d0d9ea0ca7f804347b05fac6fbf18af"},
+    {file = "h5py-3.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c3f0a0e136f2e95dd0b67146abb6668af4f1a69c81ef8651a2d316e8e01de447"},
+    {file = "h5py-3.16.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:a6fbc5367d4046801f9b7db9191b31895f22f1c6df1f9987d667854cac493538"},
+    {file = "h5py-3.16.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:fb1720028d99040792bb2fb31facb8da44a6f29df7697e0b84f0d79aff2e9bd3"},
+    {file = "h5py-3.16.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:314b6054fe0b1051c2b0cb2df5cbdab15622fb05e80f202e3b6a5eee0d6fe365"},
+    {file = "h5py-3.16.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ffbab2fedd6581f6aa31cf1639ca2cb86e02779de525667892ebf4cc9fd26434"},
+    {file = "h5py-3.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:17d1f1630f92ad74494a9a7392ab25982ce2b469fc62da6074c0ce48366a2999"},
+    {file = "h5py-3.16.0-cp311-cp311-win_arm64.whl", hash = "sha256:85b9c49dd58dc44cf70af944784e2c2038b6f799665d0dcbbc812a26e0faa859"},
+    {file = "h5py-3.16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c5313566f4643121a78503a473f0fb1e6dcc541d5115c44f05e037609c565c4d"},
+    {file = "h5py-3.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:42b012933a83e1a558c673176676a10ce2fd3759976a0fedee1e672d1e04fc9d"},
+    {file = "h5py-3.16.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:ff24039e2573297787c3063df64b60aab0591980ac898329a08b0320e0cf2527"},
+    {file = "h5py-3.16.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:dfc21898ff025f1e8e67e194965a95a8d4754f452f83454538f98f8a3fcb207e"},
+    {file = "h5py-3.16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:698dd69291272642ffda44a0ecd6cd3bda5faf9621452d255f57ce91487b9794"},
+    {file = "h5py-3.16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2b2c02b0a160faed5fb33f1ba8a264a37ee240b22e049ecc827345d0d9043074"},
+    {file = "h5py-3.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:96b422019a1c8975c2d5dadcf61d4ba6f01c31f92bbde6e4649607885fe502d6"},
+    {file = "h5py-3.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:39c2838fb1e8d97bcf1755e60ad1f3dd76a7b2a475928dc321672752678b96db"},
+    {file = "h5py-3.16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:370a845f432c2c9619db8eed334d1e610c6015796122b0e57aa46312c22617d9"},
+    {file = "h5py-3.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:42108e93326c50c2810025aade9eac9d6827524cdccc7d4b75a546e5ab308edb"},
+    {file = "h5py-3.16.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:099f2525c9dcf28de366970a5fb34879aab20491589fa89ce2863a84218bb524"},
+    {file = "h5py-3.16.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9300ad32dea9dfc5171f94d5f6948e159ed93e4701280b0f508773b3f582f402"},
+    {file = "h5py-3.16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:171038f23bccddfc23f344cadabdfc9917ff554db6a0d417180d2747fe4c75a7"},
+    {file = "h5py-3.16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7e420b539fb6023a259a1b14d4c9f6df8cf50d7268f48e161169987a57b737ff"},
+    {file = "h5py-3.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:18f2bbcd545e6991412253b98727374c356d67caa920e68dc79eab36bf5fedad"},
+    {file = "h5py-3.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:656f00e4d903199a1d58df06b711cf3ca632b874b4207b7dbec86185b5c8c7d4"},
+    {file = "h5py-3.16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9c9d307c0ef862d1cd5714f72ecfafe0a5d7529c44845afa8de9f46e5ba8bd65"},
+    {file = "h5py-3.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8c1eff849cdd53cbc73c214c30ebdb6f1bb8b64790b4b4fc36acdb5e43570210"},
+    {file = "h5py-3.16.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:e2c04d129f180019e216ee5f9c40b78a418634091c8782e1f723a6ca3658b965"},
+    {file = "h5py-3.16.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:e4360f15875a532bc7b98196c7592ed4fc92672a57c0a621355961cafb17a6dd"},
+    {file = "h5py-3.16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:3fae9197390c325e62e0a1aa977f2f62d994aa87aab182abbea85479b791197c"},
+    {file = "h5py-3.16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:43259303989ac8adacc9986695b31e35dba6fd1e297ff9c6a04b7da5542139cc"},
+    {file = "h5py-3.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:fa48993a0b799737ba7fd21e2350fa0a60701e58180fae9f2de834bc39a147ab"},
+    {file = "h5py-3.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:1897a771a7f40d05c262fc8f37376ec37873218544b70216872876c627640f63"},
+    {file = "h5py-3.16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:15922e485844f77c0b9d275396d435db3baa58292a9c2176a386e072e0cf2491"},
+    {file = "h5py-3.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:df02dd29bd247f98674634dfe41f89fd7c16ba3d7de8695ec958f58404a4e618"},
+    {file = "h5py-3.16.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:0f456f556e4e2cebeebd9d66adf8dc321770a42593494a0b6f0af54a7567b242"},
+    {file = "h5py-3.16.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:3e6cb3387c756de6a9492d601553dffea3fe11b5f22b443aac708c69f3f55e16"},
+    {file = "h5py-3.16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8389e13a1fd745ad2856873e8187fd10268b2d9677877bb667b41aebd771d8b7"},
+    {file = "h5py-3.16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:346df559a0f7dcb31cf8e44805319e2ab24b8957c45e7708ce503b2ec79ba725"},
+    {file = "h5py-3.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:4c6ab014ab704b4feaa719ae783b86522ed0bf1f82184704ed3c9e4e3228796e"},
+    {file = "h5py-3.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:faca8fb4e4319c09d83337adc80b2ca7d5c5a343c2d6f1b6388f32cfecca13c1"},
+    {file = "h5py-3.16.0.tar.gz", hash = "sha256:a0dbaad796840ccaa67a4c144a0d0c8080073c34c76d5a6941d6818678ef2738"},
+]
+
+[package.dependencies]
+numpy = ">=1.21.2"
 
 [[package]]
 name = "hbreader"
@@ -969,7 +1042,7 @@ version = "2.2.6"
 description = "Fundamental package for array computing in Python"
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["main", "dev"]
 markers = "python_version == \"3.10\""
 files = [
     {file = "numpy-2.2.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b412caa66f72040e6d268491a59f2c43bf03eb6c96dd8f0307829feb7fa2b6fb"},
@@ -1035,7 +1108,7 @@ version = "2.3.2"
 description = "Fundamental package for array computing in Python"
 optional = false
 python-versions = ">=3.11"
-groups = ["main"]
+groups = ["main", "dev"]
 markers = "python_version >= \"3.11\""
 files = [
     {file = "numpy-2.3.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:852ae5bed3478b92f093e30f785c98e0cb62fa0a939ed057c31716e18a7a22b9"},
@@ -2748,7 +2821,10 @@ files = [
     {file = "wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0"},
 ]
 
+[extras]
+h5ad = ["h5py"]
+
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "3586835a3da77a15759bc63bb51a581b735fae9c762629af9329bac959b5fe79"
+content-hash = "0b1251256d0ace4ee2b23499b5c16099f504054d97faca94313f3cbdb5dc68a1"

--- a/shared/pyproject.toml
+++ b/shared/pyproject.toml
@@ -20,12 +20,20 @@ pydantic = "^2.11.4"
 pydantic-core = "^2.33.2"
 google-api-python-client = "^2.171.0"
 urllib3 = "^2.5.0"
+# Optional: only needed by the `h5ad_storage` module (HDF5 introspection).
+# Kept out of the default install so lightweight consumers (e.g. the entry-sheet
+# Lambda) don't pull h5py. Enable via the `h5ad` extra.
+h5py = {version = "^3.8", optional = true}
+
+[tool.poetry.extras]
+h5ad = ["h5py"]
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.5"
 pytest-mock = "^3.14.0"
 python-dotenv = "^1.1.0"
 requests = "^2.32.3"
+h5py = "^3.8"
 
 [tool.pytest.ini_options]
 markers = [

--- a/shared/src/hca_validation/h5ad_storage/__init__.py
+++ b/shared/src/hca_validation/h5ad_storage/__init__.py
@@ -1,0 +1,9 @@
+"""Lightweight HDF5 storage introspection for h5ad matrices.
+
+Reports shape/nnz/dtype/size for X, raw.X and layers from the HDF5 header
+without loading matrices. Pure h5py + numpy. See hca-validation-tools#447.
+"""
+
+from .h5ad_storage import get_matrix_storage
+
+__all__ = ["get_matrix_storage"]

--- a/shared/src/hca_validation/h5ad_storage/h5ad_storage.py
+++ b/shared/src/hca_validation/h5ad_storage/h5ad_storage.py
@@ -1,0 +1,109 @@
+"""Lightweight HDF5 storage introspection for h5ad matrices.
+
+Reports per-matrix facts (shape, nnz, dtype, on-disk and in-memory size) for
+``X``, ``raw.X`` and every layer by reading **only the HDF5 header** — it never
+materializes a matrix. This is intentionally pure ``h5py`` + ``numpy`` (no
+anndata / scanpy load) so it stays cheap and can run inside the lean Batch
+validator without pulling a scientific stack.
+
+Why this exists: anndata's ``read_h5ad(path, backed="r")`` eagerly reads
+``layers`` and ``raw`` (backed mode is X-only), which on files with
+multi-billion-nonzero matrices spikes to tens of GB. Callers that only need
+*metadata about* the matrices should use this instead. See
+hca-validation-tools#447.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional, cast
+
+import h5py
+import numpy as np
+
+_SPARSE_ENCODINGS = ("csr_matrix", "csc_matrix")
+
+
+def _decode(value: Any) -> Any:
+    return value.decode() if isinstance(value, bytes) else value
+
+
+def _storage_size(dataset: h5py.Dataset) -> int:
+    """On-disk (post-compression) size of an HDF5 dataset, in bytes."""
+    return int(dataset.id.get_storage_size())
+
+
+def _matrix_info(node: Any) -> Optional[dict]:
+    """Storage facts for one matrix node (sparse group or dense dataset).
+
+    Returns ``None`` for anything that isn't a recognizable matrix.
+    """
+    encoding = _decode(node.attrs.get("encoding-type", ""))
+
+    if isinstance(node, h5py.Group) and encoding in _SPARSE_ENCODINGS:
+        data = cast(h5py.Dataset, node["data"])
+        indices = cast(h5py.Dataset, node["indices"])
+        indptr = cast(h5py.Dataset, node["indptr"])
+        shape = tuple(int(x) for x in node.attrs.get("shape", ()))
+        nnz = int(data.shape[0])
+        data_itemsize = np.dtype(data.dtype).itemsize
+        index_itemsize = np.dtype(indices.dtype).itemsize
+        indptr_itemsize = np.dtype(indptr.dtype).itemsize
+        resident = nnz * (data_itemsize + index_itemsize) + int(indptr.shape[0]) * indptr_itemsize
+        on_disk = _storage_size(data) + _storage_size(indices) + _storage_size(indptr)
+        return {
+            "format": encoding,
+            "n_obs": shape[0] if len(shape) == 2 else None,
+            "n_vars": shape[1] if len(shape) == 2 else None,
+            "nnz": nnz,
+            "data_dtype": str(np.dtype(data.dtype)),
+            "index_dtype": str(np.dtype(indices.dtype)),
+            "on_disk_bytes": int(on_disk),
+            "resident_bytes": int(resident),
+        }
+
+    if isinstance(node, h5py.Dataset):
+        shape = tuple(int(x) for x in node.shape)
+        itemsize = np.dtype(node.dtype).itemsize
+        n_elements = int(np.prod(shape)) if shape else 0
+        return {
+            "format": "dense",
+            "n_obs": shape[0] if len(shape) >= 1 else None,
+            "n_vars": shape[1] if len(shape) >= 2 else None,
+            "nnz": None,
+            "data_dtype": str(np.dtype(node.dtype)),
+            "index_dtype": None,
+            "on_disk_bytes": _storage_size(node),
+            "resident_bytes": int(n_elements * itemsize),
+        }
+
+    return None
+
+
+def get_matrix_storage(path: str) -> dict:
+    """Per-matrix storage facts for ``X``, ``raw.X`` and each layer.
+
+    Reads only HDF5 metadata — does not load matrix data. Each value carries
+    ``format``, ``n_obs``/``n_vars``, ``nnz`` (None for dense), ``data_dtype``,
+    ``index_dtype`` (None for dense), ``on_disk_bytes`` and ``resident_bytes``
+    (the estimated in-memory footprint of a full, non-backed load).
+
+    Args:
+        path: Path to an ``.h5ad`` file.
+
+    Returns:
+        ``{"X": {...} | None, "raw_X": {...} | None, "layers": {name: {...}} | None}``.
+    """
+    result: dict = {"X": None, "raw_X": None, "layers": None}
+    with h5py.File(path, "r") as f:
+        if "X" in f:
+            result["X"] = _matrix_info(f["X"])
+        raw = f["raw"] if "raw" in f else None
+        if isinstance(raw, h5py.Group) and "X" in raw:
+            result["raw_X"] = _matrix_info(raw["X"])
+        layers_group = f["layers"] if "layers" in f else None
+        if isinstance(layers_group, h5py.Group) and len(layers_group):
+            layers = {}
+            for name in layers_group:
+                layers[name] = _matrix_info(layers_group[name])
+            result["layers"] = layers
+    return result

--- a/shared/src/hca_validation/h5ad_storage/h5ad_storage.py
+++ b/shared/src/hca_validation/h5ad_storage/h5ad_storage.py
@@ -40,6 +40,11 @@ def _matrix_info(node: Any) -> Optional[dict]:
     encoding = _decode(node.attrs.get("encoding-type", ""))
 
     if isinstance(node, h5py.Group) and encoding in _SPARSE_ENCODINGS:
+        # Treat an incomplete sparse node (missing data/indices/indptr) as
+        # unrecognized rather than raising — one malformed node must not fail
+        # introspection for the whole file.
+        if not all(k in node for k in ("data", "indices", "indptr")):
+            return None
         data = cast(h5py.Dataset, node["data"])
         indices = cast(h5py.Dataset, node["indices"])
         indptr = cast(h5py.Dataset, node["indptr"])

--- a/shared/src/hca_validation/h5ad_storage/h5ad_storage.py
+++ b/shared/src/hca_validation/h5ad_storage/h5ad_storage.py
@@ -62,6 +62,7 @@ def _matrix_info(node: Any) -> Optional[dict]:
             "nnz": nnz,
             "data_dtype": str(np.dtype(data.dtype)),
             "index_dtype": str(np.dtype(indices.dtype)),
+            "indptr_dtype": str(np.dtype(indptr.dtype)),
             "on_disk_bytes": int(on_disk),
             "resident_bytes": int(resident),
         }
@@ -80,6 +81,7 @@ def _matrix_info(node: Any) -> Optional[dict]:
             "nnz": None,
             "data_dtype": str(np.dtype(node.dtype)),
             "index_dtype": None,
+            "indptr_dtype": None,
             "on_disk_bytes": _storage_size(node),
             "resident_bytes": int(n_elements * itemsize),
         }
@@ -92,8 +94,10 @@ def get_matrix_storage(path: str) -> dict:
 
     Reads only HDF5 metadata — does not load matrix data. Each value carries
     ``format``, ``n_obs``/``n_vars``, ``nnz`` (None for dense), ``data_dtype``,
-    ``index_dtype`` (None for dense), ``on_disk_bytes`` and ``resident_bytes``
-    (the estimated in-memory footprint of a full, non-backed load).
+    ``index_dtype`` and ``indptr_dtype`` (the ``indices`` and ``indptr`` dtypes
+    respectively; both None for dense — note they can differ, e.g. int32 indices
+    with int64 indptr), ``on_disk_bytes`` and ``resident_bytes`` (the estimated
+    in-memory footprint of a full, non-backed load).
 
     Args:
         path: Path to an ``.h5ad`` file.

--- a/shared/src/hca_validation/h5ad_storage/h5ad_storage.py
+++ b/shared/src/hca_validation/h5ad_storage/h5ad_storage.py
@@ -69,7 +69,10 @@ def _matrix_info(node: Any) -> Optional[dict]:
     if isinstance(node, h5py.Dataset):
         shape = tuple(int(x) for x in node.shape)
         itemsize = np.dtype(node.dtype).itemsize
-        n_elements = int(np.prod(shape)) if shape else 0
+        # dtype=object keeps the product in Python big-ints — a large dense
+        # matrix would overflow numpy's fixed-width integer (int32 on some
+        # platforms) and yield a wrong/negative resident_bytes.
+        n_elements = int(np.prod(shape, dtype=object)) if shape else 0
         return {
             "format": "dense",
             "n_obs": shape[0] if len(shape) >= 1 else None,

--- a/shared/src/hca_validation/h5ad_storage/h5ad_storage.py
+++ b/shared/src/hca_validation/h5ad_storage/h5ad_storage.py
@@ -35,8 +35,20 @@ def _storage_size(dataset: h5py.Dataset) -> int:
 def _matrix_info(node: Any) -> Optional[dict]:
     """Storage facts for one matrix node (sparse group or dense dataset).
 
-    Returns ``None`` for anything that isn't a recognizable matrix.
+    Returns ``None`` for anything that isn't a recognizable matrix, or that
+    can't be introspected. This helper is best-effort: a malformed node (e.g. a
+    scalar/string ``shape`` attr, an odd dtype) degrades to ``None`` rather than
+    aborting introspection for the whole file.
     """
+    try:
+        return _parse_matrix_node(node)
+    except Exception:
+        return None
+
+
+def _parse_matrix_node(node: Any) -> Optional[dict]:
+    """Parse one matrix node into storage facts. May raise on malformed input;
+    callers go through :func:`_matrix_info`, which degrades that to ``None``."""
     encoding = _decode(node.attrs.get("encoding-type", ""))
 
     if isinstance(node, h5py.Group) and encoding in _SPARSE_ENCODINGS:

--- a/shared/src/hca_validation/h5ad_storage/h5ad_storage.py
+++ b/shared/src/hca_validation/h5ad_storage/h5ad_storage.py
@@ -102,8 +102,13 @@ def get_matrix_storage(path: str) -> dict:
             result["raw_X"] = _matrix_info(raw["X"])
         layers_group = f["layers"] if "layers" in f else None
         if isinstance(layers_group, h5py.Group) and len(layers_group):
+            # Only keep recognizable matrices so the documented shape
+            # ({name: {...}}) holds — _matrix_info returns None for anything
+            # that isn't a sparse/dense matrix node.
             layers = {}
             for name in layers_group:
-                layers[name] = _matrix_info(layers_group[name])
-            result["layers"] = layers
+                info = _matrix_info(layers_group[name])
+                if info is not None:
+                    layers[name] = info
+            result["layers"] = layers or None
     return result

--- a/shared/tests/test_h5ad_storage.py
+++ b/shared/tests/test_h5ad_storage.py
@@ -6,7 +6,6 @@ notably the int32-vs-int64 index case that drives the resident-bytes math.
 
 import h5py
 import numpy as np
-import pytest
 
 from hca_validation.h5ad_storage import get_matrix_storage
 

--- a/shared/tests/test_h5ad_storage.py
+++ b/shared/tests/test_h5ad_storage.py
@@ -88,3 +88,27 @@ def test_no_layers_returns_none(tmp_path):
     path = tmp_path / "t.h5ad"
     _make_file(path, with_layer_int64=False)
     assert get_matrix_storage(str(path))["layers"] is None
+
+
+def test_unrecognized_layer_node_is_filtered(tmp_path):
+    """Layers that aren't sparse/dense matrices must not leak None into the
+    documented {name: {...}} shape."""
+    path = tmp_path / "t.h5ad"
+    _make_file(path, with_layer_int64=True)
+    with h5py.File(path, "a") as f:
+        # A plain group with no encoding-type is not a recognizable matrix.
+        f["layers"].create_group("not_a_matrix")
+
+    layers = get_matrix_storage(str(path))["layers"]
+    assert "not_a_matrix" not in layers          # filtered out, no None value
+    assert "denoised" in layers                  # the real matrix survives
+    assert all(v is not None for v in layers.values())
+
+
+def test_only_unrecognized_layers_returns_none(tmp_path):
+    """If no layer is a matrix, layers collapses to None, not an empty dict."""
+    path = tmp_path / "t.h5ad"
+    _make_file(path, with_layer_int64=False)
+    with h5py.File(path, "a") as f:
+        f.create_group("layers").create_group("not_a_matrix")
+    assert get_matrix_storage(str(path))["layers"] is None

--- a/shared/tests/test_h5ad_storage.py
+++ b/shared/tests/test_h5ad_storage.py
@@ -122,6 +122,21 @@ def test_unrecognized_layer_node_is_filtered(tmp_path):
     assert all(v is not None for v in layers.values())
 
 
+def test_malformed_sparse_node_degrades_to_none(tmp_path):
+    """A node that advertises a sparse encoding but has an unparseable shape attr
+    degrades to None (best-effort), and doesn't abort the whole call."""
+    path = tmp_path / "t.h5ad"
+    _make_file(path, with_raw=True, with_layer_int64=True)
+    with h5py.File(path, "a") as f:
+        # X is a valid csr group but its shape attr is a non-sequence scalar.
+        f["X"].attrs["shape"] = np.int64(5)
+
+    result = get_matrix_storage(str(path))
+    assert result["X"] is None                  # degraded, not raised
+    assert result["raw_X"] is not None          # other matrices still reported
+    assert result["layers"]["denoised"] is not None
+
+
 def test_incomplete_sparse_node_is_unrecognized(tmp_path):
     """A node advertising a sparse encoding but missing data/indices/indptr is
     treated as unrecognized (None), not a KeyError that fails the whole call."""

--- a/shared/tests/test_h5ad_storage.py
+++ b/shared/tests/test_h5ad_storage.py
@@ -1,0 +1,90 @@
+"""Tests for hca_validation.h5ad_storage.get_matrix_storage.
+
+Fixtures are built with pure h5py (no anndata) so we can pin exact dtypes —
+notably the int32-vs-int64 index case that drives the resident-bytes math.
+"""
+
+import h5py
+import numpy as np
+import pytest
+
+from hca_validation.h5ad_storage import get_matrix_storage
+
+
+def _write_csr(group, *, shape, data, indices, indptr):
+    group.attrs["encoding-type"] = "csr_matrix"
+    group.attrs["shape"] = np.array(shape, dtype="int64")
+    group.create_dataset("data", data=data)
+    group.create_dataset("indices", data=indices)
+    group.create_dataset("indptr", data=indptr)
+
+
+# The 3x4 matrix [[5,0,0,2],[0,0,0,0],[0,7,8,0]] -> nnz=4
+_DATA = np.array([5, 2, 7, 8], dtype="float32")
+_INDICES = np.array([0, 3, 1, 2])
+_INDPTR = np.array([0, 2, 2, 4])
+
+
+def _make_file(path, *, with_raw=True, with_layer_int64=True):
+    with h5py.File(path, "w") as f:
+        _write_csr(
+            f.create_group("X"),
+            shape=(3, 4), data=_DATA,
+            indices=_INDICES.astype("int32"), indptr=_INDPTR.astype("int32"),
+        )
+        if with_raw:
+            _write_csr(
+                f.create_group("raw").create_group("X"),
+                shape=(3, 4), data=_DATA,
+                indices=_INDICES.astype("int32"), indptr=_INDPTR.astype("int32"),
+            )
+        if with_layer_int64:
+            _write_csr(
+                f.create_group("layers").create_group("denoised"),
+                shape=(3, 4), data=_DATA,
+                indices=_INDICES.astype("int64"), indptr=_INDPTR.astype("int64"),
+            )
+
+
+def test_x_sparse_facts(tmp_path):
+    path = tmp_path / "t.h5ad"
+    _make_file(path)
+    r = get_matrix_storage(str(path))
+
+    x = r["X"]
+    assert x["format"] == "csr_matrix"
+    assert (x["n_obs"], x["n_vars"]) == (3, 4)
+    assert x["nnz"] == 4
+    assert x["data_dtype"] == "float32"
+    assert x["index_dtype"] == "int32"
+    # resident = nnz*(data_itemsize + index_itemsize) + indptr_len*indptr_itemsize
+    assert x["resident_bytes"] == 4 * (4 + 4) + 4 * 4
+
+
+def test_int64_layer_doubles_index_cost(tmp_path):
+    path = tmp_path / "t.h5ad"
+    _make_file(path)
+    r = get_matrix_storage(str(path))
+
+    layer = r["layers"]["denoised"]
+    assert layer["index_dtype"] == "int64"
+    # int64 indices (8B) + int64 indptr (8B): 4*(4+8) + 4*8
+    assert layer["resident_bytes"] == 4 * (4 + 8) + 4 * 8
+    # ... which is larger than the int32-indexed X holding identical data
+    assert layer["resident_bytes"] > r["X"]["resident_bytes"]
+
+
+def test_raw_present_and_absent(tmp_path):
+    with_raw = tmp_path / "with_raw.h5ad"
+    _make_file(with_raw, with_raw=True)
+    assert get_matrix_storage(str(with_raw))["raw_X"] is not None
+
+    no_raw = tmp_path / "no_raw.h5ad"
+    _make_file(no_raw, with_raw=False)
+    assert get_matrix_storage(str(no_raw))["raw_X"] is None
+
+
+def test_no_layers_returns_none(tmp_path):
+    path = tmp_path / "t.h5ad"
+    _make_file(path, with_layer_int64=False)
+    assert get_matrix_storage(str(path))["layers"] is None

--- a/shared/tests/test_h5ad_storage.py
+++ b/shared/tests/test_h5ad_storage.py
@@ -104,6 +104,21 @@ def test_unrecognized_layer_node_is_filtered(tmp_path):
     assert all(v is not None for v in layers.values())
 
 
+def test_incomplete_sparse_node_is_unrecognized(tmp_path):
+    """A node advertising a sparse encoding but missing data/indices/indptr is
+    treated as unrecognized (None), not a KeyError that fails the whole call."""
+    path = tmp_path / "t.h5ad"
+    _make_file(path, with_raw=True, with_layer_int64=True)
+    with h5py.File(path, "a") as f:
+        # X advertises csr_matrix but is missing 'indptr'.
+        del f["X"]["indptr"]
+
+    result = get_matrix_storage(str(path))
+    assert result["X"] is None                  # degraded, not raised
+    assert result["raw_X"] is not None          # other matrices still reported
+    assert result["layers"]["denoised"] is not None
+
+
 def test_only_unrecognized_layers_returns_none(tmp_path):
     """If no layer is a matrix, layers collapses to None, not an empty dict."""
     path = tmp_path / "t.h5ad"

--- a/shared/tests/test_h5ad_storage.py
+++ b/shared/tests/test_h5ad_storage.py
@@ -56,8 +56,26 @@ def test_x_sparse_facts(tmp_path):
     assert x["nnz"] == 4
     assert x["data_dtype"] == "float32"
     assert x["index_dtype"] == "int32"
+    assert x["indptr_dtype"] == "int32"
     # resident = nnz*(data_itemsize + index_itemsize) + indptr_len*indptr_itemsize
     assert x["resident_bytes"] == 4 * (4 + 4) + 4 * 4
+
+
+def test_indices_and_indptr_dtypes_reported_separately(tmp_path):
+    """index_dtype and indptr_dtype are distinct facts and can differ (the
+    int32-indices / int64-indptr case for matrices with >2^31 nonzeros)."""
+    path = tmp_path / "mixed.h5ad"
+    with h5py.File(path, "w") as f:
+        _write_csr(
+            f.create_group("X"),
+            shape=(3, 4), data=_DATA,
+            indices=_INDICES.astype("int32"), indptr=_INDPTR.astype("int64"),
+        )
+    x = get_matrix_storage(str(path))["X"]
+    assert x["index_dtype"] == "int32"
+    assert x["indptr_dtype"] == "int64"
+    # resident uses both: nnz*(4 data + 4 idx) + indptr_len*8
+    assert x["resident_bytes"] == 4 * (4 + 4) + 4 * 8
 
 
 def test_int64_layer_doubles_index_cost(tmp_path):


### PR DESCRIPTION
Closes #447.

## Problem

`read_file_metadata` opened the whole h5ad via `anndata.read_h5ad(path, backed="r")` just to read `obs` + `uns`. anndata's backed mode is **X-only** — `read_h5ad_backed` (anndata `_io/h5ad.py`) eagerly `read_elem`s `layers` and `raw`. On files with multi-billion-nonzero matrices, that open spiked to **15–24+ GB (nondeterministic)** and OOM-killed the 60 GB Batch container *mid-metadata-read*. Prod symptom: `integrated_all_tissues_object.h5ad` stuck "pending" (job `5cbae667`, exit 137, "container killed due to memory usage").

The investigation showed the validators themselves are **not** the problem.

## Measured peak RSS on the offending file (2.24M × 36.6k; X/raw.X/`ambient_corrected` each ~7.6B nnz = 256 GB if fully resident)

| step | peak RSS | outcome |
|---|---|---|
| CAP validator | 2.71 GB | ✅ completes |
| HCA schema validator (dask-chunked) | 15.42 GB | ✅ completes (26 min) |
| **metadata `read_h5ad(backed="r")`** | **15 → 24+ GB** | ❌ nondeterministic, OOMs |
| **metadata via `read_elem` (this PR)** | **1.37 GB** | ✅ |

## Change

- `read_file_metadata` now reads `obs` + `uns` via targeted `read_elem` and gets shape from the X header — never opening X/raw/layers. Summary + coverage are unchanged (they only need obs/uns; `read_elem(obs)` is anndata's own obs-read path, so output is identical).
- New `matrix_storage` payload field: per-matrix/layer `format, n_obs, n_vars, nnz, data_dtype, index_dtype, on_disk_bytes, resident_bytes`, from a new pure-h5py `hca_validation.h5ad_storage` module (HDF5 header only, no matrix load). Additive + SNS-safe — the tracker's Yup schema ignores unknown keys (persistence tracked in clevercanary/hca-atlas-tracker#1436).
- `h5py` wired as an optional `h5ad` extra on `shared` so the entry-sheet Lambda stays lean.

## Tests

- Swapped the now-bypassed `read_h5ad` mock for a mockable read seam (`_read_metadata_inputs`/`get_matrix_storage`).
- Added `test_read_file_metadata_real_h5ad` exercising the real (unmocked) read path end-to-end.
- New `shared/tests/test_h5ad_storage.py` (incl. the int32-vs-int64 index footprint case).
- Full suite green (28 dataset-validator + 4 shared); pyright clean on changed files.

## Notes

- This **supersedes** the EC2/512 GB direction in clevercanary/hca-atlas-tracker-tf-config#68 — nothing in the pipeline needs >~15 GB once this lands.
- Follow-up #448: reuse the shared helper in `hca-anndata-tools/storage.py` + fix the same backed-read OOM in `get_summary`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
