### PR TITLE
docs: add .claude/github-projects.md with cached board IDs (A5)

### DIFF
--- a/.claude/github-projects.md
+++ b/.claude/github-projects.md
@@ -1,0 +1,20 @@
+# GitHub Projects: cached IDs for this repo
+
+<!-- Seeded from cc-claude-tools templates/github-projects.template.md.
+     Discover each value ONCE (the /cc:board skill explains how) and record
+     it here so that no session ever re-scans for it. Commit this file. -->
+
+Org: clevercanary
+
+## Boards
+
+| Board | Owner | Project # | Project node ID |
+|-------|-------|-----------|-----------------|
+| CC All Projects | clevercanary | 2 | PVT_kwDOAEonNc4AAb42 |
+
+## Fields (per board)
+
+| Board | Field | Field ID | Options (name = option ID) |
+|-------|-------|----------|----------------------------|
+| CC All Projects | Status | PVTSSF_lADOAEonNc4AAb42zgAOwK4 | Backlog=58a22edc, Ongoing=f0817eab, Refinement=e75eb1a6, Dev Review=8ee48890, Dev Ready 🧠=8917969a, In Progress 🚧=47fc9ee4, Ready for Review 😬=7142a03e, Blocked 🔴=34bcf443, Done 🏆=98236657 |
+| CC All Projects | Application | PVTSSF_lADOAEonNc4AAb42zgTIT0o | HCA Validation Tools=22cb0302 |

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # Claude Code per-user settings (permissions, etc.)
 .claude/settings.local.json
 
+# Claude Code agent worktrees (isolated subagent working copies)
+.claude/worktrees/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
Closes #466

## What changed
- Adds `.claude/github-projects.md` caching GitHub Projects IDs for the **CC All Projects** board (clevercanary #2, `PVT_kwDOAEonNc4AAb42`): the Status field + option IDs and the `Application → HCA Validation Tools` option.
- Adds `.claude/worktrees/` to `.gitignore` (isolated subagent worktrees land there and shouldn't be committable).

## Why
Conformance check A5 — with issues tracked on a board, sessions should read board/field/option IDs from a cached file instead of re-scanning the board (GitHub API discipline).

## Assumptions I made
- **CC All Projects (#2) is this repo's board**, chosen by the maintainer. The API showed none of the repo's current issues are individually carded on any board yet; caching the IDs is still correct so future carding doesn't require a re-scan.
- IDs were fetched with a single bounded GraphQL query on the project's fields — no board enumeration.

## How to verify
- `cat .claude/github-projects.md` — CC All Projects row with node ID `PVT_kwDOAEonNc4AAb42` and real `PVTSSF_...` field IDs.
- `git status` in a repo with an active subagent worktree — `.claude/worktrees/` no longer appears as untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)