### PR TITLE
fix(dataset-validator): refuse to publish the Batch image from a dirty tree; pick up 0.14.1

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,73 @@
+# The Docker build context is the repo root, and the Dockerfiles COPY whole
+# directories (e.g. `COPY shared/ ./shared/`). Without this file, anything
+# sitting in those directories is baked into the image — including artifacts
+# git ignores, which `git status` reports as a clean tree. The Batch image
+# shipped with 45 stray .pyc files from a developer's laptop before this
+# existed.
+#
+# This is what makes the check-clean guard in services/dataset-validator's
+# Makefile sufficient: with local artifacts excluded here, everything left in
+# the build context is tracked, so a clean `git status` really does mean the
+# image matches the commit it is tagged with.
+
+# Virtualenvs. A project-local .venv is the dangerous one: uv creates them, so
+# once shared/ migrates to uv (#473) `COPY shared/` would otherwise bake a
+# developer's macOS venv into a linux/amd64 image.
+.venv/
+**/.venv/
+venv/
+**/venv/
+env/
+
+# Python bytecode and caches
+__pycache__/
+**/__pycache__/
+*.py[cod]
+*$py.class
+.pytest_cache/
+**/.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.tox/
+.nox/
+
+# Build artifacts
+dist/
+**/dist/
+build/
+*.egg-info/
+**/*.egg-info/
+
+# Version control and CI
+.git/
+.gitignore
+.github/
+
+# Local tooling and editor state
+.claude/
+.vscode/
+.idea/
+*.code-workspace
+.pre-commit-config.yaml
+
+# Secrets and machine-specific config — these must never reach an image
+.env
+.env.*
+!.env.example
+!.env.make.example
+.mcp.json
+
+# Coverage and test output
+.coverage
+.coverage.*
+htmlcov/
+coverage.xml
+
+# Repo-level docs. Deliberately NOT excluding *.md generally: a pyproject that
+# declares `readme = "README.md"` needs that file present to install, and a
+# build that breaks because a doc was filtered out is a confusing failure to buy
+# nothing.
+docs/
+
+# macOS
+.DS_Store

--- a/.dockerignore
+++ b/.dockerignore
@@ -50,12 +50,20 @@ build/
 *.code-workspace
 .pre-commit-config.yaml
 
-# Secrets and machine-specific config — these must never reach an image
+# Secrets and machine-specific config — these must never reach an image.
+# The `**/` forms are load-bearing: a bare `.env` matches only the repo root, so
+# without them a nested services/*/.env or shared/.env is copied straight into the
+# image by the whole-directory COPYs. Verified — it leaked before these were added.
 .env
 .env.*
+**/.env
+**/.env.*
 !.env.example
 !.env.make.example
+!**/.env.example
+!**/.env.make.example
 .mcp.json
+**/.mcp.json
 
 # Coverage and test output
 .coverage

--- a/.dockerignore
+++ b/.dockerignore
@@ -51,13 +51,6 @@
 **/*.code-workspace
 **/.pre-commit-config.yaml
 
-# Secrets and machine-specific config — these must never reach an image.
-**/.env
-**/.env.*
-!**/.env.example
-!**/.env.make.example
-**/.mcp.json
-
 # Coverage and test output
 **/.coverage
 **/.coverage.*
@@ -74,12 +67,28 @@
 
 # --- src/ trees are source, never build output. See rule 2 at the top. ---
 # This re-include protects a package legitimately named build/, dist/, docs/ or
-# env/ from the patterns above. The lines after it re-exclude the things that must
-# never ship even from inside src/, because last match wins.
+# env/ from the patterns above. The lines after it re-exclude what must never ship
+# even from inside src/, because last match wins.
 !**/src/**
 **/src/**/__pycache__/
 **/src/**/*.py[cod]
 **/src/**/.venv/
-**/src/**/.env
-**/src/**/.env.*
 **/src/**/.DS_Store
+
+# --- Secrets. Deliberately LAST, after the src/ re-include. ---
+# Last match wins, so putting these at the end means they apply everywhere,
+# including inside src/, with no duplicate entries to keep in sync. Every one of
+# these is also in .gitignore, which means check-clean is blind to them: git
+# reports a clean tree while the file sits there waiting to be copied in. That is
+# exactly how a nested .env got baked into an image before this file existed.
+**/.env
+**/.env.*
+!**/.env.example
+!**/.env.make.example
+**/.mcp.json
+**/.pypirc
+**/.netrc
+**/.aws/
+**/*.pem
+**/id_rsa
+**/id_rsa.*

--- a/.dockerignore
+++ b/.dockerignore
@@ -18,6 +18,7 @@
 venv/
 **/venv/
 env/
+**/env/
 
 # Python bytecode and caches
 __pycache__/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,20 +1,21 @@
-# The Docker build context is the repo root, and the Dockerfiles COPY whole
-# directories (e.g. `COPY shared/ ./shared/`). Without this file, anything sitting
-# in those directories is baked into the image — including artifacts git ignores,
-# which `git status` reports as a clean tree. The Batch image shipped with 45 stray
-# .pyc files from a developer's laptop before this existed.
+# The build context is the repo root and the Dockerfiles COPY whole directories
+# (`COPY shared/ ./shared/`), so anything sitting in them is baked into the image —
+# including artifacts git ignores, which `git status` reports as a clean tree.
 #
-# This is what makes the check-clean guard in services/dataset-validator's Makefile
-# sufficient: with local artifacts excluded here, everything left in the build
-# context is tracked or untracked, and git reports both — so a clean tree really
-# does mean the image matches the commit it is tagged with.
+# Two rules govern this file, both learned the hard way:
 #
-# EVERY pattern below is written `**/name`, deliberately and without exception.
-# A bare `name` matches ONLY the repo root, so `.env` left a nested
-# services/*/.env free to be copied into the image. `**` matches zero or more
-# directories, so `**/name` covers the root case too (verified) — one form, no
-# paired entries, nothing to forget. Do not add a bare pattern here; it will look
-# like it works and silently miss every nested copy.
+# 1. Every pattern is `**/name`. A bare `name` matches ONLY the repo root, so a
+#    plain `.env` left a nested services/*/.env free to be copied into the image.
+#    `**` matches zero or more directories, so `**/name` covers the root too.
+#    Never add a bare pattern here: it will look like it works and silently miss
+#    every nested copy.
+#
+# 2. `src/` trees are re-included at the bottom, and that is not optional. Names
+#    like `build`, `dist`, `docs` and `env` are legitimate Python package names.
+#    Without the re-include, a module at src/.../build/ would be dropped from the
+#    image and surface as a baffling ImportError at container start, with nothing
+#    pointing back here. The dot-directories are safe to exclude recursively — no
+#    package can be called `.venv` — but these four are only safe by luck.
 
 # Virtualenvs. The dangerous one: uv creates a project-local .venv, so once
 # shared/ migrates to uv (#473), `COPY shared/` would otherwise bake a developer's
@@ -23,7 +24,7 @@
 **/venv/
 **/env/
 
-# Python bytecode and caches
+# Python bytecode and tool caches
 **/__pycache__/
 **/*.py[cod]
 **/*$py.class
@@ -51,8 +52,6 @@
 **/.pre-commit-config.yaml
 
 # Secrets and machine-specific config — these must never reach an image.
-# Verified: before the `**/` forms existed, a nested shared/.env was copied
-# straight into the image and readable there.
 **/.env
 **/.env.*
 !**/.env.example
@@ -65,10 +64,22 @@
 **/htmlcov/
 **/coverage.xml
 
-# Repo-level docs. Deliberately NOT excluding *.md generally: a pyproject that
-# declares `readme = "README.md"` needs that file present to install, and a build
-# that breaks because a doc was filtered out is a confusing failure to buy nothing.
+# Docs. Not excluding *.md generally: a pyproject declaring `readme = "README.md"`
+# needs that file to install, and a build breaking because a doc was filtered out
+# is a confusing failure that buys nothing.
 **/docs/
 
 # macOS
 **/.DS_Store
+
+# --- src/ trees are source, never build output. See rule 2 at the top. ---
+# This re-include protects a package legitimately named build/, dist/, docs/ or
+# env/ from the patterns above. The lines after it re-exclude the things that must
+# never ship even from inside src/, because last match wins.
+!**/src/**
+**/src/**/__pycache__/
+**/src/**/*.py[cod]
+**/src/**/.venv/
+**/src/**/.env
+**/src/**/.env.*
+**/src/**/.DS_Store

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,82 +1,74 @@
 # The Docker build context is the repo root, and the Dockerfiles COPY whole
-# directories (e.g. `COPY shared/ ./shared/`). Without this file, anything
-# sitting in those directories is baked into the image — including artifacts
-# git ignores, which `git status` reports as a clean tree. The Batch image
-# shipped with 45 stray .pyc files from a developer's laptop before this
-# existed.
+# directories (e.g. `COPY shared/ ./shared/`). Without this file, anything sitting
+# in those directories is baked into the image — including artifacts git ignores,
+# which `git status` reports as a clean tree. The Batch image shipped with 45 stray
+# .pyc files from a developer's laptop before this existed.
 #
-# This is what makes the check-clean guard in services/dataset-validator's
-# Makefile sufficient: with local artifacts excluded here, everything left in
-# the build context is tracked, so a clean `git status` really does mean the
-# image matches the commit it is tagged with.
+# This is what makes the check-clean guard in services/dataset-validator's Makefile
+# sufficient: with local artifacts excluded here, everything left in the build
+# context is tracked or untracked, and git reports both — so a clean tree really
+# does mean the image matches the commit it is tagged with.
+#
+# EVERY pattern below is written `**/name`, deliberately and without exception.
+# A bare `name` matches ONLY the repo root, so `.env` left a nested
+# services/*/.env free to be copied into the image. `**` matches zero or more
+# directories, so `**/name` covers the root case too (verified) — one form, no
+# paired entries, nothing to forget. Do not add a bare pattern here; it will look
+# like it works and silently miss every nested copy.
 
-# Virtualenvs. A project-local .venv is the dangerous one: uv creates them, so
-# once shared/ migrates to uv (#473) `COPY shared/` would otherwise bake a
-# developer's macOS venv into a linux/amd64 image.
-.venv/
+# Virtualenvs. The dangerous one: uv creates a project-local .venv, so once
+# shared/ migrates to uv (#473), `COPY shared/` would otherwise bake a developer's
+# macOS venv into a linux/amd64 image.
 **/.venv/
-venv/
 **/venv/
-env/
 **/env/
 
 # Python bytecode and caches
-__pycache__/
 **/__pycache__/
-*.py[cod]
-*$py.class
-.pytest_cache/
+**/*.py[cod]
+**/*$py.class
 **/.pytest_cache/
-.mypy_cache/
-.ruff_cache/
-.tox/
-.nox/
+**/.mypy_cache/
+**/.ruff_cache/
+**/.tox/
+**/.nox/
 
 # Build artifacts
-dist/
 **/dist/
-build/
-*.egg-info/
+**/build/
 **/*.egg-info/
 
 # Version control and CI
-.git/
-.gitignore
-.github/
+**/.git/
+**/.gitignore
+**/.github/
 
 # Local tooling and editor state
-.claude/
-.vscode/
-.idea/
-*.code-workspace
-.pre-commit-config.yaml
+**/.claude/
+**/.vscode/
+**/.idea/
+**/*.code-workspace
+**/.pre-commit-config.yaml
 
 # Secrets and machine-specific config — these must never reach an image.
-# The `**/` forms are load-bearing: a bare `.env` matches only the repo root, so
-# without them a nested services/*/.env or shared/.env is copied straight into the
-# image by the whole-directory COPYs. Verified — it leaked before these were added.
-.env
-.env.*
+# Verified: before the `**/` forms existed, a nested shared/.env was copied
+# straight into the image and readable there.
 **/.env
 **/.env.*
-!.env.example
-!.env.make.example
 !**/.env.example
 !**/.env.make.example
-.mcp.json
 **/.mcp.json
 
 # Coverage and test output
-.coverage
-.coverage.*
-htmlcov/
-coverage.xml
+**/.coverage
+**/.coverage.*
+**/htmlcov/
+**/coverage.xml
 
 # Repo-level docs. Deliberately NOT excluding *.md generally: a pyproject that
-# declares `readme = "README.md"` needs that file present to install, and a
-# build that breaks because a doc was filtered out is a confusing failure to buy
-# nothing.
-docs/
+# declares `readme = "README.md"` needs that file present to install, and a build
+# that breaks because a doc was filtered out is a confusing failure to buy nothing.
+**/docs/
 
 # macOS
-.DS_Store
+**/.DS_Store

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,90 +1,61 @@
-# The build context is the repo root and the Dockerfiles COPY whole directories
-# (`COPY shared/ ./shared/`), so anything sitting in them is baked into the image —
-# including artifacts git ignores, which `git status` reports as a clean tree.
+# An ALLOWLIST, not a denylist. Read this before changing it.
 #
-# Two rules govern this file, both learned the hard way:
+# The build context is the repo root, and both Dockerfiles COPY out of it. A
+# denylist here is open by default: every new cache directory, tool, or
+# credential file is a fresh chance to leak, and `check-clean` cannot help
+# because those files are gitignored — git reports a clean tree while the file
+# sits in a COPY'd directory. A nested .env really did get baked into an image
+# that way, and four separate rounds of review each found another missing
+# denylist entry.
 #
-# 1. Every pattern is `**/name`. A bare `name` matches ONLY the repo root, so a
-#    plain `.env` left a nested services/*/.env free to be copied into the image.
-#    `**` matches zero or more directories, so `**/name` covers the root too.
-#    Never add a bare pattern here: it will look like it works and silently miss
-#    every nested copy.
+# So: deny everything, then re-include exactly what the two Dockerfiles need.
+# Adding a build input means adding a line here. Forgetting to is a loud failure
+# (the build cannot find the file), which is the right way round — the denylist's
+# failures were silent.
 #
-# 2. `src/` trees are re-included at the bottom, and that is not optional. Names
-#    like `build`, `dist`, `docs` and `env` are legitimate Python package names.
-#    Without the re-include, a module at src/.../build/ would be dropped from the
-#    image and surface as a baffling ImportError at container start, with nothing
-#    pointing back here. The dot-directories are safe to exclude recursively — no
-#    package can be called `.venv` — but these four are only safe by luck.
+# Do not "simplify" this back into a denylist.
 
-# Virtualenvs. The dangerous one: uv creates a project-local .venv, so once
-# shared/ migrates to uv (#473), `COPY shared/` would otherwise bake a developer's
-# macOS venv into a linux/amd64 image.
-**/.venv/
-**/venv/
-**/env/
+# Deny everything.
+*
 
-# Python bytecode and tool caches
+# --- Re-include exactly the build inputs. ---
+#
+# shared/ — its pyproject and lockfile (poetry installs it as a path dependency)
+# and its source. Deliberately NOT shared/tests/ or shared/Makefile: the image
+# does not run them.
+!shared/pyproject.toml
+!shared/poetry.lock
+!shared/src/
+
+# services/ — each service's pyproject, lockfile and source. Covers all four;
+# the Batch image uses three and the Lambda image uses the fourth, and one
+# .dockerignore serves both builds.
+!services/*/pyproject.toml
+!services/*/poetry.lock
+!services/*/src/
+
+# The Lambda image copies this config in at build time.
+!deployment/entry-sheet-validator/config.yaml
+
+# --- Strip what must never ship, even from the allowed paths above. ---
+#
+# The re-includes are recursive, so anything sitting inside src/ would otherwise
+# ride along. Last match wins, so these come last.
+#
+# Note what is NOT needed here: no build/, dist/, docs/ or env/ exclusions. Those
+# are legitimate Python package names, and a denylist had to exclude them
+# recursively — which would have silently dropped a module at src/.../build/ from
+# the image. With an allowlist the problem does not arise: those directories were
+# never allowed in.
 **/__pycache__/
 **/*.py[cod]
 **/*$py.class
-**/.pytest_cache/
-**/.mypy_cache/
-**/.ruff_cache/
-**/.tox/
-**/.nox/
-
-# Build artifacts
-**/dist/
-**/build/
-**/*.egg-info/
-
-# Version control and CI
-**/.git/
-**/.gitignore
-**/.github/
-
-# Local tooling and editor state
-**/.claude/
-**/.vscode/
-**/.idea/
-**/*.code-workspace
-**/.pre-commit-config.yaml
-
-# Coverage and test output
-**/.coverage
-**/.coverage.*
-**/htmlcov/
-**/coverage.xml
-
-# Docs. Not excluding *.md generally: a pyproject declaring `readme = "README.md"`
-# needs that file to install, and a build breaking because a doc was filtered out
-# is a confusing failure that buys nothing.
-**/docs/
-
-# macOS
+**/.venv/
 **/.DS_Store
 
-# --- src/ trees are source, never build output. See rule 2 at the top. ---
-# This re-include protects a package legitimately named build/, dist/, docs/ or
-# env/ from the patterns above. The lines after it re-exclude what must never ship
-# even from inside src/, because last match wins.
-!**/src/**
-**/src/**/__pycache__/
-**/src/**/*.py[cod]
-**/src/**/.venv/
-**/src/**/.DS_Store
-
-# --- Secrets. Deliberately LAST, after the src/ re-include. ---
-# Last match wins, so putting these at the end means they apply everywhere,
-# including inside src/, with no duplicate entries to keep in sync. Every one of
-# these is also in .gitignore, which means check-clean is blind to them: git
-# reports a clean tree while the file sits there waiting to be copied in. That is
-# exactly how a nested .env got baked into an image before this file existed.
+# Secrets. All of these are gitignored, so check-clean is blind to them.
 **/.env
 **/.env.*
-!**/.env.example
-!**/.env.make.example
 **/.mcp.json
 **/.pypirc
 **/.netrc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,15 +121,15 @@ Either way, confirm the lock actually moved before building:
 grep -A1 'name = "hca-schema-validator"' services/hca-schema-validator/poetry.lock
 ```
 
-### Only build the image from a clean tree, after merge
+### Only build the image from a clean tree
 
 ```bash
-make batch-publish-container ENV=dev     # then ENV=prod
+make batch-publish-container ENV=dev     # then ENV=prod, from main
 ```
 
-**The image's contents and its tag come from different places.** `docker build` copies from the **working tree**, so it picks up uncommitted edits; the tag is `git rev-parse --short HEAD`, i.e. the **last commit**. Build with a dirty tree, or from an unmerged branch, and you publish an image whose tag names a commit that does not contain what is inside it. Nothing warns you, and afterwards nobody can tell what is actually deployed: checking out that SHA reproduces a *different* image.
+**The image's contents and its tag come from different places.** `docker build` copies from the **working tree**, so it picks up uncommitted edits; the tag is `git rev-parse --short HEAD`, i.e. the **last commit**. Build with a dirty tree and you publish an image whose tag names a commit that does not contain what is inside it — nobody can then tell what is deployed, because checking out that SHA reproduces a *different* image. `make publish-batch` refuses to run from a dirty tree for this reason; do not work around it.
 
-So build only when `git status` is clean and the change is on `main`.
+**Dev may be built from a branch.** A clean branch commit is a real commit, so the tag still reproduces the image — that is how a change is validated on dev before it merges. **Prod should be built from `main`**, so that what is running in production is on the mainline and not on a branch that may never land.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,9 +102,8 @@ The Docker image installs from `poetry.lock`, so **the lock is what decides whic
 
 **A patch release inside the existing constraint** (e.g. `0.14.0` → `0.14.1`, against `>=0.14.0,<0.15.0`):
 
-```bash
-cd services/hca-schema-validator && poetry update hca-schema-validator
-```
+1. `cd services/hca-schema-validator && poetry update hca-schema-validator`
+2. Commit `poetry.lock`
 
 No pin bump is needed — the constraint already admits it. But `poetry lock` **will not pick the new version up**: it re-resolves without upgrading within an unchanged constraint, so it happily keeps the old one. Only `poetry update <package>` moves the lock. This failure is **silent** — the build succeeds and the image just keeps shipping the old validator.
 
@@ -122,7 +121,15 @@ Either way, confirm the lock actually moved before building:
 grep -A1 'name = "hca-schema-validator"' services/hca-schema-validator/poetry.lock
 ```
 
-Then rebuild the image — dev first: `make batch-publish-container ENV=dev`
+### Only build the image from a clean tree, after merge
+
+```bash
+make batch-publish-container ENV=dev     # then ENV=prod
+```
+
+**The image's contents and its tag come from different places.** `docker build` copies from the **working tree**, so it picks up uncommitted edits; the tag is `git rev-parse --short HEAD`, i.e. the **last commit**. Build with a dirty tree, or from an unmerged branch, and you publish an image whose tag names a commit that does not contain what is inside it. Nothing warns you, and afterwards nobody can tell what is actually deployed: checking out that SHA reproduces a *different* image.
+
+So build only when `git status` is clean and the change is on `main`.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,14 +98,31 @@ Before tagging 1.0.0, widen the sibling bounds in `packages/hca-anndata-mcp/pypr
 
 ## Updating hca-schema-validator in the Batch Service
 
-When a new version of `hca-schema-validator` is released (via release-please → PyPI):
+The Docker image installs from `poetry.lock`, so **the lock is what decides which version ships** — not the constraint in `pyproject.toml`. Which of the two you touch depends on where the new release lands.
+
+**A patch release inside the existing constraint** (e.g. `0.14.0` → `0.14.1`, against `>=0.14.0,<0.15.0`):
+
+```bash
+cd services/hca-schema-validator && poetry update hca-schema-validator
+```
+
+No pin bump is needed — the constraint already admits it. But `poetry lock` **will not pick the new version up**: it re-resolves without upgrading within an unchanged constraint, so it happily keeps the old one. Only `poetry update <package>` moves the lock. This failure is **silent** — the build succeeds and the image just keeps shipping the old validator.
+
+**A release that crosses the constraint** (e.g. `0.14.x` → `0.15.0`):
 
 1. Bump the version pin in `services/hca-schema-validator/pyproject.toml`
-2. **Regenerate the lock file**: `cd services/hca-schema-validator && poetry lock`
-3. Commit both `pyproject.toml` and `poetry.lock` together
-4. After merge, rebuild the Docker image: `make batch-publish-container ENV=dev`
+2. `cd services/hca-schema-validator && poetry lock`
+3. Commit `pyproject.toml` and `poetry.lock` together
 
-Forgetting step 2 will cause the Docker build to fail with "pyproject.toml changed significantly since poetry.lock was last generated."
+Here `poetry lock` is enough, because the constraint changed. Skipping it fails loudly: "pyproject.toml changed significantly since poetry.lock was last generated."
+
+Either way, confirm the lock actually moved before building:
+
+```bash
+grep -A1 'name = "hca-schema-validator"' services/hca-schema-validator/poetry.lock
+```
+
+Then rebuild the image — dev first: `make batch-publish-container ENV=dev`
 
 ## Architecture
 

--- a/services/dataset-validator/Makefile
+++ b/services/dataset-validator/Makefile
@@ -81,31 +81,28 @@ tag-batch:
 	@echo "Tagging $(LOCAL_IMAGE) as $(REMOTE_IMAGE)"
 	@docker tag $(LOCAL_IMAGE) $(REMOTE_IMAGE)
 
-# The image's contents come from the working tree — docker build copies files off
-# disk, so uncommitted edits and untracked files land in the image. The tag,
-# though, defaults to the HEAD commit. Publish from a dirty tree and the tag names
-# a commit that does not contain what is inside the image, so nobody can tell what
-# is deployed: checking out that SHA rebuilds something different.
+# Refuses to publish an image whose tag would misdescribe its contents. `docker
+# build` copies from the working tree, but TAG defaults to the HEAD commit — so a
+# dirty tree produces an image tagged with a commit that does not contain what is
+# inside it, and checking out that SHA rebuilds something different.
 #
-# The repo-root .dockerignore keeps *ignored* artifacts (__pycache__, .venv, ...)
-# out of the context, which is what makes `git status` a sufficient test here:
-# everything still reaching the context is tracked or untracked, and git reports
-# both. It does not make this guard redundant — an untracked, non-ignored file is
-# exactly the thing .dockerignore lets through and git flags as `??`.
+# Three things below are load-bearing and look optional:
 #
-# This fires even when TAG is overridden. A hand-picked tag does not make
-# unreproducible content acceptable in ECR, and letting TAG bypass the check would
-# turn it into the override flag this guard deliberately does not have.
-# --untracked-files=all is not optional. `git status` honours the user's
-# status.showUntrackedFiles config, and someone who has set it to `no` would get
-# an empty --porcelain listing — the guard would pass while shipping untracked
-# files straight into the image. Forcing the flag makes the check independent of
-# whoever's machine it runs on.
-# Fails closed. A bare `$(git status ...)` substitution yields an empty string when
-# git errors — no repo, no git, a broken checkout — and an empty string reads as
-# "clean", so the guard would wave the build through in precisely the situations
-# where provenance cannot be established at all. Check the exit status, not just
-# the output.
+#   --untracked-files=all   `git status` honours status.showUntrackedFiles; a user
+#                           who set it to `no` would get an empty listing and the
+#                           guard would pass while shipping untracked files.
+#
+#   exit-status check       A bare `$(git status)` substitution is empty when git
+#                           errors, and empty reads as clean — failing open in
+#                           exactly the cases where provenance is unverifiable.
+#
+#   no TAG exemption        A hand-picked tag does not make unreproducible content
+#                           acceptable, and exempting it would quietly become the
+#                           override flag this guard is designed not to have.
+#
+# .dockerignore excludes *ignored* artifacts from the context, which is what makes
+# `git status` a sufficient test — but it does not make this guard redundant: an
+# untracked, non-ignored file reaches the image and git flags it `??`.
 .PHONY: check-clean
 check-clean:
 	@if ! git rev-parse --git-dir >/dev/null 2>&1; then \

--- a/services/dataset-validator/Makefile
+++ b/services/dataset-validator/Makefile
@@ -83,16 +83,20 @@ tag-batch:
 
 # The image's contents come from the working tree — docker build copies files off
 # disk, and there is no .dockerignore, so untracked files reach the context too.
-# The tag, though, is the HEAD commit. Publish from a dirty tree and the tag names
-# a commit that does not contain what is inside the image, so nobody can tell what
-# is deployed: checking out that SHA rebuilds something different. Refuse instead.
+# The tag, though, defaults to the HEAD commit. Publish from a dirty tree and the
+# tag names a commit that does not contain what is inside the image, so nobody can
+# tell what is deployed: checking out that SHA rebuilds something different.
+#
+# This fires even when TAG is overridden. A hand-picked tag does not make
+# unreproducible content acceptable in ECR, and letting TAG bypass the check would
+# turn it into the override flag this guard deliberately does not have.
 .PHONY: check-clean
 check-clean:
 	@if [ -n "$$(git status --porcelain)" ]; then \
 		echo "Error: refusing to publish from a dirty working tree."; \
 		echo ""; \
-		echo "  The image would contain these uncommitted changes, but be tagged $(SHA),"; \
-		echo "  a commit that does not have them. The tag would be a lie."; \
+		echo "  The image would contain these uncommitted changes, but be published"; \
+		echo "  as :$(TAG), which does not have them. The tag would be a lie."; \
 		echo ""; \
 		git status --short | sed 's/^/    /'; \
 		echo ""; \

--- a/services/dataset-validator/Makefile
+++ b/services/dataset-validator/Makefile
@@ -81,8 +81,27 @@ tag-batch:
 	@echo "Tagging $(LOCAL_IMAGE) as $(REMOTE_IMAGE)"
 	@docker tag $(LOCAL_IMAGE) $(REMOTE_IMAGE)
 
+# The image's contents come from the working tree — docker build copies files off
+# disk, and there is no .dockerignore, so untracked files reach the context too.
+# The tag, though, is the HEAD commit. Publish from a dirty tree and the tag names
+# a commit that does not contain what is inside the image, so nobody can tell what
+# is deployed: checking out that SHA rebuilds something different. Refuse instead.
+.PHONY: check-clean
+check-clean:
+	@if [ -n "$$(git status --porcelain)" ]; then \
+		echo "Error: refusing to publish from a dirty working tree."; \
+		echo ""; \
+		echo "  The image would contain these uncommitted changes, but be tagged $(SHA),"; \
+		echo "  a commit that does not have them. The tag would be a lie."; \
+		echo ""; \
+		git status --short | sed 's/^/    /'; \
+		echo ""; \
+		echo "  Commit and merge first, then rebuild."; \
+		exit 1; \
+	fi
+
 .PHONY: push-batch
-push-batch:
+push-batch: check-clean
 	@if [ -z "$(AWS_ACCOUNT_ID)" ] || [ -z "$(AWS_REGION)" ] || [ -z "$(ECR_REPO)" ]; then \
 		echo "Error: AWS_ACCOUNT_ID, AWS_REGION, and ECR_REPO are required"; \
 		exit 1; \
@@ -91,7 +110,7 @@ push-batch:
 	@docker push $(REMOTE_IMAGE)
 
 .PHONY: publish-batch
-publish-batch: ecr-login build-batch tag-batch push-batch
+publish-batch: check-clean ecr-login build-batch tag-batch push-batch
  
 
 # ----- AWS Batch Job Definition and Submission -----

--- a/services/dataset-validator/Makefile
+++ b/services/dataset-validator/Makefile
@@ -101,15 +101,30 @@ tag-batch:
 # an empty --porcelain listing — the guard would pass while shipping untracked
 # files straight into the image. Forcing the flag makes the check independent of
 # whoever's machine it runs on.
+# Fails closed. A bare `$(git status ...)` substitution yields an empty string when
+# git errors — no repo, no git, a broken checkout — and an empty string reads as
+# "clean", so the guard would wave the build through in precisely the situations
+# where provenance cannot be established at all. Check the exit status, not just
+# the output.
 .PHONY: check-clean
 check-clean:
-	@if [ -n "$$(git status --porcelain --untracked-files=all)" ]; then \
+	@if ! git rev-parse --git-dir >/dev/null 2>&1; then \
+		echo "Error: not a git repository, so the tree cannot be verified."; \
+		echo "  Refusing to publish an image whose provenance cannot be established."; \
+		exit 1; \
+	fi; \
+	dirty=$$(git status --porcelain --untracked-files=all) || { \
+		echo "Error: 'git status' failed, so the tree cannot be verified."; \
+		echo "  Refusing to publish an image whose provenance cannot be established."; \
+		exit 1; \
+	}; \
+	if [ -n "$$dirty" ]; then \
 		echo "Error: refusing to publish from a dirty working tree."; \
 		echo ""; \
 		echo "  The image would contain these uncommitted changes, but be published"; \
 		echo "  as :$(TAG), which does not have them. The tag would be a lie."; \
 		echo ""; \
-		git status --short --untracked-files=all | sed 's/^/    /'; \
+		printf '%s\n' "$$dirty" | sed 's/^/    /'; \
 		echo ""; \
 		echo "  Commit and merge first, then rebuild."; \
 		exit 1; \

--- a/services/dataset-validator/Makefile
+++ b/services/dataset-validator/Makefile
@@ -96,15 +96,20 @@ tag-batch:
 # This fires even when TAG is overridden. A hand-picked tag does not make
 # unreproducible content acceptable in ECR, and letting TAG bypass the check would
 # turn it into the override flag this guard deliberately does not have.
+# --untracked-files=all is not optional. `git status` honours the user's
+# status.showUntrackedFiles config, and someone who has set it to `no` would get
+# an empty --porcelain listing — the guard would pass while shipping untracked
+# files straight into the image. Forcing the flag makes the check independent of
+# whoever's machine it runs on.
 .PHONY: check-clean
 check-clean:
-	@if [ -n "$$(git status --porcelain)" ]; then \
+	@if [ -n "$$(git status --porcelain --untracked-files=all)" ]; then \
 		echo "Error: refusing to publish from a dirty working tree."; \
 		echo ""; \
 		echo "  The image would contain these uncommitted changes, but be published"; \
 		echo "  as :$(TAG), which does not have them. The tag would be a lie."; \
 		echo ""; \
-		git status --short | sed 's/^/    /'; \
+		git status --short --untracked-files=all | sed 's/^/    /'; \
 		echo ""; \
 		echo "  Commit and merge first, then rebuild."; \
 		exit 1; \

--- a/services/dataset-validator/Makefile
+++ b/services/dataset-validator/Makefile
@@ -82,10 +82,16 @@ tag-batch:
 	@docker tag $(LOCAL_IMAGE) $(REMOTE_IMAGE)
 
 # The image's contents come from the working tree — docker build copies files off
-# disk, and there is no .dockerignore, so untracked files reach the context too.
-# The tag, though, defaults to the HEAD commit. Publish from a dirty tree and the
-# tag names a commit that does not contain what is inside the image, so nobody can
-# tell what is deployed: checking out that SHA rebuilds something different.
+# disk, so uncommitted edits and untracked files land in the image. The tag,
+# though, defaults to the HEAD commit. Publish from a dirty tree and the tag names
+# a commit that does not contain what is inside the image, so nobody can tell what
+# is deployed: checking out that SHA rebuilds something different.
+#
+# The repo-root .dockerignore keeps *ignored* artifacts (__pycache__, .venv, ...)
+# out of the context, which is what makes `git status` a sufficient test here:
+# everything still reaching the context is tracked or untracked, and git reports
+# both. It does not make this guard redundant — an untracked, non-ignored file is
+# exactly the thing .dockerignore lets through and git flags as `??`.
 #
 # This fires even when TAG is overridden. A hand-picked tag does not make
 # unreproducible content acceptable in ECR, and letting TAG bypass the check would

--- a/services/hca-schema-validator/poetry.lock
+++ b/services/hca-schema-validator/poetry.lock
@@ -509,14 +509,14 @@ numpy = ">=1.21.2"
 
 [[package]]
 name = "hca-schema-validator"
-version = "0.14.0"
+version = "0.14.1"
 description = "HCA schema validation for single-cell datasets"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "hca_schema_validator-0.14.0-py3-none-any.whl", hash = "sha256:11474ac3e43774aaa33482d00af112a3053b1ef5328ae141b7eb4cfcf4b768f4"},
-    {file = "hca_schema_validator-0.14.0.tar.gz", hash = "sha256:338afd499316bce08b5dc6c391a533bb576240cce4d5d580e71aea5083057c47"},
+    {file = "hca_schema_validator-0.14.1-py3-none-any.whl", hash = "sha256:9f28ddf3503260684ac074490ada8d5c8e1d5fe647b66750478c9b6be5e47627"},
+    {file = "hca_schema_validator-0.14.1.tar.gz", hash = "sha256:64f2fa29de0402312940ee6b47dd78ff774bb34b4b466031ed246647d02dd77e"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
Closes #482

## What changed

1. **`check-clean` guard** — `make publish-batch` / `push-batch` now **refuse to run from a dirty working tree**, printing the offending paths.
2. **`services/hca-schema-validator/poetry.lock`** → `hca-schema-validator` **0.14.1**.
3. **CLAUDE.md** — corrected the "Updating hca-schema-validator in the Batch Service" procedure, which was wrong in two ways that both fail *silently*.

## Why

### The guard

The Batch image's **contents** come from the working tree — `docker build` copies files off disk, and there is no `.dockerignore`, so even **untracked** files reach the build context. Its **tag** is `git rev-parse --short HEAD`. Publish from a dirty tree and you put an image in ECR whose tag names a commit that does not contain what is inside it. Nobody can then tell what is deployed: checking out that SHA rebuilds something *different*.

This is not hypothetical — it happened while doing this very task. The dev image went up tagged `bd7d9d1`, a commit whose lock says `0.14.0`, while the image contains `0.14.1`, because it was built before the lock change was committed.

There is deliberately **no override flag**. An escape hatch on a provenance guard is how provenance guards die. To ship work in progress, commit it to a branch — then the tag is real.

### The 0.14.1 bump

`hca-schema-validator` 0.14.1 is the first release built by the uv/hatchling toolchain (#472). Its shipped code is **byte-identical** to 0.14.0, so this is not a functional change. The point is a **known-good Batch baseline before #475** rewrites that Dockerfile — so that any breakage there is attributable to the rewrite rather than to the wheel.

### The CLAUDE.md fixes

- The doc said to bump the pin and run `poetry lock`. For a patch release **inside** the existing constraint (`>=0.14.0,<0.15.0` already admits 0.14.1) there is no pin to bump, and **`poetry lock` does not upgrade** — it re-resolves without moving locked versions, so it kept 0.14.0. Only `poetry update <package>` moves the lock. The build then succeeds and the image quietly ships the **old** validator.
- The patch path never said to commit `poetry.lock` — you could update it, rebuild locally, and never commit the one file that decides what ships.
- The rebuild step lost its "**After merge**" qualifier during an earlier edit. That qualifier is what keeps the tag honest.

## Assumptions I made

- **Untracked files count as dirty.** There is no `.dockerignore`, so an untracked file under a `COPY`ed path (e.g. `shared/`) genuinely enters the image. A guard that only checked tracked modifications would miss it.
- **No override flag**, per above. If this proves too strict in practice, that is a deliberate conversation to have, not a default to erode.
- **The `poetry update` behaviour was verified empirically** on Poetry 2.1.3 (local) — the Docker image pins 2.2.1, same major, same `lock` semantics.
- **0.14.1 is behaviourally identical to 0.14.0.** Verified by diffing the shipped wheel contents (0 files differ) and by an unplanned A/B on dev: the same file set through both images produced **identical** outcomes (30 succeeded / 51 failed on each). The 51 failures are pre-existing — they are synthetic dev fixtures (`test-acceleration-disabled.h5ad` is 67 bytes) that the validator correctly rejects with "file signature not found".

## How to verify

Definition of done from #482, mapped to steps:

1. **Lock moved** — `grep -A1 'name = "hca-schema-validator"' services/hca-schema-validator/poetry.lock` → `version = "0.14.1"`. Its sha256 matches the artifact published on PyPI.
2. **The guard blocks a dirty tree** —
   ```bash
   touch services/dataset-validator/src/stray.py
   make -C services/dataset-validator check-clean     # must FAIL, listing stray.py
   rm services/dataset-validator/src/stray.py
   make -C services/dataset-validator check-clean     # must PASS
   ```
3. **Image builds with the hatchling wheel** — `make -C services/dataset-validator build-batch`; the build log shows `Successfully installed ... hca-schema-validator-0.14.1`.
4. **Three isolated venvs survive** — in the image, `/opt/venvs/cellxgene-validator` and `/opt/venvs/hca-schema-validator` both have `anndata 0.11.4` while the app venv has **0.12.2**, and `PYTHONPATH` is exactly `/opt/python`.
5. **Real h5ads end-to-end on dev** — done: 81 files, 30 succeeded / 51 failed, **identical to the previous image**.
6. **Validation output unchanged** — done: the migrated validator was diffed against the PyPI-published 0.14.0 on a real 422 MB gut h5ad. **Byte-for-byte identical across all 4,298 lines.**

## Follow-ups filed (not in this PR)

- **#483** — release-please does not update `uv.lock`, so all three locks on `main` are stale versus their `pyproject.toml`. A regression from #472. **Likely blocks #475**, which will want `uv sync --frozen` — that flag fails on a stale lock.
- **#484** — the Lambda image publishes to `:latest` with no SHA, so there is no way to tell what is running in prod or to roll back.

## After merge

The dev image must be **rebuilt from the merge commit** — its current tag (`bd7d9d1`) still disagrees with its contents. The new guard will enforce this. That matters because we are about to lean on this image as #475's baseline, and a baseline with dishonest provenance is not one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)