### PR TITLE
docs(dataset-validator): correct write_validation_results_to_s3 docstring

### DIFF
--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -341,14 +341,21 @@ def write_validation_results_to_s3(
     """
     Write the full validation message JSON to S3 as a claim check.
 
-    The tracker reads this object when possible to avoid using an inline
-    SNS message that may have been truncated to fit the SNS 256 KiB limit.
-    Failures here are logged but never raise — the SNS publish is the
-    authoritative pipeline step.
+    This object is the authoritative payload. The tracker reads the results
+    from here and nowhere else: since hca-atlas-tracker#1275 it ignores the
+    SNS message body apart from the fields locating this object.
+
+    Failures here are logged but never raise, and the SNS publish still goes
+    ahead. That is deliberate — the tracker records a pointer to a missing
+    object as a `results_not_loaded` validation status carrying the S3 error,
+    whereas suppressing the publish would leave the file in its prior state
+    with no record at all. Note the tracker only ever sees the symptom
+    (`NoSuchKey`); the cause is in this function's log line alone (see #457).
 
     Args:
         message: ValidationMessage to serialize (untruncated)
-        bucket: S3 bucket (reuses the data bucket the input file came from)
+        bucket: Dedicated validation-results bucket (VALIDATION_RESULTS_BUCKET),
+            kept separate from the versioned data bucket holding the input file
         file_id: Tracker file UUID, used in the key
         batch_job_id: AWS Batch job ID, used in the key so each run gets a
             distinct object


### PR DESCRIPTION
Closes #456

## Why

Three statements in `write_validation_results_to_s3`'s docstring have been false since the tracker's claim-check cutover (hca-atlas-tracker#1275, shipped as tracker PR #1283 in May 2026):

| Claim | Reality |
| --- | --- |
| "the SNS publish is the authoritative pipeline step" | Inverted — the S3 claim check is the authoritative payload |
| "the tracker reads this object when possible" | It's the only source; the SNS body is ignored apart from the locating fields |
| `bucket` "reuses the data bucket the input file came from" | `main()` passes `VALIDATION_RESULTS_BUCKET`, a dedicated results bucket kept separate from the versioned data bucket (hca-atlas-tracker#1239) |

The first is the worst: it is the stated justification for swallowing the write failure, so a reader reasoning about that `except` block is led to exactly the wrong conclusion about which side of the pipeline is load-bearing.

The docstring also now records *why* the failure is swallowed rather than gating the SNS publish — which is the non-obvious part, and correct as written. The tracker turns a pointer-to-a-missing-object into a `results_not_loaded` validation status carrying the S3 error (`app/services/validation-results-notification.ts`). Suppressing the publish instead would leave the file in its prior state with no record at all, which is strictly worse.

## Scope

**Docstring only — no behavior change.** Nothing asserts on `__doc__`.

This is independent of #446, which does not touch this function. The staleness predates that PR; #446 merely makes the inverted sentence more conspicuous, since it removes the SNS body fallback that made the old wording half-defensible.

## Follow-up

#457 tracks the remaining gap the docstring now names: only the *symptom* (`NoSuchKey`) reaches the tracker, while the *cause* (transient S3 error, unset bucket, IAM/KMS denial) lives solely in this function's log line.

## Verification

`poetry run pytest tests/ -q` in `services/dataset-validator` → 86 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)