### PR TITLE
chore: add checked-in .claude/settings.json (A2)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "extraKnownMarketplaces": {
+    "cc-claude-tools": {
+      "source": {
+        "source": "github",
+        "repo": "clevercanary/cc-claude-tools"
+      },
+      "autoUpdate": true
+    }
+  },
+  "enabledPlugins": {
+    "cc@cc-claude-tools": true,
+    "pyright-lsp@claude-plugins-official": true
+  }
+}


### PR DESCRIPTION
Closes #464

## What changed
Adds a committed `.claude/settings.json` declaring the `cc-claude-tools` marketplace and enabling the `cc` and `pyright-lsp` plugins.

## Why
Conformance check A2 — the repo had only a gitignored `.claude/settings.local.json`, so teammates opening the repo weren't prompted to install the team plugins.

## Assumptions I made
- **Python-only repo**, so `typescript-lsp` is dropped from the template (no `package.json` anywhere); only `pyright-lsp` is kept.
- **Permission allowlist deliberately omitted** for now, per maintainer decision. A2 treats a plugins-only file as a partial pass; the allowlist (built via `/fewer-permission-prompts`) can land in a later PR. `.claude/settings.local.json` is untouched.

## How to verify
- Open the repo in Claude Code; confirm it prompts to enable `cc@cc-claude-tools` and `pyright-lsp@claude-plugins-official`.
- `cat .claude/settings.json` — marketplace + two plugins, no `typescript-lsp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)