### PR TITLE
feat!: nest CAP metadata under uns['cap_metadata']

### DIFF
--- a/packages/hca-anndata-mcp/src/hca_anndata_mcp/server.py
+++ b/packages/hca-anndata-mcp/src/hca_anndata_mcp/server.py
@@ -55,7 +55,7 @@ mcp = FastMCP(
         "check_schema_type to identify CellxGENE vs HCA layout and report the schema version, "
         "validate_schema to run the HCA schema validator and report is_valid / errors / warnings, "
         "validate_cell_annotation to run the HCA Cell Annotation validator (structural CAP checks: "
-        "annotation-set presence, well-formed semver in uns['cellannotation_schema_version'], "
+        "annotation-set presence, well-formed semver in uns['cap_metadata']['cellannotation_schema_version'], "
         "per-set metadata is a dict, required --<suffix> obs columns), complementary to validate_schema, "
         "check_cosmetic_labels_h5ad as a fast targeted alternative — checks only that "
         "producer-supplied obs label columns (tissue, cell_type, ...) match their "

--- a/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/validate.py
+++ b/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/validate.py
@@ -51,9 +51,9 @@ def validate_cell_annotation(path: str) -> dict:
 
     Wraps :class:`hca_schema_validator.HCACellAnnotationValidator` —
     Phase 1 structural checks only (presence of at least one CAP
-    annotation set, well-formed ``cellannotation_schema_version``, per-set
-    metadata is a dict, required per-set ``--<suffix>`` obs columns are
-    present). Marker-gene coverage (Phase 2, #363) and CL-term validity
+    annotation set under ``uns['cap_metadata']``, well-formed
+    ``cellannotation_schema_version``, per-set metadata is a dict, required
+    per-set ``--<suffix>`` obs columns are present). Marker-gene coverage (Phase 2, #363) and CL-term validity
     (Phase 3, #364) are not checked here; per-set required metadata
     fields (``description``, ``algorithm_name``, ...) are the upstream
     CAP-side validator's responsibility.

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/cap.py
@@ -29,8 +29,9 @@ _UNS_OPTIONAL_KEYS = [
     "hierarchy",
 ]
 
-# Deprecated top-level CAP keys. Their presence *without* a cap_metadata wrapper
-# signals the old layout, which is refused rather than normalized (issue #452).
+# Deprecated top-level CAP keys. Their presence signals the old layout — even
+# alongside a nested cap_metadata block (a mixed-layout file) — which is refused
+# rather than normalized (issue #452).
 _LEGACY_CAP_MARKERS = ("cellannotation_metadata", "cellannotation_schema_version")
 
 LEGACY_LAYOUT_ERROR = (

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/cap.py
@@ -42,8 +42,14 @@ LEGACY_LAYOUT_ERROR = (
 
 
 def is_legacy_cap_layout(uns) -> bool:
-    """True if the file carries deprecated top-level CAP keys and no cap_metadata."""
-    return CAP_METADATA_KEY not in uns and any(k in uns for k in _LEGACY_CAP_MARKERS)
+    """True if the file carries any deprecated top-level CAP key.
+
+    Fires even when a nested ``cap_metadata`` block is also present (a
+    mixed-layout file): the strict clean-break contract refuses anything
+    carrying deprecated top-level keys rather than silently letting the nested
+    block win.
+    """
+    return any(k in uns for k in _LEGACY_CAP_MARKERS)
 
 
 def resolve_cap_block(uns) -> dict | None:
@@ -113,17 +119,17 @@ def get_cap_annotations(path: str, annotation_set: str | None = None) -> dict:
         with open_h5ad(path) as adata:
             obs_columns = list(adata.obs.columns)
 
-            # Only the nested uns['cap_metadata'] layout is accepted. A legacy
-            # top-level file is surfaced via `layout` as a diagnostic but is not
-            # treated as valid CAP (has_cap_annotations stays False).
-            cap = resolve_cap_block(adata.uns)
-            if cap is not None:
-                layout = "cap_metadata"
-            elif is_legacy_cap_layout(adata.uns):
+            # Only the nested uns['cap_metadata'] layout is accepted. Any
+            # deprecated top-level marker — even alongside a nested block (a
+            # mixed-layout file) — is surfaced via `layout` as a diagnostic and
+            # is not treated as valid CAP (has_cap_annotations stays False).
+            if is_legacy_cap_layout(adata.uns):
                 layout = "legacy_toplevel"
+                cap = {}
             else:
-                layout = None
-            cap = cap or {}
+                cap = resolve_cap_block(adata.uns)
+                layout = "cap_metadata" if cap is not None else None
+                cap = cap or {}
 
             # Annotation sets are defined in cellannotation_metadata
             meta = cap.get("cellannotation_metadata", {})

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/cap.py
@@ -1,8 +1,61 @@
 """CAP (Cell Annotation Platform) schema inspection for AnnData files."""
 
+from collections.abc import Mapping
+
 from ._io import open_h5ad
 from ._serialize import make_serializable as _make_serializable
 from .write import resolve_latest
+
+# Canonical home for the CAP metadata block (issue #452).
+CAP_METADATA_KEY = "cap_metadata"
+
+# CAP uns keys the inspector reports on. `title` is the dataset title (it lives
+# at the top level of uns); the other keys constitute the CAP metadata block.
+_UNS_REQUIRED_KEYS = [
+    "cellannotation_schema_version",
+    "cellannotation_metadata",
+    "title",
+]
+
+_UNS_OPTIONAL_KEYS = [
+    "publication_timestamp",
+    "publication_version",
+    "description",
+    "cap_dataset_url",
+    "cap_publication_title",
+    "cap_publication_description",
+    "cap_publication_url",
+    "authors_list",
+    "hierarchy",
+]
+
+# Deprecated top-level CAP keys. Their presence *without* a cap_metadata wrapper
+# signals the old layout, which is refused rather than normalized (issue #452).
+_LEGACY_CAP_MARKERS = ("cellannotation_metadata", "cellannotation_schema_version")
+
+LEGACY_LAYOUT_ERROR = (
+    "Source uses the deprecated top-level CAP layout "
+    "(uns['cellannotation_metadata'] / uns['cellannotation_schema_version']). "
+    "Only the nested uns['cap_metadata'] layout is accepted; re-export the CAP "
+    "file with its metadata nested under uns['cap_metadata']."
+)
+
+
+def is_legacy_cap_layout(uns) -> bool:
+    """True if the file carries deprecated top-level CAP keys and no cap_metadata."""
+    return CAP_METADATA_KEY not in uns and any(k in uns for k in _LEGACY_CAP_MARKERS)
+
+
+def resolve_cap_block(uns) -> dict | None:
+    """Return the nested ``uns['cap_metadata']`` block as a dict, or None.
+
+    Only the canonical nested layout is accepted (issue #452) — the deprecated
+    top-level layout is *not* normalized. Callers detect it with
+    :func:`is_legacy_cap_layout` and refuse. A present-but-non-Mapping
+    ``cap_metadata`` is treated as absent.
+    """
+    block = uns.get(CAP_METADATA_KEY)
+    return dict(block) if isinstance(block, Mapping) else None
 
 # CAP obs column suffixes per the cell-annotation-schema spec
 _REQUIRED_SUFFIXES = [
@@ -24,24 +77,6 @@ _OPTIONAL_SUFFIXES = [
     "--category_cell_ontology_term",
     "--cell_ontology_assessment",
     "--confidence_score",
-]
-
-_UNS_REQUIRED_KEYS = [
-    "cellannotation_schema_version",
-    "cellannotation_metadata",
-    "title",
-]
-
-_UNS_OPTIONAL_KEYS = [
-    "publication_timestamp",
-    "publication_version",
-    "description",
-    "cap_dataset_url",
-    "cap_publication_title",
-    "cap_publication_description",
-    "cap_publication_url",
-    "authors_list",
-    "hierarchy",
 ]
 
 
@@ -78,19 +113,33 @@ def get_cap_annotations(path: str, annotation_set: str | None = None) -> dict:
         with open_h5ad(path) as adata:
             obs_columns = list(adata.obs.columns)
 
+            # Only the nested uns['cap_metadata'] layout is accepted. A legacy
+            # top-level file is surfaced via `layout` as a diagnostic but is not
+            # treated as valid CAP (has_cap_annotations stays False).
+            cap = resolve_cap_block(adata.uns)
+            if cap is not None:
+                layout = "cap_metadata"
+            elif is_legacy_cap_layout(adata.uns):
+                layout = "legacy_toplevel"
+            else:
+                layout = None
+            cap = cap or {}
+
             # Annotation sets are defined in cellannotation_metadata
-            meta = adata.uns.get("cellannotation_metadata", {})
+            meta = cap.get("cellannotation_metadata", {})
             annotation_sets = sorted(meta.keys()) if isinstance(meta, dict) else []
 
-            uns_keys = list(adata.uns.keys())
-            uns_present = [k for k in _UNS_REQUIRED_KEYS if k in uns_keys]
-            uns_missing = [k for k in _UNS_REQUIRED_KEYS if k not in uns_keys]
-            uns_optional_present = [k for k in _UNS_OPTIONAL_KEYS if k in uns_keys]
+            # CAP schema keys live in the block; `title` stays top-level.
+            present = set(cap) | ({"title"} if "title" in adata.uns else set())
+            uns_present = [k for k in _UNS_REQUIRED_KEYS if k in present]
+            uns_missing = [k for k in _UNS_REQUIRED_KEYS if k not in present]
+            uns_optional_present = [k for k in _UNS_OPTIONAL_KEYS if k in cap]
 
-            has_cap = "cellannotation_metadata" in uns_keys and len(annotation_sets) > 0
+            has_cap = "cellannotation_metadata" in cap and len(annotation_sets) > 0
 
             result = {
                 "has_cap_annotations": has_cap,
+                "layout": layout,
                 "annotation_sets": annotation_sets,
                 "uns_metadata": {
                     "required_present": uns_present,
@@ -102,11 +151,11 @@ def get_cap_annotations(path: str, annotation_set: str | None = None) -> dict:
             if not has_cap and annotation_set is None:
                 return result
 
-            if "cellannotation_metadata" in uns_keys:
-                result["cellannotation_metadata"] = _make_serializable(adata.uns["cellannotation_metadata"])
+            if "cellannotation_metadata" in cap:
+                result["cellannotation_metadata"] = _make_serializable(cap["cellannotation_metadata"])
 
-            if "authors_list" in uns_keys:
-                result["authors_list"] = _make_serializable(adata.uns["authors_list"])
+            if "authors_list" in cap:
+                result["authors_list"] = _make_serializable(cap["authors_list"])
 
             sets_to_inspect = []
             if annotation_set:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -164,6 +164,8 @@ def copy_cap_annotations(
             if cap_block is None:
                 if is_legacy_cap_layout(source.uns):
                     return {"error": LEGACY_LAYOUT_ERROR}
+                if CAP_METADATA_KEY in source.uns:
+                    return {"error": "Source uns['cap_metadata'] is malformed (not a dict/group)."}
                 return {"error": "Source has no cellannotation_metadata in uns['cap_metadata']"}
             if "cellannotation_metadata" not in cap_block:
                 return {"error": "Source has no cellannotation_metadata in uns['cap_metadata']"}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -168,7 +168,7 @@ def copy_cap_annotations(
             if cap_block is None:
                 if CAP_METADATA_KEY in source.uns:
                     return {"error": "Source uns['cap_metadata'] is malformed (not a dict/group)."}
-                return {"error": "Source has no cellannotation_metadata in uns['cap_metadata']"}
+                return {"error": "Source has no CAP metadata: uns['cap_metadata'] is missing."}
             if "cellannotation_metadata" not in cap_block:
                 return {"error": "Source has no cellannotation_metadata in uns['cap_metadata']"}
             if "cellannotation_schema_version" not in cap_block:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -23,7 +23,14 @@ from ._io import (
     verify_obs_transplant,
 )
 from ._serialize import make_serializable
-from .cap import _OPTIONAL_SUFFIXES, _REQUIRED_SUFFIXES
+from .cap import (
+    CAP_METADATA_KEY,
+    LEGACY_LAYOUT_ERROR,
+    _OPTIONAL_SUFFIXES,
+    _REQUIRED_SUFFIXES,
+    is_legacy_cap_layout,
+    resolve_cap_block,
+)
 from .marker_genes import validate_marker_genes
 from .write import (
     EDIT_LOG_KEY,
@@ -35,32 +42,12 @@ from .write import (
     resolve_latest,
 )
 
-# Cell-annotation-schema uns keys — stay at top level (HCA schema)
-_UNS_SCHEMA_TOPLEVEL = [
-    "cellannotation_schema_version",
-    "cellannotation_metadata",
-]
-
-# CAP provenance keys — collected into uns["provenance"]["cap"]
-_UNS_CAP_PROVENANCE = [
-    "cap_dataset_url",
-    "cap_publication_title",
-    "cap_publication_description",
-    "cap_publication_url",
-    "authors_list",
-    "hierarchy",
-    "description",
-    "publication_timestamp",
-    "publication_version",
-]
-
 # Demographic annotation sets — not real CAP annotations, just renamed CXG columns
 _SKIP_SETS = {"sex", "development_stage", "self_reported_ethnicity"}
 
-# Keys to detect/remove existing CAP data on overwrite
-# Top-level uns keys written by copy_cap, replaced on overwrite.
-# provenance/cap is handled separately via merge logic.
-_OVERWRITE_UNS_KEYS = set(_UNS_SCHEMA_TOPLEVEL)
+# The entire CAP block is written into uns['cap_metadata'] (issue #452);
+# replaced wholesale on overwrite.
+_OVERWRITE_UNS_KEYS = {CAP_METADATA_KEY}
 
 # Maximum percent (0–100) of cells on either side that may be absent from the
 # other. Applied to both `missing_from_hca.pct` and `missing_from_cap.pct`.
@@ -110,9 +97,9 @@ def _check_duplicate_ids(index: list[str], label: str) -> str | None:
     return f"{label} have duplicate IDs (first 5): {dupes}"
 
 
-def _get_annotation_sets(source_uns: Mapping[str, Any]) -> list[str]:
-    """Get annotation sets defined in cellannotation_metadata."""
-    meta = source_uns.get("cellannotation_metadata", {})
+def _get_annotation_sets(cap_block: Mapping[str, Any]) -> list[str]:
+    """Get annotation sets defined in the CAP block's cellannotation_metadata."""
+    meta = cap_block.get("cellannotation_metadata", {})
     if isinstance(meta, dict):
         return [s for s in meta.keys() if s not in _SKIP_SETS]
     return []
@@ -170,18 +157,26 @@ def copy_cap_annotations(
         # We use anndata here because uns contains nested dicts with
         # anndata-specific encoding that's complex to parse via raw h5py.
         with open_h5ad(source_path) as source:
-            if "cellannotation_metadata" not in source.uns:
-                return {"error": "Source has no cellannotation_metadata in uns"}
-            if "cellannotation_schema_version" not in source.uns:
-                return {"error": "Source has no cellannotation_schema_version in uns"}
+            # Only the nested uns['cap_metadata'] layout is accepted; the
+            # deprecated top-level layout is refused, not normalized. The full
+            # block travels into the target unchanged.
+            cap_block = resolve_cap_block(source.uns)
+            if cap_block is None:
+                if is_legacy_cap_layout(source.uns):
+                    return {"error": LEGACY_LAYOUT_ERROR}
+                return {"error": "Source has no cellannotation_metadata in uns['cap_metadata']"}
+            if "cellannotation_metadata" not in cap_block:
+                return {"error": "Source has no cellannotation_metadata in uns['cap_metadata']"}
+            if "cellannotation_schema_version" not in cap_block:
+                return {"error": "Source has no cellannotation_schema_version in uns['cap_metadata']"}
 
-            annotation_sets = _get_annotation_sets(source.uns)
+            annotation_sets = _get_annotation_sets(cap_block)
             if not annotation_sets:
                 return {"error": "Source has no annotation sets in cellannotation_metadata"}
 
-            cap_schema_version = str(source.uns["cellannotation_schema_version"])
-            all_uns_keys = _UNS_SCHEMA_TOPLEVEL + _UNS_CAP_PROVENANCE
-            source_uns = {k: make_serializable(source.uns[k]) for k in all_uns_keys if k in source.uns}
+            cap_schema_version = str(cap_block["cellannotation_schema_version"])
+            # resolve_cap_block already returns a fresh dict, so no extra copy.
+            source_cap_block = make_serializable(cap_block)
 
         # Read source obs via h5py (avoids slow backed-mode column access)
         with h5py.File(source_path, "r") as f:
@@ -238,12 +233,6 @@ def copy_cap_annotations(
 
             uns = f.get("uns")
             target_uns_keys = set(uns.keys()) if uns else set()
-            has_provenance_cap = (
-                uns is not None
-                and "provenance" in uns
-                and isinstance(uns["provenance"], h5py.Group)
-                and "cap" in uns["provenance"]
-            )
             raw_log = read_edit_log_h5py(f)
 
         target_index_set = set(target_index)
@@ -256,8 +245,6 @@ def copy_cap_annotations(
         existing_cap_cols = [c for c in target_obs_columns if "--" in c]
 
         existing_cap_uns = [k for k in _OVERWRITE_UNS_KEYS if k in target_uns_keys]
-        if has_provenance_cap:
-            existing_cap_uns.append("provenance/cap")
 
         if (existing_cap_cols or existing_cap_uns) and not overwrite:
             return {
@@ -295,17 +282,11 @@ def copy_cap_annotations(
         aligned_obs = source_obs_subset.reindex(target_index)
         del source_obs_subset
 
-        temp_uns = {}
-        uns_keys_added = []
-        for key in _UNS_SCHEMA_TOPLEVEL:
-            if key in source_uns:
-                temp_uns[key] = source_uns[key]
-                uns_keys_added.append(key)
-
-        cap_provenance = {k: source_uns[k] for k in _UNS_CAP_PROVENANCE if k in source_uns}
-        if cap_provenance:
-            temp_uns["provenance"] = {"cap": cap_provenance}
-            uns_keys_added.append("provenance")
+        # The entire CAP block lands in uns['cap_metadata'] (schema keys +
+        # publication provenance together). The edit log stays in
+        # uns['provenance']['edit_history'].
+        temp_uns: dict[str, Any] = {CAP_METADATA_KEY: source_cap_block}
+        uns_keys_added = [CAP_METADATA_KEY]
 
         source_basename = os.path.basename(source_path)
         source_sha256 = _compute_sha256(source_path)
@@ -365,8 +346,6 @@ def copy_cap_annotations(
                     for key in list(f_out["uns"].keys()):
                         if key in _OVERWRITE_UNS_KEYS:
                             del f_out["uns"][key]
-                    if "provenance" in f_out["uns"] and "cap" in f_out["uns"]["provenance"]:
-                        del f_out["uns"]["provenance"]["cap"]
 
                 # Transplant new obs columns from temp
                 for col in obs_cols_to_copy:
@@ -375,13 +354,7 @@ def copy_cap_annotations(
                 update_column_order(f_out, obs_cols_to_copy, deleted_cols)
 
                 for key in uns_keys_added:
-                    if key == "provenance":
-                        # Merge into existing provenance group, don't replace it
-                        prov_out = ensure_provenance_group(f_out)
-                        if "cap" in prov_out:
-                            del prov_out["cap"]
-                        f_temp.copy("uns/provenance/cap", prov_out, "cap")
-                    elif key in f_temp["uns"]:
+                    if key in f_temp["uns"]:
                         if key in f_out["uns"]:
                             del f_out["uns"][key]
                         f_temp.copy(f"uns/{key}", f_out["uns"])
@@ -392,7 +365,6 @@ def copy_cap_annotations(
                     del prov_out[EDIT_LOG_KEY]
                 if "provenance" in f_temp["uns"] and EDIT_LOG_KEY in f_temp["uns"]["provenance"]:
                     f_temp.copy(f"uns/provenance/{EDIT_LOG_KEY}", prov_out, EDIT_LOG_KEY)
-                # Remove legacy key if present
 
             # --- Step 5: Verify transplant — full column comparison ---
             verify_err = verify_obs_transplant(temp_path, output_path, obs_cols_to_copy)

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -158,12 +158,14 @@ def copy_cap_annotations(
         # anndata-specific encoding that's complex to parse via raw h5py.
         with open_h5ad(source_path) as source:
             # Only the nested uns['cap_metadata'] layout is accepted; the
-            # deprecated top-level layout is refused, not normalized. The full
-            # block travels into the target unchanged.
+            # deprecated top-level layout is refused, not normalized. Refuse it
+            # first — including a mixed file that also carries a nested block —
+            # so deprecated keys never slip through. The full block travels into
+            # the target unchanged.
+            if is_legacy_cap_layout(source.uns):
+                return {"error": LEGACY_LAYOUT_ERROR}
             cap_block = resolve_cap_block(source.uns)
             if cap_block is None:
-                if is_legacy_cap_layout(source.uns):
-                    return {"error": LEGACY_LAYOUT_ERROR}
                 if CAP_METADATA_KEY in source.uns:
                     return {"error": "Source uns['cap_metadata'] is malformed (not a dict/group)."}
                 return {"error": "Source has no cellannotation_metadata in uns['cap_metadata']"}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -241,6 +241,20 @@ def copy_cap_annotations(
             return {"error": dupe_err}
         target_var_set = set(target_var_list)
 
+        # Refuse a target carrying deprecated top-level CAP (from older tooling)
+        # rather than silently overwriting it into a mixed-layout file. Symmetric
+        # with the legacy-source refusal above (issue #452).
+        if is_legacy_cap_layout(target_uns_keys):
+            return {
+                "error": (
+                    "Target uses the deprecated top-level CAP layout "
+                    "(uns['cellannotation_metadata'] / "
+                    "uns['cellannotation_schema_version']). Only the nested "
+                    "uns['cap_metadata'] layout is accepted; re-curate the target "
+                    "into the nested layout before copying CAP into it."
+                )
+            }
+
         # Detect existing CAP obs columns: any column with "--" separator
         existing_cap_cols = [c for c in target_obs_columns if "--" in c]
 

--- a/packages/hca-anndata-tools/tests/conftest.py
+++ b/packages/hca-anndata-tools/tests/conftest.py
@@ -2,8 +2,28 @@
 
 from pathlib import Path
 
+import anndata as ad
 import pytest
 from hca_anndata_tools.testing import create_cellxgene_h5ad, create_sample_h5ad
+
+
+@pytest.fixture
+def downgrade_cap_to_legacy():
+    """Return a helper that rewrites a nested-CAP h5ad into the deprecated
+    top-level layout in place: lifts every key out of ``uns['cap_metadata']``
+    to the top level of ``uns`` and drops the wrapper. Used to exercise
+    old -> new normalization on read.
+    """
+
+    def _downgrade(path: Path) -> Path:
+        adata = ad.read_h5ad(path)
+        cap = dict(adata.uns.pop("cap_metadata"))
+        for key, value in cap.items():
+            adata.uns[key] = value
+        adata.write_h5ad(path)
+        return path
+
+    return _downgrade
 
 
 @pytest.fixture(scope="session")

--- a/packages/hca-anndata-tools/tests/conftest.py
+++ b/packages/hca-anndata-tools/tests/conftest.py
@@ -11,8 +11,9 @@ from hca_anndata_tools.testing import create_cellxgene_h5ad, create_sample_h5ad
 def downgrade_cap_to_legacy():
     """Return a helper that rewrites a nested-CAP h5ad into the deprecated
     top-level layout in place: lifts every key out of ``uns['cap_metadata']``
-    to the top level of ``uns`` and drops the wrapper. Used to exercise
-    old -> new normalization on read.
+    to the top level of ``uns`` and drops the wrapper. Used to build a
+    legacy-layout file for the detection / refusal tests (the legacy layout is
+    refused, not normalized).
     """
 
     def _downgrade(path: Path) -> Path:

--- a/packages/hca-anndata-tools/tests/test_auto_resolve_latest.py
+++ b/packages/hca-anndata-tools/tests/test_auto_resolve_latest.py
@@ -34,7 +34,7 @@ def _make_file(path: Path, *, n_obs: int, marker: str, edit_only: bool) -> None:
     )
     adata.uns["title"] = marker
     if edit_only:
-        adata.uns["cellannotation_schema_version"] = "1.0.0"
+        adata.uns["cap_metadata"] = {"cellannotation_schema_version": "1.0.0"}
         adata.obsm["X_umap"] = np.random.default_rng(0).normal(size=(n_obs, 2)).astype(np.float32)
     adata.write_h5ad(path)
 

--- a/packages/hca-anndata-tools/tests/test_cap.py
+++ b/packages/hca-anndata-tools/tests/test_cap.py
@@ -1,5 +1,6 @@
 """Tests for the get_cap_annotations function and _make_serializable helper."""
 
+import shutil
 from pathlib import Path
 
 import anndata as ad
@@ -123,13 +124,15 @@ def cap_h5ad(tmp_path_factory) -> Path:
 
     adata = ad.AnnData(X=X, obs=obs, var=var)
     adata.uns["title"] = "CAP Test"
-    adata.uns["cellannotation_schema_version"] = "0.2.0"
-    adata.uns["cellannotation_metadata"] = {
-        "my_labels": {
-            "annotation_method": "manual",
-            "description": "Test annotations",
-            "author": "test",
-            "count": np.int64(42),
+    adata.uns["cap_metadata"] = {
+        "cellannotation_schema_version": "0.2.0",
+        "cellannotation_metadata": {
+            "my_labels": {
+                "annotation_method": "manual",
+                "description": "Test annotations",
+                "author": "test",
+                "count": np.int64(42),
+            },
         },
     }
 
@@ -141,7 +144,22 @@ def cap_h5ad(tmp_path_factory) -> Path:
 def test_cap_detects_annotation_set(cap_h5ad):
     result = get_cap_annotations(str(cap_h5ad))
     assert result["has_cap_annotations"] is True
+    assert result["layout"] == "cap_metadata"
     assert "my_labels" in result["annotation_sets"]
+
+
+def test_cap_flags_legacy_toplevel_layout(cap_h5ad, tmp_path, downgrade_cap_to_legacy):
+    # An old-format file (CAP keys at top level) is NOT accepted as CAP, but the
+    # deprecated layout is surfaced via `layout` as a diagnostic. Copy the
+    # module-scoped fixture first so the in-place downgrade doesn't corrupt it.
+    legacy = tmp_path / "legacy.h5ad"
+    shutil.copy(cap_h5ad, legacy)
+    downgrade_cap_to_legacy(legacy)
+
+    result = get_cap_annotations(str(legacy))
+    assert result["has_cap_annotations"] is False
+    assert result["layout"] == "legacy_toplevel"
+    assert result["annotation_sets"] == []
 
 
 def test_cap_reports_required_columns(cap_h5ad):

--- a/packages/hca-anndata-tools/tests/test_cap.py
+++ b/packages/hca-anndata-tools/tests/test_cap.py
@@ -148,6 +148,19 @@ def test_cap_detects_annotation_set(cap_h5ad):
     assert "my_labels" in result["annotation_sets"]
 
 
+def test_cap_flags_mixed_layout(cap_h5ad, tmp_path):
+    # A mixed file (nested cap_metadata + a deprecated top-level key) is flagged
+    # legacy and not treated as valid CAP. Copy the module-scoped fixture first.
+    mixed = tmp_path / "mixed.h5ad"
+    adata = ad.read_h5ad(cap_h5ad)
+    adata.uns["cellannotation_schema_version"] = "0.2.0"
+    adata.write_h5ad(mixed)
+
+    result = get_cap_annotations(str(mixed))
+    assert result["has_cap_annotations"] is False
+    assert result["layout"] == "legacy_toplevel"
+
+
 def test_cap_flags_legacy_toplevel_layout(cap_h5ad, tmp_path, downgrade_cap_to_legacy):
     # An old-format file (CAP keys at top level) is NOT accepted as CAP, but the
     # deprecated layout is surfaced via `layout` as a diagnostic. Copy the

--- a/packages/hca-anndata-tools/tests/test_copy_cap.py
+++ b/packages/hca-anndata-tools/tests/test_copy_cap.py
@@ -218,6 +218,18 @@ def test_copy_refuses_legacy_toplevel_source(tmp_path, downgrade_cap_to_legacy):
     assert "cap_metadata" in result["error"]
 
 
+def test_copy_refuses_mixed_layout_source(cap_source, hca_target):
+    # A mixed source (nested cap_metadata AND a deprecated top-level key) is
+    # refused rather than silently accepted with the nested block winning.
+    adata = ad.read_h5ad(cap_source)
+    adata.uns["cellannotation_schema_version"] = "1.0.2"
+    adata.write_h5ad(cap_source)
+
+    result = copy_cap_annotations(str(cap_source), str(hca_target))
+    assert "error" in result
+    assert "cap_metadata" in result["error"]
+
+
 def test_copy_refuses_malformed_cap_metadata_source(cap_source, hca_target):
     # cap_metadata present but not a dict -> explicit malformed error, not the
     # generic "no cellannotation_metadata" message.

--- a/packages/hca-anndata-tools/tests/test_copy_cap.py
+++ b/packages/hca-anndata-tools/tests/test_copy_cap.py
@@ -483,7 +483,7 @@ def test_copy_target_has_cap_fails(cap_source, hca_target_with_cap):
 
 
 def test_copy_cap_preserves_cellxgene_provenance(cap_source, tmp_path):
-    """When target already has provenance/cellxgene, copy_cap adds provenance/cap alongside it."""
+    """When target already has provenance/cellxgene, copy_cap writes the CAP block to uns['cap_metadata'] alongside it (preserving the cellxgene provenance)."""
     n = len(CELL_IDS)
     rng = np.random.default_rng(99)
     X = sp.random(n, 5, density=0.3, format="csr", dtype=np.float32, random_state=rng)

--- a/packages/hca-anndata-tools/tests/test_copy_cap.py
+++ b/packages/hca-anndata-tools/tests/test_copy_cap.py
@@ -482,7 +482,7 @@ def test_copy_no_cap_source_fails(hca_target, tmp_path):
     no_cap = _make_hca_target(tmp_path / "no_cap.h5ad", CELL_IDS)
     result = copy_cap_annotations(str(no_cap), str(hca_target))
     assert "error" in result
-    assert "cellannotation_metadata" in result["error"]
+    assert "cap_metadata" in result["error"]
 
 
 def test_copy_target_has_cap_fails(cap_source, hca_target_with_cap):

--- a/packages/hca-anndata-tools/tests/test_copy_cap.py
+++ b/packages/hca-anndata-tools/tests/test_copy_cap.py
@@ -218,6 +218,21 @@ def test_copy_refuses_legacy_toplevel_source(tmp_path, downgrade_cap_to_legacy):
     assert "cap_metadata" in result["error"]
 
 
+def test_copy_refuses_legacy_target(cap_source, tmp_path):
+    # A target carrying deprecated top-level CAP (from older tooling) is refused
+    # rather than overwritten into a mixed-layout file — even with overwrite=True.
+    target = _make_hca_target(tmp_path / "legacy_target.h5ad", CELL_IDS)
+    adata = ad.read_h5ad(target)
+    adata.uns["cellannotation_schema_version"] = "1.0.2"
+    adata.uns["cellannotation_metadata"] = {"author_cell_type": {"description": "x"}}
+    adata.write_h5ad(target)
+
+    result = copy_cap_annotations(str(cap_source), str(target), overwrite=True)
+    assert "error" in result
+    assert "Target" in result["error"]
+    assert "cap_metadata" in result["error"]
+
+
 # --- Skip demographic columns ---
 
 

--- a/packages/hca-anndata-tools/tests/test_copy_cap.py
+++ b/packages/hca-anndata-tools/tests/test_copy_cap.py
@@ -73,22 +73,25 @@ def _make_cap_source(
     adata = ad.AnnData(X=X, obs=obs, var=var)
 
     adata.uns["title"] = "CAP Test Dataset"
-    adata.uns["cellannotation_schema_version"] = "1.0.2"
-    adata.uns["cellannotation_metadata"] = {
-        "author_cell_type": {
-            "algorithm_name": "NA",
-            "algorithm_version": "NA",
-            "algorithm_repo_url": "NA",
-            "annotation_method": "manual",
-            "description": "Test annotation set",
-        }
+    # Canonical layout: the entire CAP block nests under uns['cap_metadata'].
+    adata.uns["cap_metadata"] = {
+        "cellannotation_schema_version": "1.0.2",
+        "cellannotation_metadata": {
+            "author_cell_type": {
+                "algorithm_name": "NA",
+                "algorithm_version": "NA",
+                "algorithm_repo_url": "NA",
+                "annotation_method": "manual",
+                "description": "Test annotation set",
+            }
+        },
+        "authors_list": "Test Author",
+        "hierarchy": {"author_cell_type": 1},
+        "description": "A test CAP dataset",
+        "cap_dataset_url": "https://celltype.info/test",
+        "publication_timestamp": "2026-01-01",
+        "publication_version": "1.0",
     }
-    adata.uns["authors_list"] = "Test Author"
-    adata.uns["hierarchy"] = {"author_cell_type": 1}
-    adata.uns["description"] = "A test CAP dataset"
-    adata.uns["cap_dataset_url"] = "https://celltype.info/test"
-    adata.uns["publication_timestamp"] = "2026-01-01"
-    adata.uns["publication_version"] = "1.0"
 
     adata.write_h5ad(path)
     return path
@@ -176,28 +179,43 @@ def test_copy_marker_gene_validation(cap_source, hca_target):
 
 
 
-def test_copy_uns_schema_toplevel(cap_source, hca_target):
+def test_copy_uns_cap_metadata_nested(cap_source, hca_target):
     result = copy_cap_annotations(str(cap_source), str(hca_target))
     written = ad.read_h5ad(result["output_path"])
-    assert "cellannotation_schema_version" in written.uns
-    assert "cellannotation_metadata" in written.uns
+    cap = written.uns["cap_metadata"]
+    assert "cellannotation_schema_version" in cap
+    assert "cellannotation_metadata" in cap
+    # Schema keys must NOT leak to the top level.
+    assert "cellannotation_schema_version" not in written.uns
+    assert "cellannotation_metadata" not in written.uns
 
 
-def test_copy_uns_provenance_cap(cap_source, hca_target):
+def test_copy_cap_metadata_includes_provenance(cap_source, hca_target):
     result = copy_cap_annotations(str(cap_source), str(hca_target))
     written = ad.read_h5ad(result["output_path"])
-    assert "provenance" in written.uns
-    assert "cap" in written.uns["provenance"]
-    cap = written.uns["provenance"]["cap"]
+    cap = written.uns["cap_metadata"]
+    # Publication provenance travels inside the cap_metadata block.
     assert cap["cap_dataset_url"] == "https://celltype.info/test"
     assert cap["authors_list"] == "Test Author"
     assert cap["description"] == "A test CAP dataset"
     assert cap["publication_timestamp"] == "2026-01-01"
     assert cap["publication_version"] == "1.0"
-    # NOT top-level
+    # The old provenance/cap split is gone.
+    assert "provenance" not in written.uns or "cap" not in written.uns["provenance"]
+    # NOT scattered at top level either.
     assert "cap_dataset_url" not in written.uns
     assert "authors_list" not in written.uns
-    assert "cap_metadata" not in written.uns
+
+
+def test_copy_refuses_legacy_toplevel_source(tmp_path, downgrade_cap_to_legacy):
+    # An old-format source (CAP keys at top level) is refused, not normalized:
+    # only the nested cap_metadata layout is accepted.
+    src = downgrade_cap_to_legacy(_make_cap_source(tmp_path / "legacy.h5ad", CELL_IDS))
+    target = _make_hca_target(tmp_path / "target_legacy.h5ad", CELL_IDS)
+
+    result = copy_cap_annotations(str(src), str(target))
+    assert "error" in result
+    assert "cap_metadata" in result["error"]
 
 
 # --- Skip demographic columns ---
@@ -458,9 +476,10 @@ def test_copy_cap_preserves_cellxgene_provenance(cap_source, tmp_path):
     result = copy_cap_annotations(str(cap_source), str(target_path))
     assert "error" not in result
     written = ad.read_h5ad(result["output_path"])
+    # Existing cellxgene provenance is preserved alongside the new CAP block.
     assert "cellxgene" in written.uns["provenance"]
     assert written.uns["provenance"]["cellxgene"]["schema_version"] == "7.0.0"
-    assert "cap" in written.uns["provenance"]
+    assert "cap_metadata" in written.uns
 
 
 # --- Overwrite ---

--- a/packages/hca-anndata-tools/tests/test_copy_cap.py
+++ b/packages/hca-anndata-tools/tests/test_copy_cap.py
@@ -218,6 +218,18 @@ def test_copy_refuses_legacy_toplevel_source(tmp_path, downgrade_cap_to_legacy):
     assert "cap_metadata" in result["error"]
 
 
+def test_copy_refuses_malformed_cap_metadata_source(cap_source, hca_target):
+    # cap_metadata present but not a dict -> explicit malformed error, not the
+    # generic "no cellannotation_metadata" message.
+    adata = ad.read_h5ad(cap_source)
+    adata.uns["cap_metadata"] = "not-a-dict"
+    adata.write_h5ad(cap_source)
+
+    result = copy_cap_annotations(str(cap_source), str(hca_target))
+    assert "error" in result
+    assert "malformed" in result["error"].lower()
+
+
 def test_copy_refuses_legacy_target(cap_source, tmp_path):
     # A target carrying deprecated top-level CAP (from older tooling) is refused
     # rather than overwritten into a mixed-layout file — even with overwrite=True.

--- a/packages/hca-schema-validator/src/hca_schema_validator/cell_annotation_validator.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/cell_annotation_validator.py
@@ -113,17 +113,18 @@ class HCACellAnnotationValidator:
     def _resolve_cap_metadata(self, uns) -> Optional[Mapping]:
         """Return the canonical ``uns['cap_metadata']`` mapping, or None.
 
-        Strict: CAP metadata must live under ``uns['cap_metadata']``. When the
-        block is absent, records ``LEGACY_LAYOUT_ERROR`` if the deprecated
-        top-level keys are present (so the contributor knows to re-nest), else
-        ``NO_SETS_ERROR``. Returns None in every error case.
+        Strict: CAP metadata must live under ``uns['cap_metadata']``. Any
+        deprecated top-level key records ``LEGACY_LAYOUT_ERROR`` — even
+        alongside a nested block (a mixed-layout file) — so the contributor
+        knows to drop the deprecated keys. A missing block with no deprecated
+        keys records ``NO_SETS_ERROR``. Returns None in every error case.
         """
+        if "cellannotation_metadata" in uns or "cellannotation_schema_version" in uns:
+            self._error(LEGACY_LAYOUT_ERROR)
+            return None
         cap = uns.get("cap_metadata")
         if cap is None:
-            if "cellannotation_metadata" in uns or "cellannotation_schema_version" in uns:
-                self._error(LEGACY_LAYOUT_ERROR)
-            else:
-                self._error(NO_SETS_ERROR)
+            self._error(NO_SETS_ERROR)
             return None
         if not isinstance(cap, Mapping):
             self._error(

--- a/packages/hca-schema-validator/src/hca_schema_validator/cell_annotation_validator.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/cell_annotation_validator.py
@@ -1,15 +1,20 @@
 """HCA Cell Annotation validator — structural conformance to the HCA Cell Annotation schema.
 
+CAP annotation metadata is nested under ``uns['cap_metadata']`` (canonical
+layout). The deprecated top-level layout (``uns['cellannotation_metadata']`` /
+``uns['cellannotation_schema_version']``) is rejected — see issue #452.
+
 Phase 1 (see issue #362) performs four structural checks:
 
-1. At least one CAP annotation set present (``uns['cellannotation_metadata']``
-   is a non-empty dict).
-2. ``uns['cellannotation_schema_version']`` is present and well-formed.
-3. ``uns['cellannotation_metadata']`` is a dict and each per-set value is a
-   dict. The CAP AnnData schema's per-set required fields (``description``,
-   ``annotation_method``, ``algorithm_name``, ``algorithm_version``,
-   ``algorithm_repo_url``) are left to the upstream CAP-side validator; this
-   check only enforces structural shape.
+1. At least one CAP annotation set present
+   (``uns['cap_metadata']['cellannotation_metadata']`` is a non-empty dict).
+2. ``uns['cap_metadata']['cellannotation_schema_version']`` is present and
+   well-formed.
+3. ``uns['cap_metadata']['cellannotation_metadata']`` is a dict and each per-set
+   value is a dict. The CAP AnnData schema's per-set required fields
+   (``description``, ``annotation_method``, ``algorithm_name``,
+   ``algorithm_version``, ``algorithm_repo_url``) are left to the upstream
+   CAP-side validator; this check only enforces structural shape.
 4. Each annotation set has the CAP-required per-set obs columns.
 
 Marker-gene coverage (Phase 2) and CL-term validity (Phase 3) are out of
@@ -19,7 +24,8 @@ scope for this module.
 from __future__ import annotations
 
 import logging
-from typing import List
+from collections.abc import Mapping
+from typing import List, Optional
 
 import anndata as ad
 import semver
@@ -42,6 +48,16 @@ _REQUIRED_OBS_SUFFIXES = (
 NO_SETS_ERROR = (
     "No CAP annotation sets present. At least one annotation set conforming "
     "to the HCA Cell Annotation schema is required. "
+    "See https://data.humancellatlas.org/metadata/cell-annotation for details."
+)
+
+# Raised when CAP metadata is found at the deprecated top level of uns instead
+# of nested under uns['cap_metadata'] (issue #452).
+LEGACY_LAYOUT_ERROR = (
+    "CAP annotation metadata must be nested under uns['cap_metadata']. Found "
+    "the deprecated top-level layout (uns['cellannotation_metadata'] / "
+    "uns['cellannotation_schema_version']); re-export with the CAP metadata "
+    "under uns['cap_metadata']. "
     "See https://data.humancellatlas.org/metadata/cell-annotation for details."
 )
 
@@ -75,15 +91,17 @@ class HCACellAnnotationValidator:
             return False
 
         try:
-            # Check for annotation sets first. If none are present, NO_SETS_ERROR
-            # is the one actionable message — don't add schema-version noise that
-            # a contributor with no CAP attached can't meaningfully fix.
-            sets = self._check_metadata(adata.uns)
-            if sets:
-                self._check_schema_version(adata.uns)
-                obs_columns = set(adata.obs.columns)
-                for set_name in sets:
-                    self._check_set_columns(set_name, obs_columns)
+            # Resolve the canonical CAP block first. A deprecated top-level
+            # layout or a missing block is the one actionable message — don't
+            # add schema-version noise that a contributor can't meaningfully fix.
+            cap = self._resolve_cap_metadata(adata.uns)
+            if cap is not None:
+                sets = self._check_metadata(cap)
+                if sets:
+                    self._check_schema_version(cap)
+                    obs_columns = set(adata.obs.columns)
+                    for set_name in sets:
+                        self._check_set_columns(set_name, obs_columns)
         finally:
             # Guard against an unexpected non-backed return so a missing
             # `.file` attribute doesn't mask earlier validation errors.
@@ -92,38 +110,61 @@ class HCACellAnnotationValidator:
 
         return not self.errors
 
-    def _check_schema_version(self, uns) -> None:
-        if "cellannotation_schema_version" not in uns:
+    def _resolve_cap_metadata(self, uns) -> Optional[Mapping]:
+        """Return the canonical ``uns['cap_metadata']`` mapping, or None.
+
+        Strict: CAP metadata must live under ``uns['cap_metadata']``. When the
+        block is absent, records ``LEGACY_LAYOUT_ERROR`` if the deprecated
+        top-level keys are present (so the contributor knows to re-nest), else
+        ``NO_SETS_ERROR``. Returns None in every error case.
+        """
+        cap = uns.get("cap_metadata")
+        if cap is None:
+            if "cellannotation_metadata" in uns or "cellannotation_schema_version" in uns:
+                self._error(LEGACY_LAYOUT_ERROR)
+            else:
+                self._error(NO_SETS_ERROR)
+            return None
+        if not isinstance(cap, Mapping):
             self._error(
-                "uns['cellannotation_schema_version'] is missing. The HCA Cell "
-                "Annotation schema version must be recorded."
+                f"uns['cap_metadata'] must be a dict/group; got "
+                f"{type(cap).__name__}."
+            )
+            return None
+        return cap
+
+    def _check_schema_version(self, cap) -> None:
+        if "cellannotation_schema_version" not in cap:
+            self._error(
+                "uns['cap_metadata']['cellannotation_schema_version'] is missing. "
+                "The HCA Cell Annotation schema version must be recorded."
             )
             return
-        value = uns["cellannotation_schema_version"]
+        value = cap["cellannotation_schema_version"]
         if not isinstance(value, str):
             self._error(
-                f"uns['cellannotation_schema_version'] must be a semver string "
-                f"(e.g. '0.1.0'); got {value!r}."
+                f"uns['cap_metadata']['cellannotation_schema_version'] must be a "
+                f"semver string (e.g. '0.1.0'); got {value!r}."
             )
             return
         try:
             semver.Version.parse(value)
         except ValueError:
             self._error(
-                f"uns['cellannotation_schema_version'] must be a semver string "
-                f"(e.g. '0.1.0'); got {value!r}."
+                f"uns['cap_metadata']['cellannotation_schema_version'] must be a "
+                f"semver string (e.g. '0.1.0'); got {value!r}."
             )
 
-    def _check_metadata(self, uns) -> List[str]:
-        if "cellannotation_metadata" not in uns:
+    def _check_metadata(self, cap) -> List[str]:
+        if "cellannotation_metadata" not in cap:
             self._error(NO_SETS_ERROR)
             return []
 
-        metadata = uns["cellannotation_metadata"]
+        metadata = cap["cellannotation_metadata"]
         if not isinstance(metadata, dict):
             self._error(
-                f"uns['cellannotation_metadata'] must be a dict keyed by "
-                f"annotation set name; got {type(metadata).__name__}."
+                f"uns['cap_metadata']['cellannotation_metadata'] must be a dict "
+                f"keyed by annotation set name; got {type(metadata).__name__}."
             )
             return []
 
@@ -135,8 +176,8 @@ class HCACellAnnotationValidator:
         for set_name, set_meta in metadata.items():
             if not isinstance(set_meta, dict):
                 self._error(
-                    f"uns['cellannotation_metadata']['{set_name}'] must be a "
-                    f"dict; got {type(set_meta).__name__}."
+                    f"uns['cap_metadata']['cellannotation_metadata']['{set_name}'] "
+                    f"must be a dict; got {type(set_meta).__name__}."
                 )
                 continue
             annotation_sets.append(set_name)

--- a/packages/hca-schema-validator/src/hca_schema_validator/testing.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/testing.py
@@ -91,7 +91,8 @@ def create_cap_annotated_h5ad(
     """Create a small h5ad with a valid CAP annotation set.
 
     Builds on :func:`create_labelable_h5ad` and overlays the CAP structures
-    (``obs`` columns with the ``<set>--<col>`` prefix + ``uns`` metadata) that
+    (``obs`` columns with the ``<set>--<col>`` prefix + nested
+    ``uns['cap_metadata']`` metadata) that
     :class:`HCACellAnnotationValidator` expects. Returns ``path``.
 
     Tests can mutate the written file to exercise specific failure modes.
@@ -103,9 +104,9 @@ def create_cap_annotated_h5ad(
     for suffix in _CAP_COLUMN_SUFFIXES:
         adata.obs[f"{set_name}--{suffix}"] = pd.Categorical(["value"] * n_obs)
 
-    adata.uns["cellannotation_schema_version"] = schema_version
-    adata.uns["cellannotation_metadata"] = {
-        set_name: {"title": f"{set_name} title"}
+    adata.uns["cap_metadata"] = {
+        "cellannotation_schema_version": schema_version,
+        "cellannotation_metadata": {set_name: {"title": f"{set_name} title"}},
     }
 
     adata.write_h5ad(path)

--- a/packages/hca-schema-validator/tests/test_cell_annotation_validator.py
+++ b/packages/hca-schema-validator/tests/test_cell_annotation_validator.py
@@ -67,6 +67,18 @@ def test_legacy_toplevel_layout_errors(cap_h5ad):
     assert LEGACY_LAYOUT_ERROR in v.errors
 
 
+def test_mixed_layout_errors(cap_h5ad):
+    # A mixed file (nested cap_metadata AND a deprecated top-level key) is
+    # rejected — the deprecated key must not slip through.
+    def mutate(adata):
+        adata.uns["cellannotation_schema_version"] = "1.0.0"
+    _rewrite(cap_h5ad, mutate)
+
+    v = HCACellAnnotationValidator()
+    assert v.validate_adata(str(cap_h5ad)) is False
+    assert LEGACY_LAYOUT_ERROR in v.errors
+
+
 def test_missing_cap_metadata_errors(tmp_path):
     # A file with no CAP at all gets NO_SETS_ERROR, not the legacy message.
     from hca_schema_validator.testing import create_labelable_h5ad

--- a/packages/hca-schema-validator/tests/test_cell_annotation_validator.py
+++ b/packages/hca-schema-validator/tests/test_cell_annotation_validator.py
@@ -6,7 +6,10 @@ import anndata as ad
 import pytest
 
 from hca_schema_validator import HCACellAnnotationValidator
-from hca_schema_validator.cell_annotation_validator import NO_SETS_ERROR
+from hca_schema_validator.cell_annotation_validator import (
+    LEGACY_LAYOUT_ERROR,
+    NO_SETS_ERROR,
+)
 from hca_schema_validator.testing import create_cap_annotated_h5ad
 
 
@@ -22,6 +25,17 @@ def _rewrite(path, mutate):
     return path
 
 
+def _mutate_cap(adata, fn):
+    """Apply ``fn`` to a copy of uns['cap_metadata'] and reassign it.
+
+    Reassigning (rather than mutating in place) guarantees the change persists
+    through ``write_h5ad``.
+    """
+    cap = dict(adata.uns["cap_metadata"])
+    fn(cap)
+    adata.uns["cap_metadata"] = cap
+
+
 def test_happy_path(cap_h5ad):
     v = HCACellAnnotationValidator()
     assert v.validate_adata(str(cap_h5ad)) is True
@@ -31,7 +45,7 @@ def test_happy_path(cap_h5ad):
 
 def test_no_cellannotation_metadata_errors(cap_h5ad):
     def mutate(adata):
-        del adata.uns["cellannotation_metadata"]
+        _mutate_cap(adata, lambda cap: cap.pop("cellannotation_metadata"))
     _rewrite(cap_h5ad, mutate)
 
     v = HCACellAnnotationValidator()
@@ -39,9 +53,33 @@ def test_no_cellannotation_metadata_errors(cap_h5ad):
     assert NO_SETS_ERROR in v.errors
 
 
+def test_legacy_toplevel_layout_errors(cap_h5ad):
+    # Downgrade to the deprecated top-level layout: lift cap_metadata's keys to
+    # the top level of uns and drop the wrapper.
+    def mutate(adata):
+        cap = dict(adata.uns.pop("cap_metadata"))
+        for key, value in cap.items():
+            adata.uns[key] = value
+    _rewrite(cap_h5ad, mutate)
+
+    v = HCACellAnnotationValidator()
+    assert v.validate_adata(str(cap_h5ad)) is False
+    assert LEGACY_LAYOUT_ERROR in v.errors
+
+
+def test_missing_cap_metadata_errors(tmp_path):
+    # A file with no CAP at all gets NO_SETS_ERROR, not the legacy message.
+    from hca_schema_validator.testing import create_labelable_h5ad
+
+    path = create_labelable_h5ad(tmp_path / "no_cap.h5ad")
+    v = HCACellAnnotationValidator()
+    assert v.validate_adata(str(path)) is False
+    assert NO_SETS_ERROR in v.errors
+
+
 def test_empty_metadata_errors(cap_h5ad):
     def mutate(adata):
-        adata.uns["cellannotation_metadata"] = {}
+        _mutate_cap(adata, lambda cap: cap.update(cellannotation_metadata={}))
     _rewrite(cap_h5ad, mutate)
 
     v = HCACellAnnotationValidator()
@@ -51,7 +89,7 @@ def test_empty_metadata_errors(cap_h5ad):
 
 def test_metadata_wrong_type_errors(cap_h5ad):
     def mutate(adata):
-        adata.uns["cellannotation_metadata"] = "not-a-dict"
+        _mutate_cap(adata, lambda cap: cap.update(cellannotation_metadata="not-a-dict"))
     _rewrite(cap_h5ad, mutate)
 
     v = HCACellAnnotationValidator()
@@ -61,7 +99,7 @@ def test_metadata_wrong_type_errors(cap_h5ad):
 
 def test_missing_schema_version_errors(cap_h5ad):
     def mutate(adata):
-        del adata.uns["cellannotation_schema_version"]
+        _mutate_cap(adata, lambda cap: cap.pop("cellannotation_schema_version"))
     _rewrite(cap_h5ad, mutate)
 
     v = HCACellAnnotationValidator()
@@ -71,7 +109,7 @@ def test_missing_schema_version_errors(cap_h5ad):
 
 def test_malformed_schema_version_errors(cap_h5ad):
     def mutate(adata):
-        adata.uns["cellannotation_schema_version"] = "not-a-version"
+        _mutate_cap(adata, lambda cap: cap.update(cellannotation_schema_version="not-a-version"))
     _rewrite(cap_h5ad, mutate)
 
     v = HCACellAnnotationValidator()
@@ -81,7 +119,10 @@ def test_malformed_schema_version_errors(cap_h5ad):
 
 def test_set_metadata_wrong_type_errors(cap_h5ad):
     def mutate(adata):
-        adata.uns["cellannotation_metadata"] = {"author_annotation": "not-a-dict"}
+        _mutate_cap(
+            adata,
+            lambda cap: cap.update(cellannotation_metadata={"author_annotation": "not-a-dict"}),
+        )
     _rewrite(cap_h5ad, mutate)
 
     v = HCACellAnnotationValidator()
@@ -105,7 +146,7 @@ def test_missing_required_obs_column_errors(cap_h5ad):
 def test_validate_adata_resets_state(cap_h5ad, tmp_path):
     bad_path = tmp_path / "bad.h5ad"
     create_cap_annotated_h5ad(bad_path)
-    _rewrite(bad_path, lambda a: a.uns.__delitem__("cellannotation_metadata"))
+    _rewrite(bad_path, lambda a: _mutate_cap(a, lambda cap: cap.pop("cellannotation_metadata")))
 
     v = HCACellAnnotationValidator()
     assert v.validate_adata(str(bad_path)) is False


### PR DESCRIPTION
Closes #452

## What

Makes `uns['cap_metadata']` the **only** accepted home for CAP (Cell Annotation Platform) cell-annotation metadata, matching the CAP team's updated export layout. The old top-level `uns` layout is **refused, not normalized** — a clean break.

## Why

The CAP team (at our request, for clearer namespaced keys) moved their export so `cellannotation_metadata`, `cellannotation_schema_version`, and the CAP publication provenance now nest under `uns['cap_metadata']`. Our tools read/wrote the old top-level layout, so `copy_cap_annotations` failed on a new-format source (hit during breast curation). No files are published in the new format yet and gut (the only old-format atlas) will be re-exported by CAP, so a strict clean break is viable and avoids a permanent dual-format shim.

## Changes

- **`hca-anndata-tools`**
  - `resolve_cap_block()` reads only the nested block; new `is_legacy_cap_layout()` + `LEGACY_LAYOUT_ERROR` detect and refuse the deprecated layout.
  - `copy_cap_annotations` reads/writes only `uns['cap_metadata']` (replacing the old top-level + `provenance/cap` split); refuses a legacy source. Edit log stays at `provenance/edit_history`.
  - `get_cap_annotations` reports a diagnostic `layout` field (`cap_metadata` / `legacy_toplevel` / `None`); a legacy file is `has_cap_annotations: false`.
- **`hca-schema-validator`**
  - `HCACellAnnotationValidator` reads from `uns['cap_metadata']`; rejects the top-level layout with `LEGACY_LAYOUT_ERROR`.
- **`hca-anndata-mcp`** — tool docstrings updated to the nested path.

## Breaking change

The `hcaCellAnnotation` contract now requires CAP metadata nested under `uns['cap_metadata']`. `feat!` → minor bumps on the 0.x packages (`hca-schema-validator` 0.13.1→0.14.0, `hca-anndata-tools` 0.5.1→0.6.0) per `bump-minor-pre-major`.

## Testing

- `hca-anndata-tools`: 276 passed
- `hca-schema-validator`: 117 passed (incl. legacy-rejection tests)
- `make typecheck`: 0 errors

Reviewed via `/simplify` + high-effort `/code-review`.

## Follow-ups (separate)

- Bump `hca-anndata-mcp` dep pins after the tools/validator release.
- Update `evaluate-h5ad` / `curate-h5ad` skill docs' stale CAP-uns references.
- HCA Cell Annotation schema spec doc (coordinated separately).
- Gut re-export by CAP in the nested layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)