### PR TITLE
ci: upgrade release-please-action from v4 to v5

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,7 @@ jobs:
       hca_anndata_tools_release: ${{ steps.release.outputs['packages/hca-anndata-tools--release_created'] }}
       hca_anndata_mcp_release: ${{ steps.release.outputs['packages/hca-anndata-mcp--release_created'] }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
 
   publish-hca-schema-validator:


### PR DESCRIPTION
Closes #486

Upgrades `googleapis/release-please-action` from the `v4` tag to v5.0.0, pinned by commit SHA. The only breaking change in v5.0.0 is the move to the Node 24 runtime, which GitHub-hosted runners already support, so no configuration changes are needed. The SHA `45996ed1f6d02564a971a2fa1b5860e934307cf7` was verified against the upstream `v5.0.0` tag.

This same change was already merged and verified in anvilproject/anvil-portal#4036: the post-merge release-please run on `main` completed successfully and updated the open release PR as before.

## Test plan

The workflow only triggers on push to the default branch, so it cannot run on this PR branch. After merge, confirm the triggered `release-please` run completes successfully and the release PR is created or updated without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)