### PR TITLE
chore(hca-schema-validator service): bump hca-schema-validator to 0.14.0

### DIFF
--- a/services/hca-schema-validator/poetry.lock
+++ b/services/hca-schema-validator/poetry.lock
@@ -509,14 +509,14 @@ numpy = ">=1.21.2"
 
 [[package]]
 name = "hca-schema-validator"
-version = "0.13.1"
+version = "0.14.0"
 description = "HCA schema validation for single-cell datasets"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "hca_schema_validator-0.13.1-py3-none-any.whl", hash = "sha256:a4af8d01ef8b85f699d400740bdb99b3a1bb08665d8aead15a9bb7edd8cbc4ac"},
-    {file = "hca_schema_validator-0.13.1.tar.gz", hash = "sha256:1552cd462693f56d0c61db20dc972d49da4c3b3e89d2de6824716ac69ba04011"},
+    {file = "hca_schema_validator-0.14.0-py3-none-any.whl", hash = "sha256:11474ac3e43774aaa33482d00af112a3053b1ef5328ae141b7eb4cfcf4b768f4"},
+    {file = "hca_schema_validator-0.14.0.tar.gz", hash = "sha256:338afd499316bce08b5dc6c391a533bb576240cce4d5d580e71aea5083057c47"},
 ]
 
 [package.dependencies]
@@ -2099,4 +2099,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "~=3.11"
-content-hash = "d1ecba8693fc452aa41db522c2c413d466b21e18eb76d587171fd9b613fb24f1"
+content-hash = "2e852b097f1323bcd66abd5a964dce3ed774a053286adec53fac86608efd80fe"

--- a/services/hca-schema-validator/pyproject.toml
+++ b/services/hca-schema-validator/pyproject.toml
@@ -3,7 +3,7 @@ name = "hca-schema-validator-service"
 version = "0.1.0"
 requires-python = "~=3.11"
 dependencies = [
-    "hca-schema-validator (>=0.13.1,<0.14.0)"
+    "hca-schema-validator (>=0.14.0,<0.15.0)"
 ]
 
 [tool.poetry]


### PR DESCRIPTION
Closes #459

## What

`hca-schema-validator` 0.14.0 is published to PyPI (release-please #430, run on `400451d`). The service pinned `>=0.13.1,<0.14.0`, which blocked it. Bumped to `>=0.14.0,<0.15.0` and regenerated the lock.

`pyproject.toml` and `poetry.lock` are committed together, per CLAUDE.md — a stale lock fails the Docker build with *"pyproject.toml changed significantly since poetry.lock was last generated."*

## Why it needs care

0.14.0 is a **breaking** release: `check_cosmetic_labels` now warns only when labels are unverifiable or disagree (#454), and CAP metadata is nested under `uns['cap_metadata']` (#453).

## Verification

A green lock file isn't evidence the breaking release works here, so I drove both entrypoints the Batch image invokes (`HCA_SCHEMA_VALIDATOR_SCRIPT`, `HCA_CELL_ANNOTATION_VALIDATOR_SCRIPT`) against the fixture h5ads, in the service venv with 0.14.0 installed:

- **`main.py`** on `example_valid.h5ad` and `example_invalid_CL.h5ad` — well-formed JSON both times. The #454 change is directly observable: **no** "should not be populated by producers" cosmetic-label warnings, while the #409 forbidden `self_reported_ethnicity_ontology_term_id` error still fires.
- **`cell_annotation.py`** — well-formed JSON, correctly reporting the missing CAP annotation set.

Also: `pip show` confirms 0.14.0 resolved, 11 service tests pass, `make typecheck` clean across all four venvs, and the lock pins `hca-schema-validator 0.14.0`.

## Gotcha worth recording

`poetry lock` first failed with `hca-schema-validator (>=0.14.0,<0.15.0) which doesn't match any versions`, *after* the wheel was confirmed live on PyPI. That was a **stale local PyPI index cache**, not a publishing problem — `poetry cache clear PyPI --all` fixed it. Worth knowing before anyone concludes a release didn't publish.

## After merge

`make batch-publish-container ENV=dev`. That rebuild also ships the pointer-only SNS body (#446), which is merged but not yet live in the running validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)