### PR TITLE
build(migration): remove remaining Poetry references (uv migration 6/6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ make batch-publish-container ENV=dev     # then ENV=prod, from main
 
 **Service Independence:**
 - Each service has its own `pyproject.toml` and uv environment (project-local `.venv/`)
-- Services declare `hca-validation-shared` in `[project].dependencies`; `[tool.uv.sources] hca-validation-shared = { path = "../../shared", editable = true }` redirects that dependency to the local checkout for development
+- Services that depend on the shared library (`entry-sheet-validator`, `dataset-validator`) declare `hca-validation-shared` in `[project].dependencies`; `[tool.uv.sources] hca-validation-shared = { path = "../../shared", editable = true }` redirects that dependency to the local checkout for development. (`cellxgene-validator` and `hca-schema-validator` don't depend on shared.)
 - Different deployment targets allow for different dependency profiles (Lambda is lightweight, Batch has heavy scientific stack)
 
 ## Environment Configuration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ make batch-publish-container ENV=dev     # then ENV=prod, from main
 
 **Service Independence:**
 - Each service has its own `pyproject.toml` and uv environment (project-local `.venv/`)
-- Services reference shared via a uv path source: `[tool.uv.sources] hca-validation-shared = { path = "../../shared", editable = true }`
+- Services declare `hca-validation-shared` in `[project].dependencies`; `[tool.uv.sources] hca-validation-shared = { path = "../../shared", editable = true }` redirects that dependency to the local checkout for development
 - Different deployment targets allow for different dependency profiles (Lambda is lightweight, Batch has heavy scientific stack)
 
 ## Environment Configuration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,17 +29,17 @@ cd shared && make gen-schema         # Generate Pydantic models from schemas
 make test-all
 
 # Shared library tests
-cd shared && poetry run pytest tests/ -v
-cd shared && poetry run pytest tests/test_validator.py -v          # Validator only
-cd shared && poetry run pytest tests/test_entry_sheet_validator.py -v  # Entry sheet only
-cd shared && poetry run pytest tests/ -m integration -v            # Integration tests (needs creds)
-cd shared && poetry run pytest tests/ -m "not integration" -v      # Skip integration tests
+cd shared && uv run pytest tests/ -v
+cd shared && uv run pytest tests/test_validator.py -v          # Validator only
+cd shared && uv run pytest tests/test_entry_sheet_validator.py -v  # Entry sheet only
+cd shared && uv run pytest tests/ -m integration -v            # Integration tests (needs creds)
+cd shared && uv run pytest tests/ -m "not integration" -v      # Skip integration tests
 
 # Service-specific tests
 cd services/entry-sheet-validator && make test-lambda-container
-cd services/dataset-validator && poetry run pytest tests/ -v
-cd services/cellxgene-validator && poetry run pytest tests/ -v
-cd services/hca-schema-validator && poetry run pytest tests/ -v
+cd services/dataset-validator && uv run pytest tests/ -v
+cd services/cellxgene-validator && uv run pytest tests/ -v
+cd services/hca-schema-validator && uv run pytest tests/ -v
 ```
 
 ## Type Checking
@@ -148,8 +148,8 @@ make batch-publish-container ENV=dev     # then ENV=prod, from main
 - Bionetwork-specific schemas (adipose, gut, musculoskeletal) extend the core schema
 
 **Service Independence:**
-- Each service has its own `pyproject.toml` and Poetry environment
-- Services reference shared via: `hca-validation-shared = {path = "../../shared", develop = true}`
+- Each service has its own `pyproject.toml` and uv environment (project-local `.venv/`)
+- Services reference shared via a uv path source: `[tool.uv.sources] hca-validation-shared = { path = "../../shared", editable = true }`
 - Different deployment targets allow for different dependency profiles (Lambda is lightweight, Batch has heavy scientific stack)
 
 ## Environment Configuration
@@ -159,8 +159,7 @@ make batch-publish-container ENV=dev     # then ENV=prod, from main
 
 ## Key Technologies
 
-- uv for dependency management in `packages/` (project-local `.venv/`, one `uv.lock` per package — no workspace, see #248)
-- Poetry for dependency management in `shared/` and `services/` (environments cached in `~/Library/Caches/pypoetry/virtualenvs/`) — migration to uv tracked in #248
+- uv for dependency management across `packages/`, `shared/`, and `services/` (project-local `.venv/`, one `uv.lock` per project — no workspace, see #248). The Poetry→uv migration (#248) is complete.
 - LinkML for schema definition
 - Pydantic for runtime validation
 - gspread for Google Sheets API

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ make typecheck
 
 Pre-commit hook runs it on `git commit`. One-time setup: `pip install pre-commit && pre-commit install`.
 
-For Pylance to match in-editor, open the repo via `hca-validation-tools.code-workspace` (File → Open Workspace from File). Each package/service becomes its own root with its own venv (uv `.venv/` under `packages/`, poetry elsewhere), so imports resolve correctly per folder.
+For Pylance to match in-editor, open the repo via `hca-validation-tools.code-workspace` (File → Open Workspace from File). Each package/service becomes its own root with its own uv `.venv/`, so imports resolve correctly per folder.
 
 ## Deployment Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,7 +159,7 @@ make batch-publish-container ENV=dev     # then ENV=prod, from main
 
 ## Key Technologies
 
-- uv for dependency management across `packages/`, `shared/`, and `services/` (project-local `.venv/`, one `uv.lock` per project — no workspace, see #248). The Poetry→uv migration (#248) is complete.
+- uv for dependency management across `packages/`, `shared/`, and `services/` (project-local `.venv/`, its own `uv.lock` per project — no workspace, see #248). Service locks are committed; library locks under `packages/` and `shared/` are gitignored (see #483). The Poetry→uv migration (#248) is complete.
 - LinkML for schema definition
 - Pydantic for runtime validation
 - gspread for Google Sheets API

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,5 @@
 # HCA Validation Tools Makefile
-# This Makefile provides commands for validating LinkML schemas
-
-# Variables
-SCHEMA_DIR := src/hca_validation/schema
-SCHEMAS := $(wildcard shared/$(SCHEMA_DIR)/*.yaml)
-POETRY := cd shared && poetry run
-# Redirect stderr to suppress warnings from LinkML tools (duplicate -V parameter warnings)
-# These warnings are related to the LinkML tool implementation and not to schema issues
-SUPPRESS_WARNINGS := 2>/dev/null
+# This Makefile orchestrates the multi-service build; schema targets live in shared/Makefile.
 
 # Load Make-specific environment overrides (not checked in)
 # Put only simple KEY=value pairs here (no JSON).

--- a/README.md
+++ b/README.md
@@ -40,9 +40,11 @@ git clone https://github.com/your-org/hca-validation-tools.git
 cd hca-validation-tools
 
 # Build everything (schemas, data dictionaries, Docker images, run tests)
+# Note: build-all builds the Lambda container, so it needs Docker running and
+# AWS credentials (it invokes the entry-sheet build with PROFILE=excira).
 make build-all
 
-# Or install shared library only
+# Or just install the shared library (no Docker/AWS needed)
 cd shared
 uv sync
 ```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ hca-validation-tools/
 
 ## Quick Start
 
-This project uses Poetry for dependency management and Make for build automation:
+This project uses uv for dependency management and Make for build automation:
 
 ```bash
 # Clone the repository
@@ -44,7 +44,7 @@ make build-all
 
 # Or install shared library only
 cd shared
-poetry install --with dev
+uv sync
 ```
 
 ## Available Commands
@@ -94,7 +94,7 @@ GOOGLE_SERVICE_ACCOUNT='{"type": "service_account", "project_id": "your-project"
 ### Multi-Service Architecture
 - **`shared/`** - Core validation library used by all services
 - **`services/entry-sheet-validator/`** - AWS Lambda service for sheet validation
-- Each service has its own Poetry environment and test suite
+- Each service has its own uv environment and test suite
 
 ### Adding New Services
 1. Create new directory under `services/`
@@ -103,12 +103,12 @@ GOOGLE_SERVICE_ACCOUNT='{"type": "service_account", "project_id": "your-project"
 
 ## Virtual Environment Management
 
-This project uses Poetry's **cache directory** for virtual environments instead of in-project `.venv` directories:
+This project uses uv, which creates a **project-local `.venv/`** directory in each package/service:
 
-- **Shared library**: `/Users/$USER/Library/Caches/pypoetry/virtualenvs/hca-validation-shared-*/`
-- **Services**: Each service gets its own cached environment
-- **Benefits**: Cleaner project structure, better IDE integration, shared dependencies across projects
-- **VS Code**: Automatically discovers Poetry environments via `Ctrl+Shift+P` → "Python: Select Interpreter"
+- **Shared library**: `shared/.venv/`
+- **Services**: Each service gets its own `.venv/` alongside its `pyproject.toml`
+- **Reproducibility**: `uv sync` installs the exact versions from the project's `uv.lock`
+- **VS Code**: Open `hca-validation-tools.code-workspace` so each folder resolves its own `.venv`, or select the interpreter via `Ctrl+Shift+P` → "Python: Select Interpreter"
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ This project uses uv, which creates a **project-local `.venv/`** directory in ea
 
 - **Shared library**: `shared/.venv/`
 - **Services**: Each service gets its own `.venv/` alongside its `pyproject.toml`
-- **Reproducibility**: uv resolves dependencies into a `uv.lock`; `uv sync --frozen` then installs exactly those versions without re-resolving (a plain `uv sync` may update the lock)
+- **Reproducibility**: uv resolves dependencies into a `uv.lock`; `uv sync --frozen` installs exactly those versions without re-resolving (a plain `uv sync` may update the lock). The services commit their `uv.lock`, so `--frozen` works there; the library projects (`shared/`, `packages/*`) gitignore their lock (see #483), so a fresh clone re-resolves from `pyproject.toml`
 - **VS Code**: Open `hca-validation-tools.code-workspace` so each folder resolves its own `.venv`, or select the interpreter via `Ctrl+Shift+P` → "Python: Select Interpreter"
 
 ## License

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ This project uses uv, which creates a **project-local `.venv/`** directory in ea
 
 - **Shared library**: `shared/.venv/`
 - **Services**: Each service gets its own `.venv/` alongside its `pyproject.toml`
-- **Reproducibility**: `uv sync` installs the exact versions from the project's `uv.lock`
+- **Reproducibility**: uv resolves dependencies into a `uv.lock`; `uv sync --frozen` then installs exactly those versions without re-resolving (a plain `uv sync` may update the lock)
 - **VS Code**: Open `hca-validation-tools.code-workspace` so each folder resolves its own `.venv`, or select the interpreter via `Ctrl+Shift+P` → "Python: Select Interpreter"
 
 ## License

--- a/deployment/entry-sheet-validator/README.md
+++ b/deployment/entry-sheet-validator/README.md
@@ -13,7 +13,7 @@ The HCA Entry Sheet Validator is deployed as a containerized AWS Lambda function
 The Lambda function is deployed as a container image that includes all dependencies. This approach:
 
 - Ensures consistent execution environments
-- Simplifies dependency management with Poetry
+- Simplifies dependency management with uv
 - Properly handles C extensions (like pydantic_core)
 - Avoids the Lambda deployment package size limit
 
@@ -29,9 +29,9 @@ Builds a Docker container image for the Lambda function using a multi-stage buil
 
 1. Creates a temporary build directory
 2. Generates a Dockerfile with a multi-stage build:
-   - First stage installs Poetry and dependencies
+   - First stage exports the locked dependencies with uv and installs them
    - Second stage copies only the necessary files
-3. Copies Poetry files from the project root
+3. Copies the uv project files (`pyproject.toml`, `uv.lock`) from the project root
 4. Builds the container for the AWS Lambda Python 3.10 runtime
 5. Cleans up the temporary directory
 
@@ -155,7 +155,7 @@ Memory usage is monitored and reported in the response, showing approximately 24
 ## Development Notes
 
 - The `output` directory is excluded from Git to avoid committing generated test files
-- The build process copies Poetry files from the project root, ensuring the latest dependencies are used
+- The build process copies the uv project files (`pyproject.toml`, `uv.lock`) from the project root, ensuring the locked dependencies are used
 - The container includes explicit installation of pydantic and pydantic-core to handle C extensions properly
 
 ## Troubleshooting

--- a/deployment/entry-sheet-validator/README.md
+++ b/deployment/entry-sheet-validator/README.md
@@ -25,15 +25,14 @@ The Lambda function is integrated with API Gateway to provide a RESTful API endp
 
 ### `build_lambda_container.sh`
 
-Builds a Docker container image for the Lambda function using a multi-stage build process:
+Builds the Docker container image for the Lambda function. The script:
 
-1. Creates a temporary build directory
-2. Generates a Dockerfile with a multi-stage build:
-   - First stage exports the locked dependencies with uv and installs them
-   - Second stage copies only the necessary files
-3. Copies the service's uv project files (`services/entry-sheet-validator/{pyproject.toml,uv.lock}`) and the `shared/` path dependency (the Docker build context is the repo root)
-4. Builds the container for the AWS Lambda Python 3.10 runtime
-5. Cleans up the temporary directory
+1. Resolves the AWS Parameters and Secrets Lambda Extension layer to a presigned URL via `aws lambda get-layer-version-by-arn` (using the optional AWS profile passed as its first argument)
+2. Runs `docker build` against the committed `deployment/entry-sheet-validator/Dockerfile`, with the repo root as the build context and the presigned URL passed as the `EXT_URL` build arg, tagging the image `hca-entry-sheet-validator`
+
+That Dockerfile is itself multi-stage on the `public.ecr.aws/lambda/python:3.10` base:
+- The builder stage exports the locked dependencies with uv (`uv export --frozen`) and installs them into `/opt/python`
+- The final stage copies `/opt/python`, the unpacked extension, and the service + `shared/` source into the Lambda image
 
 Usage:
 

--- a/deployment/entry-sheet-validator/README.md
+++ b/deployment/entry-sheet-validator/README.md
@@ -31,7 +31,7 @@ Builds a Docker container image for the Lambda function using a multi-stage buil
 2. Generates a Dockerfile with a multi-stage build:
    - First stage exports the locked dependencies with uv and installs them
    - Second stage copies only the necessary files
-3. Copies the uv project files (`pyproject.toml`, `uv.lock`) from the project root
+3. Copies the service's uv project files (`services/entry-sheet-validator/{pyproject.toml,uv.lock}`) and the `shared/` path dependency (the Docker build context is the repo root)
 4. Builds the container for the AWS Lambda Python 3.10 runtime
 5. Cleans up the temporary directory
 
@@ -155,7 +155,7 @@ Memory usage is monitored and reported in the response, showing approximately 24
 ## Development Notes
 
 - The `output` directory is excluded from Git to avoid committing generated test files
-- The build process copies the uv project files (`pyproject.toml`, `uv.lock`) from the project root, ensuring the locked dependencies are used
+- The build process copies the service's uv project files (`services/entry-sheet-validator/{pyproject.toml,uv.lock}`) and the `shared/` source from their locations under the repo-root build context, ensuring the locked dependencies are used
 - The container includes explicit installation of pydantic and pydantic-core to handle C extensions properly
 
 ## Troubleshooting

--- a/deployment/entry-sheet-validator/dev-notes.md
+++ b/deployment/entry-sheet-validator/dev-notes.md
@@ -85,4 +85,4 @@ This document summarizes the approach, technical decisions, and workflow for bui
 
 ---
 
-_Last updated: 2025-05-26_
+_Last updated: 2026-07-16_

--- a/deployment/entry-sheet-validator/dev-notes.md
+++ b/deployment/entry-sheet-validator/dev-notes.md
@@ -5,11 +5,11 @@ This document summarizes the approach, technical decisions, and workflow for bui
 
 ---
 
-## 1. Dependency Management: Poetry & pip
-- **Development:** Poetry is used for dependency management and reproducible local environments.
-- **Lambda Runtime:** The Dockerfile installs Poetry, uses it to install dependencies, and then exports them to a `requirements.txt` file. pip then installs these into `/opt/python` (the Lambda layer directory), ensuring compatibility with AWS Lambda's expectations.
+## 1. Dependency Management: uv
+- **Development:** uv is used for dependency management and reproducible local environments (`uv.lock` pins the exact closure).
+- **Lambda Runtime:** The Dockerfile pins a uv release, runs `uv export --frozen` to produce a `requirements.txt` from the lock, then `uv pip install --target /opt/python` installs the closure into the Lambda layer directory, matching AWS Lambda's expected structure.
 
-**Why?** Poetry provides a modern workflow for development, but AWS Lambda expects dependencies in a pip-installable format and directory structure.
+**Why?** uv gives a fast, locked workflow for development, and exporting the frozen lock keeps the Lambda image installing exactly the versions that were tested locally.
 
 ---
 
@@ -70,7 +70,7 @@ This document summarizes the approach, technical decisions, and workflow for bui
 ---
 
 ## 8. Key Design Decisions
-- Use Poetry for local/dev, pip for Lambda runtime.
+- Use uv for local/dev and for exporting the locked requirements the Lambda image installs.
 - Fetch AWS extension securely at build time using a presigned URL.
 - Require correct IAM permissions for build-time resource access.
 - Keep build logic (Dockerfile) and orchestration (shell script) separate.
@@ -81,7 +81,7 @@ This document summarizes the approach, technical decisions, and workflow for bui
 ## References
 - [AWS Lambda Extensions Documentation](https://docs.aws.amazon.com/lambda/latest/dg/using-extensions.html)
 - [AWS Lambda Function URLs](https://docs.aws.amazon.com/lambda/latest/dg/urls-invocation.html)
-- [Poetry Documentation](https://python-poetry.org/docs/)
+- [uv Documentation](https://docs.astral.sh/uv/)
 
 ---
 

--- a/docs/multi-service-architecture.md
+++ b/docs/multi-service-architecture.md
@@ -79,8 +79,8 @@ hca-validation-tools/
 
 ### **Build and Development**
 
-- **No Root pyproject.toml**: Each service manages its own dependencies independently (simpler than Poetry workspaces)
-- **Path Dependencies**: Services reference shared library via `{path = "../../shared", develop = true}`
+- **No Root pyproject.toml**: Each service manages its own dependencies independently (no uv workspace — see #248)
+- **Path Dependencies**: Services reference shared library via a uv path source, `[tool.uv.sources] hca-validation-shared = { path = "../../shared", editable = true }`
 - **Independent Builds**: Each service can be built and tested independently
 - **Shared Development**: Core library changes affect all services
 - **CI/CD**: Separate build pipelines for each service
@@ -100,7 +100,7 @@ hca-validation-tools/
 **Multi-Service Architecture**
 - Shared library created at `shared/` with core validation logic
 - Entry sheet validator service extracted to `services/entry-sheet-validator/`
-- Poetry environments configured to use cache directory
+- uv environments configured with project-local `.venv/` directories
 - All tests passing including integration tests with Google Sheets API
 
 **Build System**

--- a/docs/multi-service-architecture.md
+++ b/docs/multi-service-architecture.md
@@ -80,10 +80,10 @@ hca-validation-tools/
 ### **Build and Development**
 
 - **No Root pyproject.toml**: Each service manages its own dependencies independently (no uv workspace — see #248)
-- **Path Dependencies**: Services reference shared library via a uv path source, `[tool.uv.sources] hca-validation-shared = { path = "../../shared", editable = true }`
+- **Path Dependencies**: Services declare `hca-validation-shared` in `[project].dependencies`; `[tool.uv.sources] hca-validation-shared = { path = "../../shared", editable = true }` redirects that dependency to the local checkout for development
 - **Independent Builds**: Each service can be built and tested independently
 - **Shared Development**: Core library changes affect all services
-- **CI/CD**: Separate build pipelines for each service
+- **CI/CD**: Release automation runs via `.github/workflows/release-please.yml`; there is no automated per-service test CI yet (tracked in #461)
 
 ### **Migration Strategy**
 

--- a/docs/multi-service-architecture.md
+++ b/docs/multi-service-architecture.md
@@ -80,7 +80,7 @@ hca-validation-tools/
 ### **Build and Development**
 
 - **No Root pyproject.toml**: Each service manages its own dependencies independently (no uv workspace — see #248)
-- **Path Dependencies**: Services declare `hca-validation-shared` in `[project].dependencies`; `[tool.uv.sources] hca-validation-shared = { path = "../../shared", editable = true }` redirects that dependency to the local checkout for development
+- **Path Dependencies**: Services that use the shared library (`entry-sheet-validator`, `dataset-validator`) declare `hca-validation-shared` in `[project].dependencies`; `[tool.uv.sources] hca-validation-shared = { path = "../../shared", editable = true }` redirects that dependency to the local checkout for development (`cellxgene-validator` and `hca-schema-validator` don't depend on shared)
 - **Independent Builds**: Each service can be built and tested independently
 - **Shared Development**: Core library changes affect all services
 - **CI/CD**: Release automation runs via `.github/workflows/release-please.yml`; there is no automated per-service test CI yet (tracked in #461)

--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -527,15 +527,13 @@ def get_default_hcas_validator_root_path():
     return Path(__file__).parent.parent.parent.parent / "hca-schema-validator"
 
 
-def get_poetry_venv_path_from(project_path: Path) -> str:
-    path_result = subprocess.run(
-        ["poetry", "env", "info", "--path"],
-        cwd=project_path,
-        capture_output=True,
-        text=True,
-        check=True
-    )
-    return path_result.stdout.strip()
+def get_uv_venv_path_from(project_path: Path) -> str:
+    """
+    Get the path to a uv project's virtual environment. uv places a
+    project-local `.venv/` directory next to the project's `pyproject.toml`,
+    so the venv path is `<project_path>/.venv`.
+    """
+    return str(project_path / ".venv")
 
 
 def apply_external_validator(
@@ -557,7 +555,7 @@ def apply_external_validator(
         script_path_var: Name of environment variable to get the path of the script from
         venv_path_var: Name of the environment variable from which to get the path of the virtual
             environment to call the script with
-        get_default_root_path: Function to use to get the root path of a Poetry project containing
+        get_default_root_path: Function to use to get the root path of a uv project containing
             the script if the environment variables don't exist
         default_package_name: Name of the folder in which the script is contained if the
             environment variables don't exist
@@ -572,7 +570,7 @@ def apply_external_validator(
         - The validator script should take the file path as a command-line argument, and print as
           output a JSON object containing a `valid` boolean, an `errors` array of strings, and a
           `warnings` array of strings
-        - The default Poetry project should contain the script at src/{default_package_name}/{default_script_name}
+        - The default uv project should contain the script at src/{default_package_name}/{default_script_name}
     """
 
     started_at = datetime.now(timezone.utc)
@@ -587,9 +585,9 @@ def apply_external_validator(
     # Get validator venv path from environment, if present
     venv_path = os.environ.get(venv_path_var)
 
-    # If environment variable is not present, get venv path via Poetry
+    # If environment variable is not present, use the project-local uv venv
     if venv_path is None:
-        venv_path = get_poetry_venv_path_from(get_default_root_path())
+        venv_path = get_uv_venv_path_from(get_default_root_path())
 
     try:
         # Call validator and parse output

--- a/services/dataset-validator/tests/test_dataset_validator.py
+++ b/services/dataset-validator/tests/test_dataset_validator.py
@@ -1392,10 +1392,57 @@ def _setup_valid_s3_file(s3_client, bucket_name: str, key: str):
 def _setup_corrupt_s3_file(s3_client, bucket_name: str, key: str):
     """Helper function to setup a corrupt S3 file with wrong SHA256 metadata."""
     test_content = b'mock dataset content'
-    
+
     s3_client.put_object(
         Bucket=bucket_name,
         Key=key,
         Body=test_content,
         Metadata={'source-sha256': 'wrong_hash_value'}
     )
+
+
+def test_get_uv_venv_path_from_returns_project_local_venv():
+    """The uv venv path for a project is its project-local `.venv/` directory."""
+    from dataset_validator.main import get_uv_venv_path_from
+
+    assert get_uv_venv_path_from(Path("/x/y")) == str(Path("/x/y") / ".venv")
+
+
+def test_apply_external_validator_falls_back_to_uv_venv(monkeypatch):
+    """When the venv env var is unset, the validator subprocess is invoked via
+    the project-local uv venv (`<project>/.venv/bin/python`) rather than the old
+    `poetry env info` lookup. The Batch container always sets `*_VALIDATOR_VENV`,
+    so this fallback is the local-dev path and is otherwise unexercised."""
+    from dataset_validator.main import apply_external_validator
+
+    root = Path("/fake/project")
+    # Ensure both env vars are unset so the default script path + uv venv
+    # fallback branches are exercised.
+    monkeypatch.delenv("TEST_VALIDATOR_SCRIPT", raising=False)
+    monkeypatch.delenv("TEST_VALIDATOR_VENV", raising=False)
+
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return SimpleNamespace(
+            stdout=json.dumps({"valid": True, "errors": [], "warnings": []}),
+            stderr="",
+            returncode=0,
+        )
+
+    monkeypatch.setattr("dataset_validator.main.subprocess.run", fake_run)
+
+    report = apply_external_validator(
+        Path("/data/file.h5ad"),
+        script_path_var="TEST_VALIDATOR_SCRIPT",
+        venv_path_var="TEST_VALIDATOR_VENV",
+        get_default_root_path=lambda: root,
+        default_package_name="pkg",
+        validator_name="test validator",
+    )
+
+    assert report.valid is True
+    assert captured["cmd"][0] == f"{root}/.venv/bin/python"
+    assert captured["cmd"][1] == str(root / "src" / "pkg" / "main.py")
+    assert captured["cmd"][2] == "/data/file.h5ad"

--- a/services/dataset-validator/tests/test_dataset_validator.py
+++ b/services/dataset-validator/tests/test_dataset_validator.py
@@ -17,7 +17,6 @@ import pandas as pd
 import numpy as np
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
-from dataset_validator.main import get_uv_venv_path_from
 
 
 def _setup_metadata_mocks(mock_read_inputs, mock_matrix_storage, test_adata):
@@ -42,7 +41,10 @@ def _setup_metadata_mocks(mock_read_inputs, mock_matrix_storage, test_adata):
     mock_matrix_storage.return_value = test_adata.get("matrix_storage")
 
 
-dataset_validator_venv_path = get_uv_venv_path_from(Path(__file__).parent.parent)
+# Point the external-validator subprocesses at the interpreter running the
+# tests, so the suite doesn't depend on an in-project `.venv/` existing (works
+# under `uv run pytest`, an IDE runner, or CI regardless of how the env was made).
+dataset_validator_venv_path = sys.prefix
 mock_modules_path = Path(__file__).parent / "mock-modules"
 external_validator_path_vars = {
     'CELLXGENE_VALIDATOR_VENV': dataset_validator_venv_path,

--- a/services/dataset-validator/tests/test_dataset_validator.py
+++ b/services/dataset-validator/tests/test_dataset_validator.py
@@ -41,9 +41,10 @@ def _setup_metadata_mocks(mock_read_inputs, mock_matrix_storage, test_adata):
     mock_matrix_storage.return_value = test_adata.get("matrix_storage")
 
 
-# Point the external-validator subprocesses at the interpreter running the
-# tests, so the suite doesn't depend on an in-project `.venv/` existing (works
-# under `uv run pytest`, an IDE runner, or CI regardless of how the env was made).
+# Use the venv prefix of the interpreter running the tests (apply_external_validator
+# appends `/bin/python` to this), so the suite doesn't depend on an in-project
+# `.venv/` existing — works under `uv run pytest`, an IDE runner, or CI regardless
+# of how the env was created.
 dataset_validator_venv_path = sys.prefix
 mock_modules_path = Path(__file__).parent / "mock-modules"
 external_validator_path_vars = {

--- a/services/dataset-validator/tests/test_dataset_validator.py
+++ b/services/dataset-validator/tests/test_dataset_validator.py
@@ -17,7 +17,7 @@ import pandas as pd
 import numpy as np
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
-from dataset_validator.main import get_poetry_venv_path_from
+from dataset_validator.main import get_uv_venv_path_from
 
 
 def _setup_metadata_mocks(mock_read_inputs, mock_matrix_storage, test_adata):
@@ -42,7 +42,7 @@ def _setup_metadata_mocks(mock_read_inputs, mock_matrix_storage, test_adata):
     mock_matrix_storage.return_value = test_adata.get("matrix_storage")
 
 
-dataset_validator_venv_path = get_poetry_venv_path_from(Path(__file__).parent.parent)
+dataset_validator_venv_path = get_uv_venv_path_from(Path(__file__).parent.parent)
 mock_modules_path = Path(__file__).parent / "mock-modules"
 external_validator_path_vars = {
     'CELLXGENE_VALIDATOR_VENV': dataset_validator_venv_path,
@@ -214,7 +214,7 @@ class TestDatasetValidator:
         
         # Run the validator
         result = subprocess.run(
-            ['poetry', 'run', 'python', 'src/dataset_validator/main.py'],
+            [sys.executable, 'src/dataset_validator/main.py'],
             capture_output=True,
             text=True,
             env=env


### PR DESCRIPTION
Closes #477

Final step of the Poetry→uv migration epic (#248). Most of #477's checklist was already satisfied incrementally during #473–#476 (all 8 `poetry.lock` files deleted, every Makefile converted to `uv`, pre-commit already invokes `make typecheck` which runs `uv run pyright`, no `[tool.poetry]` remains). This PR removes the last Poetry references — from docs, one dead Makefile variable block, and (found during review) one live code fallback.

## What changed
- **`Makefile` (root)** — deleted the dead `POETRY := cd shared && poetry run` variable and its orphaned siblings `SCHEMA_DIR`, `SCHEMAS`, `SUPPRESS_WARNINGS` (schema targets live in `shared/Makefile`; nothing expanded these). This cleared the DoD grep.
- **`services/dataset-validator` (code)** — `apply_external_validator()` fell back to `poetry env info --path` to locate a sibling validator's venv, and a test shelled out to `poetry run python`. Replaced with uv's project-local `.venv/` convention (`get_poetry_venv_path_from` → `get_uv_venv_path_from`, returning `<project>/.venv`) and `sys.executable` in the test. The fallback is never reached in the Batch container (the `*_VALIDATOR_VENV` env vars are always set) but was broken for local dev once the sibling services moved to uv.
- **Docs** — `CLAUDE.md` (test commands `poetry run`→`uv run`, uv path-source syntax with the declare-in-`[project].dependencies` clarification, Pylance note "poetry elsewhere"→uv, Key Technologies), `README.md` (Quick Start `uv sync` + build-all Docker/AWS prerequisite, `--frozen` scope, project-local `.venv/`), `docs/multi-service-architecture.md` (path deps, CI/CD reality, no-workspace), `deployment/entry-sheet-validator/{README,dev-notes}.md` (actual uv-based Lambda build flow).

## Why
Closes out the migration epic. Without this, the docs still tell contributors to use Poetry, the root Makefile trips `grep -rn poetry`, and — most importantly — dataset-validator still shelled out to a `poetry` binary that no longer backs any project.

## Assumptions I made
- The dataset-validator Poetry fallback is dead in production (env vars always set in the container, verified against the Dockerfile), so replacing it changes no Batch behavior; it only fixes local dev. uv's project-local `.venv/` is the correct equivalent of `poetry env info --path`.
- Kept the CLAUDE.md `hca-anndata-tools` pyright-asymmetry note — the asymmetry persists under uv (no workspace; #248), so it's still accurate.
- Kept `poetry`/`poetry.lock` mentions inside `pyproject.toml`/`.gitignore`/`.dockerignore` comments and the mcp README — accurate historical rationale, out of the DoD grep's scope.

## How to verify
Issue #477 definition of done:
- [x] **No `poetry.lock` files remain** — `find . -name poetry.lock` returns nothing.
- [x] **`grep -rn poetry` finds no references in Makefiles, workflows, Dockerfiles, or pre-commit config** — `grep -rn poetry --include=Makefile --include='*.yml' --include=Dockerfile .` → empty. (No functional Poetry remains anywhere; only intentional historical comments in `.gitignore`/`.dockerignore`/`pyproject.toml`.)
- [x] **`make test-all` and `make typecheck` pass** — test-all green earlier; after the code change, `dataset-validator` = 76 passed and `pyright` = 0 errors.
- [ ] **`make build-all` succeeds** — not run here (Docker/PROFILE-gated); no build logic changed.
- [x] **CLAUDE.md accurately describes the uv-based workflow.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)