### PR TITLE
ci: pin github actions by commit sha at current versions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,10 +32,10 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           # Pin both the build tool and the interpreter. Either one floating
           # means a release can change or break with no change on our side:
@@ -53,7 +53,7 @@ jobs:
         run: uv run --no-project --with packaging python scripts/check_sibling_deps.py packages/hca-schema-validator/dist/*
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: packages/hca-schema-validator/dist/
 
@@ -68,10 +68,10 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           # Pin both the build tool and the interpreter. Either one floating
           # means a release can change or break with no change on our side:
@@ -89,7 +89,7 @@ jobs:
         run: uv run --no-project --with packaging python scripts/check_sibling_deps.py packages/hca-anndata-tools/dist/*
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: packages/hca-anndata-tools/dist/
 
@@ -110,10 +110,10 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           # Pin both the build tool and the interpreter. Either one floating
           # means a release can change or break with no change on our side:
@@ -131,6 +131,6 @@ jobs:
         run: uv run --no-project --with packaging python scripts/check_sibling_deps.py packages/hca-anndata-mcp/dist/*
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: packages/hca-anndata-mcp/dist/


### PR DESCRIPTION
Closes #489

Upgrades every action reference in the workflows to its current version and converts all tag pins to commit SHA pins with version comments, exactly per the table in #489. Each SHA was resolved and verified against the upstream tag. Same change already merged and green in anvilproject/anvil-portal#4040.

## Test plan

- Workflows that trigger on pull requests validate the new pins on this PR itself.
- Workflows that only run on push to the default branch or on dispatch complete a green run after merge, via the next natural trigger or a manual dispatch, with no Node deprecation annotations.
- The next PyPI publish confirms the SHA-pinned publish action end to end. This PR is the prerequisite for the explicit Actions allowlist in #493.

🤖 Generated with [Claude Code](https://claude.com/claude-code)