### PR TITLE
feat(hca-schema-validator)!: warn on cosmetic labels only when unverifiable

### DIFF
--- a/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/check_cosmetic.py
+++ b/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/check_cosmetic.py
@@ -23,8 +23,13 @@ def check_cosmetic_labels_h5ad(path: str) -> dict:
     * column present + source present → row-level checks:
         - cosmetic value with NaN term ID → error
         - cosmetic value disagrees with canonical ontology label → error
+        - term ID that doesn't resolve in the ontology → silently skipped, so
+          the label goes unchecked. Only the full :func:`validate_schema` run
+          flags the bad ID, through its curie checks.
 
-    A column whose values all agree with their term IDs is silent.
+    A column is therefore silent both when its values agree with their term IDs
+    and when those term IDs couldn't be resolved at all — ``is_clean`` means
+    "nothing this check looks at is wrong", not "the file is valid".
 
     Args:
         path: Path to an .h5ad file. Auto-resolves to the latest timestamped

--- a/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/check_cosmetic.py
+++ b/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/check_cosmetic.py
@@ -18,8 +18,8 @@ def check_cosmetic_labels_h5ad(path: str) -> dict:
     For each of the controlled HCA obs label columns
     (:data:`hca_schema_validator.HCA_DERIVED_OBS_LABELS`):
 
-    * column present, source `*_ontology_term_id` absent → warning (the labels
-      can't be checked against anything)
+    * column present with at least one label, source `*_ontology_term_id`
+      absent → warning (the labels can't be checked against anything)
     * column present + source present → row-level checks:
         - cosmetic value with NaN term ID → error
         - cosmetic value disagrees with canonical ontology label → error
@@ -28,7 +28,12 @@ def check_cosmetic_labels_h5ad(path: str) -> dict:
           flags the bad ID, through its curie checks.
 
     A column is therefore silent both when its values agree with their term IDs
-    and when those term IDs couldn't be resolved at all — ``is_clean`` means
+    and when those term IDs couldn't be resolved at all.
+
+    This check looks at label/term-ID agreement and nothing else. It does not
+    detect forbidden columns (e.g. `self_reported_ethnicity`), missing required
+    columns, invalid ontology term IDs, or any other schema-level failure — all
+    of which :func:`validate_schema` catches. ``is_clean`` therefore means
     "nothing this check looks at is wrong", not "the file is valid".
 
     Args:

--- a/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/check_cosmetic.py
+++ b/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/check_cosmetic.py
@@ -11,17 +11,20 @@ def check_cosmetic_labels_h5ad(path: str) -> dict:
     """Check producer-supplied obs label columns against their `*_ontology_term_id` siblings.
 
     Targeted alternative to :func:`validate_schema` — runs only the producer-
-    cosmetic-column check (issue #377), skipping the full schema/raw/feature
-    validation pipeline. Useful when a curator wants quick feedback on
+    cosmetic-column check (issues #377, #443), skipping the full schema/raw/
+    feature validation pipeline. Useful when a curator wants quick feedback on
     label/ID drift without paying for a full validate run.
 
-    For each of the eight controlled HCA obs label columns
+    For each of the controlled HCA obs label columns
     (:data:`hca_schema_validator.HCA_DERIVED_OBS_LABELS`):
 
-    * column present → warning ("delete the column")
-    * column present + source `*_ontology_term_id` present → row-level checks:
+    * column present, source `*_ontology_term_id` absent → warning (the labels
+      can't be checked against anything)
+    * column present + source present → row-level checks:
         - cosmetic value with NaN term ID → error
         - cosmetic value disagrees with canonical ontology label → error
+
+    A column whose values all agree with their term IDs is silent.
 
     Args:
         path: Path to an .h5ad file. Auto-resolves to the latest timestamped

--- a/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/check_cosmetic.py
+++ b/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/check_cosmetic.py
@@ -27,8 +27,9 @@ def check_cosmetic_labels_h5ad(path: str) -> dict:
           the label goes unchecked. Only the full :func:`validate_schema` run
           flags the bad ID, through its curie checks.
 
-    A column is therefore silent both when its values agree with their term IDs
-    and when those term IDs couldn't be resolved at all.
+    A column is therefore silent in three cases: when its values agree with their
+    term IDs, when those term IDs couldn't be resolved at all, and when it holds
+    no labels to check.
 
     This check looks at label/term-ID agreement and nothing else. It does not
     detect forbidden columns (e.g. `self_reported_ethnicity`), missing required

--- a/packages/hca-anndata-mcp/tests/test_check_cosmetic.py
+++ b/packages/hca-anndata-mcp/tests/test_check_cosmetic.py
@@ -1,4 +1,4 @@
-"""Unit tests for the check_cosmetic_labels_h5ad MCP wrapper (#377)."""
+"""Unit tests for the check_cosmetic_labels_h5ad MCP wrapper (#377, #443)."""
 
 import anndata as ad
 import numpy as np
@@ -16,7 +16,7 @@ def test_clean_file_is_clean(tmp_path):
     assert result["error_count"] == 0
 
 
-def test_warning_when_cosmetic_present_and_matches(tmp_path):
+def test_clean_when_cosmetic_present_and_matches(tmp_path):
     path = create_labelable_h5ad(tmp_path / "matches.h5ad")
     adata = ad.read_h5ad(path)
     adata.obs["tissue"] = "lung"  # canonical for UBERON:0002048
@@ -24,9 +24,22 @@ def test_warning_when_cosmetic_present_and_matches(tmp_path):
 
     result = check_cosmetic_labels_h5ad(str(path))
     assert "error" not in result, result
-    assert result["is_clean"] is False
+    assert result["is_clean"] is True
+    assert result["warning_count"] == 0
+    assert result["error_count"] == 0
+
+
+def test_warning_when_source_column_absent(tmp_path):
+    path = create_labelable_h5ad(tmp_path / "no_source.h5ad")
+    adata = ad.read_h5ad(path)
+    adata.obs["cell_type"] = "PRODUCER_CELL_TYPE"
+    del adata.obs["cell_type_ontology_term_id"]  # cell_type is optional
+    adata.write_h5ad(path)
+
+    result = check_cosmetic_labels_h5ad(str(path))
+    assert "error" not in result, result
     assert result["warning_count"] == 1
-    assert "obs['tissue']" in result["warnings"][0]
+    assert "obs['cell_type']" in result["warnings"][0]
     assert result["error_count"] == 0
 
 

--- a/packages/hca-anndata-mcp/tests/test_check_cosmetic.py
+++ b/packages/hca-anndata-mcp/tests/test_check_cosmetic.py
@@ -38,6 +38,7 @@ def test_warning_when_source_column_absent(tmp_path):
 
     result = check_cosmetic_labels_h5ad(str(path))
     assert "error" not in result, result
+    assert result["is_clean"] is False  # is_clean is false when *either* list is non-empty
     assert result["warning_count"] == 1
     assert "obs['cell_type']" in result["warnings"][0]
     assert result["error_count"] == 0

--- a/packages/hca-anndata-mcp/tests/test_validate.py
+++ b/packages/hca-anndata-mcp/tests/test_validate.py
@@ -23,7 +23,7 @@ def test_validate_schema_missing_file():
 
 
 def test_validate_schema_surfaces_cosmetic_check(tmp_path):
-    """Confirm the new producer-cosmetic-column check (issue #377) surfaces
+    """Confirm the producer-cosmetic-column check (issues #377, #443) surfaces
     through the MCP wrapper. The wrapper just returns the validator's
     warnings/errors, so this test exercises the integration boundary
     rather than re-testing the underlying logic.
@@ -35,10 +35,6 @@ def test_validate_schema_surfaces_cosmetic_check(tmp_path):
 
     result = validate_schema(str(path))
 
-    assert any(
-        "obs['tissue']" in w and "should not be populated by producers" in w
-        for w in result["warnings"]
-    ), result["warnings"]
     assert any(
         "'WRONG_TISSUE_LABEL'" in e and "Either delete the cosmetic column" in e
         for e in result["errors"]

--- a/packages/hca-anndata-mcp/tests/test_validate.py
+++ b/packages/hca-anndata-mcp/tests/test_validate.py
@@ -39,7 +39,22 @@ def test_validate_schema_surfaces_cosmetic_check(tmp_path):
         "'WRONG_TISSUE_LABEL'" in e and "Either delete the cosmetic column" in e
         for e in result["errors"]
     ), result["errors"]
+    # #443: a drifting label is an error, never a "delete the column" warning.
+    assert not any("obs['tissue']" in w for w in result["warnings"]), result["warnings"]
     assert result["is_valid"] is False
+
+
+def test_validate_schema_no_cosmetic_warning_when_labels_match(tmp_path):
+    """#443 at the integration boundary: a verified-canonical label column is silent."""
+    path = create_labelable_h5ad(tmp_path / "matching.h5ad")
+    adata = ad.read_h5ad(path)
+    adata.obs["tissue"] = "lung"  # canonical for UBERON:0002048
+    adata.write_h5ad(path)
+
+    result = validate_schema(str(path))
+
+    assert not any("obs['tissue']" in w for w in result["warnings"]), result["warnings"]
+    assert not any("obs['tissue']" in e for e in result["errors"]), result["errors"]
 
 
 def test_validate_schema_resolves_latest(tmp_path):

--- a/packages/hca-schema-validator/src/hca_schema_validator/validator.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/validator.py
@@ -375,14 +375,17 @@ class HCAValidator(Validator):
 def check_cosmetic_labels(adata, schema_def=None):
     """Run the producer-cosmetic-column check and return (warnings, errors).
 
-    The HCA labeler populates the eight controlled obs label columns from their
-    `*_ontology_term_id` counterparts. Producers shouldn't ship the cosmetic
-    columns at all; if they do, every populated row needs a term ID and the
-    cosmetic value must agree with the canonical ontology label.
+    The controlled obs label columns are derived from their
+    `*_ontology_term_id` counterparts. Carrying them is fine as long as they
+    can be checked and they agree with canonical: `populate_labels` writes
+    them deliberately, and CellxGENE exports arrive with them. What matters is
+    that every populated row has a term ID and that the label matches the
+    canonical ontology label for it.
 
     Per-column rules (each fires independently and aggregates):
 
-    * column present → warning ("delete the column")
+    * column present, source absent → warning (nothing to check the labels
+      against)
     * column present + source present → row-level checks:
         - cosmetic value, source NaN → error ("add term ID, delete the label,
           or delete the column")
@@ -399,7 +402,7 @@ def check_cosmetic_labels(adata, schema_def=None):
 
     Returns:
         ``(warnings, errors)`` — two lists of strings, ready for the caller to
-        append to its own report. Issue #377.
+        append to its own report. Issues #377, #443.
     """
     if schema_def is None:
         schema_def = _load_default_schema_def()
@@ -416,12 +419,12 @@ def check_cosmetic_labels(adata, schema_def=None):
         if cosmetic_col not in obs.columns:
             continue
         source_col = f"{cosmetic_col}_ontology_term_id"
-        warnings.append(
-            f"obs['{cosmetic_col}'] should not be populated by producers — "
-            f"the HCA labeler populates this column from {source_col}. "
-            f"Delete the column."
-        )
         if source_col not in obs.columns:
+            warnings.append(
+                f"obs['{cosmetic_col}'] is present but {source_col} is absent, so its "
+                f"labels can't be checked against the ontology. Either add {source_col}, "
+                f"or delete the cosmetic column."
+            )
             continue
         exceptions = _collect_curie_exceptions(obs_components.get(source_col, {}))
         errors.extend(_compare_cosmetic_to_term_ids(obs, cosmetic_col, source_col, exceptions))

--- a/packages/hca-schema-validator/src/hca_schema_validator/validator.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/validator.py
@@ -386,7 +386,9 @@ def check_cosmetic_labels(adata, schema_def=None):
 
     * column present with at least one label, source absent → warning (nothing
       to check the labels against). An all-NaN column has no labels to check,
-      so it stays silent.
+      so it stays silent. The remediation depends on the source column's
+      `requirement_level`: deleting the cosmetic column is only offered when
+      the source is optional, since a required source must be added regardless.
     * column present + source present → row-level checks:
         - cosmetic value, source NaN → error ("add term ID, delete the label,
           or delete the column")
@@ -424,14 +426,25 @@ def check_cosmetic_labels(adata, schema_def=None):
             if obs[cosmetic_col].notna().any():
                 warnings.append(
                     f"obs['{cosmetic_col}'] is populated but obs['{source_col}'] is absent, "
-                    f"so its labels can't be checked against the ontology. Either add "
-                    f"obs['{source_col}'], or delete obs['{cosmetic_col}']."
+                    f"so its labels can't be checked against the ontology. "
+                    f"{_remediation_for_missing_source(obs_components, cosmetic_col, source_col)}"
                 )
             continue
         exceptions = _collect_curie_exceptions(obs_components.get(source_col, {}))
         errors.extend(_compare_cosmetic_to_term_ids(obs, cosmetic_col, source_col, exceptions))
 
     return warnings, errors
+
+
+def _remediation_for_missing_source(obs_components, cosmetic_col, source_col):
+    # Deleting the cosmetic column only silences this warning. When the source
+    # column is required by the schema, its absence is an error in its own
+    # right, so deleting is not a remediation — adding the source column is the
+    # only one. Columns carry no `requirement_level` when they are required.
+    level = str(obs_components.get(source_col, {}).get("requirement_level", "")).lower()
+    if level in ("optional", "strongly_recommended"):
+        return f"Either add obs['{source_col}'], or delete obs['{cosmetic_col}']."
+    return f"Add obs['{source_col}'] — the schema requires it."
 
 
 def _collect_curie_exceptions(source_def):

--- a/packages/hca-schema-validator/src/hca_schema_validator/validator.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/validator.py
@@ -387,8 +387,9 @@ def check_cosmetic_labels(adata, schema_def=None):
     * column present with at least one label, source absent → warning (nothing
       to check the labels against). An all-NaN column has no labels to check,
       so it stays silent. The remediation depends on the source column's
-      `requirement_level`: deleting the cosmetic column is only offered when
-      the source is optional, since a required source must be added regardless.
+      `requirement_level`: deleting the cosmetic column is only offered when the
+      source is not required (`optional` or `strongly_recommended`), since a
+      required source must be added regardless.
     * column present + source present → row-level checks:
         - cosmetic value, source NaN → error ("add term ID, delete the label,
           or delete the column")

--- a/packages/hca-schema-validator/src/hca_schema_validator/validator.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/validator.py
@@ -384,8 +384,9 @@ def check_cosmetic_labels(adata, schema_def=None):
 
     Per-column rules (each fires independently and aggregates):
 
-    * column present, source absent → warning (nothing to check the labels
-      against)
+    * column present with at least one label, source absent → warning (nothing
+      to check the labels against). An all-NaN column has no labels to check,
+      so it stays silent.
     * column present + source present → row-level checks:
         - cosmetic value, source NaN → error ("add term ID, delete the label,
           or delete the column")
@@ -420,11 +421,12 @@ def check_cosmetic_labels(adata, schema_def=None):
             continue
         source_col = f"{cosmetic_col}_ontology_term_id"
         if source_col not in obs.columns:
-            warnings.append(
-                f"obs['{cosmetic_col}'] is present but {source_col} is absent, so its "
-                f"labels can't be checked against the ontology. Either add {source_col}, "
-                f"or delete the cosmetic column."
-            )
+            if obs[cosmetic_col].notna().any():
+                warnings.append(
+                    f"obs['{cosmetic_col}'] is populated but {source_col} is absent, so its "
+                    f"labels can't be checked against the ontology. Either add {source_col}, "
+                    f"or delete the cosmetic column."
+                )
             continue
         exceptions = _collect_curie_exceptions(obs_components.get(source_col, {}))
         errors.extend(_compare_cosmetic_to_term_ids(obs, cosmetic_col, source_col, exceptions))

--- a/packages/hca-schema-validator/src/hca_schema_validator/validator.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/validator.py
@@ -423,9 +423,9 @@ def check_cosmetic_labels(adata, schema_def=None):
         if source_col not in obs.columns:
             if obs[cosmetic_col].notna().any():
                 warnings.append(
-                    f"obs['{cosmetic_col}'] is populated but {source_col} is absent, so its "
-                    f"labels can't be checked against the ontology. Either add {source_col}, "
-                    f"or delete the cosmetic column."
+                    f"obs['{cosmetic_col}'] is populated but obs['{source_col}'] is absent, "
+                    f"so its labels can't be checked against the ontology. Either add "
+                    f"obs['{source_col}'], or delete obs['{cosmetic_col}']."
                 )
             continue
         exceptions = _collect_curie_exceptions(obs_components.get(source_col, {}))

--- a/packages/hca-schema-validator/tests/test_validator.py
+++ b/packages/hca-schema-validator/tests/test_validator.py
@@ -236,6 +236,8 @@ def test_cosmetic_check_handles_optional_cell_type_with_source_present():
 
 def test_cosmetic_check_warns_when_source_column_absent():
     # The one unverifiable shape: labels with no term IDs to check them against.
+    # cell_type_ontology_term_id is optional, so deleting the label column is a
+    # real remediation and the warning offers it.
     from .fixtures.hca_fixtures import adata
 
     modified = adata.copy()
@@ -246,7 +248,23 @@ def test_cosmetic_check_warns_when_source_column_absent():
     assert len(warnings) == 1
     assert "obs['cell_type']" in warnings[0]
     assert "cell_type_ontology_term_id" in warnings[0]
+    assert "Either add" in warnings[0] and "or delete" in warnings[0]
     assert errors == []  # no source → no row-level check
+
+
+def test_cosmetic_check_missing_required_source_does_not_offer_delete():
+    # tissue_ontology_term_id is required, so deleting obs['tissue'] would only
+    # silence the warning while leaving the file missing a required column.
+    from .fixtures.hca_fixtures import adata
+
+    modified = adata.copy()
+    modified.obs["tissue"] = "lung"
+    del modified.obs["tissue_ontology_term_id"]
+    _, validator = _validate_from_fixture(modified)
+    warnings, _ = _cosmetic_check_messages(validator)
+    assert len(warnings) == 1
+    assert "Add obs['tissue_ontology_term_id']" in warnings[0]
+    assert "delete" not in warnings[0]
 
 
 def test_cosmetic_check_silent_when_column_all_nan_and_source_absent():

--- a/packages/hca-schema-validator/tests/test_validator.py
+++ b/packages/hca-schema-validator/tests/test_validator.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import pytest
-from hca_schema_validator import HCAValidator
+from hca_schema_validator import HCA_DERIVED_OBS_LABELS, HCAValidator
 
 # Test fixtures directory
 FIXTURES_DIR = Path(__file__).parent / "fixtures" / "h5ads"
@@ -151,8 +151,14 @@ def test_valid_adata_passes():
 
 
 def _cosmetic_check_messages(validator):
-    """Filter validator messages to those produced by the cosmetic-label check (#377)."""
-    warnings = [w for w in validator.warnings if "should not be populated by producers" in w]
+    """Filter validator messages to those about a derived obs label column (#377, #443).
+
+    Matches on the column name rather than on message text, so a `warnings == []`
+    assertion stays honest if the check ever starts emitting a differently-worded
+    warning about a column it should be silent on.
+    """
+    labels = [f"obs['{col}']" for col in HCA_DERIVED_OBS_LABELS]
+    warnings = [w for w in validator.warnings if any(label in w for label in labels)]
     errors = [e for e in validator.errors if "Either delete the cosmetic column" in e or "Either add the term ID" in e]
     return warnings, errors
 
@@ -166,15 +172,17 @@ def test_cosmetic_check_silent_when_columns_absent():
     assert errors == []
 
 
-def test_cosmetic_check_warning_only_when_values_match():
+def test_cosmetic_check_silent_when_values_match():
+    # A verified-canonical column is not worth reporting: populate_labels writes
+    # these deliberately, and the row-level comparison below has already proven
+    # the values right. Regression guard for #443.
     from .fixtures.hca_fixtures import adata
 
     modified = adata.copy()
     modified.obs["tissue"] = "lung"  # canonical label for UBERON:0002048
     _, validator = _validate_from_fixture(modified)
     warnings, errors = _cosmetic_check_messages(validator)
-    assert len(warnings) == 1
-    assert "obs['tissue']" in warnings[0]
+    assert warnings == []
     assert errors == []
 
 
@@ -185,7 +193,7 @@ def test_cosmetic_check_error_on_mismatch():
     modified.obs["tissue"] = "WRONG_LABEL"
     _, validator = _validate_from_fixture(modified)
     warnings, errors = _cosmetic_check_messages(validator)
-    assert len(warnings) == 1
+    assert warnings == []
     assert any(
         "'WRONG_LABEL'" in e and "UBERON:0002048" in e and "'lung'" in e
         for e in errors
@@ -200,29 +208,30 @@ def test_cosmetic_check_aggregates_across_columns():
     modified.obs["assay"] = "WRONG_ASSAY"
     _, validator = _validate_from_fixture(modified)
     warnings, errors = _cosmetic_check_messages(validator)
-    assert len(warnings) == 2
+    assert warnings == []
     assert sum("'WRONG_TISSUE'" in e for e in errors) == 1
     assert sum("'WRONG_ASSAY'" in e for e in errors) == 1
 
 
 def test_cosmetic_check_handles_optional_cell_type_with_source_present():
     # cell_type is the only optional column in HCA_DERIVED_OBS_LABELS — verify
-    # it gets the same warning + mismatch-error treatment as the required
-    # columns when the source cell_type_ontology_term_id is present.
+    # it gets the same mismatch-error treatment as the required columns when
+    # the source cell_type_ontology_term_id is present.
     from .fixtures.hca_fixtures import adata
 
     modified = adata.copy()
     modified.obs["cell_type"] = "WRONG_CELL_TYPE"
     _, validator = _validate_from_fixture(modified)
     warnings, errors = _cosmetic_check_messages(validator)
-    assert any("obs['cell_type']" in w for w in warnings)
+    assert warnings == []
     assert any(
         "'WRONG_CELL_TYPE'" in e and "CL:0000066" in e and "'epithelial cell'" in e
         for e in errors
     ), errors
 
 
-def test_cosmetic_check_warning_only_when_source_column_absent():
+def test_cosmetic_check_warns_when_source_column_absent():
+    # The one unverifiable shape: labels with no term IDs to check them against.
     from .fixtures.hca_fixtures import adata
 
     modified = adata.copy()
@@ -232,6 +241,7 @@ def test_cosmetic_check_warning_only_when_source_column_absent():
     warnings, errors = _cosmetic_check_messages(validator)
     assert len(warnings) == 1
     assert "obs['cell_type']" in warnings[0]
+    assert "cell_type_ontology_term_id" in warnings[0]
     assert errors == []  # no source → no row-level check
 
 
@@ -245,7 +255,7 @@ def test_cosmetic_check_error_on_value_with_nan_term_id():
     modified.obs.loc[modified.obs.index[0], "cell_type_ontology_term_id"] = np.nan
     _, validator = _validate_from_fixture(modified)
     warnings, errors = _cosmetic_check_messages(validator)
-    assert len(warnings) == 1
+    assert warnings == []
     assert any(
         "have NaN in cell_type_ontology_term_id" in e and "1 rows labeled 'PRODUCER_LABEL'" in e
         for e in errors
@@ -261,7 +271,7 @@ def test_cosmetic_check_skips_unresolvable_term_ids():
     modified.obs.loc[:, "tissue_ontology_term_id"] = "UBERON:9999999"  # nonexistent
     _, validator = _validate_from_fixture(modified)
     warnings, errors = _cosmetic_check_messages(validator)
-    assert len(warnings) == 1
+    assert warnings == []
     # No mismatch error — unresolvable IDs are silently skipped here (the
     # curie validator surfaces the bad ID via its own pathway).
     assert errors == []
@@ -275,7 +285,7 @@ def test_cosmetic_check_sentinel_values_match():
     modified.obs["sex_ontology_term_id"] = "unknown"
     _, validator = _validate_from_fixture(modified)
     warnings, errors = _cosmetic_check_messages(validator)
-    assert len(warnings) == 1
+    assert warnings == []
     assert errors == []
 
 
@@ -292,7 +302,7 @@ def test_cosmetic_check_sentinel_values_mismatch_errors():
     modified.obs["sex_ontology_term_id"] = "unknown"
     _, validator = _validate_from_fixture(modified)
     warnings, errors = _cosmetic_check_messages(validator)
-    assert len(warnings) == 1
+    assert warnings == []
     assert any(
         "sex_ontology_term_id" in e
         and "'PRODUCER_LABEL'" in e
@@ -314,7 +324,7 @@ def test_cosmetic_check_fires_with_ignore_labels_false():
         validator.validate_adata(str(tmp_path))
 
     warnings, errors = _cosmetic_check_messages(validator)
-    assert len(warnings) == 1
+    assert warnings == []
     assert any("'WRONG'" in e for e in errors)
 
 

--- a/packages/hca-schema-validator/tests/test_validator.py
+++ b/packages/hca-schema-validator/tests/test_validator.py
@@ -249,6 +249,20 @@ def test_cosmetic_check_warns_when_source_column_absent():
     assert errors == []  # no source → no row-level check
 
 
+def test_cosmetic_check_silent_when_column_all_nan_and_source_absent():
+    # An empty column carries no labels, so there is nothing to check against
+    # the ontology and nothing to warn about.
+    from .fixtures.hca_fixtures import adata
+
+    modified = adata.copy()
+    modified.obs["cell_type"] = np.nan
+    del modified.obs["cell_type_ontology_term_id"]  # cell_type is optional, can be removed
+    _, validator = _validate_from_fixture(modified)
+    warnings, errors = _cosmetic_check_messages(validator)
+    assert warnings == []
+    assert errors == []
+
+
 def test_cosmetic_check_error_on_value_with_nan_term_id():
     from .fixtures.hca_fixtures import adata
 

--- a/packages/hca-schema-validator/tests/test_validator.py
+++ b/packages/hca-schema-validator/tests/test_validator.py
@@ -154,12 +154,16 @@ def _cosmetic_check_messages(validator):
     """Filter validator messages to those about a derived obs label column (#377, #443).
 
     Matches on the column name rather than on message text, so a `warnings == []`
-    assertion stays honest if the check ever starts emitting a differently-worded
-    warning about a column it should be silent on.
+    or `errors == []` assertion stays honest if the check ever starts emitting a
+    differently-worded message about a column it should be silent on. Every
+    cosmetic-check message names its column as `obs['<col>']`; the curie validator's
+    errors name the bare `<col>_ontology_term_id`, so they don't collide.
     """
-    labels = [f"obs['{col}']" for col in HCA_DERIVED_OBS_LABELS]
-    warnings = [w for w in validator.warnings if any(label in w for label in labels)]
-    errors = [e for e in validator.errors if "Either delete the cosmetic column" in e or "Either add the term ID" in e]
+    def about_a_label_column(message):
+        return any(f"obs['{col}']" in message for col in HCA_DERIVED_OBS_LABELS)
+
+    warnings = [w for w in validator.warnings if about_a_label_column(w)]
+    errors = [e for e in validator.errors if about_a_label_column(e)]
     return warnings, errors
 
 


### PR DESCRIPTION
Closes #443

## Problem

`check_cosmetic_labels` emitted an unconditional warning for every derived obs label column present in `obs`:

> `obs['tissue'] should not be populated by producers — the HCA labeler populates this column from tissue_ontology_term_id. Delete the column.`

It did this **directly above** a row-level comparison that had already proven the values canonical. So a file curated with `populate_labels` (#421) drew 7 warnings instructing the curator to delete verified-correct data. Observed on both the gut myeloid run and the breast integrated object (2.1M cells, 7 warnings, **0 accompanying errors**).

## Change

Warn only when the column's `*_ontology_term_id` source is **absent** — the one shape where nothing is verifiable. When the source is present, `_compare_cosmetic_to_term_ids` (unchanged) errors on drift, and its error text already carries the delete-or-fix advice.

| State | Before | After |
|---|---|---|
| Column absent | silent | silent |
| Column present, source absent | warning | **warning** (reworded) |
| Column present, values match canonical | warning | **silent** |
| Column present, values disagree | warning + error | **error** |
| Column present, label set / term ID NaN | warning + error | **error** |

## Why verification, not the edit-log attestation #443 originally proposed

The original ticket proposed reading `uns['provenance']['edit_history']` and suppressing the warning per-column where `populate_labels` claimed to fill it. Rejected:

- **Verification beats attestation.** The row comparison observes values are canonical *now*; an edit-log entry records that a tool once claimed to fill them, and goes stale if `obs` is mutated afterwards.
- The ticket's "tamper-evident" argument doesn't hold — entry SHA256s pin the *source* file, not the resulting `obs`.
- It left a bad edge case: a canonical file that never ran `populate_labels` (clean CellxGENE export, or a careful producer) would still be warned. Now it validates clean.
- It's more code, not less.

The ticket also rejected re-verification as *"expensive (per-row ontology lookups on every validation)"*. That premise was **wrong**: `_compare_cosmetic_to_term_ids` already runs on every validation, and it isn't per-row — it `groupby`s to unique pairs and memoizes lookups. No new cost.

### What now enforces "don't hand-write these columns"? Nothing, by design.

An earlier draft of this PR claimed the policy "still lives in `HCALabeler`'s reserved-column preflight (#374)." That overstates it, and the correction is worth stating plainly:

- `HCALabeler._preflight` does raise when a target label column already exists — but it is an **anti-overwrite guard**, not a policy gate. Its only non-test caller in this repo is the `label_h5ad` MCP tool. No service invokes it: not `dataset-validator`, not `hca-schema-validator`. Someone could call it by hand if they knew to, but nothing in the upload path does.
- `populate_labels` never calls `label()` at all, precisely to avoid that preflight (`populator.py:372`). So the preflight only ever fires on files that have *not* been curated.

The honest summary: **after this PR, carrying correct label columns is allowed everywhere.** The sole remaining gate is the drift error — and that is the point. When a label and its term ID disagree, we cannot know which side is authoritative, so the validator refuses to guess, reports the disagreement with row counts, and hands it back to the producer to resolve. That check is unchanged and still blocking.

## Breaking change

`check_cosmetic_labels` and `HCAValidator.validate_adata` no longer warn about populated label columns whose values match their term IDs. Per the repo release policy this is `feat!` → minor bump on a 0.x package, so consumers pinned `<0.14.0` block on it rather than absorbing it as a patch.

**`hca-anndata-mcp` will also take a minor bump, and that is expected.** This repo merges by squash with a blank body, so the individual commit messages are discarded and release-please sees one `feat(...)!:` commit touching both release paths. There is no `linked-versions` plugin — it's plain path attribution, and the `(hca-schema-validator)` scope in the subject does not narrow it. Precedent: #409 (`feat(hca-schema-validator)!: forbid self_reported_ethnicity columns in obs`) touched the same two paths and bumped `hca-schema-validator` 0.12.1 → 0.13.0 *and* `hca-anndata-mcp` 0.5.1 → 0.6.0.

The MCP package here gets only a docstring and test updates, so its minor bump overstates the change. Accepting that, consistent with #409: the alternative is splitting into two PRs, which would leave `main` red in between because `hca-anndata-mcp` has a `develop = true` path dependency on `hca-schema-validator` and its tests assert the new warning behavior.

## Known gap, deferred

Code review surfaced that `check_cosmetic_labels_h5ad` (the standalone MCP tool, which skips the full pipeline) now returns `is_clean: true` for a file with **unresolvable** term IDs, e.g. `UBERON:9999999` — `_lookup_canonical_label` returns `None` and the comparison skips. The full validator is unaffected: it errors via the curie check (verified). This is the same shape as the open #411 (`is_clean: true` despite forbidden SRE columns), so I folded a recommendation to delete that tool into #411 rather than widening this PR.

## Testing

- 118 `hca-schema-validator` tests, 46 `hca-anndata-mcp` tests, `make typecheck` clean across all venvs.
- The `warnings == []` regression guard was verified **non-vacuous**: reintroducing the old warning makes `test_cosmetic_check_silent_when_values_match` fail.
- Behavior on the real breast object (2.1M × 36,788): `hcaSchema` errors 0 → 0, warnings 1491 → 1484.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

