### PR TITLE
ci: add test + typecheck workflow on every PR (#461 phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,23 +44,35 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # `sync-args` is `--frozen` only where a uv.lock is committed. The
+          # services commit their lock, so CI installs exactly what's locked and
+          # fails loudly on a stale lock. shared/ and packages/* gitignore their
+          # lock (#483), so there's nothing to freeze — plain `uv sync` re-resolves.
+          #
           # shared has an `integration` marker for tests needing live creds;
           # PR CI runs only the hermetic subset.
           - project: shared
+            sync-args: ''
             pytest-args: '-m "not integration"'
           # The three published packages — untested by `make test-all`, so this
           # is net-new coverage of our PyPI artifacts.
           - project: packages/hca-anndata-tools
+            sync-args: ''
             pytest-args: ''
           - project: packages/hca-anndata-mcp
+            sync-args: ''
             pytest-args: ''
           - project: packages/hca-schema-validator
+            sync-args: ''
             pytest-args: ''
           - project: services/dataset-validator
+            sync-args: '--frozen'
             pytest-args: ''
           - project: services/cellxgene-validator
+            sync-args: '--frozen'
             pytest-args: ''
           - project: services/hca-schema-validator
+            sync-args: '--frozen'
             pytest-args: ''
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -70,7 +82,7 @@ jobs:
           python-version: "3.11"
           enable-cache: true
       - name: Sync dependencies
-        run: uv sync
+        run: uv sync ${{ matrix.sync-args }}
         working-directory: ${{ matrix.project }}
       - name: Run tests
         run: uv run pytest tests/ ${{ matrix.pytest-args }} -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,77 @@
+name: CI
+
+# Phase 1 of #461: verify every PR with typecheck + tests. This is a local
+# workflow, not a caller of the shared clevercanary/.github reusable workflows
+# (those don't exist yet — see #461); migrating to them is deferred. Lint (Ruff,
+# conformance A9) is also deferred: the tree isn't Ruff-clean yet and needs a
+# mechanical sweep first.
+#
+# The entry-sheet-validator suite is intentionally excluded: its only test boots
+# a built Docker image (`hca-entry-sheet-validator:latest`) and needs AWS creds
+# (Lambda extension layer) plus a GOOGLE_SERVICE_ACCOUNT secret, so it can't run
+# on a plain PR runner. Revisit as a separate gated job.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  typecheck:
+    name: typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.10.9"
+          python-version: "3.11"
+          enable-cache: true
+      - name: Typecheck (pyright)
+        run: make typecheck
+
+  test:
+    name: test (${{ matrix.project }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # shared has an `integration` marker for tests needing live creds;
+          # PR CI runs only the hermetic subset.
+          - project: shared
+            pytest-args: '-m "not integration"'
+          # The three published packages — untested by `make test-all`, so this
+          # is net-new coverage of our PyPI artifacts.
+          - project: packages/hca-anndata-tools
+            pytest-args: ''
+          - project: packages/hca-anndata-mcp
+            pytest-args: ''
+          - project: packages/hca-schema-validator
+            pytest-args: ''
+          - project: services/dataset-validator
+            pytest-args: ''
+          - project: services/cellxgene-validator
+            pytest-args: ''
+          - project: services/hca-schema-validator
+            pytest-args: ''
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.10.9"
+          python-version: "3.11"
+          enable-cache: true
+      - name: Sync dependencies
+        run: uv sync
+        working-directory: ${{ matrix.project }}
+      - name: Run tests
+        run: uv run pytest tests/ ${{ matrix.pytest-args }} -v
+        working-directory: ${{ matrix.project }}


### PR DESCRIPTION
Part of #461 (phase 1).

## What changed
Adds `.github/workflows/ci.yml` — the first workflow that verifies pull requests. Two jobs, on `pull_request` + `push: main`:
- **typecheck**: `make typecheck` (pyright across the 4 configured venvs; already 0 errors locally).
- **test**: a matrix over the projects that run on a plain runner — `shared` (`-m "not integration"`), the **3 published `packages/`** (net-new coverage — `make test-all` never ran them), and the `dataset-validator`, `cellxgene-validator`, `hca-schema-validator` services. uv pinned `0.10.9`, Python `3.11`, per-project `uv sync` + `uv run pytest`.

## Why
`release-please.yml` was the only workflow; nothing ran tests/typecheck on a PR, so every merge to `main` was unverified. This is the prerequisite for Dependabot (#465) and the conformance workflows (#467/#468).

## Assumptions I made
- **Deliberately phase 1, not the issue's revised DoD.** The revised DoD wants a thin caller of shared reusable workflows in `clevercanary/.github` — that repo **does not exist yet**, so a local `ci.yml` is the only path now. Migrating to the shared workflow is a deferred follow-up.
- **entry-sheet-validator excluded**: its only test boots a built `hca-entry-sheet-validator:latest` image and needs AWS creds (Lambda extension layer) + a `GOOGLE_SERVICE_ACCOUNT` secret — can't run on a plain PR runner. Revisit as a gated job.
- **No lint (Ruff / A9) yet**: the tree isn't ruff-clean (`ruff check` = 399, `ruff format --check` = 75 files). Enforcing it needs a mechanical sweep first — separate PR, so it doesn't bury this diff.
- **Known fragility**: `dataset-validator`'s `test_subprocess_validation_scenarios` is non-hermetic (shells out to real S3 with fake creds; #450). It passes locally and GitHub runners have network, so it should pass — if it flakes here, that's the trigger to fix #450.

## How to verify
- **This PR is its own test** — the new workflow runs against this branch. Confirm the **typecheck** job and all **test (…)** matrix jobs go green in the Checks tab.
- Locally: `make typecheck` → 0 errors; `cd <project> && uv run pytest tests/` passes for each matrixed project.
- Definition of done (issue #461, phase 1 subset):
  - [x] A workflow runs tests + typecheck on `pull_request`.
  - [x] Covers `packages/` (previously untested).
  - [ ] Lint (A9) — deferred to the ruff-sweep follow-up.
  - [ ] Thin caller of shared reusable workflows — blocked until `clevercanary/.github` exists.
  - [ ] Required status checks on `main` — after this is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)