### PR TITLE
style: ruff format + lint sweep, enforce in CI (#313)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,24 @@ permissions:
   contents: read
 
 jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.10.9"
+          python-version: "3.11"
+          enable-cache: true
+      # Ruff pinned to match .pre-commit-config.yaml (rev v0.11.8) so local and
+      # CI agree. Config lives in ruff.toml (select = E/F/I/W; widening tracked
+      # in #467).
+      - name: Ruff lint
+        run: uvx ruff@0.11.8 check .
+      - name: Ruff format check
+        run: uvx ruff@0.11.8 format --check .
+
   typecheck:
     name: typecheck
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
     hooks:
       - id: ruff
         args: [--fix]
+      - id: ruff-format
   - repo: local
     hooks:
       - id: pyright

--- a/packages/hca-anndata-mcp/src/hca_anndata_mcp/server.py
+++ b/packages/hca-anndata-mcp/src/hca_anndata_mcp/server.py
@@ -1,6 +1,12 @@
 """FastMCP server definition and tool registration."""
 
 from fastmcp import FastMCP
+
+from hca_anndata_mcp.tools.label import label_h5ad
+from hca_anndata_mcp.tools.plot import plot_embedding_mcp
+from hca_anndata_mcp.tools.populate import populate_labels
+from hca_anndata_mcp.tools.strip import strip_forbidden_obs_columns
+from hca_anndata_mcp.tools.validate import validate_cell_annotation, validate_schema
 from hca_anndata_tools import (
     check_schema_type,
     check_x_normalization,
@@ -20,12 +26,6 @@ from hca_anndata_tools import (
     view_data,
     view_edit_log,
 )
-
-from hca_anndata_mcp.tools.label import label_h5ad
-from hca_anndata_mcp.tools.plot import plot_embedding_mcp
-from hca_anndata_mcp.tools.populate import populate_labels
-from hca_anndata_mcp.tools.strip import strip_forbidden_obs_columns
-from hca_anndata_mcp.tools.validate import validate_cell_annotation, validate_schema
 
 mcp = FastMCP(
     name="hca-anndata-mcp",

--- a/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/label.py
+++ b/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/label.py
@@ -73,10 +73,7 @@ def label_h5ad(path: str) -> dict:
             # `cell_type` column without a source means the labeler skips the
             # write, so we track source presence to avoid reporting phantom
             # writes.
-            labels_with_source = {
-                c for c in HCA_DERIVED_OBS_LABELS
-                if f"{c}_ontology_term_id" in adata.obs.columns
-            }
+            labels_with_source = {c for c in HCA_DERIVED_OBS_LABELS if f"{c}_ontology_term_id" in adata.obs.columns}
             raw_var_mirrored = adata.raw is not None
 
             labeler = HCALabeler(adata)

--- a/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/plot.py
+++ b/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/plot.py
@@ -2,8 +2,9 @@
 
 import functools
 
-from hca_anndata_tools.plot import plot_embedding as _plot_embedding
 from mcp.types import ImageContent
+
+from hca_anndata_tools.plot import plot_embedding as _plot_embedding
 
 
 @functools.wraps(_plot_embedding, updated=[])

--- a/packages/hca-anndata-mcp/tests/conftest.py
+++ b/packages/hca-anndata-mcp/tests/conftest.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import pytest
+
 from hca_anndata_tools.testing import create_sample_h5ad
 
 

--- a/packages/hca-anndata-mcp/tests/test_e2e.py
+++ b/packages/hca-anndata-mcp/tests/test_e2e.py
@@ -53,11 +53,15 @@ async def test_get_storage_info(client, sample_h5ad):
 
 @pytest.mark.asyncio
 async def test_get_descriptive_stats(client, sample_h5ad):
-    data = await _call(client, "get_descriptive_stats", {
-        "path": str(sample_h5ad),
-        "attribute": "obs",
-        "value_counts": True,
-    })
+    data = await _call(
+        client,
+        "get_descriptive_stats",
+        {
+            "path": str(sample_h5ad),
+            "attribute": "obs",
+            "value_counts": True,
+        },
+    )
     assert data["n_rows"] == 50
     assert data["columns"]["sex"]["type"] == "categorical"
     assert data["columns"]["sex"]["unique"] == 3
@@ -68,23 +72,31 @@ async def test_get_descriptive_stats(client, sample_h5ad):
 
 @pytest.mark.asyncio
 async def test_get_descriptive_stats_with_filter(client, sample_h5ad):
-    data = await _call(client, "get_descriptive_stats", {
-        "path": str(sample_h5ad),
-        "attribute": "obs",
-        "filter_column": "sex",
-        "filter_operator": "==",
-        "filter_value": "female",
-    })
+    data = await _call(
+        client,
+        "get_descriptive_stats",
+        {
+            "path": str(sample_h5ad),
+            "attribute": "obs",
+            "filter_column": "sex",
+            "filter_operator": "==",
+            "filter_value": "female",
+        },
+    )
     assert data["n_rows"] < 50
 
 
 @pytest.mark.asyncio
 async def test_view_data_obs(client, sample_h5ad):
-    data = await _call(client, "view_data", {
-        "path": str(sample_h5ad),
-        "attribute": "obs",
-        "row_end": 5,
-    })
+    data = await _call(
+        client,
+        "view_data",
+        {
+            "path": str(sample_h5ad),
+            "attribute": "obs",
+            "row_end": 5,
+        },
+    )
     assert data["type"] == "dataframe"
     assert data["slice_shape"] == [5, 4]
     assert data["full_shape"] == [50, 4]
@@ -92,12 +104,16 @@ async def test_view_data_obs(client, sample_h5ad):
 
 @pytest.mark.asyncio
 async def test_view_data_obsm(client, sample_h5ad):
-    data = await _call(client, "view_data", {
-        "path": str(sample_h5ad),
-        "attribute": "obsm",
-        "key": "X_umap",
-        "row_end": 3,
-    })
+    data = await _call(
+        client,
+        "view_data",
+        {
+            "path": str(sample_h5ad),
+            "attribute": "obsm",
+            "key": "X_umap",
+            "row_end": 3,
+        },
+    )
     assert data["type"] == "array"
     assert data["full_shape"] == [50, 2]
     assert data["slice_shape"] == [3, 2]
@@ -105,10 +121,14 @@ async def test_view_data_obsm(client, sample_h5ad):
 
 @pytest.mark.asyncio
 async def test_view_data_uns(client, sample_h5ad):
-    data = await _call(client, "view_data", {
-        "path": str(sample_h5ad),
-        "attribute": "uns",
-    })
+    data = await _call(
+        client,
+        "view_data",
+        {
+            "path": str(sample_h5ad),
+            "attribute": "uns",
+        },
+    )
     assert data["type"] == "dict"
     assert data["data"]["title"] == "Test Dataset"
 
@@ -122,11 +142,14 @@ async def test_get_cap_annotations(client, sample_h5ad):
 
 @pytest.mark.asyncio
 async def test_plot_embedding(client, sample_h5ad):
-    result = await client.call_tool("plot_embedding", {
-        "path": str(sample_h5ad),
-        "color": "cell_type",
-        "embedding": "X_umap",
-    })
+    result = await client.call_tool(
+        "plot_embedding",
+        {
+            "path": str(sample_h5ad),
+            "color": "cell_type",
+            "embedding": "X_umap",
+        },
+    )
     assert not result.is_error
     # plot_embedding returns ImageContent, not TextContent
     content = result.content[0]

--- a/packages/hca-anndata-mcp/tests/test_e2e.py
+++ b/packages/hca-anndata-mcp/tests/test_e2e.py
@@ -5,6 +5,7 @@ import json
 import pytest
 import pytest_asyncio
 from fastmcp.client import Client
+
 from hca_anndata_mcp.server import mcp
 
 

--- a/packages/hca-anndata-mcp/tests/test_label.py
+++ b/packages/hca-anndata-mcp/tests/test_label.py
@@ -26,8 +26,13 @@ def test_label_h5ad_happy_path(labelable_path):
     assert result["feature_name_nan"] == 0
     # cell_type is optional but present in the fixture, so all 7 labels written.
     assert set(result["obs_labels_written"]) == {
-        "tissue", "cell_type", "assay", "disease",
-        "sex", "organism", "development_stage",
+        "tissue",
+        "cell_type",
+        "assay",
+        "disease",
+        "sex",
+        "organism",
+        "development_stage",
     }
 
     labeled = ad.read_h5ad(result["output_path"])
@@ -52,8 +57,13 @@ def test_label_h5ad_writes_edit_log_entry(labelable_path):
     assert details["raw_var_mirrored"] is True
     assert details["observation_joinid_written"] is True
     assert set(details["obs_labels_written"]) == {
-        "tissue", "cell_type", "assay", "disease",
-        "sex", "organism", "development_stage",
+        "tissue",
+        "cell_type",
+        "assay",
+        "disease",
+        "sex",
+        "organism",
+        "development_stage",
     }
 
 

--- a/packages/hca-anndata-mcp/tests/test_label.py
+++ b/packages/hca-anndata-mcp/tests/test_label.py
@@ -5,6 +5,7 @@ import shutil
 
 import anndata as ad
 import pytest
+
 from hca_anndata_mcp.tools.label import label_h5ad
 from hca_anndata_tools.testing import create_sample_h5ad
 from hca_schema_validator.testing import create_labelable_h5ad

--- a/packages/hca-anndata-mcp/tests/test_populate.py
+++ b/packages/hca-anndata-mcp/tests/test_populate.py
@@ -49,11 +49,15 @@ def test_refuse_cellxgene_imported(tmp_path):
         description="Imported from CellxGENE Discover: test",
         details={},
     )
-    log = json.dumps([{
-        **entry,
-        "source_file": "test.h5ad",
-        "source_sha256": "0" * 64,
-    }])
+    log = json.dumps(
+        [
+            {
+                **entry,
+                "source_file": "test.h5ad",
+                "source_sha256": "0" * 64,
+            }
+        ]
+    )
     adata.uns.setdefault("provenance", {})[EDIT_LOG_KEY] = log
     adata.write_h5ad(path)
 
@@ -71,11 +75,15 @@ def test_preserves_existing_edit_log(tmp_path):
         description="Stripped HCA-forbidden obs columns (privacy): ['self_reported_ethnicity']",
         details={"obs_columns_stripped": ["self_reported_ethnicity"]},
     )
-    seed = json.dumps([{
-        **prior,
-        "source_file": "synthetic-seed.h5ad",
-        "source_sha256": "0" * 64,
-    }])
+    seed = json.dumps(
+        [
+            {
+                **prior,
+                "source_file": "synthetic-seed.h5ad",
+                "source_sha256": "0" * 64,
+            }
+        ]
+    )
     adata.uns.setdefault("provenance", {})[EDIT_LOG_KEY] = seed
     adata.write_h5ad(path)
 

--- a/packages/hca-anndata-mcp/tests/test_populate.py
+++ b/packages/hca-anndata-mcp/tests/test_populate.py
@@ -9,6 +9,7 @@ the wrapper's file-I/O contract + the cellxgene-imported origin refusal
 import json
 
 import anndata as ad
+
 from hca_anndata_mcp.tools.populate import populate_labels
 from hca_anndata_tools.write import EDIT_LOG_KEY, make_edit_entry
 from hca_schema_validator.testing import create_labelable_h5ad

--- a/packages/hca-anndata-mcp/tests/test_strip.py
+++ b/packages/hca-anndata-mcp/tests/test_strip.py
@@ -2,6 +2,7 @@
 
 import anndata as ad
 import pandas as pd
+
 from hca_anndata_mcp.tools.strip import strip_forbidden_obs_columns
 
 

--- a/packages/hca-anndata-mcp/tests/test_strip.py
+++ b/packages/hca-anndata-mcp/tests/test_strip.py
@@ -39,9 +39,7 @@ def test_strip_actually_strips(tmp_path):
     create_sample_h5ad(path)
     adata = ad.read_h5ad(path)
     adata.uns.pop("schema_version", None)
-    adata.obs["self_reported_ethnicity_ontology_term_id"] = pd.Categorical(
-        ["unknown"] * adata.n_obs
-    )
+    adata.obs["self_reported_ethnicity_ontology_term_id"] = pd.Categorical(["unknown"] * adata.n_obs)
     adata.write_h5ad(path)
 
     result = strip_forbidden_obs_columns(str(path))

--- a/packages/hca-anndata-mcp/tests/test_validate.py
+++ b/packages/hca-anndata-mcp/tests/test_validate.py
@@ -1,6 +1,7 @@
 """Unit tests for the validate_schema + validate_cell_annotation MCP wrappers."""
 
 import anndata as ad
+
 from hca_anndata_mcp.tools.validate import validate_cell_annotation, validate_schema
 from hca_anndata_tools.testing import create_sample_h5ad
 from hca_schema_validator.cell_annotation_validator import NO_SETS_ERROR

--- a/packages/hca-anndata-mcp/tests/test_validate.py
+++ b/packages/hca-anndata-mcp/tests/test_validate.py
@@ -10,7 +10,12 @@ from hca_schema_validator.testing import create_cap_annotated_h5ad, create_label
 def test_validate_schema_shape(sample_h5ad):
     result = validate_schema(str(sample_h5ad))
     assert set(result.keys()) == {
-        "filename", "is_valid", "error_count", "warning_count", "errors", "warnings",
+        "filename",
+        "is_valid",
+        "error_count",
+        "warning_count",
+        "errors",
+        "warnings",
     }
     assert isinstance(result["is_valid"], bool)
     assert result["error_count"] == len(result["errors"])
@@ -35,10 +40,9 @@ def test_validate_schema_surfaces_cosmetic_check(tmp_path):
 
     result = validate_schema(str(path))
 
-    assert any(
-        "'WRONG_TISSUE_LABEL'" in e and "Either delete the cosmetic column" in e
-        for e in result["errors"]
-    ), result["errors"]
+    assert any("'WRONG_TISSUE_LABEL'" in e and "Either delete the cosmetic column" in e for e in result["errors"]), (
+        result["errors"]
+    )
     # #443: a drifting label is an error, never a "delete the column" warning.
     assert not any("obs['tissue']" in w for w in result["warnings"]), result["warnings"]
     assert result["is_valid"] is False
@@ -91,7 +95,12 @@ def test_validate_cell_annotation_shape(tmp_path):
     path = create_cap_annotated_h5ad(tmp_path / "cap.h5ad")
     result = validate_cell_annotation(str(path))
     assert set(result.keys()) == {
-        "filename", "is_valid", "error_count", "warning_count", "errors", "warnings",
+        "filename",
+        "is_valid",
+        "error_count",
+        "warning_count",
+        "errors",
+        "warnings",
     }
     assert isinstance(result["is_valid"], bool)
     assert result["error_count"] == len(result["errors"])

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/__init__.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/__init__.py
@@ -70,6 +70,7 @@ __all__ = list(_LAZY_IMPORTS)  # pyright: ignore[reportUnsupportedDunderAll]
 def __getattr__(name: str):
     if name in _LAZY_IMPORTS:
         import importlib
+
         module = importlib.import_module(_LAZY_IMPORTS[name], __name__)
         return getattr(module, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
@@ -121,9 +121,7 @@ def read_var_gene_names(path: str) -> tuple[set[str], dict[str, str]]:
 
         gene_names = set(names)
 
-        eid_to_var_name = {
-            _strip_ensembl_version(eid): name for eid, name in zip(index, names)
-        }
+        eid_to_var_name = {_strip_ensembl_version(eid): name for eid, name in zip(index, names)}
 
         return gene_names, eid_to_var_name
 
@@ -277,10 +275,7 @@ def verify_categorical_integrity(
             actual = int((codes >= 0).sum())
             expected = expected_valid_counts[col]
             if actual != expected:
-                return (
-                    f"Column '{col}': expected {expected} valid values, "
-                    f"got {actual}"
-                )
+                return f"Column '{col}': expected {expected} valid values, got {actual}"
 
     return None
 
@@ -300,8 +295,7 @@ def verify_obs_transplant(
     """
     import numpy as np
 
-    with h5py.File(temp_path, "r") as f_temp, \
-         h5py.File(output_path, "r") as f_out:
+    with h5py.File(temp_path, "r") as f_temp, h5py.File(output_path, "r") as f_out:
         for col in columns:
             temp_item = f_temp["obs"][col]
             out_item = f_out["obs"][col]

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/cap.py
@@ -64,6 +64,7 @@ def resolve_cap_block(uns) -> dict | None:
     block = uns.get(CAP_METADATA_KEY)
     return dict(block) if isinstance(block, Mapping) else None
 
+
 # CAP obs column suffixes per the cell-annotation-schema spec
 _REQUIRED_SUFFIXES = [
     "",  # the cell label column itself

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/compress.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/compress.py
@@ -63,10 +63,7 @@ def compress_h5ad(
         if current_filter and not force:
             return {
                 "skipped": True,
-                "reason": (
-                    f"X/data already uses '{current_filter}' filter "
-                    f"(pass force=True to rewrite anyway)"
-                ),
+                "reason": (f"X/data already uses '{current_filter}' filter (pass force=True to rewrite anyway)"),
                 "current_compression": current_filter,
             }
 
@@ -85,7 +82,9 @@ def compress_h5ad(
 
         with open_h5ad(path, backed="r") as adata:
             result = write_h5ad(
-                adata, path, [entry],
+                adata,
+                path,
+                [entry],
                 compression=compression,
                 compression_opts=compression_level,
             )

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/convert.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/convert.py
@@ -125,17 +125,14 @@ def convert_cellxgene_to_hca(
 
         if cellxgene_source:
             conversions.append(
-                f"Moved cellxgene reserved keys to uns['provenance']['cellxgene']: "
-                f"{list(cellxgene_source.keys())}"
+                f"Moved cellxgene reserved keys to uns['provenance']['cellxgene']: {list(cellxgene_source.keys())}"
             )
 
         # Forbidden-by-HCA obs columns to remove (privacy — see #370). The
         # h5py block below performs the actual deletion.
         obs_columns_stripped = [c for c in _OBS_COLUMNS_TO_STRIP if c in source_obs_members]
         if obs_columns_stripped:
-            conversions.append(
-                f"Stripped HCA-forbidden obs columns (privacy): {obs_columns_stripped}"
-            )
+            conversions.append(f"Stripped HCA-forbidden obs columns (privacy): {obs_columns_stripped}")
 
         # Broadcast obs columns (categorical, 1 category, all codes=0)
         obs_data = {}
@@ -192,9 +189,7 @@ def convert_cellxgene_to_hca(
 
             shutil.copy2(path, output_path)
 
-            with h5py.File(temp_path, "r") as f_temp, \
-                 h5py.File(output_path, "a") as f_out:
-
+            with h5py.File(temp_path, "r") as f_temp, h5py.File(output_path, "a") as f_out:
                 f_out.require_group("uns")
 
                 # Delete CellxGENE reserved keys from uns

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -24,10 +24,10 @@ from ._io import (
 )
 from ._serialize import make_serializable
 from .cap import (
-    CAP_METADATA_KEY,
-    LEGACY_LAYOUT_ERROR,
     _OPTIONAL_SUFFIXES,
     _REQUIRED_SUFFIXES,
+    CAP_METADATA_KEY,
+    LEGACY_LAYOUT_ERROR,
     is_legacy_cap_layout,
     resolve_cap_block,
 )
@@ -217,7 +217,9 @@ def copy_cap_annotations(
             return {"error": "No CAP obs columns found to copy"}
 
         source_index = set(source_index_list)
-        dupe_err = _check_duplicate_ids(source_index_list, "CAP cells") or _check_duplicate_ids(source_var_list, "CAP genes")
+        dupe_err = _check_duplicate_ids(source_index_list, "CAP cells") or _check_duplicate_ids(
+            source_var_list, "CAP genes"
+        )
         if dupe_err:
             return {"error": dupe_err}
         source_var_set = set(source_var_list)
@@ -350,9 +352,7 @@ def copy_cap_annotations(
             shutil.copy2(target_path, output_path)
 
             # Transplant from temp into output
-            with h5py.File(temp_path, "r") as f_temp, \
-                 h5py.File(output_path, "a") as f_out:
-
+            with h5py.File(temp_path, "r") as f_temp, h5py.File(output_path, "a") as f_out:
                 f_out.require_group("uns")
 
                 deleted_cols = set()

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
@@ -34,8 +34,16 @@ from .write import (
 
 # Default HCA placeholder values (case-insensitive)
 _DEFAULT_PLACEHOLDERS = [
-    "unknown", "na", "n/a", "none", "not available",
-    "not applicable", "tbd", "todo", "null", "undefined",
+    "unknown",
+    "na",
+    "n/a",
+    "none",
+    "not available",
+    "not applicable",
+    "tbd",
+    "todo",
+    "null",
+    "undefined",
 ]
 
 
@@ -81,17 +89,19 @@ def list_uns_fields(path: str) -> dict:
                 is_set = name in adata.uns
                 serialized = make_serializable(current) if is_set else None
 
-                fields.append({
-                    "name": name,
-                    "title": info.title,
-                    "description": info.description,
-                    "type": _type_display(info.annotation),
-                    "required": info.required,
-                    "bionetwork_only": info.bionetwork_only,
-                    "current_value": serialized,
-                    "is_set": is_set,
-                    "examples": info.examples,
-                })
+                fields.append(
+                    {
+                        "name": name,
+                        "title": info.title,
+                        "description": info.description,
+                        "type": _type_display(info.annotation),
+                        "required": info.required,
+                        "bionetwork_only": info.bionetwork_only,
+                        "current_value": serialized,
+                        "is_set": is_set,
+                        "examples": info.examples,
+                    }
+                )
 
                 if info.required and not is_set:
                     if info.bionetwork_only:
@@ -209,8 +219,7 @@ def set_uns(
                 if invalid:
                     return {
                         "error": (
-                            f"batch_condition values {invalid} are not obs columns. "
-                            f"Valid columns: {sorted(obs_cols)}"
+                            f"batch_condition values {invalid} are not obs columns. Valid columns: {sorted(obs_cols)}"
                         )
                     }
 
@@ -219,8 +228,7 @@ def set_uns(
                 if validated_value not in obsm_keys:
                     return {
                         "error": (
-                            f"default_embedding '{validated_value}' is not an obsm key. "
-                            f"Valid keys: {sorted(obsm_keys)}"
+                            f"default_embedding '{validated_value}' is not an obsm key. Valid keys: {sorted(obsm_keys)}"
                         )
                     }
 
@@ -378,7 +386,8 @@ def replace_placeholder_values(
                 cat_ds.attrs["encoding-type"] = "string-array"
                 cat_ds.attrs["encoding-version"] = "0.2.0"
                 codes_ds = grp.create_dataset(
-                    "codes", data=new_codes.astype(codes.dtype),
+                    "codes",
+                    data=new_codes.astype(codes.dtype),
                     compression=codes_compression,
                     compression_opts=codes_compression_opts,
                     chunks=codes_chunks,
@@ -389,9 +398,7 @@ def replace_placeholder_values(
             write_edit_log_h5py(f, log_result["json"])
 
             # Verify integrity after rewrite
-            integrity_err = verify_categorical_integrity(
-                f, list(columns_fixed.keys()), expected_valid_counts
-            )
+            integrity_err = verify_categorical_integrity(f, list(columns_fixed.keys()), expected_valid_counts)
             if integrity_err:
                 raise RuntimeError(integrity_err)
 

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/inspect.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/inspect.py
@@ -54,9 +54,7 @@ def _classify_x_at_path(path: str, sample_size: int) -> dict:
     nonzero = sample[sample != 0]
     nonzero_count = int(nonzero.size)
     has_negative = bool((sample < 0).any()) if sample.size else False
-    is_integer_valued = (
-        bool(np.all(np.mod(nonzero, 1) == 0)) if nonzero_count else False
-    )
+    is_integer_valued = bool(np.all(np.mod(nonzero, 1) == 0)) if nonzero_count else False
 
     if nonzero_count == 0:
         verdict = "indeterminate"

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/marker_genes.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/marker_genes.py
@@ -85,21 +85,13 @@ def validate_marker_genes(path: str, annotation_set: str | None = None) -> dict:
 
         if annotation_set:
             if annotation_set not in all_sets:
-                return {
-                    "error": (
-                        f"Annotation set '{annotation_set}' not found. "
-                        f"Available: {all_sets}"
-                    )
-                }
+                return {"error": (f"Annotation set '{annotation_set}' not found. Available: {all_sets}")}
             sets_to_check = [annotation_set]
         else:
             sets_to_check = all_sets
 
         # Filter to sets that have marker_gene_evidence
-        sets_with_markers = [
-            s for s in sets_to_check
-            if f"{s}--marker_gene_evidence" in obs_columns
-        ]
+        sets_with_markers = [s for s in sets_to_check if f"{s}--marker_gene_evidence" in obs_columns]
 
         if not sets_with_markers:
             return {
@@ -160,6 +152,7 @@ def validate_marker_genes(path: str, annotation_set: str | None = None) -> dict:
 
         # Deduplicate top-level lists (same gene can appear in multiple sets)
         seen = set()
+
         def _dedup(items):
             out = []
             for item in items:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/normalize.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/normalize.py
@@ -50,9 +50,7 @@ def normalize_raw(path: str) -> dict:
         with open_h5ad(path, backed=None) as adata:
             # CXG schema forbids feature_is_filtered in raw.var.
             raw_source = adata.copy()
-            raw_source.var = raw_source.var.drop(
-                columns=["feature_is_filtered"], errors="ignore"
-            )
+            raw_source.var = raw_source.var.drop(columns=["feature_is_filtered"], errors="ignore")
             adata.raw = raw_source
             sc.pp.normalize_total(adata, target_sum=_TARGET_SUM)
             sc.pp.log1p(adata)

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/plot.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/plot.py
@@ -45,6 +45,7 @@ def plot_embedding(
         path = resolve_latest(path)
         # Lazy imports — scanpy/matplotlib are heavy and only needed for plotting
         import matplotlib
+
         if matplotlib.get_backend().lower() != "agg":
             matplotlib.use("Agg")
         import matplotlib.pyplot as plt

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/stats.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/stats.py
@@ -88,9 +88,7 @@ def get_descriptive_stats(
                         col_info["top"] = str(vc.index[0])
                         col_info["freq"] = int(vc.iloc[0])
                     if value_counts:
-                        col_info["value_counts"] = {
-                            str(k): int(v) for k, v in vc.items()
-                        }
+                        col_info["value_counts"] = {str(k): int(v) for k, v in vc.items()}
                     result["columns"][col] = col_info
 
             return result

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/strip.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/strip.py
@@ -152,9 +152,7 @@ def strip_forbidden_obs_columns(path: str) -> dict:
 
             entry = make_edit_entry(
                 operation="strip_forbidden_obs_columns",
-                description=(
-                    f"Stripped HCA-forbidden obs columns (privacy): {stripped}"
-                ),
+                description=(f"Stripped HCA-forbidden obs columns (privacy): {stripped}"),
                 details={"obs_columns_stripped": stripped},
             )
 

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/summary.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/summary.py
@@ -44,15 +44,11 @@ def get_summary(path: str) -> dict:
                     "type": _type_name(adata.X),
                     "dtype": _dtype_str(adata.X),
                     "shape": _shape_str(adata.X),
-                } if adata.X is not None else None,
-                "obs_columns": [
-                    {"name": col, "dtype": str(adata.obs[col].dtype)}
-                    for col in adata.obs.columns
-                ],
-                "var_columns": [
-                    {"name": col, "dtype": str(adata.var[col].dtype)}
-                    for col in adata.var.columns
-                ],
+                }
+                if adata.X is not None
+                else None,
+                "obs_columns": [{"name": col, "dtype": str(adata.obs[col].dtype)} for col in adata.obs.columns],
+                "var_columns": [{"name": col, "dtype": str(adata.var[col].dtype)} for col in adata.var.columns],
                 "obsm_keys": [
                     {"key": k, "type": _type_name(adata.obsm[k]), "shape": _shape_str(adata.obsm[k])}
                     for k in adata.obsm.keys()
@@ -61,14 +57,8 @@ def get_summary(path: str) -> dict:
                     {"key": k, "type": _type_name(adata.varm[k]), "shape": _shape_str(adata.varm[k])}
                     for k in adata.varm.keys()
                 ],
-                "obsp_keys": [
-                    {"key": k, "type": _type_name(adata.obsp[k])}
-                    for k in adata.obsp.keys()
-                ],
-                "varp_keys": [
-                    {"key": k, "type": _type_name(adata.varp[k])}
-                    for k in adata.varp.keys()
-                ],
+                "obsp_keys": [{"key": k, "type": _type_name(adata.obsp[k])} for k in adata.obsp.keys()],
+                "varp_keys": [{"key": k, "type": _type_name(adata.varp[k])} for k in adata.varp.keys()],
                 "layers": [
                     {"name": k, "type": _type_name(adata.layers[k]), "dtype": _dtype_str(adata.layers[k])}
                     for k in adata.layers.keys()

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/testing.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/testing.py
@@ -35,9 +35,7 @@ def create_sample_h5ad(path: Path) -> Path:
         {
             "sex": pd.Categorical(rng.choice(["male", "female", "unknown"], n_obs)),
             "tissue": pd.Categorical(rng.choice(["brain", "lung", "heart"], n_obs)),
-            "cell_type": pd.Categorical(rng.choice(
-                ["T cell", "B cell", "macrophage", "neuron", "epithelial"], n_obs
-            )),
+            "cell_type": pd.Categorical(rng.choice(["T cell", "B cell", "macrophage", "neuron", "epithelial"], n_obs)),
             "n_counts": rng.integers(500, 5000, n_obs).astype(np.float32),
         },
         index=[f"cell_{i}" for i in range(n_obs)],  # pyright: ignore[reportArgumentType]
@@ -89,14 +87,10 @@ def create_cellxgene_h5ad(path: Path) -> Path:
 
     obs = pd.DataFrame(
         {
-            "cell_type_ontology_term_id": pd.Categorical(
-                rng.choice(["CL:0000540", "CL:0000235"], n_obs)
-            ),
+            "cell_type_ontology_term_id": pd.Categorical(rng.choice(["CL:0000540", "CL:0000235"], n_obs)),
             "assay_ontology_term_id": pd.Categorical(["EFO:0009922"] * n_obs),
             "disease_ontology_term_id": pd.Categorical(["PATO:0000461"] * n_obs),
-            "sex_ontology_term_id": pd.Categorical(
-                rng.choice(["PATO:0000383", "PATO:0000384"], n_obs)
-            ),
+            "sex_ontology_term_id": pd.Categorical(rng.choice(["PATO:0000383", "PATO:0000384"], n_obs)),
             "tissue_ontology_term_id": pd.Categorical(["UBERON:0000966"] * n_obs),
             "self_reported_ethnicity_ontology_term_id": pd.Categorical(["unknown"] * n_obs),
             "development_stage_ontology_term_id": pd.Categorical(["HsapDv:0000087"] * n_obs),
@@ -139,8 +133,12 @@ def create_cellxgene_h5ad(path: Path) -> Path:
     # CellxGENE uns fields
     adata.uns["title"] = "snRNA-seq of Human Retina - Test Subset"
     adata.uns["schema_version"] = "7.1.0"
-    adata.uns["schema_reference"] = "https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/7.1.0/schema.md"
-    adata.uns["citation"] = "Publication: https://doi.org/10.1234/test Dataset Version: https://datasets.cellxgene.cziscience.com/test-uuid.h5ad"
+    adata.uns["schema_reference"] = (
+        "https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/7.1.0/schema.md"
+    )
+    adata.uns["citation"] = (
+        "Publication: https://doi.org/10.1234/test Dataset Version: https://datasets.cellxgene.cziscience.com/test-uuid.h5ad"
+    )
     adata.uns["organism_ontology_term_id"] = "NCBITaxon:9606"
     adata.uns["organism"] = "Homo sapiens"
 

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
@@ -85,10 +85,7 @@ def resolve_latest(path: str) -> str:
     # Glob for timestamped variants, then strict regex filter on full basename
     pattern = os.path.join(directory, f"{glob.escape(stem)}-edit-*-*-*-*-*-*.h5ad")
     full_re = re.compile(rf"^{re.escape(stem)}-edit-\d{{4}}-\d{{2}}-\d{{2}}-\d{{2}}-\d{{2}}-\d{{2}}\.h5ad$")
-    candidates = [
-        f for f in glob.glob(pattern)
-        if full_re.match(os.path.basename(f))
-    ]
+    candidates = [f for f in glob.glob(pattern) if full_re.match(os.path.basename(f))]
 
     if not candidates:
         return path
@@ -146,10 +143,7 @@ def has_edit_log_operation(adata, operation: str) -> bool:
         return False
     if not isinstance(log, list):
         return False
-    return any(
-        isinstance(entry, dict) and entry.get("operation") == operation
-        for entry in log
-    )
+    return any(isinstance(entry, dict) and entry.get("operation") == operation for entry in log)
 
 
 def make_edit_entry(
@@ -212,10 +206,7 @@ def build_edit_log(
     sha256 = source_sha256 if source_sha256 is not None else _compute_sha256(source_path)
     source_filename = os.path.basename(source_path)
 
-    stamped_entries = [
-        {**entry, "source_file": source_filename, "source_sha256": sha256}
-        for entry in edit_entries
-    ]
+    stamped_entries = [{**entry, "source_file": source_filename, "source_sha256": sha256} for entry in edit_entries]
 
     if isinstance(existing_log_raw, str):
         try:
@@ -243,11 +234,7 @@ def cleanup_previous_version(source_path: str, output_path: str) -> None:
     Never deletes the original (non-timestamped) file. Skips if output
     overwrote source in place (same-second write).
     """
-    if (
-        _is_timestamped(source_path)
-        and source_path != output_path
-        and os.path.isfile(source_path)
-    ):
+    if _is_timestamped(source_path) and source_path != output_path and os.path.isfile(source_path):
         try:
             os.remove(source_path)
         except OSError:

--- a/packages/hca-anndata-tools/tests/conftest.py
+++ b/packages/hca-anndata-tools/tests/conftest.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import anndata as ad
 import pytest
+
 from hca_anndata_tools.testing import create_cellxgene_h5ad, create_sample_h5ad
 
 

--- a/packages/hca-anndata-tools/tests/test_auto_resolve_latest.py
+++ b/packages/hca-anndata-tools/tests/test_auto_resolve_latest.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import scipy.sparse as sp
+
 from hca_anndata_tools.cap import get_cap_annotations
 from hca_anndata_tools.marker_genes import validate_marker_genes
 from hca_anndata_tools.plot import plot_embedding

--- a/packages/hca-anndata-tools/tests/test_cap.py
+++ b/packages/hca-anndata-tools/tests/test_cap.py
@@ -12,6 +12,7 @@ from hca_anndata_tools.cap import _make_serializable, get_cap_annotations
 
 # -- _make_serializable tests --------------------------------------------------
 
+
 def test_serializable_int():
     assert _make_serializable(np.int64(42)) == 42
     assert isinstance(_make_serializable(np.int64(42)), int)
@@ -62,6 +63,7 @@ def test_serializable_passthrough():
 
 # -- get_cap_annotations tests -------------------------------------------------
 
+
 def test_cap_no_annotations(sample_h5ad):
     """Sample file has no CAP annotations."""
     result = get_cap_annotations(str(sample_h5ad))
@@ -92,6 +94,7 @@ def test_cap_nonexistent_annotation_set(sample_h5ad):
 
 # -- Tests with a CAP-annotated fixture ----------------------------------------
 
+
 @pytest.fixture(scope="module")
 def cap_h5ad(tmp_path_factory) -> Path:
     """Create an h5ad with CAP-style annotation columns."""
@@ -106,16 +109,10 @@ def cap_h5ad(tmp_path_factory) -> Path:
             "my_labels": pd.Categorical(labels),
             "my_labels--cell_fullname": [f"{label} cell" for label in labels],
             "my_labels--cell_ontology_exists": rng.choice([True, False], n_obs),
-            "my_labels--cell_ontology_term_id": rng.choice(
-                ["CL:0000540", "CL:0000127", "CL:0000129"], n_obs
-            ),
-            "my_labels--cell_ontology_term": rng.choice(
-                ["neuron", "astrocyte", "microglial cell"], n_obs
-            ),
+            "my_labels--cell_ontology_term_id": rng.choice(["CL:0000540", "CL:0000127", "CL:0000129"], n_obs),
+            "my_labels--cell_ontology_term": rng.choice(["neuron", "astrocyte", "microglial cell"], n_obs),
             "my_labels--rationale": ["morphology"] * n_obs,
-            "my_labels--marker_gene_evidence": rng.choice(
-                ["RBFOX3", "GFAP", "AIF1"], n_obs
-            ),
+            "my_labels--marker_gene_evidence": rng.choice(["RBFOX3", "GFAP", "AIF1"], n_obs),
         },
         index=[f"cell_{i}" for i in range(n_obs)],
     )

--- a/packages/hca-anndata-tools/tests/test_cap.py
+++ b/packages/hca-anndata-tools/tests/test_cap.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import scipy.sparse as sp
+
 from hca_anndata_tools.cap import _make_serializable, get_cap_annotations
 
 # -- _make_serializable tests --------------------------------------------------

--- a/packages/hca-anndata-tools/tests/test_check_schema_type.py
+++ b/packages/hca-anndata-tools/tests/test_check_schema_type.py
@@ -4,6 +4,7 @@ import anndata as ad
 import numpy as np
 import pandas as pd
 import scipy.sparse as sp
+
 from hca_anndata_tools.inspect import check_schema_type
 
 

--- a/packages/hca-anndata-tools/tests/test_compress.py
+++ b/packages/hca-anndata-tools/tests/test_compress.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import scipy.sparse as sp
+
 from hca_anndata_tools.compress import compress_h5ad
 
 

--- a/packages/hca-anndata-tools/tests/test_compress.py
+++ b/packages/hca-anndata-tools/tests/test_compress.py
@@ -159,15 +159,19 @@ def test_compress_h5ad_appends_to_existing_edit_log(uncompressed_h5ad):
         prov = f.require_group("uns/provenance")
         prov.attrs.setdefault("encoding-type", "dict")
         prov.attrs.setdefault("encoding-version", "0.1.0")
-        existing = json.dumps([{
-            "timestamp": "2026-01-01T00:00:00+00:00",
-            "tool": "hca-anndata-tools",
-            "tool_version": "0.0.0",
-            "operation": "fake_prior",
-            "description": "seeded prior entry",
-            "source_file": "uncompressed.h5ad",
-            "source_sha256": "0" * 64,
-        }])
+        existing = json.dumps(
+            [
+                {
+                    "timestamp": "2026-01-01T00:00:00+00:00",
+                    "tool": "hca-anndata-tools",
+                    "tool_version": "0.0.0",
+                    "operation": "fake_prior",
+                    "description": "seeded prior entry",
+                    "source_file": "uncompressed.h5ad",
+                    "source_sha256": "0" * 64,
+                }
+            ]
+        )
         ds = prov.create_dataset("edit_history", data=existing)
         ds.attrs["encoding-type"] = "string"
         ds.attrs["encoding-version"] = "0.2.0"

--- a/packages/hca-anndata-tools/tests/test_convert.py
+++ b/packages/hca-anndata-tools/tests/test_convert.py
@@ -142,10 +142,7 @@ def test_convert_edit_log_records_sre_strip(cellxgene_h5ad):
         "self_reported_ethnicity",
     }
     # Strip is also called out in the human-readable conversions list.
-    assert any(
-        "HCA-forbidden obs columns" in c
-        for c in details["conversions"]
-    )
+    assert any("HCA-forbidden obs columns" in c for c in details["conversions"])
 
 
 def test_convert_expression_unchanged(cellxgene_h5ad):

--- a/packages/hca-anndata-tools/tests/test_convert.py
+++ b/packages/hca-anndata-tools/tests/test_convert.py
@@ -5,6 +5,7 @@ import os
 import re
 
 import anndata as ad
+
 from hca_anndata_tools.convert import _slugify, convert_cellxgene_to_hca
 from hca_anndata_tools.write import EDIT_LOG_KEY
 

--- a/packages/hca-anndata-tools/tests/test_copy_cap.py
+++ b/packages/hca-anndata-tools/tests/test_copy_cap.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import scipy.sparse as sp
+
 from hca_anndata_tools.copy_cap import copy_cap_annotations
 from hca_anndata_tools.write import EDIT_LOG_KEY
 

--- a/packages/hca-anndata-tools/tests/test_copy_cap.py
+++ b/packages/hca-anndata-tools/tests/test_copy_cap.py
@@ -33,37 +33,21 @@ def _make_cap_source(
     obs = pd.DataFrame(
         {
             "author_cell_type": pd.Categorical(labels),
-            "author_cell_type--cell_fullname": pd.Categorical(
-                [f"{label} cell" for label in labels]
-            ),
+            "author_cell_type--cell_fullname": pd.Categorical([f"{label} cell" for label in labels]),
             "author_cell_type--cell_ontology_exists": pd.Categorical(["True"] * n),
-            "author_cell_type--cell_ontology_term_id": pd.Categorical(
-                rng.choice(["CL:0000540", "CL:0000127"], n)
-            ),
-            "author_cell_type--cell_ontology_term": pd.Categorical(
-                rng.choice(["neuron", "astrocyte"], n)
-            ),
+            "author_cell_type--cell_ontology_term_id": pd.Categorical(rng.choice(["CL:0000540", "CL:0000127"], n)),
+            "author_cell_type--cell_ontology_term": pd.Categorical(rng.choice(["neuron", "astrocyte"], n)),
             "author_cell_type--rationale": pd.Categorical(["morphology"] * n),
-            "author_cell_type--marker_gene_evidence": pd.Categorical(
-                rng.choice(["GFAP", "AIF1"], n)
-            ),
+            "author_cell_type--marker_gene_evidence": pd.Categorical(rng.choice(["GFAP", "AIF1"], n)),
             "author_cell_type--canonical_marker_genes": pd.Categorical(["unknown"] * n),
             "author_cell_type--synonyms": pd.Categorical(["unknown"] * n),
             "author_cell_type--category_fullname": pd.Categorical(["neural cell"] * n),
-            "author_cell_type--category_cell_ontology_term_id": pd.Categorical(
-                ["CL:0002319"] * n
-            ),
-            "author_cell_type--category_cell_ontology_term": pd.Categorical(
-                ["neural cell"] * n
-            ),
+            "author_cell_type--category_cell_ontology_term_id": pd.Categorical(["CL:0002319"] * n),
+            "author_cell_type--category_cell_ontology_term": pd.Categorical(["neural cell"] * n),
             # Demographic columns (should NOT be copied)
             "sex--cell_ontology_term_id": pd.Categorical(["PATO:0000384"] * n),
-            "development_stage--cell_ontology_term_id": pd.Categorical(
-                ["HsapDv:0000087"] * n
-            ),
-            "self_reported_ethnicity--cell_ontology_term_id": pd.Categorical(
-                ["HANCESTRO:0005"] * n
-            ),
+            "development_stage--cell_ontology_term_id": pd.Categorical(["HsapDv:0000087"] * n),
+            "self_reported_ethnicity--cell_ontology_term_id": pd.Categorical(["HANCESTRO:0005"] * n),
             "cell_type--cell_ontology_term_id": pd.Categorical(["CL:0000540"] * n),
         },
         index=cell_ids,
@@ -178,7 +162,6 @@ def test_copy_marker_gene_validation(cap_source, hca_target):
     assert "found_in_var" in mv
 
 
-
 def test_copy_uns_cap_metadata_nested(cap_source, hca_target):
     result = copy_cap_annotations(str(cap_source), str(hca_target))
     written = ad.read_h5ad(result["output_path"])
@@ -266,7 +249,6 @@ def test_copy_skips_demographic_columns(cap_source, hca_target):
     assert "sex--cell_ontology_term_id" not in written.obs.columns
     assert "development_stage--cell_ontology_term_id" not in written.obs.columns
     assert "self_reported_ethnicity--cell_ontology_term_id" not in written.obs.columns
-
 
 
 # --- Edit log ---
@@ -384,9 +366,7 @@ def test_var_overlap_rejects_duplicate_var_ids(cap_source, tmp_path):
 
 
 def test_copy_cell_mismatch_fails(cap_source, tmp_path):
-    different_cells = _make_hca_target(
-        tmp_path / "different.h5ad", [f"other_{i}" for i in range(10)]
-    )
+    different_cells = _make_hca_target(tmp_path / "different.h5ad", [f"other_{i}" for i in range(10)])
     result = copy_cap_annotations(str(cap_source), str(different_cells))
     assert "error" in result
     assert "mismatch" in result["error"].lower()
@@ -397,9 +377,7 @@ def test_copy_cap_uncovered_fails(cap_source, tmp_path):
     # HCA is a strict subset of CAP (5 of CAP's 10 cells). HCA is fully covered,
     # but half of CAP is missing from HCA — exercises the asymmetric failure
     # where missing_from_hca exceeds the threshold while missing_from_cap is 0.
-    subset = _make_hca_target(
-        tmp_path / "subset.h5ad", [f"cell_{i}" for i in range(5)]
-    )
+    subset = _make_hca_target(tmp_path / "subset.h5ad", [f"cell_{i}" for i in range(5)])
     result = copy_cap_annotations(str(cap_source), str(subset))
     assert "error" in result
     assert "mismatch" in result["error"].lower()
@@ -413,9 +391,7 @@ def test_copy_partial_overlap_succeeds(tmp_path):
     # Threshold is inclusive, so this should succeed and the HCA-only row
     # should end up with NaN in the new CAP columns.
     target_ids = [f"cell_{i}" for i in range(19)] + ["target_only"]
-    cap_20 = _make_cap_source(
-        tmp_path / "cap_20.h5ad", [f"cell_{i}" for i in range(20)]
-    )
+    cap_20 = _make_cap_source(tmp_path / "cap_20.h5ad", [f"cell_{i}" for i in range(20)])
     target = _make_hca_target(tmp_path / "target_20.h5ad", target_ids)
 
     result = copy_cap_annotations(str(cap_20), str(target))
@@ -453,6 +429,7 @@ def test_copy_rejects_non_categorical_source_column(cap_source, hca_target):
     # bypassing anndata's auto-coercion to categorical) to simulate a source
     # that violates CAP's categorical-everywhere serialization contract.
     import h5py
+
     col = "author_cell_type--rationale"
     with h5py.File(cap_source, "a") as f:
         del f["obs"][col]
@@ -495,7 +472,8 @@ def test_copy_target_has_cap_fails(cap_source, hca_target_with_cap):
 
 
 def test_copy_cap_preserves_cellxgene_provenance(cap_source, tmp_path):
-    """When target already has provenance/cellxgene, copy_cap writes the CAP block to uns['cap_metadata'] alongside it (preserving the cellxgene provenance)."""
+    """When target already has provenance/cellxgene, copy_cap writes the CAP block
+    to uns['cap_metadata'] alongside it (preserving the cellxgene provenance)."""
     n = len(CELL_IDS)
     rng = np.random.default_rng(99)
     X = sp.random(n, 5, density=0.3, format="csr", dtype=np.float32, random_state=rng)
@@ -525,9 +503,7 @@ def test_copy_cap_preserves_cellxgene_provenance(cap_source, tmp_path):
 
 
 def test_copy_overwrite(cap_source, hca_target_with_cap):
-    result = copy_cap_annotations(
-        str(cap_source), str(hca_target_with_cap), overwrite=True
-    )
+    result = copy_cap_annotations(str(cap_source), str(hca_target_with_cap), overwrite=True)
     assert "error" not in result
     written = ad.read_h5ad(result["output_path"])
     # Old CAP column removed

--- a/packages/hca-anndata-tools/tests/test_edit.py
+++ b/packages/hca-anndata-tools/tests/test_edit.py
@@ -6,6 +6,7 @@ import anndata as ad
 import numpy as np
 import pandas as pd
 import scipy.sparse as sp
+
 from hca_anndata_tools.edit import (
     list_uns_fields,
     replace_placeholder_values,

--- a/packages/hca-anndata-tools/tests/test_helpers.py
+++ b/packages/hca-anndata-tools/tests/test_helpers.py
@@ -138,6 +138,7 @@ def test_transplant_obs_columns_basic(tmp_path):
 @pytest.fixture
 def _make_pair(tmp_path):
     """Create a matching temp/output pair with obs columns."""
+
     def _factory(obs_data: dict, index: list[str], mismatch_col: str | None = None):
         n = len(index)
         obs = pd.DataFrame(obs_data, index=index)
@@ -161,6 +162,7 @@ def _make_pair(tmp_path):
                     item["codes"][...] = codes
 
         return str(temp_path), str(output_path)
+
     return _factory
 
 
@@ -298,6 +300,7 @@ def test_build_edit_log_basic(tmp_path):
     assert "error" not in result
 
     import json
+
     log = json.loads(result["json"])
     assert len(log) == 1
     assert log[0]["tool"] == "test"
@@ -307,6 +310,7 @@ def test_build_edit_log_basic(tmp_path):
 
 def test_build_edit_log_appends(tmp_path):
     import json
+
     path = tmp_path / "test.h5ad"
     path.write_bytes(b"content")
 
@@ -327,6 +331,7 @@ def test_build_edit_log_precomputed_sha(tmp_path):
     result = build_edit_log("[]", [entry], str(path), source_sha256="abc123")
 
     import json
+
     log = json.loads(result["json"])
     assert log[0]["source_sha256"] == "abc123"
 

--- a/packages/hca-anndata-tools/tests/test_helpers.py
+++ b/packages/hca-anndata-tools/tests/test_helpers.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import scipy.sparse as sp
+
 from hca_anndata_tools._io import (
     read_categorical_data,
     read_obs_index,

--- a/packages/hca-anndata-tools/tests/test_inspect.py
+++ b/packages/hca-anndata-tools/tests/test_inspect.py
@@ -141,8 +141,15 @@ def test_check_x_normalization_return_shape_is_fixed(tmp_path):
     path = _write_h5ad(tmp_path / "shape.h5ad", X)
 
     expected = {
-        "filename", "dtype", "sample_size", "nonzero_count",
-        "nonzero_min", "nonzero_max", "is_integer_valued",
-        "has_negative", "has_raw_x", "verdict",
+        "filename",
+        "dtype",
+        "sample_size",
+        "nonzero_count",
+        "nonzero_min",
+        "nonzero_max",
+        "is_integer_valued",
+        "has_negative",
+        "has_raw_x",
+        "verdict",
     }
     assert set(check_x_normalization(str(path)).keys()) == expected

--- a/packages/hca-anndata-tools/tests/test_inspect.py
+++ b/packages/hca-anndata-tools/tests/test_inspect.py
@@ -4,6 +4,7 @@ import anndata as ad
 import numpy as np
 import pandas as pd
 import scipy.sparse as sp
+
 from hca_anndata_tools.inspect import check_x_normalization
 
 

--- a/packages/hca-anndata-tools/tests/test_marker_genes.py
+++ b/packages/hca-anndata-tools/tests/test_marker_genes.py
@@ -127,9 +127,7 @@ def marker_h5ad(tmp_path_factory) -> Path:
             "test_labels--marker_gene_evidence": pd.Categorical(
                 rng.choice(["GFAP,AIF1", "RBFOX3", "CIMAP3", "SCL25A5"], n_obs)
             ),
-            "test_labels--cell_ontology_term_id": pd.Categorical(
-                rng.choice(["CL:0000540", "CL:0000127"], n_obs)
-            ),
+            "test_labels--cell_ontology_term_id": pd.Categorical(rng.choice(["CL:0000540", "CL:0000127"], n_obs)),
         },
         index=[f"cell_{i}" for i in range(n_obs)],
     )
@@ -160,9 +158,7 @@ def clean_h5ad(tmp_path_factory) -> Path:
         {
             "organism_ontology_term_id": pd.Categorical(["NCBITaxon:9606"] * n_obs),
             "ann": pd.Categorical(rng.choice(["a", "b"], n_obs)),
-            "ann--marker_gene_evidence": pd.Categorical(
-                rng.choice(["GFAP", "AIF1,RBFOX3"], n_obs)
-            ),
+            "ann--marker_gene_evidence": pd.Categorical(rng.choice(["GFAP", "AIF1,RBFOX3"], n_obs)),
         },
         index=[f"cell_{i}" for i in range(n_obs)],
     )
@@ -256,9 +252,7 @@ def versioned_h5ad(tmp_path_factory) -> Path:
         {
             "organism_ontology_term_id": pd.Categorical(["NCBITaxon:9606"] * n_obs),
             "ann": pd.Categorical(rng.choice(["a", "b"], n_obs)),
-            "ann--marker_gene_evidence": pd.Categorical(
-                rng.choice(["GFAP", "CIMAP3"], n_obs)
-            ),
+            "ann--marker_gene_evidence": pd.Categorical(rng.choice(["GFAP", "CIMAP3"], n_obs)),
         },
         index=[f"cell_{i}" for i in range(n_obs)],
     )

--- a/packages/hca-anndata-tools/tests/test_marker_genes.py
+++ b/packages/hca-anndata-tools/tests/test_marker_genes.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import scipy.sparse as sp
+
 from hca_anndata_tools._gencode import load_gencode_reference
 from hca_anndata_tools._io import read_var_gene_names
 from hca_anndata_tools.marker_genes import (

--- a/packages/hca-anndata-tools/tests/test_normalize.py
+++ b/packages/hca-anndata-tools/tests/test_normalize.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import scipy.sparse as sp
+
 from hca_anndata_tools.normalize import normalize_raw
 
 

--- a/packages/hca-anndata-tools/tests/test_stats.py
+++ b/packages/hca-anndata-tools/tests/test_stats.py
@@ -30,7 +30,10 @@ def test_stats_categorical_column(sample_h5ad):
 
 def test_stats_value_counts(sample_h5ad):
     result = get_descriptive_stats(
-        str(sample_h5ad), attribute="obs", columns=["cell_type"], value_counts=True,
+        str(sample_h5ad),
+        attribute="obs",
+        columns=["cell_type"],
+        value_counts=True,
     )
     col = result["columns"]["cell_type"]
     assert "value_counts" in col

--- a/packages/hca-anndata-tools/tests/test_strip.py
+++ b/packages/hca-anndata-tools/tests/test_strip.py
@@ -107,11 +107,15 @@ def test_strip_preserves_existing_edit_log(sample_h5ad_for_write):
     # but we're seeding by hand here — those fields aren't required by the
     # validator unless we re-stamp. Use the minimal shape that build_edit_log
     # will accept on the next read.
-    seed_log = json.dumps([{
-        **prior_entry,
-        "source_file": "synthetic-seed.h5ad",
-        "source_sha256": "0" * 64,
-    }])
+    seed_log = json.dumps(
+        [
+            {
+                **prior_entry,
+                "source_file": "synthetic-seed.h5ad",
+                "source_sha256": "0" * 64,
+            }
+        ]
+    )
     adata.uns.setdefault("provenance", {})[EDIT_LOG_KEY] = seed_log
     adata.write_h5ad(sample_h5ad_for_write)
 

--- a/packages/hca-anndata-tools/tests/test_strip.py
+++ b/packages/hca-anndata-tools/tests/test_strip.py
@@ -5,6 +5,7 @@ import os
 
 import anndata as ad
 import pandas as pd
+
 from hca_anndata_tools.strip import (
     _OBS_COLUMNS_TO_STRIP,
     strip_forbidden_obs_columns,

--- a/packages/hca-anndata-tools/tests/test_write.py
+++ b/packages/hca-anndata-tools/tests/test_write.py
@@ -342,11 +342,15 @@ def test_has_edit_log_operation_finds_matching_entry(sample_h5ad_for_write):
 
     adata = ad.read_h5ad(str(sample_h5ad_for_write))
     entry = _make_entry(operation="import_cellxgene", description="Imported from CXG")
-    seed = json.dumps([{
-        **entry,
-        "source_file": "fake.h5ad",
-        "source_sha256": "0" * 64,
-    }])
+    seed = json.dumps(
+        [
+            {
+                **entry,
+                "source_file": "fake.h5ad",
+                "source_sha256": "0" * 64,
+            }
+        ]
+    )
     adata.uns.setdefault("provenance", {})[EDIT_LOG_KEY] = seed
 
     assert has_edit_log_operation(adata, "import_cellxgene") is True

--- a/packages/hca-anndata-tools/tests/test_write.py
+++ b/packages/hca-anndata-tools/tests/test_write.py
@@ -6,6 +6,7 @@ import os
 import re
 
 import anndata as ad
+
 from hca_anndata_tools.write import (
     EDIT_LOG_KEY,
     generate_output_path,

--- a/packages/hca-schema-validator/src/hca_schema_validator/cell_annotation_validator.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/cell_annotation_validator.py
@@ -30,7 +30,6 @@ from typing import List, Optional
 import anndata as ad
 import semver
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -127,10 +126,7 @@ class HCACellAnnotationValidator:
             self._error(NO_SETS_ERROR)
             return None
         if not isinstance(cap, Mapping):
-            self._error(
-                f"uns['cap_metadata'] must be a dict/group; got "
-                f"{type(cap).__name__}."
-            )
+            self._error(f"uns['cap_metadata'] must be a dict/group; got {type(cap).__name__}.")
             return None
         return cap
 
@@ -188,7 +184,4 @@ class HCACellAnnotationValidator:
         for suffix in _REQUIRED_OBS_SUFFIXES:
             col = f"{set_name}--{suffix}"
             if col not in obs_columns:
-                self._error(
-                    f"Annotation set '{set_name}' is missing required obs "
-                    f"column '{col}'."
-                )
+                self._error(f"Annotation set '{set_name}' is missing required obs column '{col}'.")

--- a/packages/hca-schema-validator/src/hca_schema_validator/labeler.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/labeler.py
@@ -79,10 +79,12 @@ class HCALabeler(AnnDataLabelAppender):
                 # we handle them first and skip the rest of the loop body.
                 if str(col_def.get("requirement_level", "")).lower() == "forbidden":
                     if col_name in df.columns:
-                        issues.append(col_def.get(
-                            "forbidden_error",
-                            f"Column '{col_name}' must not be present in {component_name}.",
-                        ))
+                        issues.append(
+                            col_def.get(
+                                "forbidden_error",
+                                f"Column '{col_name}' must not be present in {component_name}.",
+                            )
+                        )
                     continue
                 if "add_labels" not in col_def:
                     continue
@@ -129,9 +131,7 @@ class HCALabeler(AnnDataLabelAppender):
                     "(file appears to have been processed by cellxgene-schema add-labels already)"
                 )
         if _ORGANISM_COL in self.adata.obs.columns:
-            non_human = sorted(
-                v for v in self.adata.obs[_ORGANISM_COL].dropna().unique() if v != _HUMAN_TAXON
-            )
+            non_human = sorted(v for v in self.adata.obs[_ORGANISM_COL].dropna().unique() if v != _HUMAN_TAXON)
             if non_human:
                 issues.append(
                     f"obs['{_ORGANISM_COL}'] contains non-human values {non_human}; "
@@ -209,9 +209,7 @@ class HCALabeler(AnnDataLabelAppender):
         # anything in the ERCC table is "spike-in" regardless of its literal
         # ID shape. Unknown-organism IDs still NaN (via _map_by_organism) so
         # all five feature_* columns stay in sync — same rows NaN everywhere.
-        return self._map_by_organism(
-            ids, lambda _i, o: "spike-in" if o == SupportedOrganisms.ERCC else "gene"
-        )
+        return self._map_by_organism(ids, lambda _i, o: "spike-in" if o == SupportedOrganisms.ERCC else "gene")
 
     def preflight(self) -> None:
         """Raise ``ValueError`` if the input fails HCA preflight checks.

--- a/packages/hca-schema-validator/src/hca_schema_validator/populator.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/populator.py
@@ -141,12 +141,9 @@ def _classify_obs_column(
     # lookups to ~5 — significant on large files. Mirrors the cache shape
     # in :func:`validator._compare_cosmetic_to_term_ids`.
     canonical_cache: dict[str, Any] = {
-        str(t): _lookup_canonical_label(str(t), exceptions)
-        for t in term_id_series.dropna().unique()
+        str(t): _lookup_canonical_label(str(t), exceptions) for t in term_id_series.dropna().unique()
     }
-    canonical: pd.Series = term_id_series.map(
-        lambda t: pd.NA if pd.isna(t) else canonical_cache.get(str(t))
-    )
+    canonical: pd.Series = term_id_series.map(lambda t: pd.NA if pd.isna(t) else canonical_cache.get(str(t)))
 
     if not cosmetic_present:
         return "fill", [], canonical
@@ -235,9 +232,7 @@ def _classify_var_column(
     # they differ. NaN-existing rows are never mismatch — they're
     # either fillable (canonical has a value to give) or both-NaN
     # no-ops.
-    populated_disagreement = (~existing_nan) & (
-        canonical_nan | (existing != canonical_series)
-    )
+    populated_disagreement = (~existing_nan) & (canonical_nan | (existing != canonical_series))
     if populated_disagreement.any():
         pair_counts = (
             pd.DataFrame(
@@ -318,11 +313,7 @@ def populate_in_memory(adata: ad.AnnData) -> dict:
         }
 
     if _ORGANISM_COL in adata.obs.columns:
-        non_human = sorted(
-            v
-            for v in adata.obs[_ORGANISM_COL].dropna().unique()
-            if v != _HUMAN_TAXON
-        )
+        non_human = sorted(v for v in adata.obs[_ORGANISM_COL].dropna().unique() if v != _HUMAN_TAXON)
         if non_human:
             return {
                 "error": (
@@ -371,9 +362,7 @@ def populate_in_memory(adata: ad.AnnData) -> dict:
     # HCALabeler instance for its ``_get_mapping_dict_feature_*`` helpers
     # (we never call ``label()`` — that triggers the hardline preflight).
     labeler = HCALabeler(adata)
-    obs_components = (
-        labeler.schema_def.get("components", {}).get("obs", {}).get("columns", {})
-    )
+    obs_components = labeler.schema_def.get("components", {}).get("obs", {}).get("columns", {})
 
     filled: list[str] = []
     matched: list[str] = []
@@ -390,9 +379,7 @@ def populate_in_memory(adata: ad.AnnData) -> dict:
     for cosmetic_col in HCA_DERIVED_OBS_LABELS:
         source_col = f"{cosmetic_col}_ontology_term_id"
         exceptions = _collect_curie_exceptions(obs_components.get(source_col, {}))
-        status, col_errors, canonical = _classify_obs_column(
-            adata.obs, cosmetic_col, source_col, exceptions
-        )
+        status, col_errors, canonical = _classify_obs_column(adata.obs, cosmetic_col, source_col, exceptions)
         if status == "errored":
             errors.extend(col_errors)
         elif status == "matched":
@@ -413,9 +400,7 @@ def populate_in_memory(adata: ad.AnnData) -> dict:
 
         # adata.var
         canonical_dict = getter(var_ids)
-        status, col_errors, canonical_series = _classify_var_column(
-            adata.var, col, canonical_dict
-        )
+        status, col_errors, canonical_series = _classify_var_column(adata.var, col, canonical_dict)
         if status == "errored":
             errors.extend(col_errors)
         elif status == "matched":
@@ -426,17 +411,12 @@ def populate_in_memory(adata: ad.AnnData) -> dict:
         # adata.raw.var — same logic, separate canonical
         if raw_var is not None and raw_var_ids is not None:
             raw_canonical_dict = getter(raw_var_ids)
-            raw_status, raw_col_errors, raw_canonical_series = _classify_var_column(
-                raw_var, col, raw_canonical_dict
-            )
+            raw_status, raw_col_errors, raw_canonical_series = _classify_var_column(raw_var, col, raw_canonical_dict)
             if raw_status == "errored":
                 # Re-tag the error messages so the caller sees which side
                 # produced them (the underlying messages say "var['col']";
                 # rewrite to "raw.var['col']" for clarity).
-                errors.extend(
-                    e.replace(f"var['{col}']", f"raw.var['{col}']")
-                    for e in raw_col_errors
-                )
+                errors.extend(e.replace(f"var['{col}']", f"raw.var['{col}']") for e in raw_col_errors)
             elif raw_status == "matched":
                 matched.append(f"raw.var/{col}")
             elif raw_status == "fill":
@@ -456,9 +436,7 @@ def populate_in_memory(adata: ad.AnnData) -> dict:
                 "errors": errors,
                 "matched": matched,
                 "would_fill": sorted(
-                    list(fill_obs)
-                    + [f"var/{c}" for c in fill_var]
-                    + [f"raw.var/{c}" for c in fill_raw_var]
+                    list(fill_obs) + [f"var/{c}" for c in fill_var] + [f"raw.var/{c}" for c in fill_raw_var]
                 ),
             },
         }

--- a/packages/hca-schema-validator/src/hca_schema_validator/testing.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/testing.py
@@ -15,7 +15,6 @@ import numpy as np
 import pandas as pd
 from scipy import sparse
 
-
 # GENCODE-recognized human Ensembl IDs used in the existing labeler fixtures.
 # These all resolve to a gene symbol, so ``feature_name`` comes out fully
 # populated (helps test the happy-path overwrite reporting).

--- a/packages/hca-schema-validator/src/hca_schema_validator/validator.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/validator.py
@@ -87,15 +87,8 @@ class HCAValidator(Validator):
         super()._deep_check()
 
         # Match by substring to avoid brittle coupling to exact upstream wording
-        raw_skip_warnings = [
-            w for w in self.warnings
-            if "Validation of raw layer was not performed" in w
-        ]
-        if (
-            raw_skip_warnings
-            and "raw" in self.schema_def
-            and "assay_ontology_term_id" in self.adata.obs.columns
-        ):
+        raw_skip_warnings = [w for w in self.warnings if "Validation of raw layer was not performed" in w]
+        if raw_skip_warnings and "raw" in self.schema_def and "assay_ontology_term_id" in self.adata.obs.columns:
             for w in raw_skip_warnings:
                 self.warnings.remove(w)
             self._validate_raw()
@@ -112,13 +105,9 @@ class HCAValidator(Validator):
         if element_type == "string":
             for i in current_list:
                 if not isinstance(i, str):
-                    self.errors.append(
-                        f"Value '{i}' in list '{list_name}' is not valid, it must be a string."
-                    )
+                    self.errors.append(f"Value '{i}' in list '{list_name}' is not valid, it must be a string.")
                 elif len(i.strip()) == 0:
-                    self.errors.append(
-                        f"Value in list '{list_name}' must not be empty or whitespace-only."
-                    )
+                    self.errors.append(f"Value in list '{list_name}' must not be empty or whitespace-only.")
 
     def _validate_dataframe(self, df_name):
         """
@@ -157,8 +146,7 @@ class HCAValidator(Validator):
         # comparisons are case-insensitive throughout so the validator stays
         # symmetric with HCALabeler's preflight (which already lowercases).
         schema_columns = {
-            c for c, d in df_definition["columns"].items()
-            if str(d.get("requirement_level", "")).lower() != "forbidden"
+            c for c, d in df_definition["columns"].items() if str(d.get("requirement_level", "")).lower() != "forbidden"
         }
 
         # Extract optional, strongly_recommended, and forbidden columns
@@ -223,9 +211,7 @@ class HCAValidator(Validator):
                 if col_name in df.columns:
                     column = df[col_name]
                     if "dependencies" in col_def:
-                        column = self._validate_column_dependencies(
-                            df, df_name, col_name, col_def["dependencies"]
-                        )
+                        column = self._validate_column_dependencies(df, df_name, col_name, col_def["dependencies"])
                     if len(column) > 0:
                         if "warning_message" in col_def:
                             self.warnings.append(col_def["warning_message"])
@@ -234,10 +220,7 @@ class HCAValidator(Validator):
     def _validate_strongly_recommended(self, df, df_name, col_name, col_def):
         """Validate a strongly_recommended column: warn on missing/NaN, error on blocklist."""
         if col_name not in df.columns:
-            self.warnings.append(
-                f"Column '{col_name}' in dataframe '{df_name}' is strongly "
-                f"recommended but missing."
-            )
+            self.warnings.append(f"Column '{col_name}' in dataframe '{df_name}' is strongly recommended but missing.")
             return
 
         column = df[col_name]
@@ -249,16 +232,12 @@ class HCAValidator(Validator):
             total = len(column)
             pct = (nan_count * 100 // total) if total > 0 else 0
             self.warnings.append(
-                f"Column '{col_name}' is strongly recommended. "
-                f"{nan_count}/{total} ({pct}%) values are NaN."
+                f"Column '{col_name}' is strongly recommended. {nan_count}/{total} ({pct}%) values are NaN."
             )
 
         # Separator check — reject values containing list separators
         separators = {",", ";", "|"}
-        bad_sep_values = [
-            str(v) for v in column.dropna().unique()
-            if any(sep in str(v) for sep in separators)
-        ]
+        bad_sep_values = [str(v) for v in column.dropna().unique() if any(sep in str(v) for sep in separators)]
         if bad_sep_values:
             shown = bad_sep_values[:3]
             self.errors.append(
@@ -270,10 +249,7 @@ class HCAValidator(Validator):
         # Blocklist check — error on invalid values (case-insensitive)
         if "blocklist" in col_def:
             blocklist = {v.lower() for v in col_def["blocklist"]}
-            bad_values = [
-                str(v) for v in column.dropna().unique()
-                if str(v).strip().lower() in blocklist
-            ]
+            bad_values = [str(v) for v in column.dropna().unique() if str(v).strip().lower() in blocklist]
             if bad_values:
                 self.errors.append(
                     f"Column '{col_name}' in dataframe '{df_name}' contains "
@@ -317,10 +293,7 @@ class HCAValidator(Validator):
             organism_ontology_id = None
 
             if not organism:
-                self.warnings.append(
-                    f"Feature ID '{feature_id}' in '{df_name}' not found "
-                    f"in {version_label}."
-                )
+                self.warnings.append(f"Feature ID '{feature_id}' in '{df_name}' not found in {version_label}.")
                 continue
             else:
                 organism_ontology_id = organism.value
@@ -328,10 +301,7 @@ class HCAValidator(Validator):
             valid_gene_id = get_gene_checker(organism).is_valid_id(feature_id)
 
             if not valid_gene_id:
-                self.warnings.append(
-                    f"Feature ID '{feature_id}' in '{df_name}' not found "
-                    f"in {version_label}."
-                )
+                self.warnings.append(f"Feature ID '{feature_id}' in '{df_name}' not found in {version_label}.")
 
             if dataset_organism is not None and organism_ontology_id is not None and valid_gene_id:
                 is_descendant = organism_ontology_id in ONTOLOGY_PARSER.get_term_ancestors(dataset_organism, True)
@@ -468,10 +438,7 @@ def _load_default_schema_def():
 
 def _compare_cosmetic_to_term_ids(obs, cosmetic_col, source_col, exceptions):
     pair_counts = (
-        obs[[source_col, cosmetic_col]]
-        .astype(object)
-        .groupby([source_col, cosmetic_col], dropna=False)
-        .size()
+        obs[[source_col, cosmetic_col]].astype(object).groupby([source_col, cosmetic_col], dropna=False).size()
     )
     canonical_cache: dict[str, str | None] = {}
     errors: list[str] = []

--- a/packages/hca-schema-validator/tests/fixtures/hca_fixtures.py
+++ b/packages/hca-schema-validator/tests/fixtures/hca_fixtures.py
@@ -129,11 +129,21 @@ good_obs["suspension_type"] = good_obs["suspension_type"].astype("category")
 good_obs["tissue_type"] = good_obs["tissue_type"].astype("category")
 good_obs["tissue_type"] = good_obs["tissue_type"].cat.add_categories(["primary cell culture", "organoid", "cell line"])
 for _col in [
-    "sample_id", "library_id", "institute", "library_preparation_batch",
-    "library_sequencing_run", "alignment_software", "manner_of_death",
-    "sample_source", "sample_collection_method", "sampled_site_condition",
-    "sample_preservation_method", "sequenced_fragment", "reference_genome",
-    "cell_enrichment", "gene_annotation_version",
+    "sample_id",
+    "library_id",
+    "institute",
+    "library_preparation_batch",
+    "library_sequencing_run",
+    "alignment_software",
+    "manner_of_death",
+    "sample_source",
+    "sample_collection_method",
+    "sampled_site_condition",
+    "sample_preservation_method",
+    "sequenced_fragment",
+    "reference_genome",
+    "cell_enrichment",
+    "gene_annotation_version",
 ]:
     good_obs[_col] = good_obs[_col].astype("category")
 
@@ -275,11 +285,21 @@ good_obs_visium["tissue_type"] = good_obs_visium["tissue_type"].cat.add_categori
     ["primary cell culture", "organoid", "cell line"]
 )
 for _col in [
-    "sample_id", "library_id", "institute", "library_preparation_batch",
-    "library_sequencing_run", "alignment_software", "manner_of_death",
-    "sample_source", "sample_collection_method", "sampled_site_condition",
-    "sample_preservation_method", "sequenced_fragment", "reference_genome",
-    "cell_enrichment", "gene_annotation_version",
+    "sample_id",
+    "library_id",
+    "institute",
+    "library_preparation_batch",
+    "library_sequencing_run",
+    "alignment_software",
+    "manner_of_death",
+    "sample_source",
+    "sample_collection_method",
+    "sampled_site_condition",
+    "sample_preservation_method",
+    "sequenced_fragment",
+    "reference_genome",
+    "cell_enrichment",
+    "gene_annotation_version",
 ]:
     good_obs_visium[_col] = good_obs_visium[_col].astype("category")
 
@@ -378,11 +398,21 @@ good_obs_slide_seqv2["tissue_type"] = good_obs_slide_seqv2["tissue_type"].cat.ad
     ["primary cell culture", "organoid", "cell line"]
 )
 for _col in [
-    "sample_id", "library_id", "institute", "library_preparation_batch",
-    "library_sequencing_run", "alignment_software", "manner_of_death",
-    "sample_source", "sample_collection_method", "sampled_site_condition",
-    "sample_preservation_method", "sequenced_fragment", "reference_genome",
-    "cell_enrichment", "gene_annotation_version",
+    "sample_id",
+    "library_id",
+    "institute",
+    "library_preparation_batch",
+    "library_sequencing_run",
+    "alignment_software",
+    "manner_of_death",
+    "sample_source",
+    "sample_collection_method",
+    "sampled_site_condition",
+    "sample_preservation_method",
+    "sequenced_fragment",
+    "reference_genome",
+    "cell_enrichment",
+    "gene_annotation_version",
 ]:
     good_obs_slide_seqv2[_col] = good_obs_slide_seqv2[_col].astype("category")
 
@@ -482,11 +512,21 @@ good_obs_visium_is_single_false["tissue_type"] = good_obs_visium_is_single_false
     ["primary cell culture", "organoid", "cell line"]
 )
 for _col in [
-    "sample_id", "library_id", "institute", "library_preparation_batch",
-    "library_sequencing_run", "alignment_software", "manner_of_death",
-    "sample_source", "sample_collection_method", "sampled_site_condition",
-    "sample_preservation_method", "sequenced_fragment", "reference_genome",
-    "cell_enrichment", "gene_annotation_version",
+    "sample_id",
+    "library_id",
+    "institute",
+    "library_preparation_batch",
+    "library_sequencing_run",
+    "alignment_software",
+    "manner_of_death",
+    "sample_source",
+    "sample_collection_method",
+    "sampled_site_condition",
+    "sample_preservation_method",
+    "sequenced_fragment",
+    "reference_genome",
+    "cell_enrichment",
+    "gene_annotation_version",
 ]:
     good_obs_visium_is_single_false[_col] = good_obs_visium_is_single_false[_col].astype("category")
 
@@ -585,11 +625,21 @@ good_obs_mouse["suspension_type"] = good_obs_mouse["suspension_type"].astype("ca
 good_obs_mouse["tissue_type"] = good_obs_mouse["tissue_type"].astype("category")
 good_obs_mouse["tissue_type"] = good_obs_mouse["tissue_type"].cat.add_categories(["tissue", "organoid", "cell line"])
 for _col in [
-    "sample_id", "library_id", "institute", "library_preparation_batch",
-    "library_sequencing_run", "alignment_software", "manner_of_death",
-    "sample_source", "sample_collection_method", "sampled_site_condition",
-    "sample_preservation_method", "sequenced_fragment", "reference_genome",
-    "cell_enrichment", "gene_annotation_version",
+    "sample_id",
+    "library_id",
+    "institute",
+    "library_preparation_batch",
+    "library_sequencing_run",
+    "alignment_software",
+    "manner_of_death",
+    "sample_source",
+    "sample_collection_method",
+    "sampled_site_condition",
+    "sample_preservation_method",
+    "sequenced_fragment",
+    "reference_genome",
+    "cell_enrichment",
+    "gene_annotation_version",
 ]:
     good_obs_mouse[_col] = good_obs_mouse[_col].astype("category")
 

--- a/packages/hca-schema-validator/tests/test_cell_annotation_validator.py
+++ b/packages/hca-schema-validator/tests/test_cell_annotation_validator.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import anndata as ad
 import pytest
-
 from hca_schema_validator import HCACellAnnotationValidator
 from hca_schema_validator.cell_annotation_validator import (
     LEGACY_LAYOUT_ERROR,
@@ -46,6 +45,7 @@ def test_happy_path(cap_h5ad):
 def test_no_cellannotation_metadata_errors(cap_h5ad):
     def mutate(adata):
         _mutate_cap(adata, lambda cap: cap.pop("cellannotation_metadata"))
+
     _rewrite(cap_h5ad, mutate)
 
     v = HCACellAnnotationValidator()
@@ -60,6 +60,7 @@ def test_legacy_toplevel_layout_errors(cap_h5ad):
         cap = dict(adata.uns.pop("cap_metadata"))
         for key, value in cap.items():
             adata.uns[key] = value
+
     _rewrite(cap_h5ad, mutate)
 
     v = HCACellAnnotationValidator()
@@ -72,6 +73,7 @@ def test_mixed_layout_errors(cap_h5ad):
     # rejected — the deprecated key must not slip through.
     def mutate(adata):
         adata.uns["cellannotation_schema_version"] = "1.0.0"
+
     _rewrite(cap_h5ad, mutate)
 
     v = HCACellAnnotationValidator()
@@ -92,6 +94,7 @@ def test_missing_cap_metadata_errors(tmp_path):
 def test_empty_metadata_errors(cap_h5ad):
     def mutate(adata):
         _mutate_cap(adata, lambda cap: cap.update(cellannotation_metadata={}))
+
     _rewrite(cap_h5ad, mutate)
 
     v = HCACellAnnotationValidator()
@@ -102,6 +105,7 @@ def test_empty_metadata_errors(cap_h5ad):
 def test_metadata_wrong_type_errors(cap_h5ad):
     def mutate(adata):
         _mutate_cap(adata, lambda cap: cap.update(cellannotation_metadata="not-a-dict"))
+
     _rewrite(cap_h5ad, mutate)
 
     v = HCACellAnnotationValidator()
@@ -112,6 +116,7 @@ def test_metadata_wrong_type_errors(cap_h5ad):
 def test_missing_schema_version_errors(cap_h5ad):
     def mutate(adata):
         _mutate_cap(adata, lambda cap: cap.pop("cellannotation_schema_version"))
+
     _rewrite(cap_h5ad, mutate)
 
     v = HCACellAnnotationValidator()
@@ -122,6 +127,7 @@ def test_missing_schema_version_errors(cap_h5ad):
 def test_malformed_schema_version_errors(cap_h5ad):
     def mutate(adata):
         _mutate_cap(adata, lambda cap: cap.update(cellannotation_schema_version="not-a-version"))
+
     _rewrite(cap_h5ad, mutate)
 
     v = HCACellAnnotationValidator()
@@ -135,6 +141,7 @@ def test_set_metadata_wrong_type_errors(cap_h5ad):
             adata,
             lambda cap: cap.update(cellannotation_metadata={"author_annotation": "not-a-dict"}),
         )
+
     _rewrite(cap_h5ad, mutate)
 
     v = HCACellAnnotationValidator()
@@ -145,14 +152,12 @@ def test_set_metadata_wrong_type_errors(cap_h5ad):
 def test_missing_required_obs_column_errors(cap_h5ad):
     def mutate(adata):
         adata.obs.drop(columns=["author_annotation--rationale"], inplace=True)
+
     _rewrite(cap_h5ad, mutate)
 
     v = HCACellAnnotationValidator()
     assert v.validate_adata(str(cap_h5ad)) is False
-    assert any(
-        "author_annotation" in e and "author_annotation--rationale" in e
-        for e in v.errors
-    )
+    assert any("author_annotation" in e and "author_annotation--rationale" in e for e in v.errors)
 
 
 def test_validate_adata_resets_state(cap_h5ad, tmp_path):

--- a/packages/hca-schema-validator/tests/test_cell_annotation_validator.py
+++ b/packages/hca-schema-validator/tests/test_cell_annotation_validator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import anndata as ad
 import pytest
+
 from hca_schema_validator import HCACellAnnotationValidator
 from hca_schema_validator.cell_annotation_validator import (
     LEGACY_LAYOUT_ERROR,

--- a/packages/hca-schema-validator/tests/test_labeler.py
+++ b/packages/hca-schema-validator/tests/test_labeler.py
@@ -5,6 +5,7 @@ import copy
 import anndata
 import pandas as pd
 import pytest
+
 from hca_schema_validator import HCALabeler
 
 from .fixtures.hca_fixtures import adata as valid_adata

--- a/packages/hca-schema-validator/tests/test_labeler.py
+++ b/packages/hca-schema-validator/tests/test_labeler.py
@@ -5,7 +5,6 @@ import copy
 import anndata
 import pandas as pd
 import pytest
-
 from hca_schema_validator import HCALabeler
 
 from .fixtures.hca_fixtures import adata as valid_adata
@@ -93,8 +92,7 @@ def test_preflight_fails_on_pre_populated_obs_label(base_adata, tmp_path):
     with pytest.raises(ValueError) as excinfo:
         _label(base_adata, tmp_path)
     assert (
-        "Add labels error: Column 'tissue' is a reserved column name "
-        "of 'obs'. Remove it from h5ad and try again."
+        "Add labels error: Column 'tissue' is a reserved column name of 'obs'. Remove it from h5ad and try again."
     ) in str(excinfo.value)
 
 
@@ -147,10 +145,7 @@ def test_preflight_fails_on_pre_populated_observation_joinid(base_adata, tmp_pat
     with pytest.raises(ValueError) as excinfo:
         _label(base_adata, tmp_path)
     msg = str(excinfo.value)
-    assert (
-        "Column 'observation_joinid' is a reserved column name "
-        "of 'obs'. Remove it from h5ad and try again."
-    ) in msg
+    assert ("Column 'observation_joinid' is a reserved column name of 'obs'. Remove it from h5ad and try again.") in msg
     assert "Add labels error:" not in msg.split("observation_joinid")[0].rsplit("\n", 1)[-1]
 
 

--- a/packages/hca-schema-validator/tests/test_populator.py
+++ b/packages/hca-schema-validator/tests/test_populator.py
@@ -2,6 +2,7 @@
 
 import anndata as ad
 import pandas as pd
+
 from hca_schema_validator import populate_in_memory
 from hca_schema_validator.testing import create_labelable_h5ad
 from hca_schema_validator.validator import _lookup_canonical_label

--- a/packages/hca-schema-validator/tests/test_populator.py
+++ b/packages/hca-schema-validator/tests/test_populator.py
@@ -6,7 +6,6 @@ from hca_schema_validator import populate_in_memory
 from hca_schema_validator.testing import create_labelable_h5ad
 from hca_schema_validator.validator import _lookup_canonical_label
 
-
 # Canonical labels resolved from the fixture's term_ids. Computed once at
 # import so tests don't all pay the ontology-lookup cost.
 _FIXTURE_CANONICAL = {
@@ -109,7 +108,6 @@ def test_partial_fill_obs_when_some_rows_nan(tmp_path):
     in 'filled' (merged values), NOT in 'matched'."""
     adata = _load(create_labelable_h5ad(tmp_path / "partial_obs.h5ad"))
     # 4 rows in the fixture; pre-populate 2 with canonical, 2 with NaN.
-    n = adata.n_obs
     canonical_tissue = _FIXTURE_CANONICAL["tissue"]
     partial = pd.Categorical(
         [canonical_tissue, None, canonical_tissue, None],
@@ -141,10 +139,7 @@ def test_partial_fill_var_when_some_rows_nan(tmp_path):
 
     # On the target file: pre-populate every-other row with the canonical
     # value, leave the rest NaN.
-    partial = [
-        canonical_names[i] if i % 2 == 0 else None
-        for i in range(adata.n_vars)
-    ]
+    partial = [canonical_names[i] if i % 2 == 0 else None for i in range(adata.n_vars)]
     adata.var["feature_name"] = pd.Categorical(partial)
 
     result = populate_in_memory(adata)
@@ -178,10 +173,9 @@ def test_raw_var_mismatch_refuses_not_silently_skips(tmp_path):
     assert "error" in result
     # The error must be attributed to raw.var (the rewrite at fill-time
     # changes the prefix in the message).
-    assert any(
-        "raw.var['feature_name']" in e and "WRONG_RAW_SYMBOL" in e
-        for e in result["details"]["errors"]
-    ), result["details"]["errors"]
+    assert any("raw.var['feature_name']" in e and "WRONG_RAW_SYMBOL" in e for e in result["details"]["errors"]), result[
+        "details"
+    ]["errors"]
 
 
 def test_raw_var_fill_when_empty(tmp_path):
@@ -207,7 +201,6 @@ def test_partial_fill_refuses_when_filled_rows_mismatch(tmp_path):
     canonical → refuse entirely, no fill of the NaN rows. The whole
     point: only fill NaNs when every populated row passes verification."""
     adata = _load(create_labelable_h5ad(tmp_path / "partial_mismatch.h5ad"))
-    n = adata.n_obs
     # Producer wrote a WRONG value on 2 rows, left 2 NaN. No fill should
     # happen even though the NaN rows could be filled — the populated
     # rows fail verification.
@@ -253,9 +246,7 @@ def test_error_on_obs_mismatch(tmp_path):
     assert "error" in result
     assert "details" in result
     assert any(
-        "obs['tissue']" in e
-        and "totally-wrong-tissue-label" in e
-        and "UBERON:0002048" in e
+        "obs['tissue']" in e and "totally-wrong-tissue-label" in e and "UBERON:0002048" in e
         for e in result["details"]["errors"]
     )
 
@@ -268,10 +259,7 @@ def test_error_on_var_mismatch(tmp_path):
     result = populate_in_memory(adata)
 
     assert "error" in result
-    assert any(
-        "var['feature_name']" in e and "WRONG_SYMBOL" in e
-        for e in result["details"]["errors"]
-    )
+    assert any("var['feature_name']" in e and "WRONG_SYMBOL" in e for e in result["details"]["errors"])
 
 
 def test_error_message_distinguishes_unknown_ensembl(tmp_path):
@@ -293,10 +281,7 @@ def test_error_message_distinguishes_unknown_ensembl(tmp_path):
     msgs = result["details"]["errors"]
     # New message format for the NaN-canonical branch — should not
     # render '<NA>'.
-    nan_branch_msgs = [
-        m for m in msgs
-        if "GENCODE has no canonical value" in m
-    ]
+    nan_branch_msgs = [m for m in msgs if "GENCODE has no canonical value" in m]
     assert nan_branch_msgs, f"expected NaN-canonical branch message, got: {msgs}"
     assert not any("'<NA>'" in m for m in nan_branch_msgs), (
         f"NaN-canonical messages must not format canonical as '<NA>': {nan_branch_msgs}"
@@ -324,9 +309,7 @@ def test_partial_mix_mismatch_blocks_all(tmp_path):
 
 def test_refuse_sre_present(tmp_path):
     adata = _load(create_labelable_h5ad(tmp_path / "sre.h5ad"))
-    adata.obs["self_reported_ethnicity_ontology_term_id"] = pd.Categorical(
-        ["unknown"] * adata.n_obs
-    )
+    adata.obs["self_reported_ethnicity_ontology_term_id"] = pd.Categorical(["unknown"] * adata.n_obs)
 
     result = populate_in_memory(adata)
     assert "error" in result
@@ -371,9 +354,7 @@ def test_refuse_observation_joinid_present(tmp_path):
 
     adata = _load(create_labelable_h5ad(tmp_path / "with_joinid.h5ad"))
     # No schema_version, no provenance/cellxgene — only the joinid.
-    adata.obs["observation_joinid"] = pd.Categorical(
-        [f"joinid_{i}" for i in range(adata.n_obs)]
-    )
+    adata.obs["observation_joinid"] = pd.Categorical([f"joinid_{i}" for i in range(adata.n_obs)])
 
     result = populate_in_memory(adata)
     assert "error" in result
@@ -402,21 +383,22 @@ def test_does_NOT_check_edit_log(tmp_path):
     import json
 
     adata = _load(create_labelable_h5ad(tmp_path / "with_import.h5ad"))
-    seed = json.dumps([{
-        "timestamp": "2026-01-01T00:00:00+00:00",
-        "tool": "hca-anndata-tools",
-        "tool_version": "0.0.0",
-        "operation": "import_cellxgene",
-        "description": "Imported from CellxGENE Discover",
-        "details": {},
-        "source_file": "x.h5ad",
-        "source_sha256": "0" * 64,
-    }])
+    seed = json.dumps(
+        [
+            {
+                "timestamp": "2026-01-01T00:00:00+00:00",
+                "tool": "hca-anndata-tools",
+                "tool_version": "0.0.0",
+                "operation": "import_cellxgene",
+                "description": "Imported from CellxGENE Discover",
+                "details": {},
+                "source_file": "x.h5ad",
+                "source_sha256": "0" * 64,
+            }
+        ]
+    )
     adata.uns.setdefault("provenance", {})["edit_history"] = seed
 
     # Should NOT refuse — origin check is the wrapper's concern.
     result = populate_in_memory(adata)
-    assert "error" not in result, (
-        "populator must not check edit log; that's the wrapper's job. "
-        f"Got: {result}"
-    )
+    assert "error" not in result, f"populator must not check edit log; that's the wrapper's job. Got: {result}"

--- a/packages/hca-schema-validator/tests/test_validator.py
+++ b/packages/hca-schema-validator/tests/test_validator.py
@@ -53,7 +53,7 @@ def test_instantiate():
     """Test that HCAValidator can be instantiated."""
     validator = HCAValidator()
     assert validator is not None
-    assert hasattr(validator, 'validate_adata')
+    assert hasattr(validator, "validate_adata")
 
 
 def test_inheritance():
@@ -69,12 +69,12 @@ def test_has_validation_methods():
     validator = HCAValidator()
 
     # Public methods
-    assert hasattr(validator, 'validate_adata')
+    assert hasattr(validator, "validate_adata")
 
     # Protected methods (can override later)
-    assert hasattr(validator, '_deep_check')
-    assert hasattr(validator, '_validate_feature_ids')
-    assert hasattr(validator, '_set_schema_def')
+    assert hasattr(validator, "_deep_check")
+    assert hasattr(validator, "_validate_feature_ids")
+    assert hasattr(validator, "_set_schema_def")
 
 
 def test_validate_valid_h5ad():
@@ -138,8 +138,9 @@ def test_organism_in_obs():
 
         # Should not have errors about organism being deprecated in obs
         for error in validator.errors:
-            assert not ("organism" in error.lower() and "deprecated" in error.lower()), \
+            assert not ("organism" in error.lower() and "deprecated" in error.lower()), (
                 "organism_ontology_term_id should not be deprecated in obs for HCA schema"
+            )
 
 
 def test_valid_adata_passes():
@@ -159,6 +160,7 @@ def _cosmetic_check_messages(validator):
     cosmetic-check message names its column as `obs['<col>']`; the curie validator's
     errors name the bare `<col>_ontology_term_id`, so they don't collide.
     """
+
     def about_a_label_column(message):
         return any(f"obs['{col}']" in message for col in HCA_DERIVED_OBS_LABELS)
 
@@ -198,10 +200,7 @@ def test_cosmetic_check_error_on_mismatch():
     _, validator = _validate_from_fixture(modified)
     warnings, errors = _cosmetic_check_messages(validator)
     assert warnings == []
-    assert any(
-        "'WRONG_LABEL'" in e and "UBERON:0002048" in e and "'lung'" in e
-        for e in errors
-    ), errors
+    assert any("'WRONG_LABEL'" in e and "UBERON:0002048" in e and "'lung'" in e for e in errors), errors
 
 
 def test_cosmetic_check_aggregates_across_columns():
@@ -228,10 +227,7 @@ def test_cosmetic_check_handles_optional_cell_type_with_source_present():
     _, validator = _validate_from_fixture(modified)
     warnings, errors = _cosmetic_check_messages(validator)
     assert warnings == []
-    assert any(
-        "'WRONG_CELL_TYPE'" in e and "CL:0000066" in e and "'epithelial cell'" in e
-        for e in errors
-    ), errors
+    assert any("'WRONG_CELL_TYPE'" in e and "CL:0000066" in e and "'epithelial cell'" in e for e in errors), errors
 
 
 def test_cosmetic_check_warns_when_source_column_absent():
@@ -293,8 +289,7 @@ def test_cosmetic_check_error_on_value_with_nan_term_id():
     warnings, errors = _cosmetic_check_messages(validator)
     assert warnings == []
     assert any(
-        "have NaN in cell_type_ontology_term_id" in e and "1 rows labeled 'PRODUCER_LABEL'" in e
-        for e in errors
+        "have NaN in cell_type_ontology_term_id" in e and "1 rows labeled 'PRODUCER_LABEL'" in e for e in errors
     ), errors
 
 
@@ -339,12 +334,7 @@ def test_cosmetic_check_sentinel_values_mismatch_errors():
     _, validator = _validate_from_fixture(modified)
     warnings, errors = _cosmetic_check_messages(validator)
     assert warnings == []
-    assert any(
-        "sex_ontology_term_id" in e
-        and "'PRODUCER_LABEL'" in e
-        and "'unknown'" in e
-        for e in errors
-    ), errors
+    assert any("sex_ontology_term_id" in e and "'PRODUCER_LABEL'" in e and "'unknown'" in e for e in errors), errors
 
 
 def test_check_cosmetic_labels_loads_default_schema_when_omitted():
@@ -404,10 +394,7 @@ def test_cosmetic_check_fires_with_ignore_labels_false():
 
 
 def _forbidden_errors(validator):
-    return [
-        e for e in validator.errors
-        if "must not be present" in e and "self_reported_ethnicity" in e
-    ]
+    return [e for e in validator.errors if "must not be present" in e and "self_reported_ethnicity" in e]
 
 
 def test_forbidden_sre_columns_absent_passes():
@@ -726,6 +713,7 @@ def test_pattern_rejects_gene_annotation_version_with_trailing_garbage():
 # Direct unit tests for _validate_list and _validate_column overrides
 # ---------------------------------------------------------------------------
 
+
 class TestValidateList:
     """Direct unit tests for HCAValidator._validate_list with element_type 'string'."""
 
@@ -908,6 +896,7 @@ class TestValidateColumn:
 def test_feature_id_warnings_come_last():
     """Feature ID warnings (not found in GENCODE) should be sorted after other warnings."""
     from hca_schema_validator.validator import HCAValidator
+
     v = HCAValidator()
     # Simulate mixed warnings (with WARNING: prefix added by base validate_adata)
     v.warnings = [
@@ -983,6 +972,7 @@ def test_optional_column_emits_warning_message():
     test_adata.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
 
     from hca_schema_validator.validator import HCAValidator
+
     v = HCAValidator()
     v.reset()
     v.adata = test_adata
@@ -1017,13 +1007,9 @@ def test_raw_validation_runs_despite_unrelated_errors():
     assert is_valid is False
 
     # The "raw layer was not performed" warning should be absent
-    raw_skip_warnings = [
-        w for w in validator.warnings
-        if "Validation of raw layer was not performed" in w
-    ]
+    raw_skip_warnings = [w for w in validator.warnings if "Validation of raw layer was not performed" in w]
     assert len(raw_skip_warnings) == 0, (
-        f"Raw validation was skipped despite assay_ontology_term_id being present. "
-        f"Warnings: {validator.warnings}"
+        f"Raw validation was skipped despite assay_ontology_term_id being present. Warnings: {validator.warnings}"
     )
 
 
@@ -1045,9 +1031,7 @@ def test_non_schema_obs_column_with_unused_categories_is_skipped():
 
     _, validator = _validate_from_fixture(modified)
 
-    barcode_messages = [
-        m for m in (validator.warnings + validator.errors) if "barcode" in m
-    ]
+    barcode_messages = [m for m in (validator.warnings + validator.errors) if "barcode" in m]
     assert barcode_messages == [], (
         f"Expected no validator messages about non-schema 'barcode' column; got: {barcode_messages}"
     )
@@ -1071,10 +1055,7 @@ def test_schema_obs_column_with_unused_categories_still_warns():
 
     _, validator = _validate_from_fixture(modified)
 
-    sample_id_zero_obs = [
-        w for w in validator.warnings
-        if "sample_id" in w and "zero observations" in w
-    ]
+    sample_id_zero_obs = [w for w in validator.warnings if "sample_id" in w and "zero observations" in w]
     assert len(sample_id_zero_obs) >= 1, (
         f"Expected at least one zero-observation warning for schema column 'sample_id'; "
         f"got warnings: {validator.warnings}"

--- a/packages/hca-schema-validator/tests/test_validator.py
+++ b/packages/hca-schema-validator/tests/test_validator.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import pytest
+
 from hca_schema_validator import HCA_DERIVED_OBS_LABELS, HCAValidator
 
 # Test fixtures directory

--- a/packages/hca-schema-validator/validate_file.py
+++ b/packages/hca-schema-validator/validate_file.py
@@ -6,12 +6,14 @@ Usage:
     uv run python validate_file.py <path/to/file.h5ad>
     uv run python validate_file.py <path/to/file.h5ad> --with-labels
 """
+
 import argparse
 
 from hca_schema_validator import HCAValidator
 
 # Display constants
 SEPARATOR_WIDTH = 70
+
 
 def main():
     # Parse command-line arguments
@@ -22,16 +24,13 @@ def main():
 Examples:
   uv run python validate_file.py data.h5ad
   uv run python validate_file.py data.h5ad --with-labels
-        """
+        """,
     )
-    parser.add_argument(
-        "file",
-        help="Path to the h5ad file to validate"
-    )
+    parser.add_argument("file", help="Path to the h5ad file to validate")
     parser.add_argument(
         "--with-labels",
         action="store_true",
-        help="Include label validation (gene ID checks, etc.). Default: skip labels"
+        help="Include label validation (gene ID checks, etc.). Default: skip labels",
     )
 
     args = parser.parse_args()
@@ -71,6 +70,7 @@ Examples:
 
     if not validator.errors and not validator.warnings:
         print("No errors or warnings! 🎉\n")
+
 
 if __name__ == "__main__":
     main()

--- a/ruff.toml
+++ b/ruff.toml
@@ -8,3 +8,8 @@ extend-exclude = [
 
 [lint]
 select = ["E", "F", "I", "W"]
+
+[lint.per-file-ignores]
+# __init__.py files re-export their package's public API; the imports are
+# intentional and covered by __all__ / lazy __getattr__ patterns, not dead code.
+"__init__.py" = ["F401"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -13,3 +13,19 @@ select = ["E", "F", "I", "W"]
 # __init__.py files re-export their package's public API; the imports are
 # intentional and covered by __all__ / lazy __getattr__ patterns, not dead code.
 "__init__.py" = ["F401"]
+
+[lint.isort]
+# Declare our packages explicitly so import grouping (I001) is identical in
+# every environment. Ruff's auto-detection of first-party vs third-party varies
+# with where it runs from (it classified `hca_validation` first-party locally
+# but third-party in CI), which made the same file pass locally and fail in CI.
+known-first-party = [
+    "hca_validation",
+    "hca_anndata_tools",
+    "hca_anndata_mcp",
+    "hca_schema_validator",
+    "hca_schema_validator_service",
+    "dataset_validator",
+    "cellxgene_validator",
+    "entry_sheet_validator_lambda",
+]

--- a/services/cellxgene-validator/src/cellxgene_validator/main.py
+++ b/services/cellxgene-validator/src/cellxgene_validator/main.py
@@ -1,45 +1,46 @@
-import sys
-import logging
 import json
+import logging
+import sys
+
 from cellxgene_schema.validate import validate
 
-class ListHandler(logging.Handler):
-  """
-  Custom logging handler to capture warning and error messages.
-  """
-  def __init__(self, warning_list, error_list):
-    super().__init__()
-    self.warning_list = warning_list
-    self.error_list = error_list
 
-  def emit(self, record):
-    if record.levelno == logging.ERROR:
-      self.error_list.append(self.format(record))
-    elif record.levelno == logging.WARNING:
-      self.warning_list.append(self.format(record))
+class ListHandler(logging.Handler):
+    """
+    Custom logging handler to capture warning and error messages.
+    """
+
+    def __init__(self, warning_list, error_list):
+        super().__init__()
+        self.warning_list = warning_list
+        self.error_list = error_list
+
+    def emit(self, record):
+        if record.levelno == logging.ERROR:
+            self.error_list.append(self.format(record))
+        elif record.levelno == logging.WARNING:
+            self.warning_list.append(self.format(record))
+
 
 def run_validator(file_path):
-  logger = logging.getLogger("cellxgene_schema.validate")
-  logger.setLevel(logging.WARNING)
-  warning_messages = []
-  error_messages = []
-  logger.addHandler(ListHandler(warning_messages, error_messages))
-
-  try:
-    is_valid, _, _ = validate(file_path, ignore_labels=True)
-  except Exception as e:
-    is_valid = False
+    logger = logging.getLogger("cellxgene_schema.validate")
+    logger.setLevel(logging.WARNING)
     warning_messages = []
-    error_messages = [f"Encountered an unexpected error while calling CELLxGENE validator: {e}"]
+    error_messages = []
+    logger.addHandler(ListHandler(warning_messages, error_messages))
 
-  return {
-    "valid": is_valid,
-    "warnings": warning_messages,
-    "errors": error_messages
-  }
+    try:
+        is_valid, _, _ = validate(file_path, ignore_labels=True)
+    except Exception as e:
+        is_valid = False
+        warning_messages = []
+        error_messages = [f"Encountered an unexpected error while calling CELLxGENE validator: {e}"]
+
+    return {"valid": is_valid, "warnings": warning_messages, "errors": error_messages}
+
 
 if __name__ == "__main__":
-  if len(sys.argv) < 2:
-    raise Exception("Missing command line argument for file path")
-  
-  print(json.dumps(run_validator(sys.argv[1])))
+    if len(sys.argv) < 2:
+        raise Exception("Missing command line argument for file path")
+
+    print(json.dumps(run_validator(sys.argv[1])))

--- a/services/cellxgene-validator/tests/test_cellxgene_validator.py
+++ b/services/cellxgene-validator/tests/test_cellxgene_validator.py
@@ -1,95 +1,90 @@
 import logging
-from unittest.mock import MagicMock, patch
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 from cellxgene_validator.main import run_validator
 
-@pytest.mark.parametrize("test_case", [
-  {
-    "name": "valid_no_messages",
-    "description": "Test fully-successful validation",
-    "file_path": "test.h5ad",
-    "logs": [
-      (logging.INFO, "Info foo")
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        {
+            "name": "valid_no_messages",
+            "description": "Test fully-successful validation",
+            "file_path": "test.h5ad",
+            "logs": [(logging.INFO, "Info foo")],
+            "is_valid": True,
+            "error": None,
+            "expected_output": {"valid": True, "errors": [], "warnings": []},
+        },
+        {
+            "name": "valid_with_warnings",
+            "description": "Test successful validation with warnings",
+            "file_path": "test.h5ad",
+            "logs": [
+                (logging.INFO, "Info foo"),
+                (logging.WARNING, "Warning foo"),
+                (logging.WARNING, "Warning bar"),
+                (logging.DEBUG, "Debug foo"),
+            ],
+            "is_valid": True,
+            "error": None,
+            "expected_output": {"valid": True, "errors": [], "warnings": ["Warning foo", "Warning bar"]},
+        },
+        {
+            "name": "invalid",
+            "description": "Test validation with errors and warnings",
+            "file_path": "test.h5ad",
+            "logs": [
+                (logging.ERROR, "Error foo"),
+                (logging.WARNING, "Warning foo"),
+                (logging.ERROR, "Error bar"),
+                (logging.ERROR, "Error baz"),
+            ],
+            "is_valid": False,
+            "error": None,
+            "expected_output": {
+                "valid": False,
+                "errors": ["Error foo", "Error bar", "Error baz"],
+                "warnings": ["Warning foo"],
+            },
+        },
+        {
+            "name": "error",
+            "description": "Test validation with error in validation process",
+            "file_path": "test.h5ad",
+            "logs": [
+                (logging.WARNING, "Warning foo"),
+            ],
+            "is_valid": None,
+            "error": Exception("Error in validation"),
+            "expected_output": {
+                "valid": False,
+                "errors": ["Encountered an unexpected error while calling CELLxGENE validator: Error in validation"],
+                "warnings": [],
+            },
+        },
     ],
-    "is_valid": True,
-    "error": None,
-    "expected_output": {
-      "valid": True,
-      "errors": [],
-      "warnings": []
-    }
-  },
-  {
-    "name": "valid_with_warnings",
-    "description": "Test successful validation with warnings",
-    "file_path": "test.h5ad",
-    "logs": [
-      (logging.INFO, "Info foo"),
-      (logging.WARNING, "Warning foo"),
-      (logging.WARNING, "Warning bar"),
-      (logging.DEBUG, "Debug foo")
-    ],
-    "is_valid": True,
-    "error": None,
-    "expected_output": {
-      "valid": True,
-      "errors": [],
-      "warnings": ["Warning foo", "Warning bar"]
-    }
-  },
-  {
-    "name": "invalid",
-    "description": "Test validation with errors and warnings",
-    "file_path": "test.h5ad",
-    "logs": [
-      (logging.ERROR, "Error foo"),
-      (logging.WARNING, "Warning foo"),
-      (logging.ERROR, "Error bar"),
-      (logging.ERROR, "Error baz")
-    ],
-    "is_valid": False,
-    "error": None,
-    "expected_output": {
-      "valid": False,
-      "errors": ["Error foo", "Error bar", "Error baz"],
-      "warnings": ["Warning foo"]
-    }
-  },
-  {
-    "name": "error",
-    "description": "Test validation with error in validation process",
-    "file_path": "test.h5ad",
-    "logs": [
-      (logging.WARNING, "Warning foo"),
-    ],
-    "is_valid": None,
-    "error": Exception("Error in validation"),
-    "expected_output": {
-      "valid": False,
-      "errors": ["Encountered an unexpected error while calling CELLxGENE validator: Error in validation"],
-      "warnings": []
-    }
-  }
-], ids=lambda x: x["name"])
+    ids=lambda x: x["name"],
+)
 @patch("cellxgene_validator.main.validate")
 def test_cellxgene_validator_cases(mock_validate, test_case):
-  def do_mock_validate(_, **__):
-    logger = logging.getLogger("cellxgene_schema.validate")
-    for level, message in test_case["logs"]:
-      logger.log(level, message)
-    return (test_case["is_valid"], None, None)
+    def do_mock_validate(_, **__):
+        logger = logging.getLogger("cellxgene_schema.validate")
+        for level, message in test_case["logs"]:
+            logger.log(level, message)
+        return (test_case["is_valid"], None, None)
 
-  if test_case["error"]:
-    mock_validate.side_effect = test_case["error"]
-  else:
-    mock_validate.side_effect = do_mock_validate
+    if test_case["error"]:
+        mock_validate.side_effect = test_case["error"]
+    else:
+        mock_validate.side_effect = do_mock_validate
 
-  result = run_validator(test_case["file_path"])
+    result = run_validator(test_case["file_path"])
 
-  mock_validate.assert_called_once_with(test_case["file_path"], ignore_labels=True)
-  assert result == test_case["expected_output"]
+    mock_validate.assert_called_once_with(test_case["file_path"], ignore_labels=True)
+    assert result == test_case["expected_output"]

--- a/services/dataset-validator/src/dataset_validator/cap_validator_script.py
+++ b/services/dataset-validator/src/dataset_validator/cap_validator_script.py
@@ -21,11 +21,15 @@ from cap_upload_validator.errors import CapException, CapMultiException
 
 def main() -> None:
     if len(sys.argv) < 2:
-        print(json.dumps({
-            "valid": False,
-            "errors": ["Missing required file path argument."],
-            "warnings": [],
-        }))
+        print(
+            json.dumps(
+                {
+                    "valid": False,
+                    "errors": ["Missing required file path argument."],
+                    "warnings": [],
+                }
+            )
+        )
         sys.exit(1)
 
     file_path = sys.argv[1]
@@ -44,9 +48,7 @@ def main() -> None:
     except CapMultiException as multi_ex:
         errors.extend(str(e) for e in multi_ex.ex_list)
     except (CapException, Exception) as e:
-        errors.append(
-            f"Encountered an unexpected error while calling CAP validator: {e}"
-        )
+        errors.append(f"Encountered an unexpected error while calling CAP validator: {e}")
     finally:
         # Capture anything the validator printed, then restore stdout
         captured = sys.stdout.getvalue()

--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -12,8 +12,8 @@ import logging
 import os
 import resource
 import shutil
-import sys
 import subprocess
+import sys
 from dataclasses import asdict, dataclass, fields
 from datetime import datetime, timezone
 from pathlib import Path
@@ -21,15 +21,14 @@ from types import SimpleNamespace
 from typing import Callable, List, Optional, Tuple, cast
 
 import boto3
-from botocore.exceptions import ClientError
-from anndata.io import read_elem
 import h5py
 import pandas as pd
+from anndata.io import read_elem
+from botocore.exceptions import ClientError
 
-from hca_validation.metadata_coverage import compute_metadata_coverage
 from hca_validation.h5ad_storage import get_matrix_storage
+from hca_validation.metadata_coverage import compute_metadata_coverage
 from hca_validation.schema_utils import load_schemaview
-
 
 # S3 prefix under which full validation results are written as a "claim check".
 # The tracker reads the full results from this object; the SNS body carries only
@@ -39,33 +38,33 @@ S3_VALIDATION_METADATA_PREFIX = "validation-metadata"
 
 # Environment variable constants
 # Batch job variables
-S3_BUCKET = 'S3_BUCKET'
-S3_KEY = 'S3_KEY'
-VALIDATION_RESULTS_BUCKET = 'VALIDATION_RESULTS_BUCKET'
-LOG_LEVEL = 'LOG_LEVEL'
-FILE_ID = 'FILE_ID'
-SNS_TOPIC_ARN = 'SNS_TOPIC_ARN'
-AWS_BATCH_JOB_ID = 'AWS_BATCH_JOB_ID'
-AWS_BATCH_JOB_NAME = 'AWS_BATCH_JOB_NAME'
-AWS_DEFAULT_REGION = 'AWS_DEFAULT_REGION'
+S3_BUCKET = "S3_BUCKET"
+S3_KEY = "S3_KEY"
+VALIDATION_RESULTS_BUCKET = "VALIDATION_RESULTS_BUCKET"
+LOG_LEVEL = "LOG_LEVEL"
+FILE_ID = "FILE_ID"
+SNS_TOPIC_ARN = "SNS_TOPIC_ARN"
+AWS_BATCH_JOB_ID = "AWS_BATCH_JOB_ID"
+AWS_BATCH_JOB_NAME = "AWS_BATCH_JOB_NAME"
+AWS_DEFAULT_REGION = "AWS_DEFAULT_REGION"
 # Local file mode — bypass S3 download and integrity checks
-LOCAL_FILE = 'LOCAL_FILE'
+LOCAL_FILE = "LOCAL_FILE"
 # Validator path variables
-CELLXGENE_VALIDATOR_VENV = 'CELLXGENE_VALIDATOR_VENV'
+CELLXGENE_VALIDATOR_VENV = "CELLXGENE_VALIDATOR_VENV"
 CELLXGENE_VALIDATOR_SCRIPT = "CELLXGENE_VALIDATOR_SCRIPT"
-HCA_SCHEMA_VALIDATOR_VENV = 'HCA_SCHEMA_VALIDATOR_VENV'
+HCA_SCHEMA_VALIDATOR_VENV = "HCA_SCHEMA_VALIDATOR_VENV"
 HCA_SCHEMA_VALIDATOR_SCRIPT = "HCA_SCHEMA_VALIDATOR_SCRIPT"
 HCA_CELL_ANNOTATION_VALIDATOR_SCRIPT = "HCA_CELL_ANNOTATION_VALIDATOR_SCRIPT"
 CAP_VALIDATOR_SCRIPT = "CAP_VALIDATOR_SCRIPT"
 
 # Status constants
-STATUS_SUCCESS = 'success'
-STATUS_FAILURE = 'failure'
+STATUS_SUCCESS = "success"
+STATUS_FAILURE = "failure"
 
 # Integrity status constants
-INTEGRITY_VALID = 'valid'
-INTEGRITY_INVALID = 'invalid'
-INTEGRITY_ERROR = 'error'
+INTEGRITY_VALID = "valid"
+INTEGRITY_INVALID = "invalid"
+INTEGRITY_ERROR = "error"
 
 
 class JobContextFilter(logging.Filter):
@@ -74,11 +73,12 @@ class JobContextFilter(logging.Filter):
     In AWS Batch, the container environment is immutable for the lifetime of a job.
     We cache these values once at initialization for clarity and minimal overhead.
     """
+
     def __init__(self) -> None:
         super().__init__()
         self._job_id = os.environ.get(AWS_BATCH_JOB_ID, "unknown")
         # Prefer non-reserved name inside container
-        self._job_name = os.environ.get('BATCH_JOB_NAME', "-")
+        self._job_name = os.environ.get("BATCH_JOB_NAME", "-")
 
     def filter(self, record: logging.LogRecord) -> bool:
         record.job_id = self._job_id
@@ -89,6 +89,7 @@ class JobContextFilter(logging.Filter):
 @dataclass
 class MetadataSummary:
     """Summary of metadata from a dataset file."""
+
     title: str
     assay: List[str]
     suspension_type: List[str]
@@ -97,14 +98,17 @@ class MetadataSummary:
     cell_count: int
     gene_count: int
 
+
 @dataclass
 class ValidationToolReport:
     """Validation report and metadata of a run of an individual validation tool."""
+
     valid: bool
     errors: List[str]
     warnings: List[str]
     started_at: str
     finished_at: str
+
 
 @dataclass
 class ValidationMessagePointer:
@@ -119,67 +123,67 @@ class ValidationMessagePointer:
     containing the validation results; the location of the latter is derived
     automatically by the tracker.
     """
-    file_id: str              # UUID from Tracker database
-    status: str               # "success", "failure"
-    timestamp: str            # ISO format timestamp (UTC)
-    bucket: str               # S3 bucket name for the file that was validated
-    key: str                  # S3 object key for the file that was validated
-    batch_job_id: str         # Unique AWS Batch job ID for debugging
+
+    file_id: str  # UUID from Tracker database
+    status: str  # "success", "failure"
+    timestamp: str  # ISO format timestamp (UTC)
+    bucket: str  # S3 bucket name for the file that was validated
+    key: str  # S3 object key for the file that was validated
+    batch_job_id: str  # Unique AWS Batch job ID for debugging
 
     def to_json(self) -> str:
         """Convert to JSON string."""
-        return json.dumps(asdict(self), separators=(',', ':'))
+        return json.dumps(asdict(self), separators=(",", ":"))
 
 
 @dataclass
 class ValidationMessage(ValidationMessagePointer):
     """Full validation result. Written to S3 as a claim check; the SNS body
     carries only the ValidationMessagePointer subset (see to_pointer)."""
+
     # Optional fields
-    batch_job_name: Optional[str] = None                 # Job definition name (for context)
-    downloaded_sha256: Optional[str] = None              # SHA256 computed from downloaded file
-    source_sha256: Optional[str] = None                  # SHA256 from S3 metadata
-    integrity_status: Optional[str] = None               # "valid", "invalid", "error"
-    metadata_summary: Optional[MetadataSummary] = None   # Metadata from the file
-    tool_reports: Optional[                              # Reports for individual validation tools
+    batch_job_name: Optional[str] = None  # Job definition name (for context)
+    downloaded_sha256: Optional[str] = None  # SHA256 computed from downloaded file
+    source_sha256: Optional[str] = None  # SHA256 from S3 metadata
+    integrity_status: Optional[str] = None  # "valid", "invalid", "error"
+    metadata_summary: Optional[MetadataSummary] = None  # Metadata from the file
+    tool_reports: Optional[  # Reports for individual validation tools
         dict[str, ValidationToolReport]
     ] = None
-    metadata_coverage: Optional[dict] = None             # Per-field completeness summary (#405)
-    matrix_storage: Optional[dict] = None                # Per-matrix/layer shape + size, from HDF5 header (#447)
-    error_message: Optional[str] = None                  # Human-readable error description
+    metadata_coverage: Optional[dict] = None  # Per-field completeness summary (#405)
+    matrix_storage: Optional[dict] = None  # Per-matrix/layer shape + size, from HDF5 header (#447)
+    error_message: Optional[str] = None  # Human-readable error description
 
     def to_pointer(self) -> ValidationMessagePointer:
         """Project to the pointer-only payload published to SNS."""
-        return ValidationMessagePointer(
-            **{f.name: getattr(self, f.name) for f in fields(ValidationMessagePointer)}
-        )
+        return ValidationMessagePointer(**{f.name: getattr(self, f.name) for f in fields(ValidationMessagePointer)})
 
 
 def configure_logging() -> logging.Logger:
     """Configure logging for CloudWatch compatibility."""
     # Get log level from environment variable (default to INFO)
-    log_level = os.environ.get(LOG_LEVEL, 'INFO').upper()
-    
+    log_level = os.environ.get(LOG_LEVEL, "INFO").upper()
+
     logger = logging.getLogger(__name__)
     logger.setLevel(getattr(logging, log_level))
-    
+
     # Only add handlers if none exist (respects caplog handlers)
     if not logger.handlers:
         handler = logging.StreamHandler(sys.stdout)
         # Enrich logs with Batch context
         handler.addFilter(JobContextFilter())
         formatter = logging.Formatter(
-            '%(asctime)s [%(levelname)s] job_id=%(job_id)s job_name=%(job_name)s %(name)s: %(message)s',
-            datefmt='%Y-%m-%d %H:%M:%S'
+            "%(asctime)s [%(levelname)s] job_id=%(job_id)s job_name=%(job_name)s %(name)s: %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
         )
         handler.setFormatter(formatter)
         logger.addHandler(handler)
-    
+
     # Set boto3 logging to WARNING to reduce noise
-    logging.getLogger('boto3').setLevel(logging.WARNING)
-    logging.getLogger('botocore').setLevel(logging.WARNING)
-    logging.getLogger('urllib3').setLevel(logging.WARNING)
-    
+    logging.getLogger("boto3").setLevel(logging.WARNING)
+    logging.getLogger("botocore").setLevel(logging.WARNING)
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+
     return logger
 
 
@@ -217,25 +221,25 @@ def publish_validation_result(message: ValidationMessage, sns_topic_arn: str) ->
 
         # Create SNS client
         # Let boto3 resolve region from the environment/metadata
-        sns_client = boto3.client('sns')
+        sns_client = boto3.client("sns")
 
         # Publish message
         response = sns_client.publish(
             TopicArn=sns_topic_arn,
             Message=message.to_pointer().to_json(),
-            Subject=f"Dataset Validation Result - {message.status.upper()}"
+            Subject=f"Dataset Validation Result - {message.status.upper()}",
         )
-        
-        message_id = response.get('MessageId', 'unknown')
+
+        message_id = response.get("MessageId", "unknown")
         logger.info("Successfully published SNS message: %s", message_id)
         return True
-        
+
     except ClientError as e:
-        error_code = e.response.get('Error', {}).get('Code', 'Unknown')
-        error_message = e.response.get('Error', {}).get('Message', str(e))
+        error_code = e.response.get("Error", {}).get("Code", "Unknown")
+        error_message = e.response.get("Error", {}).get("Message", str(e))
         logger.error("SNS publish failed [%s]: %s", error_code, error_message)
         return False
-        
+
     except Exception as e:
         logger.error("Unexpected error publishing to SNS: %s", str(e))
         return False
@@ -274,12 +278,12 @@ def write_validation_results_to_s3(
     """
     key = f"{S3_VALIDATION_METADATA_PREFIX}/{file_id}/{batch_job_id}.json"
     try:
-        s3_client = boto3.client('s3')
+        s3_client = boto3.client("s3")
         s3_client.put_object(
             Bucket=bucket,
             Key=key,
-            Body=message.to_json().encode('utf-8'),
-            ContentType='application/json',
+            Body=message.to_json().encode("utf-8"),
+            ContentType="application/json",
         )
         logger.info("S3 claim check write succeeded for file %s", file_id)
         return True
@@ -298,21 +302,21 @@ def create_work_directory(work_dir: str = "/tmp/dataset_validator") -> Path:
 def compute_sha256(file_path: Path) -> str:
     """
     Compute SHA256 hash of a file using streaming to handle large files efficiently.
-    
+
     Args:
         file_path: Path to the file to hash
-        
+
     Returns:
         Hexadecimal SHA256 hash string
     """
     logger.debug("Computing SHA256 for: %s", file_path)
     sha256_hash = hashlib.sha256()
-    
+
     with open(file_path, "rb") as f:
         # Read file in 64KB chunks to handle large files efficiently
         for chunk in iter(lambda: f.read(65536), b""):
             sha256_hash.update(chunk)
-    
+
     computed_hash = sha256_hash.hexdigest()
     logger.debug("Computed SHA256: %s", computed_hash)
     return computed_hash
@@ -321,23 +325,22 @@ def compute_sha256(file_path: Path) -> str:
 def verify_file_integrity(file_path: Path, expected_sha256: str) -> bool:
     """
     Verify file integrity by comparing computed SHA256 with expected value.
-    
+
     Args:
         file_path: Path to the file to verify
         expected_sha256: Expected SHA256 hash from S3 metadata
-        
+
     Returns:
         True if hashes match, False otherwise
     """
     logger.info("Verifying file integrity: %s", file_path)
     computed_sha256 = compute_sha256(file_path)
-    
+
     if computed_sha256.lower() == expected_sha256.lower():
         logger.info("File integrity verified successfully")
         return True
     else:
-        logger.error("File integrity check failed - computed: %s, expected: %s", 
-                    computed_sha256, expected_sha256)
+        logger.error("File integrity check failed - computed: %s, expected: %s", computed_sha256, expected_sha256)
         return False
 
 
@@ -349,7 +352,7 @@ def get_column_unique_values_if_present(df: pd.DataFrame, name: str, map_value=s
         df: Dataframe to get values from
         name: Name of the dataframe column to get values from
         map_value: Function to apply to each value to get the value to be used in the result (defaults to `str`)
-    
+
     Returns:
         Unique mapped values from the specified column
     """
@@ -481,9 +484,7 @@ def apply_cap_validator(file_path: Path) -> ValidationToolReport:
     started_at = datetime.now(timezone.utc)
 
     # Determine script path from env var or default (co-located script)
-    script_path = os.environ.get(CAP_VALIDATOR_SCRIPT) or str(
-        get_default_cap_validator_script_path()
-    )
+    script_path = os.environ.get(CAP_VALIDATOR_SCRIPT) or str(get_default_cap_validator_script_path())
 
     try:
         result = subprocess.run(
@@ -494,9 +495,7 @@ def apply_cap_validator(file_path: Path) -> ValidationToolReport:
         if result.stderr:
             logger.warning("CAP validator stderr: %s", result.stderr.strip())
         if result.returncode != 0:
-            raise subprocess.CalledProcessError(
-                result.returncode, script_path, result.stdout, result.stderr
-            )
+            raise subprocess.CalledProcessError(result.returncode, script_path, result.stdout, result.stderr)
         validator_output = json.loads(result.stdout)
     except Exception as e:
         message = f"Encountered an unexpected error while calling CAP validator: {e}"
@@ -544,7 +543,7 @@ def apply_external_validator(
     get_default_root_path: Callable[[], Path],
     default_package_name: str,
     validator_name: str,
-    default_script_name: str = "main.py"
+    default_script_name: str = "main.py",
 ) -> ValidationToolReport:
     """
     Apply an external validator to the given file by calling a Python script via command line,
@@ -595,17 +594,13 @@ def apply_external_validator(
             [f"{venv_path}/bin/python", str(validator_script_path), str(file_path)],
             capture_output=True,
             text=True,
-            check=True
+            check=True,
         )
         validator_output = json.loads(validator_result.stdout)
     except Exception as e:
         message = f"Encountered an unexpected error while calling {validator_name} script: {e}"
         logger.error(message)
-        validator_output = {
-            "valid": False,
-            "errors": [message],
-            "warnings": []
-        }
+        validator_output = {"valid": False, "errors": [message], "warnings": []}
 
     finished_at = datetime.now(timezone.utc)
 
@@ -614,7 +609,7 @@ def apply_external_validator(
         errors=validator_output["errors"],
         warnings=validator_output["warnings"],
         started_at=started_at.isoformat(),
-        finished_at=finished_at.isoformat()
+        finished_at=finished_at.isoformat(),
     )
 
 
@@ -641,7 +636,7 @@ def apply_cellxgene_validator(file_path: Path) -> ValidationToolReport:
         venv_path_var=CELLXGENE_VALIDATOR_VENV,
         get_default_root_path=get_default_cxg_validator_root_path,
         default_package_name="cellxgene_validator",
-        validator_name="CELLxGENE validator"
+        validator_name="CELLxGENE validator",
     )
 
 
@@ -662,7 +657,7 @@ def apply_hca_schema_validator(file_path: Path) -> ValidationToolReport:
         venv_path_var=HCA_SCHEMA_VALIDATOR_VENV,
         get_default_root_path=get_default_hcas_validator_root_path,
         default_package_name="hca_schema_validator_service",
-        validator_name="HCA schema validator"
+        validator_name="HCA schema validator",
     )
 
 
@@ -683,22 +678,22 @@ def apply_hca_cell_annotation_validator(file_path: Path) -> ValidationToolReport
         get_default_root_path=get_default_hcas_validator_root_path,
         default_package_name="hca_schema_validator_service",
         default_script_name="cell_annotation.py",
-        validator_name="HCA cell annotation validator"
+        validator_name="HCA cell annotation validator",
     )
 
 
 def download_s3_file(bucket: str, key: str, local_path: Path) -> str | None:
     """
     Download a file from S3 to the local work directory and extract metadata.
-    
+
     Args:
         bucket: S3 bucket name
         key: S3 object key
         local_path: Local file path to save the downloaded file
-        
+
     Returns:
         Source SHA256 from S3 metadata, or None if not available
-        
+
     Raises:
         ClientError: AWS S3 errors (permissions, missing files, etc.)
         Exception: Other errors (network, disk space, etc.)
@@ -706,21 +701,21 @@ def download_s3_file(bucket: str, key: str, local_path: Path) -> str | None:
     logger.info("Starting download: s3://%s/%s", bucket, key)
     try:
         # Let boto3 resolve region from the environment/metadata
-        s3_client = boto3.client('s3')
-        
+        s3_client = boto3.client("s3")
+
         # Get object metadata first
         response = s3_client.head_object(Bucket=bucket, Key=key)
-        source_sha256 = response.get('Metadata', {}).get('source-sha256')
-        
+        source_sha256 = response.get("Metadata", {}).get("source-sha256")
+
         # Download the file
         s3_client.download_file(bucket, key, str(local_path))
         logger.info("Successfully downloaded to %s", local_path)
-        
+
         if source_sha256:
             logger.info("Source SHA256 from metadata: %s", source_sha256)
         else:
             logger.warning("No source-sha256 metadata found for s3://%s/%s", bucket, key)
-        
+
         return source_sha256
     except ClientError as e:
         logger.error("S3 download failed: %s", e)
@@ -744,15 +739,15 @@ def validate_environment() -> tuple[dict[str, str | None], list[str]]:
     local_file = os.environ.get(LOCAL_FILE)
 
     env_vars = {
-        'local_file': local_file,
-        'bucket': os.environ.get(S3_BUCKET) or ("local" if local_file else None),
-        'key': os.environ.get(S3_KEY) or (local_file if local_file else None),
-        'validation_results_bucket': os.environ.get(VALIDATION_RESULTS_BUCKET),
-        'file_id': os.environ.get(FILE_ID) or ("local" if local_file else None),
-        'sns_topic_arn': os.environ.get(SNS_TOPIC_ARN),
-        'batch_job_id': os.environ.get(AWS_BATCH_JOB_ID) or ("local" if local_file else None),
+        "local_file": local_file,
+        "bucket": os.environ.get(S3_BUCKET) or ("local" if local_file else None),
+        "key": os.environ.get(S3_KEY) or (local_file if local_file else None),
+        "validation_results_bucket": os.environ.get(VALIDATION_RESULTS_BUCKET),
+        "file_id": os.environ.get(FILE_ID) or ("local" if local_file else None),
+        "sns_topic_arn": os.environ.get(SNS_TOPIC_ARN),
+        "batch_job_id": os.environ.get(AWS_BATCH_JOB_ID) or ("local" if local_file else None),
         # Read non-reserved job name if provided
-        'batch_job_name': os.environ.get('BATCH_JOB_NAME')
+        "batch_job_name": os.environ.get("BATCH_JOB_NAME"),
     }
 
     # In local file mode, all fields get defaults; only the file must exist
@@ -763,13 +758,13 @@ def validate_environment() -> tuple[dict[str, str | None], list[str]]:
         return env_vars, missing_vars
 
     # Check required variables (batch_job_name is optional; region is resolved by boto3)
-    required_vars = ['bucket', 'key', 'file_id', 'sns_topic_arn', 'batch_job_id']
+    required_vars = ["bucket", "key", "file_id", "sns_topic_arn", "batch_job_id"]
     var_name_mapping = {
-        'bucket': 'S3_BUCKET',
-        'key': 'S3_KEY',
-        'file_id': 'FILE_ID',
-        'sns_topic_arn': 'SNS_TOPIC_ARN',
-        'batch_job_id': 'AWS_BATCH_JOB_ID'
+        "bucket": "S3_BUCKET",
+        "key": "S3_KEY",
+        "file_id": "FILE_ID",
+        "sns_topic_arn": "SNS_TOPIC_ARN",
+        "batch_job_id": "AWS_BATCH_JOB_ID",
     }
     missing_vars = []
 
@@ -784,24 +779,24 @@ def validate_environment() -> tuple[dict[str, str | None], list[str]]:
 def create_failure_message(env_vars: dict[str, str | None], error: str, start_time: datetime) -> ValidationMessage:
     """Create ValidationMessage for failure cases."""
     return ValidationMessage(
-        file_id=env_vars.get('file_id') or "unknown",
+        file_id=env_vars.get("file_id") or "unknown",
         status=STATUS_FAILURE,
         timestamp=start_time.isoformat(),
-        bucket=env_vars.get('bucket') or "unknown",
-        key=env_vars.get('key') or "unknown",
-        batch_job_id=env_vars.get('batch_job_id') or "unknown",
-        batch_job_name=env_vars.get('batch_job_name'),
-        error_message=error
+        bucket=env_vars.get("bucket") or "unknown",
+        key=env_vars.get("key") or "unknown",
+        batch_job_id=env_vars.get("batch_job_id") or "unknown",
+        batch_job_name=env_vars.get("batch_job_name"),
+        error_message=error,
     )
 
 
 def cleanup_files(work_dir: Optional[Path] = None) -> None:
     """
     Clean up work directory after validation.
-    
+
     This function attempts to remove the entire work directory (including downloaded files)
     but logs warnings if cleanup fails without affecting the validation result.
-    
+
     Args:
         work_dir: Path to the work directory to remove
     """
@@ -833,7 +828,7 @@ def main() -> int:
 
         # Validate environment variables
         env_vars, missing_vars = validate_environment()
-        local_mode = bool(env_vars.get('local_file'))
+        local_mode = bool(env_vars.get("local_file"))
 
         if missing_vars:
             error_msg = f"Missing required environment variables: {', '.join(missing_vars)}"
@@ -843,10 +838,10 @@ def main() -> int:
             return exit_code
 
         # Required env vars are guaranteed non-None after the missing_vars check above
-        file_id = env_vars['file_id']
-        bucket = env_vars['bucket']
-        key = env_vars['key']
-        batch_job_id = env_vars['batch_job_id']
+        file_id = env_vars["file_id"]
+        bucket = env_vars["bucket"]
+        key = env_vars["key"]
+        batch_job_id = env_vars["batch_job_id"]
         # TODO: this check is redundant; see issue 399
         if file_id is None or bucket is None or key is None or batch_job_id is None:
             raise RuntimeError("Required env vars unexpectedly None after missing_vars check")
@@ -859,12 +854,12 @@ def main() -> int:
             bucket=bucket,
             key=key,
             batch_job_id=batch_job_id,
-            batch_job_name=env_vars['batch_job_name']
+            batch_job_name=env_vars["batch_job_name"],
         )
 
         if local_mode:
             # Local file mode — skip S3 download and integrity checks
-            local_file_path = env_vars['local_file']
+            local_file_path = env_vars["local_file"]
             if local_file_path is None:
                 raise RuntimeError("local_mode set but LOCAL_FILE env var is None")
             local_file = Path(local_file_path)
@@ -933,8 +928,11 @@ def main() -> int:
         # apply_cellxgene_validator back in. See #382.
         now_iso = datetime.now(timezone.utc).isoformat()
         cellxgene_validation_report = ValidationToolReport(
-            valid=True, errors=[], warnings=[],
-            started_at=now_iso, finished_at=now_iso,
+            valid=True,
+            errors=[],
+            warnings=[],
+            started_at=now_iso,
+            finished_at=now_iso,
         )
 
         # Call HCA schema validator
@@ -951,7 +949,7 @@ def main() -> int:
             "cap": cap_validation_report,
             "cellxgene": cellxgene_validation_report,
             "hcaSchema": hca_schema_validation_report,
-            "hcaCellAnnotation": hca_cell_annotation_validation_report
+            "hcaCellAnnotation": hca_cell_annotation_validation_report,
         }
 
         logger.info("Validation completed successfully")
@@ -979,16 +977,14 @@ def main() -> int:
         # Attempt to write full results to S3 as a claim check before SNS.
         # Skipped in local mode (no real bucket) and when env validation
         # never resolved a real bucket/file_id/batch_job_id (early-exit path).
-        s3_bucket = env_vars.get('validation_results_bucket')
-        s3_file_id = env_vars.get('file_id')
-        s3_batch_job_id = env_vars.get('batch_job_id')
+        s3_bucket = env_vars.get("validation_results_bucket")
+        s3_file_id = env_vars.get("file_id")
+        s3_batch_job_id = env_vars.get("batch_job_id")
         if validation_message and not local_mode and s3_bucket and s3_file_id and s3_batch_job_id:
-            write_validation_results_to_s3(
-                validation_message, s3_bucket, s3_file_id, s3_batch_job_id
-            )
+            write_validation_results_to_s3(validation_message, s3_bucket, s3_file_id, s3_batch_job_id)
 
         # Publish or print results
-        sns_topic_arn = env_vars.get('sns_topic_arn')
+        sns_topic_arn = env_vars.get("sns_topic_arn")
         if validation_message and sns_topic_arn:
             publish_success = publish_validation_result(validation_message, sns_topic_arn)
             if not publish_success:

--- a/services/dataset-validator/tests/mock-modules/cap_validator.py
+++ b/services/dataset-validator/tests/mock-modules/cap_validator.py
@@ -1,15 +1,18 @@
 import json
 import os
 
-
 if __name__ == "__main__":
     # Allow tests to inject an error via environment variable
     error = os.environ.get("CAP_MOCK_ERROR")
     if error:
-        print(json.dumps({
-            "valid": False,
-            "errors": [f"Encountered an unexpected error while calling CAP validator: {error}"],
-            "warnings": [],
-        }))
+        print(
+            json.dumps(
+                {
+                    "valid": False,
+                    "errors": [f"Encountered an unexpected error while calling CAP validator: {error}"],
+                    "warnings": [],
+                }
+            )
+        )
     else:
         print(json.dumps({"valid": True, "errors": [], "warnings": []}))

--- a/services/dataset-validator/tests/mock-modules/cellxgene_validator.py
+++ b/services/dataset-validator/tests/mock-modules/cellxgene_validator.py
@@ -1,2 +1,2 @@
 if __name__ == "__main__":
-  print('{"valid": false, "warnings": ["WARNING: test"], "errors": ["ERROR: test"]}')
+    print('{"valid": false, "warnings": ["WARNING: test"], "errors": ["ERROR: test"]}')

--- a/services/dataset-validator/tests/mock-modules/hca_cell_annotation_validator.py
+++ b/services/dataset-validator/tests/mock-modules/hca_cell_annotation_validator.py
@@ -1,2 +1,2 @@
 if __name__ == "__main__":
-  print('{"valid": false, "warnings": ["WARNING: test baz"], "errors": ["ERROR: test baz"]}')
+    print('{"valid": false, "warnings": ["WARNING: test baz"], "errors": ["ERROR: test baz"]}')

--- a/services/dataset-validator/tests/mock-modules/hca_schema_validator.py
+++ b/services/dataset-validator/tests/mock-modules/hca_schema_validator.py
@@ -1,2 +1,2 @@
 if __name__ == "__main__":
-  print('{"valid": false, "warnings": ["WARNING: test bar"], "errors": ["ERROR: test bar"]}')
+    print('{"valid": false, "warnings": ["WARNING: test bar"], "errors": ["ERROR: test bar"]}')

--- a/services/dataset-validator/tests/test_cleanup.py
+++ b/services/dataset-validator/tests/test_cleanup.py
@@ -1,14 +1,12 @@
 """
 Tests for file cleanup functionality in dataset validator.
 """
+
 import logging
-import os
 import sys
 import tempfile
-import logging
 from pathlib import Path
-from unittest.mock import patch, MagicMock
-import pytest
+from unittest.mock import patch
 
 # Add src directory to Python path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
@@ -20,25 +18,25 @@ def test_cleanup_files_success(caplog):
     """Test successful cleanup of work directory."""
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_path = Path(temp_dir)
-        
+
         # Create work directory with files
         work_dir = temp_path / "work"
         work_dir.mkdir()
         (work_dir / "downloaded_file.h5ad").write_text("test content")
         (work_dir / "nested_file.txt").write_text("nested content")
-        
+
         # Verify directory and files exist before cleanup
         assert work_dir.exists()
         assert (work_dir / "downloaded_file.h5ad").exists()
         assert (work_dir / "nested_file.txt").exists()
-        
+
         # Capture logs from the dataset_validator.main logger
         with caplog.at_level(logging.INFO, logger="dataset_validator.main"):
             cleanup_files(work_dir)
-        
+
         # Verify entire work directory is removed
         assert not work_dir.exists()
-        
+
         # Check log messages
         assert "Successfully removed work directory" in caplog.text
 
@@ -46,14 +44,14 @@ def test_cleanup_files_success(caplog):
 def test_cleanup_files_nonexistent_directory(caplog):
     """Test cleanup with non-existent directory (should not error)."""
     nonexistent_dir = Path("/tmp/nonexistent_dir")
-    
+
     # Ensure directory doesn't exist
     assert not nonexistent_dir.exists()
-    
+
     # Capture logs from the dataset_validator.main logger
     with caplog.at_level(logging.INFO, logger="dataset_validator.main"):
         cleanup_files(nonexistent_dir)
-    
+
     # Should log that no directory to clean up
     assert "No work directory to clean up" in caplog.text
 
@@ -62,7 +60,7 @@ def test_cleanup_files_none_parameter(caplog):
     """Test cleanup with None parameter."""
     with caplog.at_level(logging.INFO, logger="dataset_validator.main"):
         cleanup_files(None)
-    
+
     # Should log that no directory to clean up
     assert "No work directory to clean up" in caplog.text
 
@@ -73,12 +71,14 @@ def test_cleanup_files_directory_removal_error(caplog):
         temp_path = Path(temp_dir)
         work_dir = temp_path / "work"
         work_dir.mkdir()
-        
+
         # Mock shutil.rmtree to raise an exception
-        with patch('dataset_validator.main.shutil.rmtree', side_effect=OSError("Directory busy")), \
-             caplog.at_level(logging.WARNING, logger="dataset_validator.main"):
+        with (
+            patch("dataset_validator.main.shutil.rmtree", side_effect=OSError("Directory busy")),
+            caplog.at_level(logging.WARNING, logger="dataset_validator.main"),
+        ):
             cleanup_files(work_dir)
-        
+
         # Check warning was logged
         assert "Failed to remove work directory" in caplog.text
         assert "Directory busy" in caplog.text
@@ -88,50 +88,55 @@ def test_cleanup_files_directory_removal_error(caplog):
 def test_cleanup_integration_with_main_function():
     """Test that cleanup is called during main() execution."""
     # This test verifies cleanup is integrated into the main flow
-    with patch('dataset_validator.main.cleanup_files') as mock_cleanup, \
-         patch('dataset_validator.main.validate_environment') as mock_validate:
-        
+    with (
+        patch("dataset_validator.main.cleanup_files") as mock_cleanup,
+        patch("dataset_validator.main.validate_environment") as mock_validate,
+    ):
         # Mock environment validation to fail early (missing vars)
-        mock_validate.return_value = ({}, ['S3_BUCKET=None'])
-        
+        mock_validate.return_value = ({}, ["S3_BUCKET=None"])
+
         from dataset_validator.main import main
-        
+
         # Run main function
         exit_code = main()
-        
+
         # Should exit with failure due to missing env vars
         assert exit_code == 1
-        
+
         # Cleanup should still be called (in finally block) with work_dir=None
         mock_cleanup.assert_called_once_with(None)
 
 
 def test_cleanup_preserves_exit_code(caplog):
     """Test that cleanup errors don't change the main function exit code."""
-    with patch('dataset_validator.main.validate_environment') as mock_validate, \
-         patch('dataset_validator.main.download_s3_file', side_effect=Exception("Download failed")), \
-         patch('shutil.rmtree', side_effect=OSError("Permission denied")), \
-         patch('pathlib.Path.exists', return_value=True), \
-         patch('tempfile.mkdtemp', return_value='/tmp/test_work_dir'):
-        
+    with (
+        patch("dataset_validator.main.validate_environment") as mock_validate,
+        patch("dataset_validator.main.download_s3_file", side_effect=Exception("Download failed")),
+        patch("shutil.rmtree", side_effect=OSError("Permission denied")),
+        patch("pathlib.Path.exists", return_value=True),
+        patch("tempfile.mkdtemp", return_value="/tmp/test_work_dir"),
+    ):
         # Mock environment validation to succeed so we get to file download
-        mock_validate.return_value = ({
-            'bucket': 'test-bucket',
-            'key': 'test-key.h5ad',
-            'file_id': 'test-file-123',
-            'sns_topic_arn': 'arn:aws:sns:us-east-1:123456789012:test-topic',
-            'batch_job_id': 'test-job-456',
-            'batch_job_name': 'test-job-name'
-        }, [])
-        
+        mock_validate.return_value = (
+            {
+                "bucket": "test-bucket",
+                "key": "test-key.h5ad",
+                "file_id": "test-file-123",
+                "sns_topic_arn": "arn:aws:sns:us-east-1:123456789012:test-topic",
+                "batch_job_id": "test-job-456",
+                "batch_job_name": "test-job-name",
+            },
+            [],
+        )
+
         from dataset_validator.main import main
-        
+
         # Capture logs to verify cleanup warning is logged
         with caplog.at_level(logging.WARNING):
             exit_code = main()
-        
+
         # Should still exit with 1 (download failure), not affected by cleanup error
         assert exit_code == 1
-        
+
         # Verify cleanup warning was logged
         assert any("Failed to remove work directory" in record.message for record in caplog.records)

--- a/services/dataset-validator/tests/test_dataset_validator.py
+++ b/services/dataset-validator/tests/test_dataset_validator.py
@@ -4,17 +4,17 @@ import json
 import logging
 import os
 import subprocess
+import sys
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Dict, Any, List
+from typing import Dict
 from unittest.mock import MagicMock, patch
-import sys
 
 import boto3
+import numpy as np
+import pandas as pd
 import pytest
 from moto import mock_s3, mock_sns
-import pandas as pd
-import numpy as np
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
@@ -48,12 +48,12 @@ def _setup_metadata_mocks(mock_read_inputs, mock_matrix_storage, test_adata):
 dataset_validator_venv_path = sys.prefix
 mock_modules_path = Path(__file__).parent / "mock-modules"
 external_validator_path_vars = {
-    'CELLXGENE_VALIDATOR_VENV': dataset_validator_venv_path,
-    'CELLXGENE_VALIDATOR_SCRIPT': str(mock_modules_path / "cellxgene_validator.py"),
-    'HCA_SCHEMA_VALIDATOR_VENV': dataset_validator_venv_path,
-    'HCA_SCHEMA_VALIDATOR_SCRIPT': str(mock_modules_path / "hca_schema_validator.py"),
-    'HCA_CELL_ANNOTATION_VALIDATOR_SCRIPT': str(mock_modules_path / "hca_cell_annotation_validator.py"),
-    'CAP_VALIDATOR_SCRIPT': str(mock_modules_path / "cap_validator.py"),
+    "CELLXGENE_VALIDATOR_VENV": dataset_validator_venv_path,
+    "CELLXGENE_VALIDATOR_SCRIPT": str(mock_modules_path / "cellxgene_validator.py"),
+    "HCA_SCHEMA_VALIDATOR_VENV": dataset_validator_venv_path,
+    "HCA_SCHEMA_VALIDATOR_SCRIPT": str(mock_modules_path / "hca_schema_validator.py"),
+    "HCA_CELL_ANNOTATION_VALIDATOR_SCRIPT": str(mock_modules_path / "hca_cell_annotation_validator.py"),
+    "CAP_VALIDATOR_SCRIPT": str(mock_modules_path / "cap_validator.py"),
 }
 
 
@@ -61,47 +61,47 @@ external_validator_path_vars = {
 def mock_aws():
     """Fixture that provides mocked AWS services (S3 and SNS)."""
     # Set AWS_DEFAULT_REGION for consistent behavior
-    original_region = os.environ.get('AWS_DEFAULT_REGION')
-    os.environ['AWS_DEFAULT_REGION'] = 'us-east-1'
-    
+    original_region = os.environ.get("AWS_DEFAULT_REGION")
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
     try:
         with mock_s3(), mock_sns():
             # Create S3 client and buckets
-            s3_client = boto3.client('s3', region_name='us-east-1')
-            s3_client.create_bucket(Bucket='test-bucket')
-            s3_client.create_bucket(Bucket='test-results-bucket')
+            s3_client = boto3.client("s3", region_name="us-east-1")
+            s3_client.create_bucket(Bucket="test-bucket")
+            s3_client.create_bucket(Bucket="test-results-bucket")
 
             # Create SNS client and topic
-            sns_client = boto3.client('sns', region_name='us-east-1')
-            topic_response = sns_client.create_topic(Name='test-topic')
-            topic_arn = topic_response['TopicArn']
+            sns_client = boto3.client("sns", region_name="us-east-1")
+            topic_response = sns_client.create_topic(Name="test-topic")
+            topic_arn = topic_response["TopicArn"]
 
             yield {
-                's3_client': s3_client,
-                'sns_client': sns_client,
-                'topic_arn': topic_arn,
-                'bucket_name': 'test-bucket',
-                'validation_results_bucket_name': 'test-results-bucket',
+                "s3_client": s3_client,
+                "sns_client": sns_client,
+                "topic_arn": topic_arn,
+                "bucket_name": "test-bucket",
+                "validation_results_bucket_name": "test-results-bucket",
             }
     finally:
         # Restore original region
         if original_region is None:
-            os.environ.pop('AWS_DEFAULT_REGION', None)
+            os.environ.pop("AWS_DEFAULT_REGION", None)
         else:
-            os.environ['AWS_DEFAULT_REGION'] = original_region
+            os.environ["AWS_DEFAULT_REGION"] = original_region
 
 
 @pytest.fixture
 def base_env_vars():
     """Fixture that provides base environment variables for testing."""
     return {
-        'S3_BUCKET': 'test-bucket',
-        'S3_KEY': 'test/file.h5ad',
-        'FILE_ID': 'test-file-uuid',
-        'SNS_TOPIC_ARN': 'arn:aws:sns:us-east-1:123456789012:test-topic',
-        'AWS_BATCH_JOB_ID': 'test-job-id',
-        'BATCH_JOB_NAME': 'test-job',
-        'AWS_DEFAULT_REGION': 'us-east-1'
+        "S3_BUCKET": "test-bucket",
+        "S3_KEY": "test/file.h5ad",
+        "FILE_ID": "test-file-uuid",
+        "SNS_TOPIC_ARN": "arn:aws:sns:us-east-1:123456789012:test-topic",
+        "AWS_BATCH_JOB_ID": "test-job-id",
+        "BATCH_JOB_NAME": "test-job",
+        "AWS_DEFAULT_REGION": "us-east-1",
     }
 
 
@@ -109,19 +109,19 @@ def base_env_vars():
 def env_manager():
     """Fixture that provides environment variable management utilities."""
     original_env = {}
-    
+
     def set_env(env_vars: Dict[str, str]):
         """Set environment variables and save originals for cleanup."""
         for key, value in env_vars.items():
             original_env[key] = os.environ.get(key)
             os.environ[key] = value
-    
+
     def clear_env(keys: list):
         """Clear specific environment variables."""
         for key in keys:
             original_env[key] = os.environ.get(key)
             os.environ.pop(key, None)
-    
+
     def restore_env():
         """Restore original environment variables."""
         for key, value in original_env.items():
@@ -130,102 +130,97 @@ def env_manager():
             else:
                 os.environ[key] = value
         original_env.clear()
-    
-    yield {
-        'set': set_env,
-        'clear': clear_env,
-        'restore': restore_env
-    }
-    
+
+    yield {"set": set_env, "clear": clear_env, "restore": restore_env}
+
     # Cleanup after test
     restore_env()
+
 
 class TestDatasetValidator:
     """Test cases for the dataset validator main functionality."""
 
-    @pytest.mark.parametrize("test_case", [
-        {
-            "name": "no_config",
-            "description": "Test that validator fails when no S3 config is provided",
-            "env_vars": {},  # Empty - will clear S3_BUCKET and S3_KEY
-            "clear_vars": ['S3_BUCKET', 'S3_KEY'],
-            "expected_exit_code": 1,
-            "expected_logs": [
-                "Dataset Validator starting",
-                "Missing required environment variables"
-            ]
-        },
-        {
-            "name": "invalid_s3_config", 
-            "description": "Test that validator fails when invalid S3 config is provided",
-            "env_vars": {
-                'S3_BUCKET': 'invalid-test-bucket',
-                'S3_KEY': 'invalid/test/file.h5ad',
-                'FILE_ID': 'test-file-uuid',
-                'SNS_TOPIC_ARN': 'arn:aws:sns:us-east-1:123456789012:test-topic',
-                'AWS_BATCH_JOB_ID': 'test-job-id',
-                'AWS_DEFAULT_REGION': 'us-east-1'
+    @pytest.mark.parametrize(
+        "test_case",
+        [
+            {
+                "name": "no_config",
+                "description": "Test that validator fails when no S3 config is provided",
+                "env_vars": {},  # Empty - will clear S3_BUCKET and S3_KEY
+                "clear_vars": ["S3_BUCKET", "S3_KEY"],
+                "expected_exit_code": 1,
+                "expected_logs": ["Dataset Validator starting", "Missing required environment variables"],
             },
-            "clear_vars": [],
-            "expected_exit_code": 1,
-            "expected_logs": [
-                "Dataset Validator starting",
-                "Work directory created:",
-                "Processing S3 file: s3://invalid-test-bucket/invalid/test/file.h5ad",
-                "S3 download failed",
-                "Dataset Validator failed:"
-            ]
-        },
-        {
-            "name": "work_directory_creation",
-            "description": "Test that work directory is created correctly with valid S3 config",
-            "env_vars": {
-                'S3_BUCKET': 'test-bucket',
-                'S3_KEY': 'test/file.h5ad',
-                'FILE_ID': 'test-file-uuid',
-                'SNS_TOPIC_ARN': 'arn:aws:sns:us-east-1:123456789012:test-topic',
-                'AWS_BATCH_JOB_ID': 'test-job-id',
-                'AWS_DEFAULT_REGION': 'us-east-1',
-                'BATCH_JOB_NAME': 'test-job'
+            {
+                "name": "invalid_s3_config",
+                "description": "Test that validator fails when invalid S3 config is provided",
+                "env_vars": {
+                    "S3_BUCKET": "invalid-test-bucket",
+                    "S3_KEY": "invalid/test/file.h5ad",
+                    "FILE_ID": "test-file-uuid",
+                    "SNS_TOPIC_ARN": "arn:aws:sns:us-east-1:123456789012:test-topic",
+                    "AWS_BATCH_JOB_ID": "test-job-id",
+                    "AWS_DEFAULT_REGION": "us-east-1",
+                },
+                "clear_vars": [],
+                "expected_exit_code": 1,
+                "expected_logs": [
+                    "Dataset Validator starting",
+                    "Work directory created:",
+                    "Processing S3 file: s3://invalid-test-bucket/invalid/test/file.h5ad",
+                    "S3 download failed",
+                    "Dataset Validator failed:",
+                ],
             },
-            "clear_vars": [],
-            "expected_exit_code": 1,
-            "expected_logs": [
-                "Work directory created: /tmp/dataset_validator"
-            ]
-        }
-    ], ids=lambda x: x["name"])
+            {
+                "name": "work_directory_creation",
+                "description": "Test that work directory is created correctly with valid S3 config",
+                "env_vars": {
+                    "S3_BUCKET": "test-bucket",
+                    "S3_KEY": "test/file.h5ad",
+                    "FILE_ID": "test-file-uuid",
+                    "SNS_TOPIC_ARN": "arn:aws:sns:us-east-1:123456789012:test-topic",
+                    "AWS_BATCH_JOB_ID": "test-job-id",
+                    "AWS_DEFAULT_REGION": "us-east-1",
+                    "BATCH_JOB_NAME": "test-job",
+                },
+                "clear_vars": [],
+                "expected_exit_code": 1,
+                "expected_logs": ["Work directory created: /tmp/dataset_validator"],
+            },
+        ],
+        ids=lambda x: x["name"],
+    )
     def test_subprocess_validation_scenarios(self, test_case):
         """Parameterized test for various subprocess validation scenarios."""
         # Prepare environment
         env = os.environ.copy()
-        
+
         # Add mock AWS credentials for subprocess tests
-        env.update({
-            'AWS_ACCESS_KEY_ID': 'testing',
-            'AWS_SECRET_ACCESS_KEY': 'testing',
-            'AWS_SECURITY_TOKEN': 'testing',
-            'AWS_SESSION_TOKEN': 'testing'
-        })
-        
+        env.update(
+            {
+                "AWS_ACCESS_KEY_ID": "testing",
+                "AWS_SECRET_ACCESS_KEY": "testing",
+                "AWS_SECURITY_TOKEN": "testing",
+                "AWS_SESSION_TOKEN": "testing",
+            }
+        )
+
         # Clear specified variables
         for var in test_case["clear_vars"]:
             env.pop(var, None)
-            
+
         # Set test-specific variables
         env.update(test_case["env_vars"])
-        
+
         # Run the validator
         result = subprocess.run(
-            [sys.executable, 'src/dataset_validator/main.py'],
-            capture_output=True,
-            text=True,
-            env=env
+            [sys.executable, "src/dataset_validator/main.py"], capture_output=True, text=True, env=env
         )
-        
+
         # Verify exit code
         assert result.returncode == test_case["expected_exit_code"]
-        
+
         # Verify expected log messages
         for expected_log in test_case["expected_logs"]:
             assert expected_log in result.stdout
@@ -237,8 +232,8 @@ def test_missing_sns_topic_logs_error_and_exits(caplog, env_manager, base_env_va
 
     # Set up environment with missing SNS_TOPIC_ARN
     test_env = base_env_vars.copy()
-    del test_env['SNS_TOPIC_ARN']  # Remove SNS topic to test missing variable
-    env_manager['set'](test_env)
+    del test_env["SNS_TOPIC_ARN"]  # Remove SNS topic to test missing variable
+    env_manager["set"](test_env)
 
     # Capture logs from the specific logger
     with caplog.at_level(logging.ERROR, logger="dataset_validator.main"):
@@ -257,9 +252,9 @@ def test_missing_bucket_skips_s3_claim_check(caplog, env_manager, base_env_vars)
     from dataset_validator.main import main
 
     test_env = base_env_vars.copy()
-    del test_env['S3_BUCKET']
-    env_manager['set'](test_env)
-    env_manager['clear'](['S3_BUCKET'])
+    del test_env["S3_BUCKET"]
+    env_manager["set"](test_env)
+    env_manager["clear"](["S3_BUCKET"])
 
     with caplog.at_level(logging.INFO, logger="dataset_validator.main"):
         result = main()
@@ -270,81 +265,81 @@ def test_missing_bucket_skips_s3_claim_check(caplog, env_manager, base_env_vars)
     assert "S3 claim check write" not in caplog.text
 
 
-@pytest.mark.parametrize("test_case", [
-    {
-        "name": "all_present",
-        "description": "Test reading metadata with all fields present",
-        "adata": {
-            "obs": {
-                "assay": ["assay-a", "assay-b", "assay-b", "assay-c", "assay-a"],
-                "suspension_type": [
-                    "suspension-type-a",
-                    "suspension-type-a",
-                    "suspension-type-a",
-                    "suspension-type-a",
-                    "suspension-type-a",
-                ],
-                "tissue": ["tissue-a", "tissue-a", "tissue-b", "tissue-a", "tissue-a"],
-                "disease": ["disease-a", "disease-b", "disease-c", "disease-d", "disease-e"]
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        {
+            "name": "all_present",
+            "description": "Test reading metadata with all fields present",
+            "adata": {
+                "obs": {
+                    "assay": ["assay-a", "assay-b", "assay-b", "assay-c", "assay-a"],
+                    "suspension_type": [
+                        "suspension-type-a",
+                        "suspension-type-a",
+                        "suspension-type-a",
+                        "suspension-type-a",
+                        "suspension-type-a",
+                    ],
+                    "tissue": ["tissue-a", "tissue-a", "tissue-b", "tissue-a", "tissue-a"],
+                    "disease": ["disease-a", "disease-b", "disease-c", "disease-d", "disease-e"],
+                },
+                "uns": {"title": "test-dataset-123"},
+                "n_vars": 12,
             },
-            "uns": {"title": "test-dataset-123"},
-            "n_vars": 12
-        },
-        "expected_result": {
-            "title": "test-dataset-123",
-            "assay": ["assay-a", "assay-b", "assay-c"],
-            "suspension_type": ["suspension-type-a"],
-            "tissue": ["tissue-a", "tissue-b"],
-            "disease": ["disease-a", "disease-b", "disease-c", "disease-d", "disease-e"],
-            "cell_count": 5,
-            "gene_count": 12
-        }
-    },
-    {
-        "name": "all_missing",
-        "description": "Test reading metadata with all possible fields absent",
-        "adata": {
-            "obs": {},
-            "uns": {},
-            "n_vars": 0
-        },
-        "expected_result": {
-            "title": "",
-            "assay": [],
-            "suspension_type": [],
-            "tissue": [],
-            "disease": [],
-            "cell_count": 0,
-            "gene_count": 0
-        }
-    },
-    {
-        "name": "nan",
-        "description": "Test that NAN is converted to string",
-        "adata": {
-            "obs": {
-                "assay": ["assay-a", "assay-b", np.nan],
-                "suspension_type": ["suspension-type-a", np.nan, "suspension-type-b"],
-                "tissue": [np.nan, "tissue-a", "tissue-a"],
-                "disease": ["disease-a", np.nan, np.nan]
+            "expected_result": {
+                "title": "test-dataset-123",
+                "assay": ["assay-a", "assay-b", "assay-c"],
+                "suspension_type": ["suspension-type-a"],
+                "tissue": ["tissue-a", "tissue-b"],
+                "disease": ["disease-a", "disease-b", "disease-c", "disease-d", "disease-e"],
+                "cell_count": 5,
+                "gene_count": 12,
             },
-            "uns": {"title": "test-dataset-456"},
-            "n_vars": 23
         },
-        "expected_result": {
-            "title": "test-dataset-456",
-            "assay": ["assay-a", "assay-b", "nan"],
-            "suspension_type": ["suspension-type-a", "nan", "suspension-type-b"],
-            "tissue": ["nan", "tissue-a"],
-            "disease": ["disease-a", "nan"],
-            "cell_count": 3,
-            "gene_count": 23
-        }
-    }
-], ids=lambda x: x["name"])
+        {
+            "name": "all_missing",
+            "description": "Test reading metadata with all possible fields absent",
+            "adata": {"obs": {}, "uns": {}, "n_vars": 0},
+            "expected_result": {
+                "title": "",
+                "assay": [],
+                "suspension_type": [],
+                "tissue": [],
+                "disease": [],
+                "cell_count": 0,
+                "gene_count": 0,
+            },
+        },
+        {
+            "name": "nan",
+            "description": "Test that NAN is converted to string",
+            "adata": {
+                "obs": {
+                    "assay": ["assay-a", "assay-b", np.nan],
+                    "suspension_type": ["suspension-type-a", np.nan, "suspension-type-b"],
+                    "tissue": [np.nan, "tissue-a", "tissue-a"],
+                    "disease": ["disease-a", np.nan, np.nan],
+                },
+                "uns": {"title": "test-dataset-456"},
+                "n_vars": 23,
+            },
+            "expected_result": {
+                "title": "test-dataset-456",
+                "assay": ["assay-a", "assay-b", "nan"],
+                "suspension_type": ["suspension-type-a", "nan", "suspension-type-b"],
+                "tissue": ["nan", "tissue-a"],
+                "disease": ["disease-a", "nan"],
+                "cell_count": 3,
+                "gene_count": 23,
+            },
+        },
+    ],
+    ids=lambda x: x["name"],
+)
 def test_extract_metadata_summary_scenarios(test_case):
     """Parameterized test for the metadata summary extraction (obs/uns -> MetadataSummary)."""
-    from dataset_validator.main import _extract_metadata_summary, MetadataSummary
+    from dataset_validator.main import MetadataSummary, _extract_metadata_summary
 
     # _extract_metadata_summary only reads .obs/.uns/.n_obs/.n_vars
     obs = pd.DataFrame(test_case["adata"]["obs"])
@@ -369,13 +364,16 @@ def test_read_file_metadata_real_h5ad(tmp_path):
 
     n_obs, n_vars = 5, 8
     X = sp.random(n_obs, n_vars, density=0.5, format="csr", dtype=np.float32)
-    obs = pd.DataFrame({
-        "assay": ["a", "a", "b", "b", "a"],
-        "suspension_type": ["cell"] * 5,
-        "tissue": ["lung"] * 5,
-        "disease": ["normal"] * 5,
-        "donor_id": ["d1", "d1", "d2", "d2", "d2"],
-    }, index=[f"cell{i}" for i in range(n_obs)])
+    obs = pd.DataFrame(
+        {
+            "assay": ["a", "a", "b", "b", "a"],
+            "suspension_type": ["cell"] * 5,
+            "tissue": ["lung"] * 5,
+            "disease": ["normal"] * 5,
+            "donor_id": ["d1", "d1", "d2", "d2", "d2"],
+        },
+        index=[f"cell{i}" for i in range(n_obs)],
+    )
     adata = ad.AnnData(X=X, obs=obs)
     adata.uns["title"] = "tiny"
     adata.raw = adata
@@ -443,7 +441,7 @@ def test_read_shape_var_fallback_is_robust(tmp_path):
     path4 = tmp_path / "weird4.h5ad"
     with h5py.File(path4, "w") as f:
         x = f.create_group("X")
-        x.attrs["shape"] = np.int64(5)            # scalar, not a 2-tuple
+        x.attrs["shape"] = np.int64(5)  # scalar, not a 2-tuple
         var = f.create_group("var")
         var.attrs["_index"] = "gene_id"
         var.create_dataset("gene_id", data=np.arange(7))
@@ -466,15 +464,24 @@ def test_matrix_storage_excluded_from_sns_message():
     # tool reports — the case that previously slipped past the length limiter.
     big_layers = {
         f"layer_{i}": {
-            "format": "csr_matrix", "n_obs": 1, "n_vars": 1, "nnz": 0,
-            "data_dtype": "float32", "index_dtype": "int64",
-            "on_disk_bytes": 0, "resident_bytes": 0,
+            "format": "csr_matrix",
+            "n_obs": 1,
+            "n_vars": 1,
+            "nnz": 0,
+            "data_dtype": "float32",
+            "index_dtype": "int64",
+            "on_disk_bytes": 0,
+            "resident_bytes": 0,
         }
         for i in range(5000)
     }
     msg = ValidationMessage(
-        file_id="f", status="success", timestamp="2024-01-01T00:00:00Z",
-        bucket="b", key="k", batch_job_id="j",
+        file_id="f",
+        status="success",
+        timestamp="2024-01-01T00:00:00Z",
+        bucket="b",
+        key="k",
+        batch_job_id="j",
         matrix_storage={"X": None, "raw_X": None, "layers": big_layers},
     )
 
@@ -485,34 +492,33 @@ def test_matrix_storage_excluded_from_sns_message():
     # ...while the SNS body carries the six pointer fields and nothing else,
     # however large matrix_storage grows.
     sns = json.loads(msg.to_pointer().to_json())
-    assert set(sns) == {
-        "file_id", "status", "timestamp", "bucket", "key", "batch_job_id"
-    }
+    assert set(sns) == {"file_id", "status", "timestamp", "bucket", "key", "batch_job_id"}
 
 
-@pytest.mark.parametrize("test_case", [
-    {
-        "name": "success",
-        "description": "Test successful CAP validation via mock subprocess",
-        "cap_mock_error": None,
-        "expected_report": {
-            "valid": True,
-            "errors": []
-        }
-    },
-    {
-        "name": "error",
-        "description": "Test CAP validation error via mock subprocess",
-        "cap_mock_error": "Error in CAP validator",
-        "expected_report": {
-            "valid": False,
-            "errors": ["Encountered an unexpected error while calling CAP validator: Error in CAP validator"]
-        }
-    }
-], ids=lambda x: x["name"])
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        {
+            "name": "success",
+            "description": "Test successful CAP validation via mock subprocess",
+            "cap_mock_error": None,
+            "expected_report": {"valid": True, "errors": []},
+        },
+        {
+            "name": "error",
+            "description": "Test CAP validation error via mock subprocess",
+            "cap_mock_error": "Error in CAP validator",
+            "expected_report": {
+                "valid": False,
+                "errors": ["Encountered an unexpected error while calling CAP validator: Error in CAP validator"],
+            },
+        },
+    ],
+    ids=lambda x: x["name"],
+)
 def test_cap_validator_scenarios(test_case, monkeypatch):
     """Parameterized test for CAP validation via subprocess."""
-    from dataset_validator.main import apply_cap_validator, ValidationToolReport
+    from dataset_validator.main import ValidationToolReport, apply_cap_validator
 
     # Point at the mock CAP validator script
     monkeypatch.setenv("CAP_VALIDATOR_SCRIPT", str(mock_modules_path / "cap_validator.py"))
@@ -535,46 +541,51 @@ def test_cap_validator_scenarios(test_case, monkeypatch):
 def _build_cap_multi_exception(exceptions):
     """Helper to build a CapMultiException from a list of exceptions."""
     from cap_upload_validator.errors import CapMultiException
+
     multi_ex = CapMultiException()
     for ex in exceptions:
         multi_ex.append(ex)
     return multi_ex
 
 
-@pytest.mark.parametrize("test_case", [
-    {
-        "name": "success",
-        "description": "Test cap_validator_script with successful validation",
-        "exception": None,
-        "expected_valid": True,
-        "expected_errors": []
-    },
-    {
-        "name": "cap_exception",
-        "description": "Test cap_validator_script with CapException",
-        "exception": "AnnDataMissingCountMatrix",
-        "expected_valid": False,
-        "expected_errors_contain": "AnnDataMissingCountMatrix"
-    },
-    {
-        "name": "cap_multi_exception",
-        "description": "Test cap_validator_script with CapMultiException (multiple errors)",
-        "exception": "CapMultiException",
-        "expected_valid": False,
-        "expected_error_count": 2
-    },
-    {
-        "name": "generic_exception",
-        "description": "Test cap_validator_script with unexpected Exception",
-        "exception": "Exception",
-        "expected_valid": False,
-        "expected_errors_contain": "Encountered an unexpected error"
-    }
-], ids=lambda x: x["name"])
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        {
+            "name": "success",
+            "description": "Test cap_validator_script with successful validation",
+            "exception": None,
+            "expected_valid": True,
+            "expected_errors": [],
+        },
+        {
+            "name": "cap_exception",
+            "description": "Test cap_validator_script with CapException",
+            "exception": "AnnDataMissingCountMatrix",
+            "expected_valid": False,
+            "expected_errors_contain": "AnnDataMissingCountMatrix",
+        },
+        {
+            "name": "cap_multi_exception",
+            "description": "Test cap_validator_script with CapMultiException (multiple errors)",
+            "exception": "CapMultiException",
+            "expected_valid": False,
+            "expected_error_count": 2,
+        },
+        {
+            "name": "generic_exception",
+            "description": "Test cap_validator_script with unexpected Exception",
+            "exception": "Exception",
+            "expected_valid": False,
+            "expected_errors_contain": "Encountered an unexpected error",
+        },
+    ],
+    ids=lambda x: x["name"],
+)
 @patch("dataset_validator.cap_validator_script.UploadValidator")
 def test_cap_validator_script_scenarios(mock_upload_validator, test_case):
     """Unit tests for cap_validator_script.py exception handling."""
-    from cap_upload_validator.errors import CapException, CapMultiException, AnnDataMissingCountMatrix
+    from cap_upload_validator.errors import AnnDataMissingCountMatrix, CapException
     from dataset_validator.cap_validator_script import main
 
     mock_instance = MagicMock()
@@ -583,9 +594,7 @@ def test_cap_validator_script_scenarios(mock_upload_validator, test_case):
     if test_case["exception"] == "AnnDataMissingCountMatrix":
         mock_instance.validate.side_effect = AnnDataMissingCountMatrix()
     elif test_case["exception"] == "CapMultiException":
-        mock_instance.validate.side_effect = _build_cap_multi_exception([
-            CapException(), AnnDataMissingCountMatrix()
-        ])
+        mock_instance.validate.side_effect = _build_cap_multi_exception([CapException(), AnnDataMissingCountMatrix()])
     elif test_case["exception"] == "Exception":
         mock_instance.validate.side_effect = Exception("something broke")
     # else: no exception, validate() succeeds
@@ -596,6 +605,7 @@ def test_cap_validator_script_scenarios(mock_upload_validator, test_case):
     # afterward — which restores to our patched StringIO, so the final JSON lands here.
     with patch("sys.argv", ["cap_validator_script.py", "test-file.h5ad"]):
         import io
+
         captured = io.StringIO()
         with patch("sys.stdout", captured):
             main()
@@ -608,92 +618,93 @@ def test_cap_validator_script_scenarios(mock_upload_validator, test_case):
     if "expected_errors" in test_case:
         assert output["errors"] == test_case["expected_errors"]
     if "expected_errors_contain" in test_case:
-        assert any(test_case["expected_errors_contain"] in e for e in output["errors"]), \
+        assert any(test_case["expected_errors_contain"] in e for e in output["errors"]), (
             f"Expected error containing '{test_case['expected_errors_contain']}', got: {output['errors']}"
+        )
     if "expected_error_count" in test_case:
-        assert len(output["errors"]) == test_case["expected_error_count"], \
+        assert len(output["errors"]) == test_case["expected_error_count"], (
             f"Expected {test_case['expected_error_count']} errors, got {len(output['errors'])}: {output['errors']}"
+        )
 
     mock_upload_validator.assert_called_once_with("test-file.h5ad")
     mock_instance.validate.assert_called_once()
 
 
-@pytest.mark.parametrize("test_case", [
-    {
-        "name": "success",
-        "description": "Test successful SNS message publishing",
-        "message_data": {
-            'file_id': 'test-file-123',
-            'status': 'success',
-            'timestamp': '2024-01-01T12:00:00Z',
-            'bucket': 'test-bucket',
-            'key': 'test/file.h5ad',
-            'batch_job_id': 'job-123',
-            'batch_job_name': 'test-job',
-            'downloaded_sha256': 'abc123',
-            'source_sha256': 'abc123',
-            'integrity_status': 'valid',
-            'metadata_summary': None,
-            'tool_reports': None,
-            'metadata_coverage': None,
-            'matrix_storage': None,
-            'error_message': None
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        {
+            "name": "success",
+            "description": "Test successful SNS message publishing",
+            "message_data": {
+                "file_id": "test-file-123",
+                "status": "success",
+                "timestamp": "2024-01-01T12:00:00Z",
+                "bucket": "test-bucket",
+                "key": "test/file.h5ad",
+                "batch_job_id": "job-123",
+                "batch_job_name": "test-job",
+                "downloaded_sha256": "abc123",
+                "source_sha256": "abc123",
+                "integrity_status": "valid",
+                "metadata_summary": None,
+                "tool_reports": None,
+                "metadata_coverage": None,
+                "matrix_storage": None,
+                "error_message": None,
+            },
+            "use_valid_topic": True,
+            "expected_result": True,
+            "log_level": logging.INFO,
+            "expected_logs": ["Publishing validation result to SNS topic", "Successfully published SNS message"],
         },
-        "use_valid_topic": True,
-        "expected_result": True,
-        "log_level": logging.INFO,
-        "expected_logs": [
-            "Publishing validation result to SNS topic",
-            "Successfully published SNS message"
-        ]
-    },
-    {
-        "name": "invalid_topic",
-        "description": "Test SNS publishing with invalid topic ARN",
-        "message_data": {
-            'file_id': 'test-file-123',
-            'status': 'failure',
-            'timestamp': '2024-01-01T12:00:00Z',
-            'bucket': 'test-bucket',
-            'key': 'test/file.h5ad',
-            'batch_job_id': 'job-123',
-            'error_message': 'Test error'
+        {
+            "name": "invalid_topic",
+            "description": "Test SNS publishing with invalid topic ARN",
+            "message_data": {
+                "file_id": "test-file-123",
+                "status": "failure",
+                "timestamp": "2024-01-01T12:00:00Z",
+                "bucket": "test-bucket",
+                "key": "test/file.h5ad",
+                "batch_job_id": "job-123",
+                "error_message": "Test error",
+            },
+            "use_valid_topic": False,
+            "expected_result": False,
+            "log_level": logging.ERROR,
+            "expected_logs": ["SNS publish failed"],
         },
-        "use_valid_topic": False,
-        "expected_result": False,
-        "log_level": logging.ERROR,
-        "expected_logs": [
-            "SNS publish failed"
-        ]
-    }
-], ids=lambda x: x["name"])
+    ],
+    ids=lambda x: x["name"],
+)
 def test_publish_validation_result_scenarios(caplog, mock_aws, test_case):
     """Parameterized test for SNS publishing scenarios."""
-    from dataset_validator.main import publish_validation_result, ValidationMessage, configure_logging
-    
+    from dataset_validator.main import ValidationMessage, configure_logging, publish_validation_result
+
     # Configure logging for the test
     configure_logging()
-    
+
     # Create test validation message
     message = ValidationMessage(**test_case["message_data"])
-    
+
     # Choose topic ARN based on test case
     if test_case["use_valid_topic"]:
-        topic_arn = mock_aws['topic_arn']
+        topic_arn = mock_aws["topic_arn"]
     else:
-        topic_arn = 'arn:aws:sns:us-east-1:123456789012:nonexistent-topic'
-    
+        topic_arn = "arn:aws:sns:us-east-1:123456789012:nonexistent-topic"
+
     # Test publishing
     with caplog.at_level(test_case["log_level"], logger="dataset_validator.main"):
         result = publish_validation_result(message, topic_arn)
-    
+
     # Verify result
     assert result is test_case["expected_result"]
-    
+
     # Verify expected log messages
     for expected_log in test_case["expected_logs"]:
         assert expected_log in caplog.text
-    
+
     # For success case, verify the SNS body is the pointer-only payload
     # — file_id / status / timestamp / bucket / key / batch_job_id and nothing
     # else. The full ValidationMessage lives in the S3 claim check.
@@ -712,20 +723,21 @@ def test_publish_validation_result_scenarios(caplog, mock_aws, test_case):
 def _build_message(**overrides) -> "object":
     """Helper to build a ValidationMessage for claim-check tests."""
     from dataset_validator.main import ValidationMessage
+
     base = {
-        'file_id': 'test-file-uuid',
-        'status': 'success',
-        'timestamp': '2024-01-01T12:00:00Z',
-        'bucket': 'test-bucket',
-        'key': 'datasets/test.h5ad',
-        'batch_job_id': 'job-abc',
-        'batch_job_name': 'test-job',
-        'downloaded_sha256': 'abc123',
-        'source_sha256': 'abc123',
-        'integrity_status': 'valid',
-        'metadata_summary': None,
-        'tool_reports': None,
-        'error_message': None,
+        "file_id": "test-file-uuid",
+        "status": "success",
+        "timestamp": "2024-01-01T12:00:00Z",
+        "bucket": "test-bucket",
+        "key": "datasets/test.h5ad",
+        "batch_job_id": "job-abc",
+        "batch_job_name": "test-job",
+        "downloaded_sha256": "abc123",
+        "source_sha256": "abc123",
+        "integrity_status": "valid",
+        "metadata_summary": None,
+        "tool_reports": None,
+        "error_message": None,
     }
     base.update(overrides)
     return ValidationMessage(**base)
@@ -733,39 +745,37 @@ def _build_message(**overrides) -> "object":
 
 def test_write_validation_results_to_s3_success(caplog, mock_aws):
     """Successful claim-check write places a JSON object at the expected key."""
-    from dataset_validator.main import write_validation_results_to_s3, configure_logging
+    from dataset_validator.main import configure_logging, write_validation_results_to_s3
+
     configure_logging()
 
-    message = _build_message(file_id='file-1', batch_job_id='job-1')
+    message = _build_message(file_id="file-1", batch_job_id="job-1")
 
     with caplog.at_level(logging.INFO, logger="dataset_validator.main"):
-        result = write_validation_results_to_s3(
-            message, mock_aws['bucket_name'], 'file-1', 'job-1'
-        )
+        result = write_validation_results_to_s3(message, mock_aws["bucket_name"], "file-1", "job-1")
 
     assert result is True
     assert "S3 claim check write succeeded for file file-1" in caplog.text
 
-    obj = mock_aws['s3_client'].get_object(
-        Bucket=mock_aws['bucket_name'],
-        Key='validation-metadata/file-1/job-1.json',
+    obj = mock_aws["s3_client"].get_object(
+        Bucket=mock_aws["bucket_name"],
+        Key="validation-metadata/file-1/job-1.json",
     )
-    body = obj['Body'].read().decode('utf-8')
+    body = obj["Body"].read().decode("utf-8")
     assert json.loads(body) == json.loads(message.to_json())
-    assert obj['ContentType'] == 'application/json'
+    assert obj["ContentType"] == "application/json"
 
 
 def test_write_validation_results_to_s3_failure(caplog, mock_aws):
     """Write to a nonexistent bucket logs the error and returns False without raising."""
-    from dataset_validator.main import write_validation_results_to_s3, configure_logging
+    from dataset_validator.main import configure_logging, write_validation_results_to_s3
+
     configure_logging()
 
-    message = _build_message(file_id='file-2', batch_job_id='job-2')
+    message = _build_message(file_id="file-2", batch_job_id="job-2")
 
     with caplog.at_level(logging.ERROR, logger="dataset_validator.main"):
-        result = write_validation_results_to_s3(
-            message, 'nonexistent-bucket', 'file-2', 'job-2'
-        )
+        result = write_validation_results_to_s3(message, "nonexistent-bucket", "file-2", "job-2")
 
     assert result is False
     assert "S3 claim check write failed for file file-2" in caplog.text
@@ -782,8 +792,8 @@ def test_write_validation_results_to_s3_writes_full_untruncated_json(mock_aws):
     a payload actually runs to since #400/#402.
     """
     from dataset_validator.main import (
-        write_validation_results_to_s3,
         ValidationToolReport,
+        write_validation_results_to_s3,
     )
 
     # Comfortably larger than the 250 KB the old SNS body was capped at, so the
@@ -793,99 +803,106 @@ def test_write_validation_results_to_s3_writes_full_untruncated_json(mock_aws):
     huge_errors = [f"error-{i}" for i in range(20000)]
     tool_reports = {
         "cap": ValidationToolReport(
-            valid=False, errors=huge_errors, warnings=[],
-            started_at='2024-01-01T12:00:00Z', finished_at='2024-01-01T12:00:01Z',
+            valid=False,
+            errors=huge_errors,
+            warnings=[],
+            started_at="2024-01-01T12:00:00Z",
+            finished_at="2024-01-01T12:00:01Z",
         ),
         "cellxgene": ValidationToolReport(
-            valid=True, errors=[], warnings=[],
-            started_at='2024-01-01T12:00:00Z', finished_at='2024-01-01T12:00:01Z',
+            valid=True,
+            errors=[],
+            warnings=[],
+            started_at="2024-01-01T12:00:00Z",
+            finished_at="2024-01-01T12:00:01Z",
         ),
         "hcaSchema": ValidationToolReport(
-            valid=True, errors=[], warnings=[],
-            started_at='2024-01-01T12:00:00Z', finished_at='2024-01-01T12:00:01Z',
+            valid=True,
+            errors=[],
+            warnings=[],
+            started_at="2024-01-01T12:00:00Z",
+            finished_at="2024-01-01T12:00:01Z",
         ),
         "hcaCellAnnotation": ValidationToolReport(
-            valid=True, errors=[], warnings=[],
-            started_at='2024-01-01T12:00:00Z', finished_at='2024-01-01T12:00:01Z',
+            valid=True,
+            errors=[],
+            warnings=[],
+            started_at="2024-01-01T12:00:00Z",
+            finished_at="2024-01-01T12:00:01Z",
         ),
     }
-    message = _build_message(
-        file_id='file-3', batch_job_id='job-3', tool_reports=tool_reports
-    )
+    message = _build_message(file_id="file-3", batch_job_id="job-3", tool_reports=tool_reports)
 
     # Sanity: the message must actually exceed the old SNS cap, otherwise the
     # test wouldn't be meaningfully exercising the claim-check use case.
     full_json = message.to_json()
     assert len(full_json) > OLD_SNS_CAP
 
-    assert write_validation_results_to_s3(
-        message, mock_aws['bucket_name'], 'file-3', 'job-3'
-    ) is True
+    assert write_validation_results_to_s3(message, mock_aws["bucket_name"], "file-3", "job-3") is True
 
-    obj = mock_aws['s3_client'].get_object(
-        Bucket=mock_aws['bucket_name'],
-        Key='validation-metadata/file-3/job-3.json',
+    obj = mock_aws["s3_client"].get_object(
+        Bucket=mock_aws["bucket_name"],
+        Key="validation-metadata/file-3/job-3.json",
     )
-    body = obj['Body'].read().decode('utf-8')
+    body = obj["Body"].read().decode("utf-8")
     assert body == full_json
 
 
-@pytest.mark.parametrize("test_case", [
-    {
-        "name": "success",
-        "description": "Local file mode completes validation, skips S3 and prints JSON to stdout",
-        "adata": {
-            "obs": {
-                "assay": ["assay-a"],
-                "suspension_type": ["cell"],
-                "tissue": ["lung"],
-                "disease": ["normal"]
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        {
+            "name": "success",
+            "description": "Local file mode completes validation, skips S3 and prints JSON to stdout",
+            "adata": {
+                "obs": {"assay": ["assay-a"], "suspension_type": ["cell"], "tissue": ["lung"], "disease": ["normal"]},
+                "uns": {"title": "local-test"},
+                "n_vars": 10,
             },
-            "uns": {"title": "local-test"},
-            "n_vars": 10
+            "expected_exit_code": 0,
+            "expected_logs": [
+                "Local file mode: validating",
+                "Validation completed successfully",
+            ],
+            "unexpected_logs": [
+                "Starting download:",
+                "Verifying file integrity",
+                "Publishing validation result to SNS",
+                "S3 claim check write",
+            ],
+            "expected_stdout": {
+                "status": "success",
+                "integrity_status": "valid",
+                "file_id": "local",
+                "batch_job_id": "local",
+                "bucket": "local",
+                "metadata_summary": {
+                    "title": "local-test",
+                    "assay": ["assay-a"],
+                    "suspension_type": ["cell"],
+                    "tissue": ["lung"],
+                    "disease": ["normal"],
+                    "cell_count": 1,
+                    "gene_count": 10,
+                },
+            },
         },
-        "expected_exit_code": 0,
-        "expected_logs": [
-            "Local file mode: validating",
-            "Validation completed successfully",
-        ],
-        "unexpected_logs": [
-            "Starting download:",
-            "Verifying file integrity",
-            "Publishing validation result to SNS",
-            "S3 claim check write",
-        ],
-        "expected_stdout": {
-            "status": "success",
-            "integrity_status": "valid",
-            "file_id": "local",
-            "batch_job_id": "local",
-            "bucket": "local",
-            "metadata_summary": {
-                "title": "local-test",
-                "assay": ["assay-a"],
-                "suspension_type": ["cell"],
-                "tissue": ["lung"],
-                "disease": ["normal"],
-                "cell_count": 1,
-                "gene_count": 10
-            }
-        }
-    },
-    {
-        "name": "file_not_found",
-        "description": "Local file mode fails when file does not exist",
-        "adata": None,
-        "local_file_override": "/nonexistent/path.h5ad",
-        "expected_exit_code": 1,
-        "expected_logs": [
-            "Missing required environment variables",
-            "file does not exist",
-        ],
-        "unexpected_logs": [],
-        "expected_stdout": None
-    }
-], ids=lambda x: x["name"])
+        {
+            "name": "file_not_found",
+            "description": "Local file mode fails when file does not exist",
+            "adata": None,
+            "local_file_override": "/nonexistent/path.h5ad",
+            "expected_exit_code": 1,
+            "expected_logs": [
+                "Missing required environment variables",
+                "file does not exist",
+            ],
+            "unexpected_logs": [],
+            "expected_stdout": None,
+        },
+    ],
+    ids=lambda x: x["name"],
+)
 @patch("dataset_validator.main.get_matrix_storage")
 @patch("dataset_validator.main._read_metadata_inputs")
 def test_local_file_mode(mock_read_inputs, mock_matrix_storage, caplog, env_manager, tmp_path, test_case, capsys):
@@ -899,12 +916,14 @@ def test_local_file_mode(mock_read_inputs, mock_matrix_storage, caplog, env_mana
         Path(local_file).touch()
 
     # Set only LOCAL_FILE — no S3/SNS/Batch vars
-    env_manager['set']({
-        'LOCAL_FILE': local_file,
-        **external_validator_path_vars,
-    })
+    env_manager["set"](
+        {
+            "LOCAL_FILE": local_file,
+            **external_validator_path_vars,
+        }
+    )
     # Ensure S3/SNS vars are not set
-    env_manager['clear'](['S3_BUCKET', 'S3_KEY', 'FILE_ID', 'SNS_TOPIC_ARN', 'AWS_BATCH_JOB_ID'])
+    env_manager["clear"](["S3_BUCKET", "S3_KEY", "FILE_ID", "SNS_TOPIC_ARN", "AWS_BATCH_JOB_ID"])
 
     # Drive the metadata read seam (obs/uns/shape + matrix storage)
     _setup_metadata_mocks(mock_read_inputs, mock_matrix_storage, test_case["adata"])
@@ -934,280 +953,272 @@ def test_local_file_mode(mock_read_inputs, mock_matrix_storage, caplog, env_mana
         assert "hcaCellAnnotation" in output["tool_reports"]
 
 
-@pytest.mark.parametrize("test_case", [
-    {
-        "name": "success",
-        "description": "Test complete validation workflow with successful validation",
-        "s3_key": "datasets/test.h5ad",
-        "file_id": "test-file-123",
-        "batch_job_id": "job-456",
-        "batch_job_name": "test-validation-job",
-        "setup_s3": lambda s3_client, bucket_name: _setup_valid_s3_file(s3_client, bucket_name, "datasets/test.h5ad"),
-        "adata": {
-            "obs": {
-                "assay": ["assay-a", "assay-b", "assay-b", "assay-c", "assay-a"],
-                "suspension_type": [
-                    "suspension-type-a",
-                    "suspension-type-a",
-                    "suspension-type-a",
-                    "suspension-type-a",
-                    "suspension-type-a",
-                ],
-                "tissue": ["tissue-a", "tissue-a", "tissue-b", "tissue-a", "tissue-a"],
-                "disease": ["disease-a", "disease-b", "disease-c", "disease-d", "disease-e"]
-            },
-            "uns": {"title": "test-dataset-123"},
-            "n_vars": 14
-        },
-        "expected_exit_code": 0,
-        "expected_logs": [
-            "Dataset Validator starting",
-            "Processing S3 file: s3://test-bucket/datasets/test.h5ad",
-            "Work directory created:",
-            "File ready for validation:",
-            "Validation completed successfully",
-            "Publishing validation result to SNS topic",
-            "Successfully published SNS message",
-            "Dataset Validator completed successfully"
-        ],
-        "expected_sns_message": {
-            "status": "success",
-            "integrity_status": "valid",
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        {
+            "name": "success",
+            "description": "Test complete validation workflow with successful validation",
+            "s3_key": "datasets/test.h5ad",
             "file_id": "test-file-123",
             "batch_job_id": "job-456",
             "batch_job_name": "test-validation-job",
-            "error_message": None,
-            "metadata_summary": {
-                "title": "test-dataset-123",
-                "assay": ["assay-a", "assay-b", "assay-c"],
-                "suspension_type": ["suspension-type-a"],
-                "tissue": ["tissue-a", "tissue-b"],
-                "disease": ["disease-a", "disease-b", "disease-c", "disease-d", "disease-e"],
-                "cell_count": 5,
-                "gene_count": 14
+            "setup_s3": lambda s3_client, bucket_name: _setup_valid_s3_file(
+                s3_client, bucket_name, "datasets/test.h5ad"
+            ),
+            "adata": {
+                "obs": {
+                    "assay": ["assay-a", "assay-b", "assay-b", "assay-c", "assay-a"],
+                    "suspension_type": [
+                        "suspension-type-a",
+                        "suspension-type-a",
+                        "suspension-type-a",
+                        "suspension-type-a",
+                        "suspension-type-a",
+                    ],
+                    "tissue": ["tissue-a", "tissue-a", "tissue-b", "tissue-a", "tissue-a"],
+                    "disease": ["disease-a", "disease-b", "disease-c", "disease-d", "disease-e"],
+                },
+                "uns": {"title": "test-dataset-123"},
+                "n_vars": 14,
             },
-            "tool_reports": {
-                "cap": {
-                    "valid": True,
-                    "errors": [],
-                    "warnings": []
+            "expected_exit_code": 0,
+            "expected_logs": [
+                "Dataset Validator starting",
+                "Processing S3 file: s3://test-bucket/datasets/test.h5ad",
+                "Work directory created:",
+                "File ready for validation:",
+                "Validation completed successfully",
+                "Publishing validation result to SNS topic",
+                "Successfully published SNS message",
+                "Dataset Validator completed successfully",
+            ],
+            "expected_sns_message": {
+                "status": "success",
+                "integrity_status": "valid",
+                "file_id": "test-file-123",
+                "batch_job_id": "job-456",
+                "batch_job_name": "test-validation-job",
+                "error_message": None,
+                "metadata_summary": {
+                    "title": "test-dataset-123",
+                    "assay": ["assay-a", "assay-b", "assay-c"],
+                    "suspension_type": ["suspension-type-a"],
+                    "tissue": ["tissue-a", "tissue-b"],
+                    "disease": ["disease-a", "disease-b", "disease-c", "disease-d", "disease-e"],
+                    "cell_count": 5,
+                    "gene_count": 14,
                 },
-                # cellxgene is stubbed in main.py (apply_cellxgene_validator
-                # is no longer called) — see #382. Expected output reflects
-                # the empty stub, not the mock script's "ERROR: test" output.
-                "cellxgene": {
-                    "valid": True,
-                    "errors": [],
-                    "warnings": []
+                "tool_reports": {
+                    "cap": {"valid": True, "errors": [], "warnings": []},
+                    # cellxgene is stubbed in main.py (apply_cellxgene_validator
+                    # is no longer called) — see #382. Expected output reflects
+                    # the empty stub, not the mock script's "ERROR: test" output.
+                    "cellxgene": {"valid": True, "errors": [], "warnings": []},
+                    "hcaSchema": {"valid": False, "errors": ["ERROR: test bar"], "warnings": ["WARNING: test bar"]},
+                    "hcaCellAnnotation": {
+                        "valid": False,
+                        "errors": ["ERROR: test baz"],
+                        "warnings": ["WARNING: test baz"],
+                    },
                 },
-                "hcaSchema": {
-                    "valid": False,
-                    "errors": ["ERROR: test bar"],
-                    "warnings": ["WARNING: test bar"]
-                },
-                "hcaCellAnnotation": {
-                    "valid": False,
-                    "errors": ["ERROR: test baz"],
-                    "warnings": ["WARNING: test baz"]
-                }
-            }
-        }
-    },
-    {
-        "name": "download_failure",
-        "description": "Test complete validation workflow with S3 download failure",
-        "s3_key": "datasets/nonexistent.h5ad",
-        "file_id": "test-file-456",
-        "batch_job_id": "job-789",
-        "batch_job_name": None,
-        "setup_s3": lambda s3_client, bucket_name: None,  # Don't upload any file
-        "adata": None,
-        "expected_exit_code": 1,
-        "expected_logs": [
-            "Dataset Validator starting",
-            "Processing S3 file: s3://test-bucket/datasets/nonexistent.h5ad",
-            "S3 download failed",
-            "Dataset Validator failed:",
-            "Publishing validation result to SNS topic",
-            "Successfully published SNS message"
-        ],
-        "expected_sns_message": {
-            "status": "failure",
-            "integrity_status": None,
+            },
+        },
+        {
+            "name": "download_failure",
+            "description": "Test complete validation workflow with S3 download failure",
+            "s3_key": "datasets/nonexistent.h5ad",
             "file_id": "test-file-456",
             "batch_job_id": "job-789",
             "batch_job_name": None,
-            "metadata_summary": None,
-            "tool_reports": None
-        }
-    },
-    {
-        "name": "integrity_failure",
-        "description": "Test complete validation workflow with file integrity failure",
-        "s3_key": "datasets/corrupt.h5ad",
-        "file_id": "test-file-789",
-        "batch_job_id": "job-101",
-        "batch_job_name": None,
-        "setup_s3": lambda s3_client, bucket_name: _setup_corrupt_s3_file(
-            s3_client, bucket_name, "datasets/corrupt.h5ad"
-        ),
-        "adata": None,
-        "expected_exit_code": 1,
-        "expected_logs": [
-            "Dataset Validator starting",
-            "File ready for validation:",
-            "File integrity verification failed - terminating",
-            "Publishing validation result to SNS topic",
-            "Successfully published SNS message"
-        ],
-        "expected_sns_message": {
-            "status": "failure",
-            "integrity_status": "invalid",
+            "setup_s3": lambda s3_client, bucket_name: None,  # Don't upload any file
+            "adata": None,
+            "expected_exit_code": 1,
+            "expected_logs": [
+                "Dataset Validator starting",
+                "Processing S3 file: s3://test-bucket/datasets/nonexistent.h5ad",
+                "S3 download failed",
+                "Dataset Validator failed:",
+                "Publishing validation result to SNS topic",
+                "Successfully published SNS message",
+            ],
+            "expected_sns_message": {
+                "status": "failure",
+                "integrity_status": None,
+                "file_id": "test-file-456",
+                "batch_job_id": "job-789",
+                "batch_job_name": None,
+                "metadata_summary": None,
+                "tool_reports": None,
+            },
+        },
+        {
+            "name": "integrity_failure",
+            "description": "Test complete validation workflow with file integrity failure",
+            "s3_key": "datasets/corrupt.h5ad",
             "file_id": "test-file-789",
             "batch_job_id": "job-101",
             "batch_job_name": None,
-            "metadata_summary": None,
-            "tool_reports": None
-        }
-    },
-    {
-        "name": "metadata_failure",
-        "description": "Test complete validation workflow with failure reading metadata",
-        "s3_key": "datasets/test.h5ad",
-        "file_id": "test-file-123",
-        "batch_job_id": "job-456",
-        "batch_job_name": "test-validation-job",
-        "setup_s3": lambda s3_client, bucket_name: _setup_valid_s3_file(s3_client, bucket_name, "datasets/test.h5ad"),
-        "adata": {
-            "exception": Exception("Test metadata error")
+            "setup_s3": lambda s3_client, bucket_name: _setup_corrupt_s3_file(
+                s3_client, bucket_name, "datasets/corrupt.h5ad"
+            ),
+            "adata": None,
+            "expected_exit_code": 1,
+            "expected_logs": [
+                "Dataset Validator starting",
+                "File ready for validation:",
+                "File integrity verification failed - terminating",
+                "Publishing validation result to SNS topic",
+                "Successfully published SNS message",
+            ],
+            "expected_sns_message": {
+                "status": "failure",
+                "integrity_status": "invalid",
+                "file_id": "test-file-789",
+                "batch_job_id": "job-101",
+                "batch_job_name": None,
+                "metadata_summary": None,
+                "tool_reports": None,
+            },
         },
-        "expected_exit_code": 1,
-        "expected_logs": [
-            "Dataset Validator starting",
-            "Processing S3 file: s3://test-bucket/datasets/test.h5ad",
-            "Work directory created:",
-            "File ready for validation:",
-            "Error reading metadata:",
-            "Dataset Validator failed:",
-            "Publishing validation result to SNS topic",
-            "Successfully published SNS message"
-        ],
-        "expected_sns_message": {
-            "status": "failure",
-            "integrity_status": "valid",
+        {
+            "name": "metadata_failure",
+            "description": "Test complete validation workflow with failure reading metadata",
+            "s3_key": "datasets/test.h5ad",
             "file_id": "test-file-123",
             "batch_job_id": "job-456",
             "batch_job_name": "test-validation-job",
-            "error_message": "Dataset Validator failed: Test metadata error",
-            "metadata_summary": None,
-            "tool_reports": None
-        }
-    },
-    {
-        "name": "cap_failure",
-        "description": "Test complete validation workflow with successful validation",
-        "s3_key": "datasets/test.h5ad",
-        "file_id": "test-file-123",
-        "batch_job_id": "job-456",
-        "batch_job_name": "test-validation-job",
-        "setup_s3": lambda s3_client, bucket_name: _setup_valid_s3_file(s3_client, bucket_name, "datasets/test.h5ad"),
-        "adata": {
-            "obs": {
-                "assay": ["assay-a", "assay-b", "assay-b", "assay-c", "assay-a"],
-                "suspension_type": [
-                    "suspension-type-a",
-                    "suspension-type-a",
-                    "suspension-type-a",
-                    "suspension-type-a",
-                    "suspension-type-a",
-                ],
-                "tissue": ["tissue-a", "tissue-a", "tissue-b", "tissue-a", "tissue-a"],
-                "disease": ["disease-a", "disease-b", "disease-c", "disease-d", "disease-e"]
+            "setup_s3": lambda s3_client, bucket_name: _setup_valid_s3_file(
+                s3_client, bucket_name, "datasets/test.h5ad"
+            ),
+            "adata": {"exception": Exception("Test metadata error")},
+            "expected_exit_code": 1,
+            "expected_logs": [
+                "Dataset Validator starting",
+                "Processing S3 file: s3://test-bucket/datasets/test.h5ad",
+                "Work directory created:",
+                "File ready for validation:",
+                "Error reading metadata:",
+                "Dataset Validator failed:",
+                "Publishing validation result to SNS topic",
+                "Successfully published SNS message",
+            ],
+            "expected_sns_message": {
+                "status": "failure",
+                "integrity_status": "valid",
+                "file_id": "test-file-123",
+                "batch_job_id": "job-456",
+                "batch_job_name": "test-validation-job",
+                "error_message": "Dataset Validator failed: Test metadata error",
+                "metadata_summary": None,
+                "tool_reports": None,
             },
-            "uns": {"title": "test-dataset-123"},
-            "n_vars": 17
         },
-        "cap_mock_error": "Error in CAP validator",
-        "expected_exit_code": 0,
-        "expected_logs": [
-            "Dataset Validator starting",
-            "Processing S3 file: s3://test-bucket/datasets/test.h5ad",
-            "Work directory created:",
-            "File ready for validation:",
-            "Validation completed successfully",
-            "Publishing validation result to SNS topic",
-            "Successfully published SNS message",
-            "Dataset Validator completed successfully"
-        ],
-        "expected_sns_message": {
-            "status": "success",
-            "integrity_status": "valid",
+        {
+            "name": "cap_failure",
+            "description": "Test complete validation workflow with successful validation",
+            "s3_key": "datasets/test.h5ad",
             "file_id": "test-file-123",
             "batch_job_id": "job-456",
             "batch_job_name": "test-validation-job",
-            "error_message": None,
-            "metadata_summary": {
-                "title": "test-dataset-123",
-                "assay": ["assay-a", "assay-b", "assay-c"],
-                "suspension_type": ["suspension-type-a"],
-                "tissue": ["tissue-a", "tissue-b"],
-                "disease": ["disease-a", "disease-b", "disease-c", "disease-d", "disease-e"],
-                "cell_count": 5,
-                "gene_count": 17
+            "setup_s3": lambda s3_client, bucket_name: _setup_valid_s3_file(
+                s3_client, bucket_name, "datasets/test.h5ad"
+            ),
+            "adata": {
+                "obs": {
+                    "assay": ["assay-a", "assay-b", "assay-b", "assay-c", "assay-a"],
+                    "suspension_type": [
+                        "suspension-type-a",
+                        "suspension-type-a",
+                        "suspension-type-a",
+                        "suspension-type-a",
+                        "suspension-type-a",
+                    ],
+                    "tissue": ["tissue-a", "tissue-a", "tissue-b", "tissue-a", "tissue-a"],
+                    "disease": ["disease-a", "disease-b", "disease-c", "disease-d", "disease-e"],
+                },
+                "uns": {"title": "test-dataset-123"},
+                "n_vars": 17,
             },
-            "tool_reports": {
-                "cap": {
-                    "valid": False,
-                    "errors": ["Encountered an unexpected error while calling CAP validator: Error in CAP validator"],
-                    "warnings": []
+            "cap_mock_error": "Error in CAP validator",
+            "expected_exit_code": 0,
+            "expected_logs": [
+                "Dataset Validator starting",
+                "Processing S3 file: s3://test-bucket/datasets/test.h5ad",
+                "Work directory created:",
+                "File ready for validation:",
+                "Validation completed successfully",
+                "Publishing validation result to SNS topic",
+                "Successfully published SNS message",
+                "Dataset Validator completed successfully",
+            ],
+            "expected_sns_message": {
+                "status": "success",
+                "integrity_status": "valid",
+                "file_id": "test-file-123",
+                "batch_job_id": "job-456",
+                "batch_job_name": "test-validation-job",
+                "error_message": None,
+                "metadata_summary": {
+                    "title": "test-dataset-123",
+                    "assay": ["assay-a", "assay-b", "assay-c"],
+                    "suspension_type": ["suspension-type-a"],
+                    "tissue": ["tissue-a", "tissue-b"],
+                    "disease": ["disease-a", "disease-b", "disease-c", "disease-d", "disease-e"],
+                    "cell_count": 5,
+                    "gene_count": 17,
                 },
-                # cellxgene stubbed in main.py — see #382.
-                "cellxgene": {
-                    "valid": True,
-                    "errors": [],
-                    "warnings": []
+                "tool_reports": {
+                    "cap": {
+                        "valid": False,
+                        "errors": [
+                            "Encountered an unexpected error while calling CAP validator: Error in CAP validator"
+                        ],
+                        "warnings": [],
+                    },
+                    # cellxgene stubbed in main.py — see #382.
+                    "cellxgene": {"valid": True, "errors": [], "warnings": []},
+                    "hcaSchema": {"valid": False, "errors": ["ERROR: test bar"], "warnings": ["WARNING: test bar"]},
+                    "hcaCellAnnotation": {
+                        "valid": False,
+                        "errors": ["ERROR: test baz"],
+                        "warnings": ["WARNING: test baz"],
+                    },
                 },
-                "hcaSchema": {
-                    "valid": False,
-                    "errors": ["ERROR: test bar"],
-                    "warnings": ["WARNING: test bar"]
-                },
-                "hcaCellAnnotation": {
-                    "valid": False,
-                    "errors": ["ERROR: test baz"],
-                    "warnings": ["WARNING: test baz"]
-                }
-            }
-        }
-    }
-], ids=lambda x: x["name"])
+            },
+        },
+    ],
+    ids=lambda x: x["name"],
+)
 @patch("dataset_validator.main.get_matrix_storage")
 @patch("dataset_validator.main._read_metadata_inputs")
-def test_end_to_end_validation_scenarios(mock_read_inputs, mock_matrix_storage, caplog, mock_aws, env_manager, test_case):
+def test_end_to_end_validation_scenarios(
+    mock_read_inputs, mock_matrix_storage, caplog, mock_aws, env_manager, test_case
+):
     """Parameterized test for end-to-end validation scenarios."""
     from dataset_validator.main import main
 
     # Setup S3 file based on test case
-    test_case["setup_s3"](mock_aws['s3_client'], mock_aws['bucket_name'])
+    test_case["setup_s3"](mock_aws["s3_client"], mock_aws["bucket_name"])
 
     # Set environment variables using fixture
     test_env = {
-        'S3_BUCKET': mock_aws['bucket_name'],
-        'S3_KEY': test_case["s3_key"],
-        'VALIDATION_RESULTS_BUCKET': mock_aws['validation_results_bucket_name'],
-        'FILE_ID': test_case["file_id"],
-        'SNS_TOPIC_ARN': mock_aws['topic_arn'],
-        'AWS_BATCH_JOB_ID': test_case["batch_job_id"],
-        **external_validator_path_vars
+        "S3_BUCKET": mock_aws["bucket_name"],
+        "S3_KEY": test_case["s3_key"],
+        "VALIDATION_RESULTS_BUCKET": mock_aws["validation_results_bucket_name"],
+        "FILE_ID": test_case["file_id"],
+        "SNS_TOPIC_ARN": mock_aws["topic_arn"],
+        "AWS_BATCH_JOB_ID": test_case["batch_job_id"],
+        **external_validator_path_vars,
     }
     if test_case["batch_job_name"]:
-        test_env['BATCH_JOB_NAME'] = test_case["batch_job_name"]
-    env_manager['set'](test_env)
+        test_env["BATCH_JOB_NAME"] = test_case["batch_job_name"]
+    env_manager["set"](test_env)
     # Manage CAP_MOCK_ERROR: set if specified, clear otherwise to prevent bleed between tests
     if test_case.get("cap_mock_error"):
-        env_manager['set']({'CAP_MOCK_ERROR': test_case["cap_mock_error"]})
+        env_manager["set"]({"CAP_MOCK_ERROR": test_case["cap_mock_error"]})
     else:
-        env_manager['clear'](['CAP_MOCK_ERROR'])
+        env_manager["clear"](["CAP_MOCK_ERROR"])
 
     # Drive the metadata read seam (obs/uns/shape + matrix storage)
     _setup_metadata_mocks(mock_read_inputs, mock_matrix_storage, test_case["adata"])
@@ -1228,7 +1239,7 @@ def test_end_to_end_validation_scenarios(mock_read_inputs, mock_matrix_storage, 
         mock_aws,
         caplog,
         test_case["expected_sns_message"],
-        source_bucket=mock_aws['bucket_name'],
+        source_bucket=mock_aws["bucket_name"],
         source_key=test_case["s3_key"],
     )
     assert "S3 claim check write succeeded" in caplog.text
@@ -1244,28 +1255,34 @@ def test_unset_validation_results_bucket_skips_s3_claim_check(
     from dataset_validator.main import main
 
     s3_key = "datasets/test.h5ad"
-    _setup_valid_s3_file(mock_aws['s3_client'], mock_aws['bucket_name'], s3_key)
+    _setup_valid_s3_file(mock_aws["s3_client"], mock_aws["bucket_name"], s3_key)
 
-    env_manager['set']({
-        'S3_BUCKET': mock_aws['bucket_name'],
-        'S3_KEY': s3_key,
-        'FILE_ID': 'test-file-no-results-bucket',
-        'SNS_TOPIC_ARN': mock_aws['topic_arn'],
-        'AWS_BATCH_JOB_ID': 'job-no-results-bucket',
-        **external_validator_path_vars,
-    })
-    env_manager['clear'](['VALIDATION_RESULTS_BUCKET', 'CAP_MOCK_ERROR'])
+    env_manager["set"](
+        {
+            "S3_BUCKET": mock_aws["bucket_name"],
+            "S3_KEY": s3_key,
+            "FILE_ID": "test-file-no-results-bucket",
+            "SNS_TOPIC_ARN": mock_aws["topic_arn"],
+            "AWS_BATCH_JOB_ID": "job-no-results-bucket",
+            **external_validator_path_vars,
+        }
+    )
+    env_manager["clear"](["VALIDATION_RESULTS_BUCKET", "CAP_MOCK_ERROR"])
 
-    _setup_metadata_mocks(mock_read_inputs, mock_matrix_storage, {
-        "obs": {
-            "assay": ["assay-a"],
-            "suspension_type": ["cell"],
-            "tissue": ["lung"],
-            "disease": ["normal"],
+    _setup_metadata_mocks(
+        mock_read_inputs,
+        mock_matrix_storage,
+        {
+            "obs": {
+                "assay": ["assay-a"],
+                "suspension_type": ["cell"],
+                "tissue": ["lung"],
+                "disease": ["normal"],
+            },
+            "uns": {"title": "test"},
+            "n_vars": 10,
         },
-        "uns": {"title": "test"},
-        "n_vars": 10,
-    })
+    )
 
     with caplog.at_level(logging.INFO, logger="dataset_validator.main"):
         result = main()
@@ -1279,23 +1296,23 @@ def test_unset_validation_results_bucket_skips_s3_claim_check(
 def _get_last_sns_message(sns_backend, topic_arn):
     """Helper function to extract and parse the last SNS message from moto backend."""
     import json
-    
+
     # Get all sent notifications for our topic
     all_sent_notifications = sns_backend.topics[topic_arn].sent_notifications
     assert len(all_sent_notifications) > 0, "No SNS messages were published"
-    
+
     # Parse the last published message
     last_notification = all_sent_notifications[-1]
-    
+
     # Handle different moto notification formats
     if isinstance(last_notification, dict):
-        message_content = last_notification['Message']
+        message_content = last_notification["Message"]
     elif isinstance(last_notification, tuple):
         # In some moto versions, notifications are stored as tuples
         message_content = last_notification[1]  # Usually (subject, message, ...)
     else:
         message_content = str(last_notification)
-    
+
     return json.loads(message_content)
 
 
@@ -1303,6 +1320,7 @@ def _get_sns_backend():
     """Return moto's in-memory SNS backend for us-east-1."""
     from moto.core import DEFAULT_ACCOUNT_ID
     from moto.sns import sns_backends
+
     return sns_backends[DEFAULT_ACCOUNT_ID]["us-east-1"]
 
 
@@ -1319,7 +1337,7 @@ def _validate_published_result(mock_aws, caplog, expected_message, source_bucket
     appear on both the SNS pointer and the claim-check body and must match.
     """
 
-    topic_arn = mock_aws['topic_arn']
+    topic_arn = mock_aws["topic_arn"]
 
     # Verify at least one message was published
     assert "Successfully published SNS message" in caplog.text
@@ -1330,9 +1348,9 @@ def _validate_published_result(mock_aws, caplog, expected_message, source_bucket
     # SNS body is pointer-only — assert the exact set of keys plus their values
     # for fields the test pins. timestamp isn't pinned by the test cases but
     # must be present (it's a required pointer field).
-    assert set(sns_body.keys()) == {
-        "file_id", "status", "timestamp", "bucket", "key", "batch_job_id"
-    }, f"SNS body should be pointer-only, got keys: {sorted(sns_body.keys())}"
+    assert set(sns_body.keys()) == {"file_id", "status", "timestamp", "bucket", "key", "batch_job_id"}, (
+        f"SNS body should be pointer-only, got keys: {sorted(sns_body.keys())}"
+    )
     assert sns_body["status"] == expected_message["status"]
     assert sns_body["file_id"] == expected_message["file_id"]
     assert sns_body["batch_job_id"] == expected_message["batch_job_id"]
@@ -1341,21 +1359,15 @@ def _validate_published_result(mock_aws, caplog, expected_message, source_bucket
 
     # Heavy fields are asserted on the S3 claim check, which is the
     # authoritative payload.
-    expected_key = (
-        f"validation-metadata/{expected_message['file_id']}"
-        f"/{expected_message['batch_job_id']}.json"
-    )
-    claim_obj = mock_aws['s3_client'].get_object(
-        Bucket=mock_aws['validation_results_bucket_name'], Key=expected_key
-    )
-    claim_body = json.loads(claim_obj['Body'].read().decode('utf-8'))
+    expected_key = f"validation-metadata/{expected_message['file_id']}/{expected_message['batch_job_id']}.json"
+    claim_obj = mock_aws["s3_client"].get_object(Bucket=mock_aws["validation_results_bucket_name"], Key=expected_key)
+    claim_body = json.loads(claim_obj["Body"].read().decode("utf-8"))
 
     assert claim_body["status"] == expected_message["status"]
     assert claim_body["bucket"] == source_bucket
     assert claim_body["key"] == source_key
     assert claim_body["integrity_status"] == expected_message["integrity_status"], (
-        f"Expected integrity_status '{expected_message['integrity_status']}', "
-        f"got '{claim_body['integrity_status']}'"
+        f"Expected integrity_status '{expected_message['integrity_status']}', got '{claim_body['integrity_status']}'"
     )
     assert claim_body["file_id"] == expected_message["file_id"]
     assert claim_body["batch_job_id"] == expected_message["batch_job_id"]
@@ -1378,27 +1390,18 @@ def _validate_published_result(mock_aws, caplog, expected_message, source_bucket
 def _setup_valid_s3_file(s3_client, bucket_name: str, key: str):
     """Helper function to setup a valid S3 file with correct SHA256 metadata."""
     import hashlib
-    test_content = b'mock dataset content for validation'
+
+    test_content = b"mock dataset content for validation"
     expected_sha256 = hashlib.sha256(test_content).hexdigest()
-    
-    s3_client.put_object(
-        Bucket=bucket_name,
-        Key=key,
-        Body=test_content,
-        Metadata={'source-sha256': expected_sha256}
-    )
+
+    s3_client.put_object(Bucket=bucket_name, Key=key, Body=test_content, Metadata={"source-sha256": expected_sha256})
 
 
 def _setup_corrupt_s3_file(s3_client, bucket_name: str, key: str):
     """Helper function to setup a corrupt S3 file with wrong SHA256 metadata."""
-    test_content = b'mock dataset content'
+    test_content = b"mock dataset content"
 
-    s3_client.put_object(
-        Bucket=bucket_name,
-        Key=key,
-        Body=test_content,
-        Metadata={'source-sha256': 'wrong_hash_value'}
-    )
+    s3_client.put_object(Bucket=bucket_name, Key=key, Body=test_content, Metadata={"source-sha256": "wrong_hash_value"})
 
 
 def test_get_uv_venv_path_from_returns_project_local_venv():

--- a/services/dataset-validator/tests/test_dataset_validator.py
+++ b/services/dataset-validator/tests/test_dataset_validator.py
@@ -360,6 +360,7 @@ def test_read_file_metadata_real_h5ad(tmp_path):
     without loading matrices (the #447 fix path: no read_h5ad(backed="r"))."""
     import anndata as ad
     import scipy.sparse as sp
+
     from dataset_validator.main import read_file_metadata
 
     n_obs, n_vars = 5, 8
@@ -404,6 +405,7 @@ def test_read_shape_var_fallback_is_robust(tmp_path):
     """When X has no shape header, _read_shape falls back to var — and must
     degrade (n_vars=0) rather than raise on a missing/malformed var index."""
     import h5py
+
     from dataset_validator.main import _read_shape
 
     obs = pd.DataFrame({"a": [1, 2, 3]})
@@ -586,6 +588,7 @@ def _build_cap_multi_exception(exceptions):
 def test_cap_validator_script_scenarios(mock_upload_validator, test_case):
     """Unit tests for cap_validator_script.py exception handling."""
     from cap_upload_validator.errors import AnnDataMissingCountMatrix, CapException
+
     from dataset_validator.cap_validator_script import main
 
     mock_instance = MagicMock()

--- a/services/dataset-validator/tests/test_docker_smoke.py
+++ b/services/dataset-validator/tests/test_docker_smoke.py
@@ -1,59 +1,57 @@
-import os
-import time
-import pytest
 import subprocess
 import tempfile
 from pathlib import Path
+
+import pytest
 
 
 @pytest.fixture(scope="module", autouse=True)
 def dataset_validator_container():
     """Build and run the dataset-validator Docker container for testing."""
     image_name = "hca-dataset-validator:test"
-    
+
     # Teardown logic to ensure container is stopped/removed and clean up test artifacts
     def teardown():
         # Stop and remove any test containers
         subprocess.run(["docker", "stop", "dataset-validator-test"], capture_output=True)
         subprocess.run(["docker", "rm", "dataset-validator-test"], capture_output=True)
-        
+
         # Remove any temporary containers that might have been created during tests
-        result = subprocess.run(["docker", "ps", "-a", "--filter", f"ancestor={image_name}", "-q"], 
-                              capture_output=True, text=True)
+        result = subprocess.run(
+            ["docker", "ps", "-a", "--filter", f"ancestor={image_name}", "-q"], capture_output=True, text=True
+        )
         if result.stdout.strip():
-            container_ids = result.stdout.strip().split('\n')
+            container_ids = result.stdout.strip().split("\n")
             for container_id in container_ids:
                 subprocess.run(["docker", "rm", "-f", container_id], capture_output=True)
-        
+
         # Clean up any dangling volumes or networks created during testing
         subprocess.run(["docker", "system", "prune", "-f", "--volumes"], capture_output=True)
-    
+
     teardown()  # Clean up before starting (in case of leftovers)
-    
+
     # Build the container first - need to run from project root
     project_root = Path(__file__).parent.parent.parent.parent
-    build_result = subprocess.run([
-        "docker", "build", 
-        "-f", "deployment/dataset-validator/Dockerfile",
-        "-t", image_name,
-        "."
-    ], capture_output=True, text=True, cwd=project_root)
-    
+    build_result = subprocess.run(
+        ["docker", "build", "-f", "deployment/dataset-validator/Dockerfile", "-t", image_name, "."],
+        capture_output=True,
+        text=True,
+        cwd=project_root,
+    )
+
     if build_result.returncode != 0:
         pytest.fail(f"Docker build failed: {build_result.stderr}")
-    
+
     yield image_name
     teardown()
 
 
 def test_docker_container_help(dataset_validator_container):
     """Test that the Docker container can run and show help/usage."""
-    result = subprocess.run([
-        "docker", "run", "--rm", 
-        dataset_validator_container,
-        "--help"
-    ], capture_output=True, text=True, timeout=30)
-    
+    result = subprocess.run(
+        ["docker", "run", "--rm", dataset_validator_container, "--help"], capture_output=True, text=True, timeout=30
+    )
+
     # Should exit with non-zero (missing required env vars) and show error message
     assert result.returncode != 0
     assert "Dataset Validator starting" in result.stdout
@@ -62,11 +60,10 @@ def test_docker_container_help(dataset_validator_container):
 
 def test_docker_container_missing_env_vars(dataset_validator_container):
     """Test that the Docker container fails gracefully with missing environment variables."""
-    result = subprocess.run([
-        "docker", "run", "--rm",
-        dataset_validator_container
-    ], capture_output=True, text=True, timeout=30)
-    
+    result = subprocess.run(
+        ["docker", "run", "--rm", dataset_validator_container], capture_output=True, text=True, timeout=30
+    )
+
     # Should exit with non-zero due to missing required environment variables
     assert result.returncode != 0
     # Should mention missing environment variables (check stdout where logs go)
@@ -77,37 +74,52 @@ def test_docker_container_missing_env_vars(dataset_validator_container):
 def test_docker_container_with_mock_env_vars(dataset_validator_container):
     """Test that the Docker container starts properly with required environment variables."""
     # Create a temporary directory for any potential file operations
-    with tempfile.TemporaryDirectory() as temp_dir:
-        result = subprocess.run([
-            "docker", "run", "--rm",
-            "-e", "S3_BUCKET=test-bucket",
-            "-e", "S3_KEY=test-key.h5ad", 
-            "-e", "FILE_ID=test-file-123",
-            "-e", "SNS_TOPIC_ARN=arn:aws:sns:us-east-1:123456789012:test-topic",
-            "-e", "AWS_BATCH_JOB_ID=test-job-456",
-            "-e", "AWS_ACCESS_KEY_ID=fake",
-            "-e", "AWS_SECRET_ACCESS_KEY=fake",
-            "-e", "AWS_DEFAULT_REGION=us-east-1",
-            dataset_validator_container
-        ], capture_output=True, text=True, timeout=30)
-        
+    with tempfile.TemporaryDirectory():
+        result = subprocess.run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "-e",
+                "S3_BUCKET=test-bucket",
+                "-e",
+                "S3_KEY=test-key.h5ad",
+                "-e",
+                "FILE_ID=test-file-123",
+                "-e",
+                "SNS_TOPIC_ARN=arn:aws:sns:us-east-1:123456789012:test-topic",
+                "-e",
+                "AWS_BATCH_JOB_ID=test-job-456",
+                "-e",
+                "AWS_ACCESS_KEY_ID=fake",
+                "-e",
+                "AWS_SECRET_ACCESS_KEY=fake",
+                "-e",
+                "AWS_DEFAULT_REGION=us-east-1",
+                dataset_validator_container,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
         # Should fail due to AWS credentials/S3 access, but should start properly
         # and show our expected log messages before failing
         assert "Dataset Validator starting" in result.stderr or "Dataset Validator starting" in result.stdout
-        
+
         # Should attempt to process the S3 file
         expected_s3_url = "s3://test-bucket/test-key.h5ad"
         assert expected_s3_url in result.stderr or expected_s3_url in result.stdout
 
 
-
 def test_docker_container_file_structure(dataset_validator_container):
     """Test that the application files are correctly placed in the container."""
-    result = subprocess.run([
-        "docker", "run", "--rm", "--entrypoint", "ls",
-        dataset_validator_container,
-        "-la", "/app/dataset_validator/"
-    ], capture_output=True, text=True, timeout=30)
+    result = subprocess.run(
+        ["docker", "run", "--rm", "--entrypoint", "ls", dataset_validator_container, "-la", "/app/dataset_validator/"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
 
     assert result.returncode == 0
     assert "main.py" in result.stdout
@@ -120,15 +132,24 @@ def test_docker_metadata_coverage_schema_loads(dataset_validator_container):
     venv: missing schema/*.yaml files in /app/hca_validation/, missing
     linkml_runtime in the main venv, etc.
     """
-    result = subprocess.run([
-        "docker", "run", "--rm", "--entrypoint", "python",
-        dataset_validator_container,
-        "-c",
-        "from hca_validation.metadata_coverage import compute_metadata_coverage, SCHEMA_NAME; "
-        "from hca_validation.schema_utils import load_schemaview, coverage_classes; "
-        "sv = load_schemaview(); "
-        "print(f'{SCHEMA_NAME}|{sv.schema.version}|{\",\".join(coverage_classes(sv))}')"
-    ], capture_output=True, text=True, timeout=30)
+    result = subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--entrypoint",
+            "python",
+            dataset_validator_container,
+            "-c",
+            "from hca_validation.metadata_coverage import compute_metadata_coverage, SCHEMA_NAME; "
+            "from hca_validation.schema_utils import load_schemaview, coverage_classes; "
+            "sv = load_schemaview(); "
+            "print(f'{SCHEMA_NAME}|{sv.schema.version}|{\",\".join(coverage_classes(sv))}')",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
 
     assert result.returncode == 0, f"stderr: {result.stderr}"
     schema_name, version, classes = result.stdout.strip().split("|")
@@ -158,17 +179,23 @@ def test_docker_subprocess_validator_imports_resolve(dataset_validator_container
     # If the imports were broken (the PYTHONPATH bug), stderr would contain
     # `ImportError` from line 4 (`from hca_schema_validator import HCAValidator`)
     # and the missing-arg check would never run.
-    result = subprocess.run([
-        "docker", "run", "--rm",
-        "--entrypoint", "/opt/venvs/hca-schema-validator/bin/python",
-        dataset_validator_container,
-        "/app/hca_schema_validator/main.py"
-    ], capture_output=True, text=True, timeout=30)
+    result = subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--entrypoint",
+            "/opt/venvs/hca-schema-validator/bin/python",
+            dataset_validator_container,
+            "/app/hca_schema_validator/main.py",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
 
     assert result.returncode != 0  # script raises on missing argv
     assert "ImportError" not in result.stderr, (
         f"schema validator subprocess could not import its own package: {result.stderr}"
     )
-    assert "Missing command line argument" in result.stderr, (
-        f"expected post-import argv check; got: {result.stderr}"
-    )
+    assert "Missing command line argument" in result.stderr, f"expected post-import argv check; got: {result.stderr}"

--- a/services/dataset-validator/tests/test_metadata_coverage.py
+++ b/services/dataset-validator/tests/test_metadata_coverage.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List
 import pandas as pd
 import pytest
 
-from hca_validation.metadata_coverage import compute_metadata_coverage, SCHEMA_NAME
+from hca_validation.metadata_coverage import SCHEMA_NAME, compute_metadata_coverage
 from hca_validation.metadata_coverage.metadata_coverage import _assert_invariant
 from hca_validation.schema_utils import load_schemaview
 
@@ -36,10 +36,12 @@ def field_entry(result: Dict[str, Any], entity_class: str, field: str) -> Dict[s
 
 class TestEntities:
     def test_record_counts_use_distinct_identifier_values(self, schemaview):
-        obs = pd.DataFrame({
-            "donor_id":  ["D1", "D1", "D2", "D2", "D2"],
-            "sample_id": ["S1", "S1", "S2", "S2", "S3"],
-        })
+        obs = pd.DataFrame(
+            {
+                "donor_id": ["D1", "D1", "D2", "D2", "D2"],
+                "sample_id": ["S1", "S1", "S2", "S2", "S3"],
+            }
+        )
         result = compute_metadata_coverage(make_adata(obs), schemaview)
         assert result["entities"]["obs"]["record_count"] == 5
         assert result["entities"]["dataset"]["record_count"] == 1
@@ -47,10 +49,12 @@ class TestEntities:
         assert result["entities"]["sample"]["record_count"] == 3
 
     def test_donor_count_excludes_cells_with_missing_donor_id(self, schemaview):
-        obs = pd.DataFrame({
-            "donor_id":  ["D1", "D1", None, None, "D2"],
-            "sample_id": ["S1", "S1", "S2", "S2", "S3"],
-        })
+        obs = pd.DataFrame(
+            {
+                "donor_id": ["D1", "D1", None, None, "D2"],
+                "sample_id": ["S1", "S1", "S2", "S2", "S3"],
+            }
+        )
         result = compute_metadata_coverage(make_adata(obs), schemaview)
         assert result["entities"]["donor"]["record_count"] == 2
 
@@ -62,19 +66,23 @@ class TestEntities:
 
 class TestObsGrainIdentifierCoverage:
     def test_full_donor_id_population_has_no_issues(self, schemaview):
-        obs = pd.DataFrame({
-            "donor_id":  ["D1", "D2", "D3"],
-            "sample_id": ["S1", "S2", "S3"],
-        })
+        obs = pd.DataFrame(
+            {
+                "donor_id": ["D1", "D2", "D3"],
+                "sample_id": ["S1", "S2", "S3"],
+            }
+        )
         result = compute_metadata_coverage(make_adata(obs), schemaview)
         donor_id = field_entry(result, "obs", "donor_id")
         assert donor_id == {"entity_class": "obs", "field": "donor_id", "complete": 3, "missing": 0, "inconsistent": 0}
 
     def test_missing_donor_id_reported_at_obs_grain_only(self, schemaview):
-        obs = pd.DataFrame({
-            "donor_id":  ["D1", "D1", None, None, "D2"],
-            "sample_id": ["S1", "S1", "S2", "S2", "S3"],
-        })
+        obs = pd.DataFrame(
+            {
+                "donor_id": ["D1", "D1", None, None, "D2"],
+                "sample_id": ["S1", "S1", "S2", "S2", "S3"],
+            }
+        )
         result = compute_metadata_coverage(make_adata(obs), schemaview)
         entry = field_entry(result, "obs", "donor_id")
         assert entry["complete"] == 3
@@ -84,11 +92,13 @@ class TestObsGrainIdentifierCoverage:
 
 class TestEntityPropertyCoverage:
     def test_complete_field_emits_empty_issues(self, schemaview):
-        obs = pd.DataFrame({
-            "donor_id":  ["D1", "D1", "D2"],
-            "sample_id": ["S1", "S1", "S2"],
-            "sex_ontology_term_id": ["PATO:0000383", "PATO:0000383", "PATO:0000384"],
-        })
+        obs = pd.DataFrame(
+            {
+                "donor_id": ["D1", "D1", "D2"],
+                "sample_id": ["S1", "S1", "S2"],
+                "sex_ontology_term_id": ["PATO:0000383", "PATO:0000383", "PATO:0000384"],
+            }
+        )
         result = compute_metadata_coverage(make_adata(obs), schemaview)
         entry = field_entry(result, "donor", "sex_ontology_term_id")
         assert entry == {
@@ -100,11 +110,13 @@ class TestEntityPropertyCoverage:
         }
 
     def test_partial_population_buckets_as_missing(self, schemaview):
-        obs = pd.DataFrame({
-            "donor_id":  ["D1", "D1", "D2", "D2"],
-            "sample_id": ["S1", "S1", "S2", "S2"],
-            "manner_of_death": ["1", "1", None, "3"],  # D2 has one null row
-        })
+        obs = pd.DataFrame(
+            {
+                "donor_id": ["D1", "D1", "D2", "D2"],
+                "sample_id": ["S1", "S1", "S2", "S2"],
+                "manner_of_death": ["1", "1", None, "3"],  # D2 has one null row
+            }
+        )
         result = compute_metadata_coverage(make_adata(obs), schemaview)
         entry = field_entry(result, "donor", "manner_of_death")
         assert entry["complete"] == 1
@@ -112,11 +124,13 @@ class TestEntityPropertyCoverage:
         assert entry["inconsistent"] == 0
 
     def test_disagreeing_values_bucket_as_inconsistent(self, schemaview):
-        obs = pd.DataFrame({
-            "donor_id":  ["D1", "D1", "D2", "D2"],
-            "sample_id": ["S1", "S1", "S2", "S2"],
-            "manner_of_death": ["1", "2", "3", "3"],  # D1 has two distinct values
-        })
+        obs = pd.DataFrame(
+            {
+                "donor_id": ["D1", "D1", "D2", "D2"],
+                "sample_id": ["S1", "S1", "S2", "S2"],
+                "manner_of_death": ["1", "2", "3", "3"],  # D1 has two distinct values
+            }
+        )
         result = compute_metadata_coverage(make_adata(obs), schemaview)
         entry = field_entry(result, "donor", "manner_of_death")
         assert entry["complete"] == 1
@@ -127,11 +141,13 @@ class TestEntityPropertyCoverage:
         # D1 has both null and conflicting values (inconsistent precedence applies).
         # D2 has only nulls (missing).
         # D3 is complete.
-        obs = pd.DataFrame({
-            "donor_id":  ["D1", "D1", "D1", "D2", "D2", "D3", "D3"],
-            "sample_id": ["S1", "S1", "S1", "S2", "S2", "S3", "S3"],
-            "manner_of_death": ["1", "2", None, None, None, "0", "0"],
-        })
+        obs = pd.DataFrame(
+            {
+                "donor_id": ["D1", "D1", "D1", "D2", "D2", "D3", "D3"],
+                "sample_id": ["S1", "S1", "S1", "S2", "S2", "S3", "S3"],
+                "manner_of_death": ["1", "2", None, None, None, "0", "0"],
+            }
+        )
         result = compute_metadata_coverage(make_adata(obs), schemaview)
         entry = field_entry(result, "donor", "manner_of_death")
         assert entry["complete"] == 1  # D3
@@ -139,10 +155,12 @@ class TestEntityPropertyCoverage:
         assert entry["missing"] == 1  # D2
 
     def test_field_absent_from_obs_reports_all_missing(self, schemaview):
-        obs = pd.DataFrame({
-            "donor_id":  ["D1", "D1", "D2"],
-            "sample_id": ["S1", "S1", "S2"],
-        })
+        obs = pd.DataFrame(
+            {
+                "donor_id": ["D1", "D1", "D2"],
+                "sample_id": ["S1", "S1", "S2"],
+            }
+        )
         result = compute_metadata_coverage(make_adata(obs), schemaview)
         entry = field_entry(result, "donor", "manner_of_death")
         assert entry["complete"] == 0
@@ -155,16 +173,16 @@ class TestEntityPropertyCoverage:
         # present, including zero), with no nested `issues` map. Regressions in
         # the emission helper would surface here even if full-dict equality
         # tests above were softened.
-        obs = pd.DataFrame({
-            "donor_id":  ["D1"],
-            "sample_id": ["S1"],
-            "sex_ontology_term_id": ["PATO:0000384"],
-        })
+        obs = pd.DataFrame(
+            {
+                "donor_id": ["D1"],
+                "sample_id": ["S1"],
+                "sex_ontology_term_id": ["PATO:0000384"],
+            }
+        )
         result = compute_metadata_coverage(make_adata(obs), schemaview)
         for entry in result["field_coverage"]:
-            assert set(entry.keys()) == {
-                "entity_class", "field", "complete", "missing", "inconsistent"
-            }, entry
+            assert set(entry.keys()) == {"entity_class", "field", "complete", "missing", "inconsistent"}, entry
             assert "issues" not in entry, entry
 
 
@@ -190,11 +208,13 @@ class TestDatasetClassSlots:
 
     def test_dataset_obs_slot_complete_when_consistent(self, schemaview):
         # gene_annotation_version is annDataLocation=obs but owned by the Dataset class.
-        obs = pd.DataFrame({
-            "donor_id":  ["D1", "D1", "D2"],
-            "sample_id": ["S1", "S1", "S2"],
-            "gene_annotation_version": ["v1", "v1", "v1"],
-        })
+        obs = pd.DataFrame(
+            {
+                "donor_id": ["D1", "D1", "D2"],
+                "sample_id": ["S1", "S1", "S2"],
+                "gene_annotation_version": ["v1", "v1", "v1"],
+            }
+        )
         result = compute_metadata_coverage(make_adata(obs), schemaview)
         entry = field_entry(result, "dataset", "gene_annotation_version")
         assert entry["complete"] == 1
@@ -202,11 +222,13 @@ class TestDatasetClassSlots:
         assert entry["inconsistent"] == 0
 
     def test_dataset_obs_slot_inconsistent_across_cells(self, schemaview):
-        obs = pd.DataFrame({
-            "donor_id":  ["D1", "D2"],
-            "sample_id": ["S1", "S2"],
-            "gene_annotation_version": ["v1", "v2"],
-        })
+        obs = pd.DataFrame(
+            {
+                "donor_id": ["D1", "D2"],
+                "sample_id": ["S1", "S2"],
+                "gene_annotation_version": ["v1", "v2"],
+            }
+        )
         result = compute_metadata_coverage(make_adata(obs), schemaview)
         entry = field_entry(result, "dataset", "gene_annotation_version")
         assert entry["complete"] == 0
@@ -229,11 +251,13 @@ class TestSchemaMetadata:
 
 class TestInvariant:
     def test_passes_for_real_output(self, schemaview):
-        obs = pd.DataFrame({
-            "donor_id":  ["D1", "D1", "D2", None],
-            "sample_id": ["S1", "S1", "S2", "S2"],
-            "manner_of_death": ["1", "2", "3", "3"],
-        })
+        obs = pd.DataFrame(
+            {
+                "donor_id": ["D1", "D1", "D2", None],
+                "sample_id": ["S1", "S1", "S2", "S2"],
+                "manner_of_death": ["1", "2", "3", "3"],
+            }
+        )
         result = compute_metadata_coverage(make_adata(obs), schemaview)
         for entry in result["field_coverage"]:
             expected = result["entities"][entry["entity_class"]]["record_count"]
@@ -283,9 +307,7 @@ class TestFieldCoverageEnumeration:
         pairs = [(e["entity_class"], e["field"]) for e in result["field_coverage"]]
         assert len(pairs) == len(set(pairs)), f"duplicate entries: {pairs}"
         # entity_class values are the canonical lowercase HCA grains only.
-        assert {e["entity_class"] for e in result["field_coverage"]} <= {
-            "obs", "dataset", "donor", "sample"
-        }
+        assert {e["entity_class"] for e in result["field_coverage"]} <= {"obs", "dataset", "donor", "sample"}
 
     def test_cell_entity_class_absent_in_v0(self, schemaview):
         # The Cell LinkML class has no slots in v0, so no entity_class == "cell"
@@ -321,10 +343,12 @@ class TestEmptyStringSentinels:
     """
 
     def test_empty_string_donor_id_does_not_inflate_donor_count(self, schemaview):
-        obs = pd.DataFrame({
-            "donor_id":  ["D1", "D1", "", "  ", "D2"],
-            "sample_id": ["S1", "S1", "S2", "S2", "S3"],
-        })
+        obs = pd.DataFrame(
+            {
+                "donor_id": ["D1", "D1", "", "  ", "D2"],
+                "sample_id": ["S1", "S1", "S2", "S2", "S3"],
+            }
+        )
         result = compute_metadata_coverage(make_adata(obs), schemaview)
         # Two real donors (D1, D2), not four.
         assert result["entities"]["donor"]["record_count"] == 2
@@ -335,11 +359,13 @@ class TestEmptyStringSentinels:
         assert donor_id_entry["inconsistent"] == 0
 
     def test_empty_string_entity_property_is_missing_not_complete(self, schemaview):
-        obs = pd.DataFrame({
-            "donor_id":  ["D1", "D1", "D2", "D2"],
-            "sample_id": ["S1", "S1", "S2", "S2"],
-            "manner_of_death": ["1", "1", "", "  "],  # D2 has no real value
-        })
+        obs = pd.DataFrame(
+            {
+                "donor_id": ["D1", "D1", "D2", "D2"],
+                "sample_id": ["S1", "S1", "S2", "S2"],
+                "manner_of_death": ["1", "1", "", "  "],  # D2 has no real value
+            }
+        )
         result = compute_metadata_coverage(make_adata(obs), schemaview)
         entry = field_entry(result, "donor", "manner_of_death")
         assert entry["complete"] == 1  # D1
@@ -350,10 +376,12 @@ class TestEmptyStringSentinels:
         # Real h5ad files often store donor_id / sample_id as pd.Categorical for
         # memory efficiency on millions of rows. Empty string as a category must
         # normalize to NA the same way it does for object-dtype columns.
-        obs = pd.DataFrame({
-            "donor_id":  pd.Categorical(["D1", "D1", "", "  ", "D2"]),
-            "sample_id": pd.Categorical(["S1", "S1", "S2", "S2", "S3"]),
-        })
+        obs = pd.DataFrame(
+            {
+                "donor_id": pd.Categorical(["D1", "D1", "", "  ", "D2"]),
+                "sample_id": pd.Categorical(["S1", "S1", "S2", "S2", "S3"]),
+            }
+        )
         result = compute_metadata_coverage(make_adata(obs), schemaview)
         assert result["entities"]["donor"]["record_count"] == 2
         entry = field_entry(result, "obs", "donor_id")
@@ -377,11 +405,10 @@ class TestEmptyStringSentinels:
         # study_pi and batch_condition are multivalued uns fields. A list with
         # only empty / whitespace elements should count as missing, not complete.
         import numpy as np
+
         obs = pd.DataFrame({"donor_id": ["D1"], "sample_id": ["S1"]})
         for empty_list in ([""], ["   "], ["", "  "], np.array([""], dtype=object), []):
-            result = compute_metadata_coverage(
-                make_adata(obs, {"study_pi": empty_list}), schemaview
-            )
+            result = compute_metadata_coverage(make_adata(obs, {"study_pi": empty_list}), schemaview)
             entry = field_entry(result, "dataset", "study_pi")
             assert entry["complete"] == 0, f"input: {empty_list!r}"
             assert entry["missing"] == 1, f"input: {empty_list!r}"
@@ -390,9 +417,7 @@ class TestEmptyStringSentinels:
     def test_uns_list_with_one_populated_element_is_complete(self, schemaview):
         # If any element of the list is a real value, the slot is populated.
         obs = pd.DataFrame({"donor_id": ["D1"], "sample_id": ["S1"]})
-        result = compute_metadata_coverage(
-            make_adata(obs, {"study_pi": ["", "Smith, John"]}), schemaview
-        )
+        result = compute_metadata_coverage(make_adata(obs, {"study_pi": ["", "Smith, John"]}), schemaview)
         entry = field_entry(result, "dataset", "study_pi")
         assert entry["complete"] == 1
         assert entry["missing"] == 0

--- a/services/dataset-validator/tests/test_missing_metadata.py
+++ b/services/dataset-validator/tests/test_missing_metadata.py
@@ -1,12 +1,10 @@
 """Test for missing SHA256 metadata scenario."""
 
-import json
 import logging
 import os
 from pathlib import Path
 
 import boto3
-import pytest
 from moto import mock_s3, mock_sns
 
 
@@ -15,52 +13,53 @@ from moto import mock_s3, mock_sns
 def test_end_to_end_validation_missing_sha256_metadata(caplog):
     """Test complete validation workflow with missing SHA256 metadata."""
     import sys
+
     sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
-    
+
     from dataset_validator.main import main
-    
+
     # Setup mock S3
-    s3_client = boto3.client('s3', region_name='us-east-1')
-    s3_client.create_bucket(Bucket='test-bucket')
-    
+    s3_client = boto3.client("s3", region_name="us-east-1")
+    s3_client.create_bucket(Bucket="test-bucket")
+
     # Upload file WITHOUT SHA256 metadata
-    test_content = b'mock dataset content'
+    test_content = b"mock dataset content"
     s3_client.put_object(
-        Bucket='test-bucket',
-        Key='datasets/no-metadata.h5ad',
-        Body=test_content
+        Bucket="test-bucket",
+        Key="datasets/no-metadata.h5ad",
+        Body=test_content,
         # No Metadata parameter - missing source-sha256
     )
-    
+
     # Setup mock SNS
-    sns_client = boto3.client('sns', region_name='us-east-1')
-    topic_response = sns_client.create_topic(Name='validation-results')
-    topic_arn = topic_response['TopicArn']
-    
+    sns_client = boto3.client("sns", region_name="us-east-1")
+    topic_response = sns_client.create_topic(Name="validation-results")
+    topic_arn = topic_response["TopicArn"]
+
     # Set environment variables
     test_env = {
-        'S3_BUCKET': 'test-bucket',
-        'S3_KEY': 'datasets/no-metadata.h5ad',
-        'FILE_ID': 'test-file-999',
-        'SNS_TOPIC_ARN': topic_arn,
-        'AWS_BATCH_JOB_ID': 'job-999',
-        'AWS_DEFAULT_REGION': 'us-east-1'
+        "S3_BUCKET": "test-bucket",
+        "S3_KEY": "datasets/no-metadata.h5ad",
+        "FILE_ID": "test-file-999",
+        "SNS_TOPIC_ARN": topic_arn,
+        "AWS_BATCH_JOB_ID": "job-999",
+        "AWS_DEFAULT_REGION": "us-east-1",
     }
-    
+
     # Save original environment
     original_env = {}
     for key in test_env:
         original_env[key] = os.environ.get(key)
         os.environ[key] = test_env[key]
-    
+
     try:
         # Run main function
         with caplog.at_level(logging.INFO, logger="dataset_validator.main"):
             result = main()
-        
+
         # Should fail
         assert result == 1
-        
+
         # Verify log messages
         assert "Dataset Validator starting" in caplog.text
         assert "File ready for validation:" in caplog.text
@@ -68,7 +67,7 @@ def test_end_to_end_validation_missing_sha256_metadata(caplog):
         assert "No source SHA256 metadata found - cannot validate file integrity - terminating" in caplog.text
         assert "Publishing validation result to SNS topic" in caplog.text
         assert "Successfully published SNS message" in caplog.text
-        
+
     finally:
         # Restore original environment
         for key, value in original_env.items():

--- a/services/entry-sheet-validator/src/entry_sheet_validator_lambda/handler.py
+++ b/services/entry-sheet-validator/src/entry_sheet_validator_lambda/handler.py
@@ -10,13 +10,16 @@ HCA validation tools, and returns the validation results as JSON.
 
 # Standard library imports
 import json
-import traceback
-import os
-import psutil
 import logging
-from http import HTTPStatus
+import os
+import traceback
 from dataclasses import asdict
-from typing import Dict, Any, List, Optional, Union, Tuple
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Tuple
+
+import psutil
+
+from hca_validation.entry_sheet_validator.process_sheet import process_google_sheet
 
 # Third-party / local imports
 from hca_validation.entry_sheet_validator.validate_sheet import (
@@ -24,7 +27,6 @@ from hca_validation.entry_sheet_validator.validate_sheet import (
     SheetValidationResult,
     make_summary_without_entities,
 )
-from hca_validation.entry_sheet_validator.process_sheet import process_google_sheet
 
 # Configure logging
 logger = logging.getLogger()
@@ -41,14 +43,11 @@ ERROR_TO_STATUS: dict[str, HTTPStatus] = {
     "auth_unresolved": HTTPStatus.UNAUTHORIZED,
     "auth_invalid_format": HTTPStatus.UNAUTHORIZED,
     "auth_error": HTTPStatus.UNAUTHORIZED,
-
     # Permission issues
     "permission_denied": HTTPStatus.FORBIDDEN,
-
     # Resource not found
     "sheet_not_found": HTTPStatus.NOT_FOUND,
     "worksheet_not_found": HTTPStatus.NOT_FOUND,
-
     # Service unavailable
     "max_api_retries": HTTPStatus.SERVICE_UNAVAILABLE,
 }
@@ -57,16 +56,16 @@ ERROR_TO_STATUS: dict[str, HTTPStatus] = {
 def extract_validation_errors(sheet_id: str, bionetwork: Optional[str] = None) -> Tuple[SheetValidationResult, int]:
     """
     Extract validation errors from a Google Sheet.
-    
+
     Args:
         sheet_id: The ID of the Google Sheet
         bionetwork: Optional biological network identifier (currently unused by the validator)
-        
+
     Returns:
         Tuple containing (SheetValidationResult, list of validation error objects, http_status_code)
         where http_status_code is the appropriate HTTP status code (200, 400, 401, 404, etc.)
     """
-    
+
     # Run the validation with our custom handler
     try:
         # Call the process_google_sheet function to perform validation and check for fixes
@@ -75,7 +74,7 @@ def extract_validation_errors(sheet_id: str, bionetwork: Optional[str] = None) -
             bionetwork=bionetwork,
         )
         error_code = validation_result.error_code
-        
+
         # Resolve HTTP status code using the mapping. Default logic:
         #   • No error_code   → 200 OK
         #   • Known error     → mapped status
@@ -94,11 +93,11 @@ def extract_validation_errors(sheet_id: str, bionetwork: Optional[str] = None) -
                 spreadsheet_metadata=None,
                 error_code="bad_request",
                 summary=make_summary_without_entities(1),
-                errors=[error_info]
+                errors=[error_info],
             ),
             HTTPStatus.BAD_REQUEST.value,
         )
-    
+
     except Exception as e:
         # If there's an error in the validation process itself
         error_msg = f"Error in validation process: {str(e)}"
@@ -109,11 +108,11 @@ def extract_validation_errors(sheet_id: str, bionetwork: Optional[str] = None) -
                 spreadsheet_metadata=None,
                 error_code="internal_error",
                 summary=make_summary_without_entities(1),
-                errors=[error_info]
+                errors=[error_info],
             ),
-            500
+            500,
         )
-    
+
     return validation_result, http_status_code
 
 
@@ -123,24 +122,25 @@ def get_memory_usage():
     process = psutil.Process(os.getpid())
     memory_info = process.memory_info()
     memory_mb = memory_info.rss / (1024 * 1024)  # Convert to MB
-    
+
     # Get Lambda memory limit if available
-    memory_limit = int(os.environ.get('AWS_LAMBDA_FUNCTION_MEMORY_SIZE', 0))
-    
+    memory_limit = int(os.environ.get("AWS_LAMBDA_FUNCTION_MEMORY_SIZE", 0))
+
     return {
-        'memory_used_mb': round(memory_mb, 2),
-        'memory_limit_mb': memory_limit,
-        'memory_utilization_percent': round((memory_mb / memory_limit * 100), 2) if memory_limit else None
+        "memory_used_mb": round(memory_mb, 2),
+        "memory_limit_mb": memory_limit,
+        "memory_utilization_percent": round((memory_mb / memory_limit * 100), 2) if memory_limit else None,
     }
+
 
 def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     """
     AWS Lambda handler function for validating HCA entry sheets in Google Sheets format.
-    
+
     Args:
         event: Lambda event object containing the sheet_id parameter
         context: Lambda context object
-        
+
     Returns:
         Dictionary with validation results including any validation errors
     """
@@ -148,56 +148,46 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     initial_memory = get_memory_usage()
     logger.info(f"Initial memory usage: {initial_memory}")
     logger.info(f"Event: {event}")
-    
+
     try:
         # Check if this is an API Gateway request
-        if 'body' in event:
+        if "body" in event:
             try:
                 # Parse the body if it's a string (from API Gateway)
-                if isinstance(event['body'], str):
-                    body = json.loads(event['body'])
+                if isinstance(event["body"], str):
+                    body = json.loads(event["body"])
                 else:
-                    body = event['body']
-                    
-                sheet_id = body.get('sheet_id')
-                bionetwork = body.get('bionetwork')
+                    body = event["body"]
+
+                sheet_id = body.get("sheet_id")
+                bionetwork = body.get("bionetwork")
             except Exception as e:
                 logger.warning(f"Error parsing request body: {str(e)}")
                 return {
-                    'statusCode': HTTPStatus.BAD_REQUEST.value,
-                    'body': json.dumps({
-                        'error': f"Invalid request body: {str(e)}"
-                    }),
-                    'headers': {
-                        'Content-Type': 'application/json',
-                        'Access-Control-Allow-Origin': '*'
-                    }
+                    "statusCode": HTTPStatus.BAD_REQUEST.value,
+                    "body": json.dumps({"error": f"Invalid request body: {str(e)}"}),
+                    "headers": {"Content-Type": "application/json", "Access-Control-Allow-Origin": "*"},
                 }
         else:
             # Direct Lambda invocation
-            sheet_id = event.get('sheet_id')
-            bionetwork = event.get('bionetwork')
-        
+            sheet_id = event.get("sheet_id")
+            bionetwork = event.get("bionetwork")
+
         if not sheet_id:
             return {
-                'statusCode': HTTPStatus.BAD_REQUEST.value,
-                'body': json.dumps({
-                    'error': 'Missing required parameter: sheet_id'
-                }),
-                'headers': {
-                    'Content-Type': 'application/json',
-                    'Access-Control-Allow-Origin': '*'
-                }
+                "statusCode": HTTPStatus.BAD_REQUEST.value,
+                "body": json.dumps({"error": "Missing required parameter: sheet_id"}),
+                "headers": {"Content-Type": "application/json", "Access-Control-Allow-Origin": "*"},
             }
-        
+
         # Log memory usage before validation
         pre_validation_memory = get_memory_usage()
         logger.info(f"Memory usage before validation: {pre_validation_memory}")
-        
+
         # Extract validation errors using the entry sheet validator
         validation_result, http_status_code = extract_validation_errors(sheet_id, bionetwork)
         spreadsheet_metadata = validation_result.spreadsheet_metadata
-        
+
         # Log memory usage after validation
         post_validation_memory = get_memory_usage()
         logger.info(f"Memory usage after validation: {post_validation_memory}")
@@ -205,37 +195,36 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             f"Validation completed with error_code: {validation_result.error_code}, "
             f"http_status_code: {http_status_code}"
         )
-        
+
         # Prepare the response data
         response_data = {
-            'sheet_id': sheet_id,
-            'sheet_title': None if spreadsheet_metadata is None else spreadsheet_metadata.spreadsheet_title,
-            'last_updated': None if spreadsheet_metadata is None else {
+            "sheet_id": sheet_id,
+            "sheet_title": None if spreadsheet_metadata is None else spreadsheet_metadata.spreadsheet_title,
+            "last_updated": None
+            if spreadsheet_metadata is None
+            else {
                 "date": spreadsheet_metadata.last_updated_date,
                 "by": spreadsheet_metadata.last_updated_by,
-                "by_email": spreadsheet_metadata.last_updated_email
+                "by_email": spreadsheet_metadata.last_updated_email,
             },
-            'can_edit': None if spreadsheet_metadata is None else spreadsheet_metadata.can_edit,
-            'errors': [asdict(e) for e in validation_result.errors],
-            'valid': len(validation_result.errors) == 0,
-            'error_code': validation_result.error_code,
-            'summary': validation_result.summary,
-            'memory_usage': {
-                'initial': initial_memory,
-                'pre_validation': pre_validation_memory,
-                'post_validation': post_validation_memory
-            }
+            "can_edit": None if spreadsheet_metadata is None else spreadsheet_metadata.can_edit,
+            "errors": [asdict(e) for e in validation_result.errors],
+            "valid": len(validation_result.errors) == 0,
+            "error_code": validation_result.error_code,
+            "summary": validation_result.summary,
+            "memory_usage": {
+                "initial": initial_memory,
+                "pre_validation": pre_validation_memory,
+                "post_validation": post_validation_memory,
+            },
         }
-        
+
         # Check if this was called via API Gateway (event has 'httpMethod')
-        if 'httpMethod' in event or 'requestContext' in event:
+        if "httpMethod" in event or "requestContext" in event:
             return {
-                'statusCode': http_status_code,
-                'body': json.dumps(response_data),
-                'headers': {
-                    'Content-Type': 'application/json',
-                    'Access-Control-Allow-Origin': '*'
-                }
+                "statusCode": http_status_code,
+                "body": json.dumps(response_data),
+                "headers": {"Content-Type": "application/json", "Access-Control-Allow-Origin": "*"},
             }
         else:
             # Direct Lambda invocation
@@ -244,22 +233,16 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         # Log the error
         logger.error(f"Error: {str(e)}")
         logger.error(traceback.format_exc())
-        
+
         # Prepare error response
-        error_response = {
-            'error': str(e),
-            'traceback': traceback.format_exc()
-        }
-        
+        error_response = {"error": str(e), "traceback": traceback.format_exc()}
+
         # Check if this was called via API Gateway
-        if 'httpMethod' in event or 'requestContext' in event:
+        if "httpMethod" in event or "requestContext" in event:
             return {
-                'statusCode': 500,
-                'body': json.dumps(error_response),
-                'headers': {
-                    'Content-Type': 'application/json',
-                    'Access-Control-Allow-Origin': '*'
-                }
+                "statusCode": 500,
+                "body": json.dumps(error_response),
+                "headers": {"Content-Type": "application/json", "Access-Control-Allow-Origin": "*"},
             }
         else:
             # Direct Lambda invocation
@@ -269,9 +252,7 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
 # For local testing
 if __name__ == "__main__":
     # Test with a sample event
-    test_event = {
-        'sheet_id': '1oPFb6qb0Y2HeoQqjSGRe_TlsZPRLwq-HUlVF0iqtVlY'
-    }
-    
+    test_event = {"sheet_id": "1oPFb6qb0Y2HeoQqjSGRe_TlsZPRLwq-HUlVF0iqtVlY"}
+
     result = handler(test_event, None)
     print(json.dumps(result, indent=2))

--- a/services/entry-sheet-validator/src/entry_sheet_validator_lambda/test_lambda.py
+++ b/services/entry-sheet-validator/src/entry_sheet_validator_lambda/test_lambda.py
@@ -8,29 +8,31 @@ This script allows you to test the Lambda function locally with different Google
 It can load service account credentials from a file or from the .env file.
 """
 
-import json
-import sys
-import os
 import argparse
+import json
+import os
 from pathlib import Path
+
 from dotenv import load_dotenv
+
 from hca_validation.lambda_functions.entry_sheet_validator_lambda.handler import handler
+
 
 def main():
     """Run the Lambda function with a test event."""
     # Parse command line arguments
-    parser = argparse.ArgumentParser(description='Test the HCA Entry Sheet Validator Lambda function')
-    parser.add_argument('--sheet-id', type=str, 
-                        default='1oPFb6qb0Y2HeoQqjSGRe_TlsZPRLwq-HUlVF0iqtVlY',
-                        help='Google Sheet ID to validate')
-    parser.add_argument('--sheet-index', type=int, default=0,
-                        help='Sheet index (0-based)')
-    parser.add_argument('--creds-file', type=str,
-                        help='Path to service account credentials JSON file')
-    parser.add_argument('--env-file', type=str,
-                        help='Path to .env file with GOOGLE_SERVICE_ACCOUNT variable')
+    parser = argparse.ArgumentParser(description="Test the HCA Entry Sheet Validator Lambda function")
+    parser.add_argument(
+        "--sheet-id",
+        type=str,
+        default="1oPFb6qb0Y2HeoQqjSGRe_TlsZPRLwq-HUlVF0iqtVlY",
+        help="Google Sheet ID to validate",
+    )
+    parser.add_argument("--sheet-index", type=int, default=0, help="Sheet index (0-based)")
+    parser.add_argument("--creds-file", type=str, help="Path to service account credentials JSON file")
+    parser.add_argument("--env-file", type=str, help="Path to .env file with GOOGLE_SERVICE_ACCOUNT variable")
     args = parser.parse_args()
-    
+
     # Load service account credentials if provided
     if args.creds_file:
         if os.path.exists(args.creds_file):
@@ -40,7 +42,7 @@ def main():
                 os.environ["GOOGLE_SERVICE_ACCOUNT"] = credentials
         else:
             print(f"Warning: Credentials file not found at {args.creds_file}")
-    
+
     # Load from .env file if provided
     elif args.env_file:
         if os.path.exists(args.env_file):
@@ -48,7 +50,7 @@ def main():
             load_dotenv(args.env_file)
         else:
             print(f"Warning: .env file not found at {args.env_file}")
-    
+
     # Try to load from default .env file location
     else:
         # Look for .env file in project root
@@ -57,39 +59,38 @@ def main():
         if env_file.exists():
             print(f"Loading environment variables from {env_file}")
             load_dotenv(env_file)
-    
+
     # Create a test event
-    test_event = {
-        'sheet_id': args.sheet_id
-    }
-    
+    test_event = {"sheet_id": args.sheet_id}
+
     print(f"Testing Lambda function with sheet ID: {args.sheet_id}")
-    
+
     # Call the Lambda function
     result = handler(test_event, None)
-    
+
     # Print the result
     print("\nResult:")
     print(json.dumps(result, indent=2))
-    
+
     # Print a summary
-    if 'body' in result:
+    if "body" in result:
         # API Gateway response format
-        body = json.loads(result['body'])
-        is_valid = body.get('valid', False)
-        errors = body.get('errors', [])
-        sheet_title = body.get('sheet_title', 'Unknown')
+        body = json.loads(result["body"])
+        is_valid = body.get("valid", False)
+        errors = body.get("errors", [])
+        sheet_title = body.get("sheet_title", "Unknown")
     else:
         # Direct Lambda invocation format
-        is_valid = result.get('valid', False)
-        errors = result.get('errors', [])
-        sheet_title = result.get('sheet_title', 'Unknown')
-    
+        is_valid = result.get("valid", False)
+        errors = result.get("errors", [])
+        sheet_title = result.get("sheet_title", "Unknown")
+
     print(f"\nSheet title: {sheet_title}")
     if is_valid:
         print("\n✅ Sheet is valid! No errors found.")
     else:
         print(f"\n❌ Sheet has {len(errors)} validation errors.")
+
 
 if __name__ == "__main__":
     main()

--- a/services/entry-sheet-validator/tests/test_lambda_container_smoke.py
+++ b/services/entry-sheet-validator/tests/test_lambda_container_smoke.py
@@ -1,9 +1,11 @@
-import os
-import time
-import requests
-import pytest
-import subprocess
 import json
+import os
+import subprocess
+import time
+
+import pytest
+import requests
+
 
 @pytest.fixture(scope="module", autouse=True)
 def lambda_container():
@@ -11,27 +13,37 @@ def lambda_container():
     def teardown():
         subprocess.run(["docker", "stop", "lambda-test-smoke"], capture_output=True)
         subprocess.run(["docker", "rm", "lambda-test-smoke"], capture_output=True)
+
     teardown()  # Clean up before starting (in case of leftovers)
     # Start the container
     env = os.environ.get("GOOGLE_SERVICE_ACCOUNT", "")
-    result = subprocess.run([
-        "docker", "run", "-d", "--rm", "--name", "lambda-test-smoke", "-p", "9000:8080",
-        "-e", f"GOOGLE_SERVICE_ACCOUNT={env}",
-        "hca-entry-sheet-validator:latest"
-    ], capture_output=True, text=True)
+    result = subprocess.run(
+        [
+            "docker",
+            "run",
+            "-d",
+            "--rm",
+            "--name",
+            "lambda-test-smoke",
+            "-p",
+            "9000:8080",
+            "-e",
+            f"GOOGLE_SERVICE_ACCOUNT={env}",
+            "hca-entry-sheet-validator:latest",
+        ],
+        capture_output=True,
+        text=True,
+    )
     container_id = result.stdout.strip()
     time.sleep(5)
     yield container_id
     teardown()
 
+
 def test_lambda_container_smoke(lambda_container):
     """Basic smoke test: POSTs a minimal event to the Lambda container and checks for a valid response."""
     event = {"sheet_id": "1oPFb6qb0Y2HeoQqjSGRe_TlsZPRLwq-HUlVF0iqtVlY"}
-    response = requests.post(
-        "http://localhost:9000/2015-03-31/functions/function/invocations",
-        json=event,
-        timeout=10
-    )
+    response = requests.post("http://localhost:9000/2015-03-31/functions/function/invocations", json=event, timeout=10)
     assert response.status_code in (200, 400, 401)
     data = response.json()
     # Accept both direct and API Gateway-style responses
@@ -42,14 +54,11 @@ def test_lambda_container_smoke(lambda_container):
     else:
         assert "valid" in data
 
+
 def test_lambda_happy_path(lambda_container):
     """Test Lambda container with a valid public sheet_id (happy path)."""
     event = {"sheet_id": "1oPFb6qb0Y2HeoQqjSGRe_TlsZPRLwq-HUlVF0iqtVlY"}
-    response = requests.post(
-        "http://localhost:9000/2015-03-31/functions/function/invocations",
-        json=event,
-        timeout=10
-    )
+    response = requests.post("http://localhost:9000/2015-03-31/functions/function/invocations", json=event, timeout=10)
     assert response.status_code in (200, 400, 401)
     data = response.json()
     # Handle API Gateway-style response
@@ -64,16 +73,10 @@ def test_lambda_happy_path(lambda_container):
     Smoke test: POST a test event to the running Lambda container via RIE and check the response.
     Assumes the container is running on localhost:9000.
     """
-    event = {
-        "queryStringParameters": {
-            "sheet_id": "1Gp2yocEq9OWECfDgCVbExIgzYfM7s6nJV5ftyn-SMXQ"
-        }
-    }
+    event = {"queryStringParameters": {"sheet_id": "1Gp2yocEq9OWECfDgCVbExIgzYfM7s6nJV5ftyn-SMXQ"}}
     try:
         response = requests.post(
-            "http://localhost:9000/2015-03-31/functions/function/invocations",
-            json=event,
-            timeout=10
+            "http://localhost:9000/2015-03-31/functions/function/invocations", json=event, timeout=10
         )
     except Exception as e:
         pytest.fail(f"Failed to contact Lambda container: {e}")

--- a/services/hca-schema-validator/src/hca_schema_validator_service/_log_capture.py
+++ b/services/hca-schema-validator/src/hca_schema_validator_service/_log_capture.py
@@ -14,60 +14,60 @@ from typing import Callable, List, Optional
 
 
 class ListHandler(logging.Handler):
-  """Capture warning and error log records into lists."""
+    """Capture warning and error log records into lists."""
 
-  def __init__(self, warning_list: List[str], error_list: List[str]) -> None:
-    super().__init__()
-    self.warning_list = warning_list
-    self.error_list = error_list
+    def __init__(self, warning_list: List[str], error_list: List[str]) -> None:
+        super().__init__()
+        self.warning_list = warning_list
+        self.error_list = error_list
 
-  def emit(self, record: logging.LogRecord) -> None:
-    if record.levelno == logging.ERROR:
-      self.error_list.append(self.format(record))
-    elif record.levelno == logging.WARNING:
-      self.warning_list.append(self.format(record))
+    def emit(self, record: logging.LogRecord) -> None:
+        if record.levelno == logging.ERROR:
+            self.error_list.append(self.format(record))
+        elif record.levelno == logging.WARNING:
+            self.warning_list.append(self.format(record))
 
 
 def run_with_captured_logs(
-  *,
-  file_path: str,
-  logger_name: str,
-  validate: Callable[[str], bool],
-  unexpected_error_prefix: str,
-  postprocess_warnings: Optional[Callable[[List[str]], List[str]]] = None,
+    *,
+    file_path: str,
+    logger_name: str,
+    validate: Callable[[str], bool],
+    unexpected_error_prefix: str,
+    postprocess_warnings: Optional[Callable[[List[str]], List[str]]] = None,
 ) -> dict:
-  """Invoke ``validate(file_path)`` with warnings/errors captured from ``logger_name``.
+    """Invoke ``validate(file_path)`` with warnings/errors captured from ``logger_name``.
 
-  Unexpected exceptions are converted to a single-error failure response
-  prefixed with ``unexpected_error_prefix``. ``postprocess_warnings`` lets
-  callers reorder or filter the captured warning list before returning.
-  """
-  logger = logging.getLogger(logger_name)
-  logger.setLevel(logging.WARNING)
-  warning_messages: List[str] = []
-  error_messages: List[str] = []
-  handler = ListHandler(warning_messages, error_messages)
-  logger.addHandler(handler)
+    Unexpected exceptions are converted to a single-error failure response
+    prefixed with ``unexpected_error_prefix``. ``postprocess_warnings`` lets
+    callers reorder or filter the captured warning list before returning.
+    """
+    logger = logging.getLogger(logger_name)
+    logger.setLevel(logging.WARNING)
+    warning_messages: List[str] = []
+    error_messages: List[str] = []
+    handler = ListHandler(warning_messages, error_messages)
+    logger.addHandler(handler)
 
-  try:
     try:
-      is_valid = validate(file_path)
-    except Exception as e:
-      is_valid = False
-      # Clear in place so the ListHandler's references stay consistent with
-      # the locals we return — rebinding would leave the handler pointing at
-      # the partially-filled originals.
-      warning_messages.clear()
-      error_messages.clear()
-      error_messages.append(f"{unexpected_error_prefix}: {e}")
-  finally:
-    logger.removeHandler(handler)
+        try:
+            is_valid = validate(file_path)
+        except Exception as e:
+            is_valid = False
+            # Clear in place so the ListHandler's references stay consistent with
+            # the locals we return — rebinding would leave the handler pointing at
+            # the partially-filled originals.
+            warning_messages.clear()
+            error_messages.clear()
+            error_messages.append(f"{unexpected_error_prefix}: {e}")
+    finally:
+        logger.removeHandler(handler)
 
-  if postprocess_warnings is not None:
-    warning_messages = postprocess_warnings(warning_messages)
+    if postprocess_warnings is not None:
+        warning_messages = postprocess_warnings(warning_messages)
 
-  return {
-    "valid": is_valid,
-    "warnings": warning_messages,
-    "errors": error_messages,
-  }
+    return {
+        "valid": is_valid,
+        "warnings": warning_messages,
+        "errors": error_messages,
+    }

--- a/services/hca-schema-validator/src/hca_schema_validator_service/cell_annotation.py
+++ b/services/hca-schema-validator/src/hca_schema_validator_service/cell_annotation.py
@@ -4,24 +4,24 @@ import sys
 from hca_schema_validator import HCACellAnnotationValidator
 
 try:
-  from ._log_capture import run_with_captured_logs
+    from ._log_capture import run_with_captured_logs
 except ImportError:  # direct script execution (e.g. `python cell_annotation.py <file>`)
-  from _log_capture import run_with_captured_logs  # type: ignore[no-redef]
+    from _log_capture import run_with_captured_logs  # type: ignore[no-redef]
 
 validator_logger_name = "hca_schema_validator.cell_annotation_validator"
 
 
 def run_validator(file_path):
-  return run_with_captured_logs(
-    file_path=file_path,
-    logger_name=validator_logger_name,
-    validate=lambda p: HCACellAnnotationValidator().validate_adata(p),
-    unexpected_error_prefix="Encountered an unexpected error while calling HCA cell annotation validator",
-  )
+    return run_with_captured_logs(
+        file_path=file_path,
+        logger_name=validator_logger_name,
+        validate=lambda p: HCACellAnnotationValidator().validate_adata(p),
+        unexpected_error_prefix="Encountered an unexpected error while calling HCA cell annotation validator",
+    )
 
 
 if __name__ == "__main__":
-  if len(sys.argv) < 2:
-    raise Exception("Missing command line argument for file path")
+    if len(sys.argv) < 2:
+        raise Exception("Missing command line argument for file path")
 
-  print(json.dumps(run_validator(sys.argv[1])))
+    print(json.dumps(run_validator(sys.argv[1])))

--- a/services/hca-schema-validator/src/hca_schema_validator_service/main.py
+++ b/services/hca-schema-validator/src/hca_schema_validator_service/main.py
@@ -4,9 +4,9 @@ import sys
 from hca_schema_validator import HCAValidator
 
 try:
-  from ._log_capture import ListHandler, run_with_captured_logs
+    from ._log_capture import ListHandler, run_with_captured_logs
 except ImportError:  # direct script execution (e.g. `python main.py <file>`)
-  from _log_capture import ListHandler, run_with_captured_logs  # type: ignore[no-redef]
+    from _log_capture import ListHandler, run_with_captured_logs  # type: ignore[no-redef]
 
 __all__ = ["ListHandler", "run_validator", "validator_logger_name"]
 
@@ -14,24 +14,24 @@ validator_logger_name = "hca_schema_validator._vendored.cellxgene_schema.validat
 
 
 def _reorder_feature_id_warnings_last(warnings):
-  other, feature_id = [], []
-  for w in warnings:
-    (feature_id if "Feature ID '" in w else other).append(w)
-  return other + feature_id
+    other, feature_id = [], []
+    for w in warnings:
+        (feature_id if "Feature ID '" in w else other).append(w)
+    return other + feature_id
 
 
 def run_validator(file_path):
-  return run_with_captured_logs(
-    file_path=file_path,
-    logger_name=validator_logger_name,
-    validate=lambda p: HCAValidator(ignore_labels=True).validate_adata(p),
-    unexpected_error_prefix="Encountered an unexpected error while calling HCA schema validator",
-    postprocess_warnings=_reorder_feature_id_warnings_last,
-  )
+    return run_with_captured_logs(
+        file_path=file_path,
+        logger_name=validator_logger_name,
+        validate=lambda p: HCAValidator(ignore_labels=True).validate_adata(p),
+        unexpected_error_prefix="Encountered an unexpected error while calling HCA schema validator",
+        postprocess_warnings=_reorder_feature_id_warnings_last,
+    )
 
 
 if __name__ == "__main__":
-  if len(sys.argv) < 2:
-    raise Exception("Missing command line argument for file path")
+    if len(sys.argv) < 2:
+        raise Exception("Missing command line argument for file path")
 
-  print(json.dumps(run_validator(sys.argv[1])))
+    print(json.dumps(run_validator(sys.argv[1])))

--- a/services/hca-schema-validator/tests/test_cell_annotation.py
+++ b/services/hca-schema-validator/tests/test_cell_annotation.py
@@ -12,7 +12,7 @@ CELL_ANNOTATION_SCRIPT = SRC_DIR / "hca_schema_validator_service" / "cell_annota
 MAIN_SCRIPT = SRC_DIR / "hca_schema_validator_service" / "main.py"
 
 sys.path.insert(0, str(SRC_DIR))
-from hca_schema_validator_service.cell_annotation import (
+from hca_schema_validator_service.cell_annotation import (  # noqa: E402
     run_validator,
     validator_logger_name,
 )
@@ -131,9 +131,7 @@ def test_subprocess_script_imports_cleanly(script_path, tmp_path):
         capture_output=True,
         text=True,
     )
-    assert "Traceback" not in result.stderr, (
-        f"{script_path.name} failed at import or early execution: {result.stderr}"
-    )
+    assert "Traceback" not in result.stderr, f"{script_path.name} failed at import or early execution: {result.stderr}"
 
 
 def test_cell_annotation_subprocess_returns_json(tmp_path):
@@ -147,9 +145,7 @@ def test_cell_annotation_subprocess_returns_json(tmp_path):
         capture_output=True,
         text=True,
     )
-    assert result.returncode == 0, (
-        f"stdout={result.stdout!r} stderr={result.stderr!r}"
-    )
+    assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
     output = json.loads(result.stdout)
     assert output["valid"] is False
     assert any("Unable to read h5ad file" in e for e in output["errors"])

--- a/services/hca-schema-validator/tests/test_hca_schema_validator.py
+++ b/services/hca-schema-validator/tests/test_hca_schema_validator.py
@@ -1,105 +1,100 @@
 import logging
-from unittest.mock import MagicMock, patch
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 from hca_schema_validator_service.main import (
-  run_validator,
-  validator_logger_name,
+    run_validator,
+    validator_logger_name,
 )
 
-@pytest.mark.parametrize("test_case", [
-  {
-    "name": "valid_no_messages",
-    "description": "Test fully-successful validation",
-    "file_path": "test.h5ad",
-    "logs": [
-      (logging.INFO, "Info foo")
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        {
+            "name": "valid_no_messages",
+            "description": "Test fully-successful validation",
+            "file_path": "test.h5ad",
+            "logs": [(logging.INFO, "Info foo")],
+            "is_valid": True,
+            "error": None,
+            "expected_output": {"valid": True, "errors": [], "warnings": []},
+        },
+        {
+            "name": "valid_with_warnings",
+            "description": "Test successful validation with warnings",
+            "file_path": "test.h5ad",
+            "logs": [
+                (logging.INFO, "Info foo"),
+                (logging.WARNING, "Warning foo"),
+                (logging.WARNING, "Warning bar"),
+                (logging.DEBUG, "Debug foo"),
+            ],
+            "is_valid": True,
+            "error": None,
+            "expected_output": {"valid": True, "errors": [], "warnings": ["Warning foo", "Warning bar"]},
+        },
+        {
+            "name": "invalid",
+            "description": "Test validation with errors and warnings",
+            "file_path": "test.h5ad",
+            "logs": [
+                (logging.ERROR, "Error foo"),
+                (logging.WARNING, "Warning foo"),
+                (logging.ERROR, "Error bar"),
+                (logging.ERROR, "Error baz"),
+            ],
+            "is_valid": False,
+            "error": None,
+            "expected_output": {
+                "valid": False,
+                "errors": ["Error foo", "Error bar", "Error baz"],
+                "warnings": ["Warning foo"],
+            },
+        },
+        {
+            "name": "error",
+            "description": "Test validation with error in validation process",
+            "file_path": "test.h5ad",
+            "logs": [
+                (logging.WARNING, "Warning foo"),
+            ],
+            "is_valid": None,
+            "error": Exception("Error in validation"),
+            "expected_output": {
+                "valid": False,
+                "errors": ["Encountered an unexpected error while calling HCA schema validator: Error in validation"],
+                "warnings": [],
+            },
+        },
     ],
-    "is_valid": True,
-    "error": None,
-    "expected_output": {
-      "valid": True,
-      "errors": [],
-      "warnings": []
-    }
-  },
-  {
-    "name": "valid_with_warnings",
-    "description": "Test successful validation with warnings",
-    "file_path": "test.h5ad",
-    "logs": [
-      (logging.INFO, "Info foo"),
-      (logging.WARNING, "Warning foo"),
-      (logging.WARNING, "Warning bar"),
-      (logging.DEBUG, "Debug foo")
-    ],
-    "is_valid": True,
-    "error": None,
-    "expected_output": {
-      "valid": True,
-      "errors": [],
-      "warnings": ["Warning foo", "Warning bar"]
-    }
-  },
-  {
-    "name": "invalid",
-    "description": "Test validation with errors and warnings",
-    "file_path": "test.h5ad",
-    "logs": [
-      (logging.ERROR, "Error foo"),
-      (logging.WARNING, "Warning foo"),
-      (logging.ERROR, "Error bar"),
-      (logging.ERROR, "Error baz")
-    ],
-    "is_valid": False,
-    "error": None,
-    "expected_output": {
-      "valid": False,
-      "errors": ["Error foo", "Error bar", "Error baz"],
-      "warnings": ["Warning foo"]
-    }
-  },
-  {
-    "name": "error",
-    "description": "Test validation with error in validation process",
-    "file_path": "test.h5ad",
-    "logs": [
-      (logging.WARNING, "Warning foo"),
-    ],
-    "is_valid": None,
-    "error": Exception("Error in validation"),
-    "expected_output": {
-      "valid": False,
-      "errors": ["Encountered an unexpected error while calling HCA schema validator: Error in validation"],
-      "warnings": []
-    }
-  }
-], ids=lambda x: x["name"])
+    ids=lambda x: x["name"],
+)
 @patch("hca_schema_validator_service.main.HCAValidator")
 def test_hca_schema_validator_cases(mock_hca_validator, test_case):
-  def do_mock_validate(_, **__):
-    logger = logging.getLogger(validator_logger_name)
-    for level, message in test_case["logs"]:
-      logger.log(level, message)
-    return test_case["is_valid"]
+    def do_mock_validate(_, **__):
+        logger = logging.getLogger(validator_logger_name)
+        for level, message in test_case["logs"]:
+            logger.log(level, message)
+        return test_case["is_valid"]
 
-  mock_validator_instance = MagicMock()
-  mock_hca_validator.return_value = mock_validator_instance
+    mock_validator_instance = MagicMock()
+    mock_hca_validator.return_value = mock_validator_instance
 
-  mock_validate_adata = MagicMock()
-  mock_validator_instance.validate_adata = mock_validate_adata
+    mock_validate_adata = MagicMock()
+    mock_validator_instance.validate_adata = mock_validate_adata
 
-  if test_case["error"]:
-    mock_validate_adata.side_effect = test_case["error"]
-  else:
-    mock_validate_adata.side_effect = do_mock_validate
-  
-  result = run_validator(test_case["file_path"])
+    if test_case["error"]:
+        mock_validate_adata.side_effect = test_case["error"]
+    else:
+        mock_validate_adata.side_effect = do_mock_validate
 
-  mock_hca_validator.assert_called_once_with(ignore_labels=True)
-  mock_validate_adata.assert_called_once_with(test_case["file_path"])
-  assert result == test_case["expected_output"]
+    result = run_validator(test_case["file_path"])
+
+    mock_hca_validator.assert_called_once_with(ignore_labels=True)
+    mock_validate_adata.assert_called_once_with(test_case["file_path"])
+    assert result == test_case["expected_output"]

--- a/shared/src/hca_validation/data_dictionary/generate_dictionary.py
+++ b/shared/src/hca_validation/data_dictionary/generate_dictionary.py
@@ -7,22 +7,24 @@ of the HCA validation schema, which can be used as a data dictionary.
 By default, the dictionary is saved to the 'data_dictionaries' directory in the project root.
 """
 
-import sys
 import json
+import sys
 from pathlib import Path
-from typing import Dict, Any
-from linkml_runtime import SchemaView
+from typing import Any, Dict
+
 import jsonasobj2
+from linkml_runtime import SchemaView
 
 from hca_validation.schema_utils import get_class_entity_type
+
 
 def transform_schema_to_data_dictionary(schemaview: SchemaView) -> Dict[str, Any]:
     """
     Transform the LinkML schema into the requested data dictionary format.
-    
+
     Args:
         schema_dict: The expanded LinkML schema dictionary
-        
+
     Returns:
         A dictionary in the requested format for the data dictionary
     """
@@ -31,21 +33,12 @@ def transform_schema_to_data_dictionary(schemaview: SchemaView) -> Dict[str, Any
         "name": "tier_1",
         "title": "HCA Tier 1 Metadata",
         "classes": [],
-        "prefixes": {
-            "cxg": "https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.2.0/schema.md"
-        },
-        "annotations": {
-            "cxg": "CELLxGENE"
-        }
+        "prefixes": {"cxg": "https://github.com/chanzuckerberg/single-cell-curation/blob/main/schema/5.2.0/schema.md"},
+        "annotations": {"cxg": "CELLxGENE"},
     }
-    
+
     # Names of the classes to include in output
-    included_classes = {
-        "Dataset",
-        "Donor",
-        "Sample",
-        "Cell"
-    }
+    included_classes = {"Dataset", "Donor", "Sample", "Cell"}
 
     # Get set of names of all enums in the schema
     schema_enum_names = set(schemaview.all_enums())
@@ -55,15 +48,15 @@ def transform_schema_to_data_dictionary(schemaview: SchemaView) -> Dict[str, Any
         # Skip abstract classes or other non-relevant classes
         if class_info.abstract or class_name not in included_classes:
             continue
-            
+
         # Create the class entry with title-cased name for title
         class_entry = {
             "title": class_name.title(),  # Ensure title case
             "description": class_info.description or "",
             "name": get_class_entity_type(class_name),  # Use lowercase entity type
-            "attributes": []
+            "attributes": [],
         }
-        
+
         # Get all slots for this class, sorting values from the returned set to retain consistent order
         all_slots = sorted(schemaview.class_induced_slots(class_name), key=lambda slot: slot.name)
 
@@ -77,57 +70,58 @@ def transform_schema_to_data_dictionary(schemaview: SchemaView) -> Dict[str, Any
                 "description": slot_info.description or "",
                 "range": slot_info.range if slot_info.range is not None else "string",
                 "required": slot_info.required if slot_info.required is not None else False,
-                "multivalued": slot_info.multivalued if slot_info.multivalued is not None else False
+                "multivalued": slot_info.multivalued if slot_info.multivalued is not None else False,
             }
-            
+
             # Add examples if available
             if slot_info.examples:
                 # Get the first example value
                 example = slot_info.examples[0]
                 attribute["example"] = example.value
-            
+
             # Add annotations if available - format as requested
             if slot_info.annotations:
                 formatted_annotations = {}
                 for annot_name, annot_info in jsonasobj2.items(slot_info.annotations):
                     formatted_annotations[annot_name] = annot_info.value
                 attribute["annotations"] = formatted_annotations
-            
+
             # Add rationale if available in comments - as a string, not an array
             if slot_info.comments:
                 if isinstance(slot_info.comments, list):
                     attribute["rationale"] = "\n".join(slot_info.comments)
                 else:
                     attribute["rationale"] = slot_info.comments
-            
+
             # Add values information if available in notes - as a string, not an array
             if slot_info.notes:
                 if isinstance(slot_info.notes, list):
                     attribute["values"] = "\n".join(slot_info.notes)
                 else:
                     attribute["values"] = slot_info.notes
-            
+
             # If this is an enum, add the values
             if slot_info.range in schema_enum_names:
                 enum_info = schemaview.induced_enum(slot_info.range)
                 values_list = []
-                for pv_name in (enum_info.permissible_values or {}):
+                for pv_name in enum_info.permissible_values or {}:
                     values_list.append(pv_name)
                 if values_list:
                     attribute["values"] = "; ".join(values_list)
-            
+
             # Add the attribute to the class
             class_entry["attributes"].append(attribute)
-        
+
         # Add the class to the output
         output["classes"].append(class_entry)
-    
+
     return output
+
 
 def generate_dictionary(schema_path=None, output_path=None):
     """
     Generate a data dictionary JSON from the specified schema file.
-    
+
     Args:
         schema_path: Path to the schema file (default: core.yaml in the schema directory)
         output_path: Path to write the output JSON (default: standard path in data_dictionaries directory)
@@ -135,33 +129,34 @@ def generate_dictionary(schema_path=None, output_path=None):
     # Get paths
     current_dir = Path(__file__).parent
     project_root = current_dir.parent.parent.parent.parent
-    
+
     # Default to core.yaml if no schema path is provided
     if schema_path is None:
         # Get the path to the schema directory (in shared library)
         schema_dir = project_root / "shared" / "src" / "hca_validation" / "schema"
         schema_path = schema_dir / "core.yaml"
-    
+
     # Load the schema
     schemaview = SchemaView(str(schema_path), merge_imports=True)
-    
+
     # Transform the schema into the requested format
     data_dict = transform_schema_to_data_dictionary(schemaview)
-    
+
     # If no output path is provided, use the standard path
     if output_path is None:
         # Create data_dictionaries directory if it doesn't exist
         data_dict_dir = project_root / "data_dictionaries"
         data_dict_dir.mkdir(exist_ok=True)
-        
+
         # Use a standard filename based on the schema name
         schema_name = Path(schema_path).stem
         output_path = data_dict_dir / f"{schema_name}_data_dictionary.json"
-    
+
     # Write to file
     with open(output_path, "w", encoding="utf-8") as fh:
         json.dump(data_dict, fh, indent=2)
     print(f"Data dictionary written to {output_path}")
+
 
 def main():
     """Command-line entry point."""
@@ -173,11 +168,12 @@ def main():
         current_dir = Path(__file__).parent
         schema_dir = current_dir.parent / "schema"
         schema_path = schema_dir / "core.yaml"
-    
+
     # If a specific output path is provided as an argument, use it
     output_path = sys.argv[2] if len(sys.argv) > 2 else None
-    
+
     generate_dictionary(schema_path, output_path)
+
 
 if __name__ == "__main__":
     main()

--- a/shared/src/hca_validation/entry_sheet_validator/apply_fixes.py
+++ b/shared/src/hca_validation/entry_sheet_validator/apply_fixes.py
@@ -1,61 +1,60 @@
 from typing import List
+
 import gspread
 
 from hca_validation.entry_sheet_validator.validate_sheet import SheetErrorInfo, SheetValidationResult
 
 
 def get_fix_value_range(a1: str, value: str):
-  """
-  Create a value range dict to be passed to gspread in order to set the specified cell to the given raw value
-  
-  Args:
-    a1:
-      The A1 notation of the cell to set the value of
-    value:
-      The value to be written to the cell
-    
-  Returns:
-    dict:
-      A value range dictionary without a specified worksheet
-  """
-  return {
-    "range": a1,
-    "values": [[value]]
-  }
+    """
+    Create a value range dict to be passed to gspread in order to set the specified cell to the given raw value
+
+    Args:
+      a1:
+        The A1 notation of the cell to set the value of
+      value:
+        The value to be written to the cell
+
+    Returns:
+      dict:
+        A value range dictionary without a specified worksheet
+    """
+    return {"range": a1, "values": [[value]]}
 
 
 def get_fix_value_ranges_by_entity_type(errors: List[SheetErrorInfo], entity_types: List[str], sheet_id: str):
-  """
-  Create value range dicts to be passed to gspread in order to fix the given errors, organized by entity type
+    """
+    Create value range dicts to be passed to gspread in order to fix the given errors, organized by entity type
 
-  If multiple errors for the same cell specify fixes, only the first is included in the returned list
-  
-  Args:
-    errors:
-      List of validation errors that may have fixes specified
-    entity_types:
-      List of entity types that the errors may apply to
-    
-  Returns:
-    dict:
-      Dictionary mapping entity types to lists of value range dicts.
-  """
-  import logging
-  logger = logging.getLogger(__name__)
-  
-  cells_with_fixes = set()
-  value_ranges = {entity_type: [] for entity_type in entity_types}
+    If multiple errors for the same cell specify fixes, only the first is included in the returned list
 
-  for error in errors:
-    has_fields_for_fix = error.input_fix is not None and error.entity_type is not None and error.cell is not None
-    cell_has_existing_fix = (error.entity_type, error.cell) in cells_with_fixes
-    if has_fields_for_fix and not cell_has_existing_fix:
-      value_ranges[error.entity_type].append(get_fix_value_range(error.cell, error.input_fix))
-      cells_with_fixes.add((error.entity_type, error.cell))
-    elif cell_has_existing_fix:
-      logger.error(f"Found duplicate fix for cell {error.cell} of {error.entity_type} sheet in {sheet_id}")
-  
-  return value_ranges
+    Args:
+      errors:
+        List of validation errors that may have fixes specified
+      entity_types:
+        List of entity types that the errors may apply to
+
+    Returns:
+      dict:
+        Dictionary mapping entity types to lists of value range dicts.
+    """
+    import logging
+
+    logger = logging.getLogger(__name__)
+
+    cells_with_fixes = set()
+    value_ranges = {entity_type: [] for entity_type in entity_types}
+
+    for error in errors:
+        has_fields_for_fix = error.input_fix is not None and error.entity_type is not None and error.cell is not None
+        cell_has_existing_fix = (error.entity_type, error.cell) in cells_with_fixes
+        if has_fields_for_fix and not cell_has_existing_fix:
+            value_ranges[error.entity_type].append(get_fix_value_range(error.cell, error.input_fix))
+            cells_with_fixes.add((error.entity_type, error.cell))
+        elif cell_has_existing_fix:
+            logger.error(f"Found duplicate fix for cell {error.cell} of {error.entity_type} sheet in {sheet_id}")
+
+    return value_ranges
 
 
 def apply_fixes(
@@ -64,38 +63,38 @@ def apply_fixes(
     worksheets: List[gspread.Worksheet],
     sheet_id: str,
 ) -> bool:
-  """
-  Apply available fixes from the given validation result to the given gspread worksheets
-  
-  Args:
-    validation_result:
-      SheetValidationResult containing validation errors that may have fixes specified
-    entity_types:
-      List of entity types being processed
-    worksheets:
-      List of gspread worksheets, corresponding element-wise to entity_types
-    sheet_id:
-      Google Sheet ID, for error reporting
-    
-  Returns:
-    bool:
-      True if any fixes were applied to any worksheet, False if no fixes were applied
+    """
+    Apply available fixes from the given validation result to the given gspread worksheets
 
-  Raises:
-    gspread.exceptions.APIError:
-      May be raised if a gspread operation fails
-  """
-  worksheets_by_entity_type = dict(zip(entity_types, worksheets))
+    Args:
+      validation_result:
+        SheetValidationResult containing validation errors that may have fixes specified
+      entity_types:
+        List of entity types being processed
+      worksheets:
+        List of gspread worksheets, corresponding element-wise to entity_types
+      sheet_id:
+        Google Sheet ID, for error reporting
 
-  value_ranges_by_entity_type = get_fix_value_ranges_by_entity_type(validation_result.errors, entity_types, sheet_id)
+    Returns:
+      bool:
+        True if any fixes were applied to any worksheet, False if no fixes were applied
 
-  made_fixes = False
+    Raises:
+      gspread.exceptions.APIError:
+        May be raised if a gspread operation fails
+    """
+    worksheets_by_entity_type = dict(zip(entity_types, worksheets))
 
-  for entity_type, value_ranges in value_ranges_by_entity_type.items():
-    if not value_ranges:
-      continue
-    worksheet = worksheets_by_entity_type[entity_type]
-    worksheet.batch_update(value_ranges)
-    made_fixes = True
-  
-  return made_fixes
+    value_ranges_by_entity_type = get_fix_value_ranges_by_entity_type(validation_result.errors, entity_types, sheet_id)
+
+    made_fixes = False
+
+    for entity_type, value_ranges in value_ranges_by_entity_type.items():
+        if not value_ranges:
+            continue
+        worksheet = worksheets_by_entity_type[entity_type]
+        worksheet.batch_update(value_ranges)
+        made_fixes = True
+
+    return made_fixes

--- a/shared/src/hca_validation/entry_sheet_validator/find_fixes.py
+++ b/shared/src/hca_validation/entry_sheet_validator/find_fixes.py
@@ -1,11 +1,12 @@
 import dataclasses
 from typing import List, Optional
+
 from linkml_runtime import SchemaView
 from linkml_runtime.linkml_model.meta import ClassDefinition
 
-from hca_validation.schema_utils import load_schemaview, get_entity_class_name
-from .validate_sheet import SheetErrorInfo
+from hca_validation.schema_utils import get_entity_class_name, load_schemaview
 
+from .validate_sheet import SheetErrorInfo
 
 # Spreadsheet values to identify possible fixes for
 # Mapping tuple of entity type, slot, and input value to corrected value
@@ -36,7 +37,7 @@ def add_fix_to_error_if_available(
     # Require string input value to avoid values that consist of the entire input row
     if error.entity_type is None or error.column is None or not isinstance(error.input, str):
         return error
-    
+
     entity_induced_class = schemaview.induced_class(get_entity_class_name(error.entity_type, bionetwork))
     input_fix = get_fixed_value(error.entity_type, entity_induced_class, error.column, error.input)
 
@@ -51,7 +52,7 @@ def add_fixes_to_errors(errors: List[SheetErrorInfo], bionetwork: Optional[str])
     Args:
         errors: List of error info objects
         bionetwork: Bionetwork associated with the data the errors come from
-    
+
     Returns:
         List of errors with fixes added where possible
     """

--- a/shared/src/hca_validation/entry_sheet_validator/process_sheet.py
+++ b/shared/src/hca_validation/entry_sheet_validator/process_sheet.py
@@ -1,7 +1,11 @@
 import dataclasses
 from typing import List, Optional
+
 import gspread
 
+from .apply_fixes import apply_fixes
+from .common import default_entity_types
+from .find_fixes import add_fixes_to_errors
 from .validate_sheet import (
     SheetReadError,
     SheetValidationResult,
@@ -11,9 +15,7 @@ from .validate_sheet import (
     read_sheet_with_service_account,
     validate_google_sheet,
 )
-from .find_fixes import add_fixes_to_errors
-from .apply_fixes import apply_fixes
-from .common import default_entity_types
+
 
 def process_google_sheet(
     sheet_id: str,
@@ -32,12 +34,13 @@ def process_google_sheet(
         entity_types: List of entity types to validate. Determines which worksheets are read and which schema is
             used for each.
         bionetwork: Optional string identifying the biological network context.
-        
+
     Returns:
         SheetValidationResult object
     """
 
     import logging
+
     logger = logging.getLogger(__name__)
 
     # Initialize sheet_data variable so it can be referenced during exception handling
@@ -77,10 +80,10 @@ def process_google_sheet(
                 errors_with_fix_info = add_fixes_to_errors(validation_result.errors, bionetwork)
                 if any(error.input_fix is not None for error in errors_with_fix_info):
                     logger.error(f"Sheet {sheet_id} still has fixes available after fixes were applied")
-        
+
         # Return validation result
         return validation_result
-    
+
     except gspread.exceptions.APIError as e:
         logger.error(f"Google Sheets API error: {e}")
         return make_validation_result_for_whole_sheet_error(
@@ -88,7 +91,7 @@ def process_google_sheet(
             entity_types=entity_types,
             error_code="api_error",
             error_message=f"Received error {e.code} from Google Sheets API: {e.error['message']}",
-            spreadsheet_metadata=None if sheet_data is None else sheet_data.spreadsheet_metadata
+            spreadsheet_metadata=None if sheet_data is None else sheet_data.spreadsheet_metadata,
         )
     except SheetReadError as read_error:
         return make_read_error_validation_result(sheet_id, entity_types, read_error)

--- a/shared/src/hca_validation/entry_sheet_validator/validate_sheet.py
+++ b/shared/src/hca_validation/entry_sheet_validator/validate_sheet.py
@@ -1,42 +1,45 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from enum import Enum
-import re
-import pandas as pd
-import sys
-import time
-import os
 import json
-from pathlib import Path
-from typing import Any, Mapping, Optional, List, Union, Callable
+import os
+import re
+import sys
 from dataclasses import dataclass
-from pydantic import ValidationError
-from linkml_runtime import SchemaView
-
-from .common import default_entity_types
-
-# Import dotenv for loading environment variables
-from dotenv import load_dotenv
+from enum import Enum
+from pathlib import Path
+from typing import Any, List, Mapping, Optional
 
 # Import libraries for Google API access
 import gspread
-from google.oauth2 import service_account
-from google.auth.transport.requests import AuthorizedSession
-from google.auth.credentials import Credentials
+import pandas as pd
+import requests
 import requests.adapters
 import urllib3
-import requests
+
+# Import dotenv for loading environment variables
+from dotenv import load_dotenv
+from google.auth.credentials import Credentials
+from google.auth.transport.requests import AuthorizedSession
+from google.oauth2 import service_account
+from linkml_runtime import SchemaView
+from pydantic import ValidationError
+
+from .common import default_entity_types
+
 
 @dataclass
 class ApiInstances:
     """Container for instances of APIs used in the validation process."""
+
     gspread: gspread.Client
     drive: Any
+
 
 @dataclass
 class WorksheetInfo:
     """Container for Google Sheets worksheet data and metadata."""
+
     data: pd.DataFrame
     worksheet_id: int
     source_columns: List[Any]
@@ -46,37 +49,42 @@ class WorksheetInfo:
         """
         Get A1 notation given a 1-based row index and a column name
         """
-        return gspread.utils.rowcol_to_a1(
-            self.source_rows_start_index + row,
-            self.source_columns.index(column) + 1
-        )
+        return gspread.utils.rowcol_to_a1(self.source_rows_start_index + row, self.source_columns.index(column) + 1)
+
 
 @dataclass
 class SpreadsheetMetadata:
     """Container for Google Sheet metadata"""
+
     spreadsheet_title: str
     last_updated_date: str
     last_updated_by: str
     last_updated_email: Optional[str]
     can_edit: bool
 
+
 @dataclass
 class SpreadsheetInfo:
     """Container for Google Sheet data and metadata."""
+
     spreadsheet_metadata: SpreadsheetMetadata
     worksheets: List[WorksheetInfo]
+
 
 @dataclass
 class SheetReadError(Exception):
     """Exception raised when reading a Google Sheet fails."""
+
     error_code: str
     error_message: Optional[str] = None
     spreadsheet_metadata: Optional[SpreadsheetMetadata] = None
     worksheet_id: Optional[int] = None
 
+
 @dataclass
 class SheetErrorInfo:
     """Container for info regarding an error that occurred while reading and validating a Google Sheet."""
+
     entity_type: Optional[str]
     worksheet_id: Optional[int]
     message: str
@@ -87,97 +95,93 @@ class SheetErrorInfo:
     input: Optional[Any] = None
     input_fix: Optional[str] = None
 
+
 @dataclass
 class SheetValidationResult:
     """Container for general info on the outcome of a Google Sheet validation."""
+
     successful: bool
     spreadsheet_metadata: Optional[SpreadsheetMetadata]
     error_code: Optional[str]
     summary: Mapping[str, int | None]
     errors: List[SheetErrorInfo]
 
+
 # Custom sentinel value used to detect missing parameters
 class MissingSentinel(Enum):
     MISSING = 0
+
 
 MISSING = MissingSentinel.MISSING
 
 # Possible bionetworks that a sheet may be associated with
 allowed_bionetwork_names = [
-  "adipose",
-  "breast",
-  "development",
-  "eye",
-  "genetic-diversity",
-  "gut",
-  "heart",
-  "immune",
-  "kidney",
-  "liver",
-  "lung",
-  "musculoskeletal",
-  "nervous-system",
-  "oral",
-  "organoid",
-  "pancreas",
-  "reproduction",
-  "skin",
+    "adipose",
+    "breast",
+    "development",
+    "eye",
+    "genetic-diversity",
+    "gut",
+    "heart",
+    "immune",
+    "kidney",
+    "liver",
+    "lung",
+    "musculoskeletal",
+    "nervous-system",
+    "oral",
+    "organoid",
+    "pancreas",
+    "reproduction",
+    "skin",
 ]
 
 # Mapping of supported entity types to information about how they're represented in spreadsheets
 sheet_structure_by_entity_type = {
-    "dataset": {
-        "sheet_index": 0,
-        "primary_key_field": "dataset_id"
-    },
-    "donor": {
-        "sheet_index": 1,
-        "primary_key_field": "donor_id"
-    },
-    "sample": {
-        "sheet_index": 2,
-        "primary_key_field": "sample_id"
-    }
+    "dataset": {"sheet_index": 0, "primary_key_field": "dataset_id"},
+    "donor": {"sheet_index": 1, "primary_key_field": "donor_id"},
+    "sample": {"sheet_index": 2, "primary_key_field": "sample_id"},
 }
 
 # Load environment variables from .env file if it exists
 # Find project root more reliably
 project_root = Path(__file__).resolve().parents[4]  # Go up to project root
-dotenv_path = project_root / '.env'
+dotenv_path = project_root / ".env"
 if dotenv_path.exists():
     load_dotenv(dotenv_path=dotenv_path)
+
 
 def get_secret_from_extension(secret_name):
     """
     Retrieve a secret from the AWS Parameters and Secrets Lambda Extension.
-    
+
     Args:
         secret_name (str): The name of the secret to retrieve.
-        
+
     Returns:
         str: The secret value, or None if there was an error.
     """
-    import os
-    import requests
-    import json
     import logging
-    
+    import os
+
+    import requests
+
     logger = logging.getLogger(__name__)
-    
+
     # Constants for the Secrets Extension
     SECRETS_EXTENSION_PORT = 2773
     SECRETS_EXTENSION_ENDPOINT = f"http://localhost:{SECRETS_EXTENSION_PORT}/secretsmanager/get?secretId"
-    
+
     # Check if we're running in a Lambda environment
-    if 'AWS_LAMBDA_FUNCTION_NAME' not in os.environ:
+    if "AWS_LAMBDA_FUNCTION_NAME" not in os.environ:
         logger.info("Not running in Lambda environment, skipping extension")
         return None
-    
+
     try:
         logger.info(f"Retrieving secret {secret_name} from extension...")
         headers = {"X-Aws-Parameters-Secrets-Token": os.environ.get("AWS_SESSION_TOKEN", "")}
         url = f"{SECRETS_EXTENSION_ENDPOINT}={secret_name}"
-        
+
         response = requests.get(url, headers=headers)
         response.raise_for_status()
         secret_data = response.json()
@@ -186,6 +190,7 @@ def get_secret_from_extension(secret_name):
     except Exception as e:
         logger.error(f"Error retrieving secret from extension: {e}")
         return None
+
 
 def create_requests_session(credentials: Credentials) -> requests.Session:
     """
@@ -197,31 +202,31 @@ def create_requests_session(credentials: Credentials) -> requests.Session:
         status_forcelist=(429, 500, 502, 503, 504),
         backoff_factor=10,
         backoff_jitter=5,
-        respect_retry_after_header=True
+        respect_retry_after_header=True,
     )
     session.mount("https://", requests.adapters.HTTPAdapter(max_retries=retry_cfg))
     return session
 
+
 def init_apis() -> ApiInstances:
+    import logging
     import os
-    import json
     import traceback
+
     import gspread
     from googleapiclient.discovery import build
     from googleapiclient.errors import HttpError as GoogleHttpError
-    from google.oauth2 import service_account
-    import logging
-    
+
     # Configure logging
     logger = logging.getLogger(__name__)
-    
+
     # Get the environment (default to 'dev' if not specified)
     environment = os.environ.get("ENVIRONMENT", "dev")
     secret_name = f"{environment}/hca-atlas-tracker/google-service-account"
-    
+
     # Try to get service account credentials from the AWS Parameters and Secrets Lambda Extension
     service_account_json_from_extension = get_secret_from_extension(secret_name)
-    
+
     # If we got credentials from the extension, use those
     if service_account_json_from_extension:
         logger.info("Using service account credentials from AWS Parameters and Secrets Lambda Extension")
@@ -229,21 +234,21 @@ def init_apis() -> ApiInstances:
     else:
         # Fall back to environment variable
         logger.info("Falling back to environment variable for service account credentials")
-        service_account_json = os.environ.get('GOOGLE_SERVICE_ACCOUNT', None)
-    
+        service_account_json = os.environ.get("GOOGLE_SERVICE_ACCOUNT", None)
+
     if not service_account_json:
         error_msg = (
             "No service account credentials found in GOOGLE_SERVICE_ACCOUNT environment variable or Secrets Extension"
         )
         logger.error(error_msg)
-        raise SheetReadError(error_code='auth_missing')
-    
+        raise SheetReadError(error_code="auth_missing")
+
     # Log the length and first few characters of the credentials to verify they're present
     logger.info(f"Service account credentials found: Length={len(service_account_json)} chars")
-    
+
     # Check if the credentials contain unresolved secret references
     # Check for CloudFormation resolve syntax
-    if service_account_json.startswith('{{resolve:'):
+    if service_account_json.startswith("{{resolve:"):
         logger.error(
             f"Service account credentials were not resolved from Secrets Manager (CloudFormation syntax): "
             f"{service_account_json[:50]}..."
@@ -252,10 +257,10 @@ def init_apis() -> ApiInstances:
             "Check that the Lambda function has the correct permissions to access the secret and that the secret "
             "exists."
         )
-        raise SheetReadError(error_code='auth_unresolved')
+        raise SheetReadError(error_code="auth_unresolved")
 
     # Check for AWS shorthand syntax
-    if service_account_json.startswith('aws:secretsmanager:'):
+    if service_account_json.startswith("aws:secretsmanager:"):
         logger.error(
             f"Service account credentials were not resolved from Secrets Manager (AWS shorthand syntax): "
             f"{service_account_json[:50]}..."
@@ -264,20 +269,20 @@ def init_apis() -> ApiInstances:
             "Check that the Lambda function has the correct permissions to access the secret and that the secret "
             "exists."
         )
-        raise SheetReadError(error_code='auth_unresolved')
-    
+        raise SheetReadError(error_code="auth_unresolved")
+
     try:
         # Parse the service account JSON
         logger.info("Attempting to parse service account JSON...")
         credentials_dict = json.loads(service_account_json)
-        
+
         # Log some non-sensitive parts of the credentials to verify structure
-        safe_keys = ['type', 'project_id', 'client_email', 'auth_uri', 'token_uri']
+        safe_keys = ["type", "project_id", "client_email", "auth_uri", "token_uri"]
         cred_info = {k: credentials_dict.get(k) for k in safe_keys if k in credentials_dict}
         logger.info(f"Parsed credentials structure: {json.dumps(cred_info)}")
-        
+
         # Verify the required fields are present
-        required_fields = ['private_key', 'client_email', 'token_uri']
+        required_fields = ["private_key", "client_email", "token_uri"]
         missing_fields = [field for field in required_fields if field not in credentials_dict]
         if missing_fields:
             error_msg = f"Service account credentials missing required fields: {missing_fields}"
@@ -286,24 +291,24 @@ def init_apis() -> ApiInstances:
                 f"Error: {error_msg}. Check that the service account JSON has the correct format and contains all "
                 "required fields."
             )
-            raise SheetReadError(error_code='auth_invalid_format')
-        
+            raise SheetReadError(error_code="auth_invalid_format")
+
         logger.info(f"Creating credentials object for service account: {credentials_dict.get('client_email')}")
-        
+
         # Create credentials object
         try:
             credentials = service_account.Credentials.from_service_account_info(
                 credentials_dict,
                 scopes=[
-                    'https://www.googleapis.com/auth/spreadsheets',
-                    'https://www.googleapis.com/auth/drive.metadata.readonly'
-                ]
+                    "https://www.googleapis.com/auth/spreadsheets",
+                    "https://www.googleapis.com/auth/drive.metadata.readonly",
+                ],
             )
             logger.info("Successfully created credentials object")
         except Exception as cred_error:
             logger.error(f"Error creating Google credentials object: {cred_error}")
-            raise SheetReadError(error_code='auth_error')
-        
+            raise SheetReadError(error_code="auth_error")
+
         # Authenticate with gspread
         logger.info("Authorizing with gspread...")
         try:
@@ -311,8 +316,8 @@ def init_apis() -> ApiInstances:
             logger.info("Successfully authorized with gspread")
         except Exception as auth_error:
             logger.error(f"Error authorizing with Google Sheets API: {auth_error}")
-            raise SheetReadError(error_code='auth_error')
-        
+            raise SheetReadError(error_code="auth_error")
+
         # Authenticate with Drive API
         logger.info("Authorizing with Drive API...")
         try:
@@ -320,24 +325,23 @@ def init_apis() -> ApiInstances:
             logger.info("Successfully authorized with Drive API")
         except Exception as auth_error:
             logger.error(f"Error authorizing with Google Drive API: {auth_error}")
-            raise SheetReadError(error_code='auth_error')
-        
+            raise SheetReadError(error_code="auth_error")
+
         return ApiInstances(gspread=gc, drive=drive)
-    
+
     except json.JSONDecodeError as json_error:
         logger.error(f"Invalid JSON format in service account credentials: {json_error}")
-        raise SheetReadError(error_code='auth_invalid_format')
+        raise SheetReadError(error_code="auth_invalid_format")
     except gspread.exceptions.APIError as e:
         logger.error(f"Google Sheets API error: {e}")
         raise SheetReadError(
-            error_code='api_error',
-            error_message=f"Received error {e.code} from Google Sheets API: {e.error['message']}"
+            error_code="api_error",
+            error_message=f"Received error {e.code} from Google Sheets API: {e.error['message']}",
         )
     except GoogleHttpError as e:
         logger.error(f"Google API error: {e}")
         raise SheetReadError(
-            error_code="api_error",
-            error_message=f"Received error {e.status_code} from Google API: {e.reason}"
+            error_code="api_error", error_message=f"Received error {e.status_code} from Google API: {e.reason}"
         )
     except requests.exceptions.RetryError as e:
         logger.error(f"Reached maximum configured API retries: {e}")
@@ -348,25 +352,23 @@ def init_apis() -> ApiInstances:
         logger.error(f"Unexpected error initializing APIs with service account: {e}")
         logger.error(f"Exception type: {type(e).__name__}")
         logger.error(f"Traceback: {traceback.format_exc()}")
-        raise SheetReadError(error_code='api_error')
+        raise SheetReadError(error_code="api_error")
+
 
 def read_worksheets(
-    sheet_id: str,
-    spreadsheet_metadata: SpreadsheetMetadata,
-    spreadsheet: gspread.Spreadsheet,
-    sheet_indices: List[int]
+    sheet_id: str, spreadsheet_metadata: SpreadsheetMetadata, spreadsheet: gspread.Spreadsheet, sheet_indices: List[int]
 ) -> tuple[List[WorksheetInfo], List[gspread.Worksheet]]:
     import logging
+
     logger = logging.getLogger(__name__)
-    
+
     # Get list of worksheets
 
     all_worksheets = spreadsheet.worksheets()
     worksheets: List[gspread.Worksheet] = []
 
     logger.info(
-        f"Attempting to get worksheets of spreadsheet {sheet_id} at indices: "
-        f"{', '.join(str(i) for i in sheet_indices)}"
+        f"Attempting to get worksheets of spreadsheet {sheet_id} at indices: {', '.join(str(i) for i in sheet_indices)}"
     )
     for sheet_index in sheet_indices:
         if not sheet_index < len(all_worksheets):
@@ -374,13 +376,13 @@ def read_worksheets(
                 f"Error accessing Google Sheet with service account: Worksheet index {sheet_index} not found in "
                 f"sheet {sheet_id}"
             )
-            raise SheetReadError(error_code='worksheet_not_found', spreadsheet_metadata=spreadsheet_metadata)
+            raise SheetReadError(error_code="worksheet_not_found", spreadsheet_metadata=spreadsheet_metadata)
         worksheets.append(all_worksheets[sheet_index])
-    
-    logger.info(f"Successfully retrieved worksheets")
+
+    logger.info("Successfully retrieved worksheets")
 
     # Get data from worksheets
-    
+
     logger.info("Retrieving worksheets data...")
 
     api_result = spreadsheet.values_batch_get(
@@ -405,7 +407,7 @@ def read_worksheets(
                     data=df,
                     worksheet_id=worksheet.id,
                     source_columns=source_columns,
-                    source_rows_start_index=source_rows_start_index
+                    source_rows_start_index=source_rows_start_index,
                 )
             )
         else:
@@ -415,8 +417,9 @@ def read_worksheets(
                 spreadsheet_metadata=spreadsheet_metadata,
                 worksheet_id=worksheet.id,
             )
-    
+
     return worksheets_info, worksheets
+
 
 def read_sheet_with_service_account(
     sheet_id: str,
@@ -425,7 +428,7 @@ def read_sheet_with_service_account(
 ) -> tuple[SpreadsheetInfo, List[gspread.Worksheet]]:
     """
     Read data from a Google Sheet using a service account for authentication.
-    
+
     Args:
         sheet_id (str): The ID of the Google Sheet to read.
         entity_types (List[str], optional): The entity types whose worksheets to read. Defaults to ["dataset"].
@@ -435,18 +438,19 @@ def read_sheet_with_service_account(
         info: SpreadsheetInfo object containing list of WorksheetInfo corresponding to
             the provided entity_types
         worksheets: List of gspread worksheets
-    
+
     Raises:
         SheetReadError containing error code and, if available, sheet title and worksheet ID
     """
+    import logging
     import traceback
+
     import gspread
     from googleapiclient.errors import HttpError as GoogleHttpError
-    import logging
-    
+
     # Configure logging
     logger = logging.getLogger(__name__)
-    
+
     # Get sheet indices
     sheet_indices = [sheet_structure_by_entity_type[t]["sheet_index"] for t in entity_types]
 
@@ -463,90 +467,93 @@ def read_sheet_with_service_account(
             # Open the spreadsheet and get the worksheets
             logger.info(f"Attempting to open spreadsheet with ID: {sheet_id}")
             spreadsheet = apis.gspread.open_by_key(sheet_id)
-            
+
             # Get the spreadsheet title
             sheet_title = spreadsheet.title
             logger.info(f"Successfully opened spreadsheet: '{sheet_title}'")
 
             # Get the spreadsheet metadata from Drive
             logger.info(f"Attempting to get metadata for spreadsheet with ID: {sheet_id}")
-            file_metadata = apis.drive.files().get(
-                fileId=sheet_id,
-                fields="modifiedTime, lastModifyingUser(displayName, emailAddress), capabilities(canModifyContent)",
-            ).execute()
+            file_metadata = (
+                apis.drive.files()
+                .get(
+                    fileId=sheet_id,
+                    fields="modifiedTime, lastModifyingUser(displayName, emailAddress), capabilities(canModifyContent)",
+                )
+                .execute()
+            )
             last_updated_date = file_metadata["modifiedTime"]
             last_modifying_user = file_metadata.get("lastModifyingUser", {})
             last_updated_by = last_modifying_user.get("displayName", "unknown")
             last_updated_email = last_modifying_user.get("emailAddress") or None
             can_edit = file_metadata["capabilities"]["canModifyContent"]
-            logger.info(f"Successfully got metadata from Drive API")
-        
+            logger.info("Successfully got metadata from Drive API")
+
             spreadsheet_metadata = SpreadsheetMetadata(
                 spreadsheet_title=sheet_title,
                 last_updated_date=last_updated_date,
                 last_updated_by=last_updated_by,
                 last_updated_email=last_updated_email,
-                can_edit=can_edit
+                can_edit=can_edit,
             )
 
             # Get all worksheets
             sheets_info, gspread_worksheets = read_worksheets(
                 sheet_id, spreadsheet_metadata, spreadsheet, sheet_indices
             )
-            
+
             return SpreadsheetInfo(spreadsheet_metadata, sheets_info), gspread_worksheets
-        
+
         except gspread.exceptions.SpreadsheetNotFound:
             logger.error(f"Sheet {sheet_id} not found. Check if the sheet ID is correct.")
             logger.error(
                 f"Error accessing Google Sheet with service account: Sheet {sheet_id} not found or not accessible "
                 "with provided credentials"
             )
-            raise SheetReadError(error_code='sheet_not_found', spreadsheet_metadata=spreadsheet_metadata)
+            raise SheetReadError(error_code="sheet_not_found", spreadsheet_metadata=spreadsheet_metadata)
         except PermissionError as e:
             logger.error(f"Permission denied accessing sheet {sheet_id}: {e}")
-            logger.error(f"Make sure the service account has access to the sheet.")
-            raise SheetReadError(error_code='permission_denied', spreadsheet_metadata=spreadsheet_metadata)
+            logger.error("Make sure the service account has access to the sheet.")
+            raise SheetReadError(error_code="permission_denied", spreadsheet_metadata=spreadsheet_metadata)
         except gspread.exceptions.APIError as e:
             logger.error(f"Google Sheets API error: {e}")
             raise SheetReadError(
-                error_code='api_error',
+                error_code="api_error",
                 error_message=f"Received error {e.code} from Google Sheets API: {e.error['message']}",
-                spreadsheet_metadata=spreadsheet_metadata
+                spreadsheet_metadata=spreadsheet_metadata,
             )
         except GoogleHttpError as e:
             logger.error(f"Google API error: {e}")
             raise SheetReadError(
                 error_code="api_error",
                 error_message=f"Received error {e.status_code} from Google API: {e.reason}",
-                spreadsheet_metadata=spreadsheet_metadata
+                spreadsheet_metadata=spreadsheet_metadata,
             )
         except requests.exceptions.RetryError as e:
             logger.error(f"Reached maximum configured API retries: {e}")
             raise SheetReadError(error_code="max_api_retries", spreadsheet_metadata=spreadsheet_metadata)
-            
+
     except SheetReadError as e:
         raise e
     except Exception as e:
         logger.error(f"Unexpected error accessing Google Sheet with service account: {e}")
         logger.error(f"Exception type: {type(e).__name__}")
         logger.error(f"Traceback: {traceback.format_exc()}")
-        raise SheetReadError(error_code='api_error', spreadsheet_metadata=spreadsheet_metadata)
+        raise SheetReadError(error_code="api_error", spreadsheet_metadata=spreadsheet_metadata)
+
 
 def normalize_dataframe_values(df: pd.DataFrame, schemaview: SchemaView, class_name: str) -> pd.DataFrame:
     """
     Normalize a dataframe by dropping columns with empty names and casting types according to the given schema class.
     """
 
-    class_slots_by_name = {
-        slot.name: slot for slot in schemaview.class_induced_slots(class_name)
-    }
+    class_slots_by_name = {slot.name: slot for slot in schemaview.class_induced_slots(class_name)}
 
     # An integer should consist of an optional negative sign, followed by either a nonzero number of non-separated
     # digits,
     # or 1-3 digits followed by a nonzero number of comma-separated three-digit groups
     int_re = re.compile(r"^-?(?:\d+|\d{1,3}(?:,\d{3})+)$")
-    
+
     def parse_int(value):
         if int_re.fullmatch(value) is None:
             return value
@@ -558,12 +565,14 @@ def normalize_dataframe_values(df: pd.DataFrame, schemaview: SchemaView, class_n
     def map_column(name):
         # Get slot info from schema if available
         slot = class_slots_by_name.get(name)
-        
+
         # Determine how to parse a non-empty value in this column
         parse_value = parse_int if slot is not None and slot.range == "integer" else lambda v: v
         if slot is not None and slot.multivalued:
             parse_item = parse_value
-            parse_value = lambda v: parse_list(v, parse_item)
+
+            def parse_value(v):
+                return parse_list(v, parse_item)
 
         # Map over the column, converting whitespace-only value to None and parsing other values where applicable
         # Use the Series constructor with a list comprehension to ensure that values are put directly into an object
@@ -574,19 +583,14 @@ def normalize_dataframe_values(df: pd.DataFrame, schemaview: SchemaView, class_n
             index=df.index,
         )
 
-    return pd.DataFrame({
-        name: map_column(name)
-        for name in df.columns
-        if name and name.strip() != ""
-    })
+    return pd.DataFrame({name: map_column(name) for name in df.columns if name and name.strip() != ""})
+
 
 def make_summary_without_entities(
     error_count: int, entity_types: List[str] = default_entity_types
 ) -> dict[str, int | None]:
-    return {
-        **{f"{entity_type}_count": None for entity_type in entity_types},
-        "error_count": error_count
-    }
+    return {**{f"{entity_type}_count": None for entity_type in entity_types}, "error_count": error_count}
+
 
 def make_validation_result_for_whole_sheet_error(
     *,
@@ -596,26 +600,24 @@ def make_validation_result_for_whole_sheet_error(
     error_message: Optional[str] = None,
     spreadsheet_metadata: Optional[SpreadsheetMetadata] = None,
     worksheet_id: Optional[int] = None,
-    entity_type: Optional[str] = None
+    entity_type: Optional[str] = None,
 ) -> SheetValidationResult:
     error_msg = error_message or f"Error processing sheet {sheet_id} (Error: {error_code})"
-    error_info = SheetErrorInfo(
-        entity_type=entity_type,
-        worksheet_id=worksheet_id,
-        message=error_msg
-    )
+    error_info = SheetErrorInfo(entity_type=entity_type, worksheet_id=worksheet_id, message=error_msg)
     return SheetValidationResult(
         successful=False,
         spreadsheet_metadata=spreadsheet_metadata,
         error_code=error_code,
         summary=make_summary_without_entities(1, entity_types),
-        errors=[error_info]
+        errors=[error_info],
     )
+
 
 def make_read_error_validation_result(
     sheet_id: str, entity_types: List[str], read_error: SheetReadError
 ) -> SheetValidationResult:
     import logging
+
     logger = logging.getLogger()
 
     error_msg = (
@@ -623,7 +625,7 @@ def make_read_error_validation_result(
         or f"Could not access or read data from sheet {sheet_id} (Error: {read_error.error_code})"
     )
     logger.warning(f"Sheet access failed with error code: {read_error.error_code}")
-    
+
     logger.warning(f"{error_msg}")
     return make_validation_result_for_whole_sheet_error(
         sheet_id=sheet_id,
@@ -631,29 +633,32 @@ def make_read_error_validation_result(
         error_code=read_error.error_code,
         error_message=error_msg,
         spreadsheet_metadata=read_error.spreadsheet_metadata,
-        worksheet_id=read_error.worksheet_id
+        worksheet_id=read_error.worksheet_id,
     )
 
+
 def handle_validation_error(
-        validation_error: ValidationError,
-        *,
-        validation_summary: dict[str, int],
-        validation_errors_list: List[SheetErrorInfo],
-        entity_type: str,
-        sheet_info: WorksheetInfo,
-        row_index: int | MissingSentinel = MISSING,
-        row_id: Optional[Any] | MissingSentinel = MISSING
+    validation_error: ValidationError,
+    *,
+    validation_summary: dict[str, int],
+    validation_errors_list: List[SheetErrorInfo],
+    entity_type: str,
+    sheet_info: WorksheetInfo,
+    row_index: int | MissingSentinel = MISSING,
+    row_id: Optional[Any] | MissingSentinel = MISSING,
 ):
     for error in validation_error.errors():
         # Update error count
         validation_summary["error_count"] += 1
-        
+
         # Use row index from error if possible
         error_row_index = error.get("ctx", {}).get("row_index", row_index)
-        if error_row_index is MISSING: raise ValueError(f"No row index provided for {entity_type} error {error}")
+        if error_row_index is MISSING:
+            raise ValueError(f"No row index provided for {entity_type} error {error}")
         # Use row ID from error if possible
         error_row_id = error.get("ctx", {}).get("row_id", row_id)
-        if error_row_id is MISSING: raise ValueError(f"No row ID provided for {entity_type} error {error}")
+        if error_row_id is MISSING:
+            raise ValueError(f"No row ID provided for {entity_type} error {error}")
         # Get field name if available
         error_column_name = None if len(error["loc"]) == 0 else error["loc"][0]
         # Get A1 if possible
@@ -673,9 +678,10 @@ def handle_validation_error(
                 primary_key=error_row_id,
                 input=error["input"],
                 # Leave empty to be potentially populated after the sheet has been fully processed by the validator
-                input_fix=None
+                input_fix=None,
             )
         )
+
 
 def validate_google_sheet(
     sheet_id: str,
@@ -688,13 +694,13 @@ def validate_google_sheet(
     """
     Validate data from a Google Sheet starting at row 6 until the first empty row.
     Uses service account credentials from environment variables to access the sheet.
-    
+
     Args:
         sheet_id: The ID of the Google Sheet (required)
         entity_types: List of entity types to validate. Determines which worksheets are read and which schema is
             used for each.
         bionetwork: Optional string identifying the biological network context.
-        
+
     Returns:
         SheetValidationResult: Object with fields:
         - successful: boolean indicating if validation passed
@@ -708,9 +714,11 @@ def validate_google_sheet(
     if bionetwork is not None and bionetwork not in allowed_bionetwork_names:
         raise ValueError(f"'{bionetwork}' is not a valid bionetwork")
 
-    from hca_validation.validator import validate, validate_id_uniqueness, validate_referential_integrity
-    from hca_validation.schema_utils import load_schemaview, get_entity_class_name
     import logging
+
+    from hca_validation.schema_utils import get_entity_class_name, load_schemaview
+    from hca_validation.validator import validate, validate_id_uniqueness, validate_referential_integrity
+
     logger = logging.getLogger()
 
     invalid_entity_types = [t for t in entity_types if t not in sheet_structure_by_entity_type]
@@ -719,19 +727,15 @@ def validate_google_sheet(
 
     # Load schema for use in interpreting and validating input values
     schemaview = load_schemaview()
-    
+
     if sheet_read_result is None:
         logger.info(f"Reading sheet: {sheet_id}")
         try:
             # Read the sheet with service account credentials
-            sheet_read_result = read_sheet_with_service_account(
-                sheet_id,
-                entity_types,
-                apis
-            )[0]
+            sheet_read_result = read_sheet_with_service_account(sheet_id, entity_types, apis)[0]
         except SheetReadError as read_error:
             return make_read_error_validation_result(sheet_id, entity_types, read_error)
-    
+
     # Mapping from entity type to dataframe of rows to validate, with normalized values, and an index containing
     # the original 1-based indices of the rows
     rows_to_validate_by_entity_type = {}
@@ -742,45 +746,45 @@ def validate_google_sheet(
         # Skip the first column if it has no slot name
         if len(df.columns) > 1 and df.columns[0].strip() == "":
             df = df.iloc[:, 1:]
-        
+
         # Print information about the sheet structure
         logger.info(f"Sheet has {len(df)} {entity_type} rows total")
-        
+
         # Find rows with actual data to validate
         row_indices = []
-        
+
         # Debug: Print the first few rows to understand the structure
         logger.debug("Sheet structure:")
         for i in range(min(10, len(df))):
             if i < len(df):
                 first_col = df.iloc[i, 0] if not pd.isna(df.iloc[i, 0]) else "<empty>"
-                logger.debug(f"Row {i+1} (index {i}): {first_col}")
-        
+                logger.debug(f"Row {i + 1} (index {i}): {first_col}")
+
         # Process from row 6 until the first empty row
         start_row_index = 4  # Row 6 (1-based including header) is index 4 (0-based excluding header)
         current_row_index = start_row_index
-        
+
         logger.info(f"Processing {entity_type} data rows starting from row 6 (index {start_row_index})...")
-        
+
         while current_row_index < len(df):
             # Get the current row
             row = df.iloc[current_row_index]
-            
+
             # Check if row is empty (all values are NaN or empty strings)
-            is_empty = row.isna().all() or all(str(val).strip() == '' for val in row if not pd.isna(val))
-            
+            is_empty = row.isna().all() or all(str(val).strip() == "" for val in row if not pd.isna(val))
+
             if is_empty:
                 # Stop at the first empty row
                 logger.debug(f"Found empty row at row {current_row_index + 1}, stopping")
                 break
-            
+
             # Add non-empty row for validation
             logger.debug(f"Adding row {current_row_index + 1} for validation")
             row_indices.append(current_row_index)
-            
+
             # Move to the next row
             current_row_index += 1
-        
+
         logger.info(f"Found {len(row_indices)} {entity_type} rows to validate.")
 
         # Set the dataframe index to 1-based indices
@@ -792,15 +796,13 @@ def validate_google_sheet(
 
         # Save the dataframe with normalized values
         rows_to_validate_by_entity_type[entity_type] = normalize_dataframe_values(
-            source_rows_to_validate,
-            schemaview,
-            get_entity_class_name(entity_type, bionetwork)
+            source_rows_to_validate, schemaview, get_entity_class_name(entity_type, bionetwork)
         )
-    
+
     # Set up validation summary with entity counts and initial error count
     validation_summary = {
         **{f"{entity_type}_count": len(rows_df) for entity_type, rows_df in rows_to_validate_by_entity_type.items()},
-        "error_count": 0
+        "error_count": 0,
     }
 
     # Check for sheets without rows to validate
@@ -809,8 +811,7 @@ def validate_google_sheet(
     ]
     if entity_types_missing_rows:
         error_msg = (
-            f"No data found to validate starting from row 6 for entity type(s): "
-            f"{', '.join(entity_types_missing_rows)}"
+            f"No data found to validate starting from row 6 for entity type(s): {', '.join(entity_types_missing_rows)}"
         )
         logger.warning(error_msg)
         error_worksheet_id = None
@@ -818,18 +819,14 @@ def validate_google_sheet(
         if len(entity_types_missing_rows) == 1:
             error_entity_type = entity_types_missing_rows[0]
             error_worksheet_id = sheet_read_result.worksheets[entity_types.index(error_entity_type)].worksheet_id
-        error_info = SheetErrorInfo(
-            entity_type=error_entity_type,
-            worksheet_id=error_worksheet_id,
-            message=error_msg
-        )
+        error_info = SheetErrorInfo(entity_type=error_entity_type, worksheet_id=error_worksheet_id, message=error_msg)
         validation_summary["error_count"] = 1
         return SheetValidationResult(
             successful=False,
             spreadsheet_metadata=sheet_read_result.spreadsheet_metadata,
             error_code="no_data",
             summary=validation_summary,
-            errors=[error_info]
+            errors=[error_info],
         )
 
     # Initialize list of validation errors
@@ -852,7 +849,7 @@ def validate_google_sheet(
                 validation_summary=validation_summary,
                 validation_errors_list=validation_errors,
                 entity_type=entity_type,
-                sheet_info=sheet_info
+                sheet_info=sheet_info,
             )
         # Validate references and report results
         references_validation_error = validate_referential_integrity(
@@ -865,13 +862,13 @@ def validate_google_sheet(
                 validation_summary=validation_summary,
                 validation_errors_list=validation_errors,
                 entity_type=entity_type,
-                sheet_info=sheet_info
+                sheet_info=sheet_info,
             )
         # Validate each row
         for row_index, row in rows_to_validate.iterrows():
             # Convert row to dictionary
             row_dict = row.to_dict()
-            
+
             primary_key_field = sheet_structure_by_entity_type[entity_type]["primary_key_field"]
             row_primary_key = (
                 f"{primary_key_field}:{row_dict[primary_key_field]}" if primary_key_field in row_dict else None
@@ -890,7 +887,7 @@ def validate_google_sheet(
                         entity_type=entity_type,
                         sheet_info=sheet_info,
                         row_index=row_index,
-                        row_id=row_primary_key
+                        row_id=row_primary_key,
                     )
             except Exception as e:
                 all_valid_in_worksheet = False
@@ -903,7 +900,7 @@ def validate_google_sheet(
                         worksheet_id=sheet_info.worksheet_id,
                         message=str(e),
                         row=row_index,
-                        primary_key=row_primary_key
+                        primary_key=row_primary_key,
                     )
                 )
 
@@ -914,10 +911,9 @@ def validate_google_sheet(
             logger.warning(f"Validation found errors in some of the {len(rows_to_validate)} {entity_type} rows.")
             logger.warning("Please check the schema requirements and update the data accordingly.")
             logger.info(
-                f"Schema location: "
-                f"{os.path.join(os.path.dirname(__file__), f'../../schema/{entity_type}.yaml')}"
+                f"Schema location: {os.path.join(os.path.dirname(__file__), f'../../schema/{entity_type}.yaml')}"
             )
-    
+
     # Summary
     if all_valid:
         logger.info(f"All rows for the {len(entity_types)} specified entity types are valid!")
@@ -926,16 +922,16 @@ def validate_google_sheet(
             spreadsheet_metadata=sheet_read_result.spreadsheet_metadata,
             error_code=None,
             summary=validation_summary,
-            errors=validation_errors
+            errors=validation_errors,
         )
     else:
         logger.warning(f"Validation found errors in some of the {len(entity_types)} entity types.")
         return SheetValidationResult(
             successful=False,
             spreadsheet_metadata=sheet_read_result.spreadsheet_metadata,
-            error_code='validation_error',
+            error_code="validation_error",
             summary=validation_summary,
-            errors=validation_errors
+            errors=validation_errors,
         )
 
 

--- a/shared/src/hca_validation/metadata_coverage/__init__.py
+++ b/shared/src/hca_validation/metadata_coverage/__init__.py
@@ -5,4 +5,4 @@ LinkML class. See PRD `prd-metadata-coverage.md` in hca-atlas-tracker for the
 wire format and rationale.
 """
 
-from .metadata_coverage import compute_metadata_coverage, SCHEMA_NAME
+from .metadata_coverage import SCHEMA_NAME, compute_metadata_coverage

--- a/shared/src/hca_validation/metadata_coverage/metadata_coverage.py
+++ b/shared/src/hca_validation/metadata_coverage/metadata_coverage.py
@@ -36,7 +36,6 @@ from hca_validation.schema_utils import (
     iter_coverage_slots,
 )
 
-
 SCHEMA_NAME = "tier_1"
 
 
@@ -72,11 +71,7 @@ def compute_metadata_coverage(adata: Any, schemaview: SchemaView) -> Dict[str, A
         # in obs, regardless of whether the column is present. A missing column is
         # the canonical "identifier not populated anywhere" signal and must not be
         # silently dropped — otherwise downstream can't distinguish it from drift.
-        if (
-            identifier is not None
-            and get_slot_anndata_location(identifier) == "obs"
-            and identifier_name is not None
-        ):
+        if identifier is not None and get_slot_anndata_location(identifier) == "obs" and identifier_name is not None:
             field_coverage.append(_obs_identifier_entry(identifier_name, obs))
 
         # Bucket all obs-grain entity-property slots in one vectorized pass per class.
@@ -89,13 +84,15 @@ def compute_metadata_coverage(adata: Any, schemaview: SchemaView) -> Dict[str, A
             if location == "uns":
                 field_coverage.append(_uns_entry(entity_class, slot_name, uns))
             elif location == "obs":
-                field_coverage.append(_obs_entry(
-                    entity_class=entity_class,
-                    slot_name=slot_name,
-                    obs=obs,
-                    grouped=grouped,
-                    record_count=record_count,
-                ))
+                field_coverage.append(
+                    _obs_entry(
+                        entity_class=entity_class,
+                        slot_name=slot_name,
+                        obs=obs,
+                        grouped=grouped,
+                        record_count=record_count,
+                    )
+                )
 
     _assert_invariant(entities, field_coverage)
 

--- a/shared/src/hca_validation/schema_utils/__init__.py
+++ b/shared/src/hca_validation/schema_utils/__init__.py
@@ -5,13 +5,13 @@ This module provides utilities for interacting with the HCA schema.
 """
 
 from .schema_utils import (
-    load_schemaview,
-    get_entity_class_name,
+    coverage_classes,
     get_class_entity_type,
-    get_class_identifier_name,
     get_class_foreign_keys,
+    get_class_identifier_name,
+    get_entity_class_name,
     get_slot_anndata_location,
     is_deprecated_slot,
-    coverage_classes,
     iter_coverage_slots,
+    load_schemaview,
 )

--- a/shared/src/hca_validation/schema_utils/schema_utils.py
+++ b/shared/src/hca_validation/schema_utils/schema_utils.py
@@ -1,5 +1,6 @@
 import os
 from typing import Iterator, List, Optional, Tuple
+
 import jsonasobj2
 from linkml_runtime import SchemaView
 from linkml_runtime.linkml_model.meta import SlotDefinition
@@ -7,22 +8,14 @@ from linkml_runtime.linkml_model.meta import SlotDefinition
 # Map entity types and bionetworks to their corresponding class names
 schema_classes = {
     "dataset": {
-      "DEFAULT": "Dataset",
-      "adipose": "AdiposeDataset",
-      "gut": "GutDataset",
-      "musculoskeletal": "MusculoskeletalDataset",
+        "DEFAULT": "Dataset",
+        "adipose": "AdiposeDataset",
+        "gut": "GutDataset",
+        "musculoskeletal": "MusculoskeletalDataset",
     },
-    "donor": {
-      "DEFAULT": "Donor"
-    },
-    "sample": {
-      "DEFAULT": "Sample",
-      "adipose": "AdiposeSample",
-      "gut": "GutSample"
-    },
-    "cell": {
-      "DEFAULT": "Cell"
-    }
+    "donor": {"DEFAULT": "Donor"},
+    "sample": {"DEFAULT": "Sample", "adipose": "AdiposeSample", "gut": "GutSample"},
+    "cell": {"DEFAULT": "Cell"},
 }
 
 # Derive mapping from class name to entity type
@@ -44,9 +37,10 @@ def load_schemaview():
 def get_entity_class_name(schema_type: str, bionetwork: Optional[str] = None) -> str:
     # Validate schema type
     if schema_type not in schema_classes:
-        raise ValueError(f"Unsupported schema type: {schema_type}. "
-                       f"Supported types are: {', '.join(schema_classes.keys())}")
-    
+        raise ValueError(
+            f"Unsupported schema type: {schema_type}. Supported types are: {', '.join(schema_classes.keys())}"
+        )
+
     type_classes = schema_classes[schema_type]
     return type_classes.get(bionetwork, type_classes["DEFAULT"])
 
@@ -101,9 +95,7 @@ def coverage_classes(schemaview: SchemaView) -> List[str]:
     return eligible
 
 
-def iter_coverage_slots(
-    schemaview: SchemaView, class_name: str
-) -> Iterator[Tuple[str, str]]:
+def iter_coverage_slots(schemaview: SchemaView, class_name: str) -> Iterator[Tuple[str, str]]:
     """Yield (slot_name, annDataLocation) for slots of `class_name` that participate
     in coverage reporting at entity grain.
 
@@ -132,7 +124,7 @@ def get_class_foreign_keys(schemaview: SchemaView, class_name: str):
     Args:
       schemaview: Schemaview to get class and slot info from
       class_name: Name of class to get slots for
-    
+
     Returns:
       List of (slot name, slot range) tuples
     """

--- a/shared/src/hca_validation/validator/validator.py
+++ b/shared/src/hca_validation/validator/validator.py
@@ -3,11 +3,13 @@ HCA Validation Tools - Main Validator Module
 
 This module provides the main validation functionality for HCA data using Pydantic models.
 """
+
 import itertools
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Optional
+
+import pandas as pd
 from linkml_runtime import SchemaView
 from pydantic import ValidationError
-import pandas as pd
 from pydantic_core import InitErrorDetails, PydanticCustomError
 
 import hca_validation.schema.generated.core as schema
@@ -19,40 +21,28 @@ from hca_validation.schema_utils.schema_utils import (
 
 # Map schema types and bionetworks to their corresponding class names
 schema_classes = {
-    "dataset": {
-      "DEFAULT": "Dataset",
-      "adipose": "AdiposeDataset",
-      "gut": "GutDataset"
-    },
-    "donor": {
-      "DEFAULT": "Donor"
-    },
-    "sample": {
-      "DEFAULT": "Sample",
-      "adipose": "AdiposeSample",
-      "gut": "GutSample"
-    },
-    "cell": {
-      "DEFAULT": "Cell"
-    }
+    "dataset": {"DEFAULT": "Dataset", "adipose": "AdiposeDataset", "gut": "GutDataset"},
+    "donor": {"DEFAULT": "Donor"},
+    "sample": {"DEFAULT": "Sample", "adipose": "AdiposeSample", "gut": "GutSample"},
+    "cell": {"DEFAULT": "Cell"},
 }
 
 
 def validate(data: Dict[str, Any], *, class_name: str) -> Optional[ValidationError]:
     """
     Validate HCA data against a schema using Pydantic models.
-    
+
     Args:
         data: The data to validate as a dictionary
         schema_type: Type of schema to validate against ('dataset', 'donor', 'sample', 'cell')
-        
+
     Returns:
         Returns a Pydantic ValidationError if validation fails, or None if validation succeeds
-        
+
     Raises:
         ValueError: If an unsupported schema type is provided
     """
-    
+
     try:
         # Validate using the appropriate Pydantic model
         model = getattr(schema, class_name)
@@ -71,7 +61,7 @@ def validate_id_uniqueness(data: pd.DataFrame, schemaview: SchemaView, class_nam
         data: A dataframe containing the entities to validate
         schemaview: The schemaview to use to determine the identifier slot
         class_name: The schema class name of the entities being validated
-    
+
     Returns:
         A Pydantic ValidationError if any duplicate IDs appear, or None otherwise
     """
@@ -80,33 +70,28 @@ def validate_id_uniqueness(data: pd.DataFrame, schemaview: SchemaView, class_nam
 
     if id_name not in data:
         return None
-    
+
     # Get IDs that are not missing and appear multiple times
     duplicate_ids = data[id_name][data[id_name].notna() & data[id_name].duplicated(keep=False)]
 
     if len(duplicate_ids) == 0:
         return None
-    
+
     def get_row_error_details(index, id) -> InitErrorDetails:
         # Provide row-specific info to facilitate error handling
-        ctx = {
-            "row_index": index,
-            "row_id": id
-        }
+        ctx = {"row_index": index, "row_id": id}
         return {
             "type": PydanticCustomError("duplicate_id", "Duplicate identifier {row_id}", ctx),
             "loc": (id_name,),
             "input": id,
-            "ctx": ctx
+            "ctx": ctx,
         }
 
     return ValidationError.from_exception_data(
         title="Duplicate identifiers",
-        line_errors=[
-            get_row_error_details(index, value)
-            for index, value in duplicate_ids.items()
-        ]
+        line_errors=[get_row_error_details(index, value) for index, value in duplicate_ids.items()],
     )
+
 
 def validate_referential_integrity(
     data_by_entity_type: dict[str, pd.DataFrame], schemaview: SchemaView, class_name: str
@@ -119,7 +104,7 @@ def validate_referential_integrity(
         data_by_entity_type: Dict containing dataframes for all entity types, keyed by entity type
         schemaview: The schemaview to use to determine class and slot relationships
         class_name: The schema class name of the entities being validated
-    
+
     Returns:
         A Pydantic ValidationError if any referenced entities are missing, or None otherwise
     """
@@ -133,7 +118,7 @@ def validate_referential_integrity(
             "row_index": index,
             "row_id": id,
             "foreign_entity_type": foreign_entity_type,
-            "foreign_key_value": fk_value
+            "foreign_key_value": fk_value,
         }
         return {
             "type": PydanticCustomError(
@@ -143,7 +128,7 @@ def validate_referential_integrity(
             ),
             "loc": (fk_slot_name,),
             "input": fk_value,
-            "ctx": ctx
+            "ctx": ctx,
         }
 
     line_errors = []
@@ -166,21 +151,15 @@ def validate_referential_integrity(
             ]
         # Get iterable of row IDs; default to all-None if the ID column doesn't exist
         missing_ref_row_ids = (
-            missing_ref_rows[id_name]
-            if id_name in missing_ref_rows
-            else itertools.repeat(None, len(missing_ref_rows))
+            missing_ref_rows[id_name] if id_name in missing_ref_rows else itertools.repeat(None, len(missing_ref_rows))
         )
         # Add errors to list
         line_errors.extend(
             get_row_error_details(index, id_value, fk_value, fk_slot_name, fk_entity_type)
             for (index, fk_value), id_value in zip(missing_ref_rows[fk_slot_name].items(), missing_ref_row_ids)
         )
-    
+
     if not line_errors:
         return None
 
-    return ValidationError.from_exception_data(
-        title="Missing referenced entities",
-        line_errors=line_errors
-    )
-
+    return ValidationError.from_exception_data(title="Missing referenced entities", line_errors=line_errors)

--- a/shared/tests/conftest.py
+++ b/shared/tests/conftest.py
@@ -3,7 +3,6 @@
 
 """Shared test configuration for HCA validation tools."""
 
-import pytest
 import sys
 from pathlib import Path
 

--- a/shared/tests/test_entry_sheet_validator.py
+++ b/shared/tests/test_entry_sheet_validator.py
@@ -8,29 +8,28 @@ This script tests the functionality of the entry sheet validator, including:
 2. Handling error conditions (sheet not found, access denied, etc.)
 3. Validating sheet content
 """
-import os
-import json
-from typing import List
-import pytest
-from unittest.mock import DEFAULT, patch, MagicMock, call
-import pandas as pd
-from google.oauth2.service_account import Credentials
-import gspread
-from gspread.exceptions import SpreadsheetNotFound, WorksheetNotFound, APIError
 
+import json
+import os
+from unittest.mock import DEFAULT, MagicMock, patch
+
+import gspread
+import pandas as pd
+import pytest
+from gspread.exceptions import SpreadsheetNotFound
+
+from hca_validation.entry_sheet_validator.common import default_entity_types
+from hca_validation.entry_sheet_validator.process_sheet import process_google_sheet
 from hca_validation.entry_sheet_validator.validate_sheet import (
     ApiInstances,
     SheetReadError,
-    SheetErrorInfo,
     SheetValidationResult,
     SpreadsheetInfo,
     SpreadsheetMetadata,
     WorksheetInfo,
     read_sheet_with_service_account,
-    validate_google_sheet
+    validate_google_sheet,
 )
-from hca_validation.entry_sheet_validator.process_sheet import process_google_sheet
-from hca_validation.entry_sheet_validator.common import default_entity_types
 
 # Test sheet IDs
 PUBLIC_SHEET_ID = "1oPFb6qb0Y2HeoQqjSGRe_TlsZPRLwq-HUlVF0iqtVlY"  # This is a public sheet
@@ -39,67 +38,115 @@ NONEXISTENT_SHEET_ID = "1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"  # This shee
 
 # Sample data for mocking
 # Generic data
-SAMPLE_SHEET_DATA = pd.DataFrame({
-    'column1': ['', '', '', '', 'value1', 'value2'],
-    'column2': ['', '', '', '', 'value3', 'value4']
-})
+SAMPLE_SHEET_DATA = pd.DataFrame(
+    {"column1": ["", "", "", "", "value1", "value2"], "column2": ["", "", "", "", "value3", "value4"]}
+)
 # Data without rows to validate
-SAMPLE_SHEET_DATA_WITHOUT_ENTITIES = pd.DataFrame({
-    'column1': ['', '', '', ''],
-})
+SAMPLE_SHEET_DATA_WITHOUT_ENTITIES = pd.DataFrame(
+    {
+        "column1": ["", "", "", ""],
+    }
+)
 # Data to test parsing of empty values and lists
-SAMPLE_SHEET_DATA_WITH_CASTS = pd.DataFrame({
-    'contact_email': ['', '', '', '', "foo@example.com", '   ', 'bar@example.com'],
-    'study_pi': ['', '', '', '', 'Foo', 'Bar; Baz', '']
-})
+SAMPLE_SHEET_DATA_WITH_CASTS = pd.DataFrame(
+    {
+        "contact_email": ["", "", "", "", "foo@example.com", "   ", "bar@example.com"],
+        "study_pi": ["", "", "", "", "Foo", "Bar; Baz", ""],
+    }
+)
 # Data to test parsing of integers, including invalid values that will be left as strings
-SAMPLE_SHEET_DATA_WITH_INTEGERS = pd.DataFrame({
-    'cell_number_loaded': [
-        '', '', '', '', '1', '-23', '456', '', '7890', '1,234', '-56,789', '123,456', '78,901,234', '56,78',
-        '9,012345',
-    ],
-    # Required to prevent the empty value above from being treated as the end of the data
-    'sample_id': ['', '', '', '', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k']
-})
+SAMPLE_SHEET_DATA_WITH_INTEGERS = pd.DataFrame(
+    {
+        "cell_number_loaded": [
+            "",
+            "",
+            "",
+            "",
+            "1",
+            "-23",
+            "456",
+            "",
+            "7890",
+            "1,234",
+            "-56,789",
+            "123,456",
+            "78,901,234",
+            "56,78",
+            "9,012345",
+        ],
+        # Required to prevent the empty value above from being treated as the end of the data
+        "sample_id": ["", "", "", "", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"],
+    }
+)
 # Data to test parsing of integers, with values that can all be represented as optional integers
-SAMPLE_SHEET_DATA_WITH_VALID_AND_MISSING_INTEGERS = pd.DataFrame({
-    'cell_number_loaded': ['', '', '', '', '1', '-23', '', '7890'],
-    # Required to prevent the empty value above from being treated as the end of the data
-    'sample_id': ['', '', '', '', 'a', 'b', 'c', 'd']
-})
+SAMPLE_SHEET_DATA_WITH_VALID_AND_MISSING_INTEGERS = pd.DataFrame(
+    {
+        "cell_number_loaded": ["", "", "", "", "1", "-23", "", "7890"],
+        # Required to prevent the empty value above from being treated as the end of the data
+        "sample_id": ["", "", "", "", "a", "b", "c", "d"],
+    }
+)
 # Data to test validation of ID uniqueness
-SAMPLE_SHEET_DATA_WITH_DUPLICATE_IDS = pd.DataFrame({
-    'dataset_id': ['', '', '', '', 'foo', 'bar', 'foo', '', '', 'baz', 'baz', 'baz'],
-    # This column is required to prevent the empty IDs from being treated as the end of the data
-    'description': ['', '', '', '', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']
-})
+SAMPLE_SHEET_DATA_WITH_DUPLICATE_IDS = pd.DataFrame(
+    {
+        "dataset_id": ["", "", "", "", "foo", "bar", "foo", "", "", "baz", "baz", "baz"],
+        # This column is required to prevent the empty IDs from being treated as the end of the data
+        "description": ["", "", "", "", "a", "b", "c", "d", "e", "f", "g", "h"],
+    }
+)
 # Data to test validation of referential integrity
-SAMPLE_DATASETS_SHEET_DATA_WITH_REFERENCES = pd.DataFrame({
-    'dataset_id': ['', '', '', '', 'dataset_a', 'dataset_b', 'dataset_c']
-})
-SAMPLE_DONORS_SHEET_DATA_WITH_REFERENCES = pd.DataFrame({
-    # References to datasets, which do have an ID column; contains empty cells and references to missing datasets
-    'dataset_id': [
-        '', '', '', '', 'dataset_b', 'dataset_a', '', 'dataset_missing_a', 'dataset_missing_b', 'dataset_b', '',
-        'dataset_a', 'dataset_missing_b',
-    ],
-    # Prevent the empty IDs from being treated as the end of the data
-    'description': ['', '', '', '', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']
-})
-SAMPLE_SAMPLES_SHEET_DATA_WITH_REFERENCES = pd.DataFrame({
-    # Missing references to datasets
-    # References to donors, which are missing an ID column; contains empty cells
-    'donor_id': ['', '', '', '', 'donor_b', '', 'donor_a', '', '', 'donor_b', 'donor_b'],
-    # Prevent the empty IDs from being treated as the end of the data
-    'description': ['', '', '', '', 'a', 'b', 'c', 'd', 'e', 'f', 'g']
-})
+SAMPLE_DATASETS_SHEET_DATA_WITH_REFERENCES = pd.DataFrame(
+    {"dataset_id": ["", "", "", "", "dataset_a", "dataset_b", "dataset_c"]}
+)
+SAMPLE_DONORS_SHEET_DATA_WITH_REFERENCES = pd.DataFrame(
+    {
+        # References to datasets, which do have an ID column; contains empty cells and references to missing datasets
+        "dataset_id": [
+            "",
+            "",
+            "",
+            "",
+            "dataset_b",
+            "dataset_a",
+            "",
+            "dataset_missing_a",
+            "dataset_missing_b",
+            "dataset_b",
+            "",
+            "dataset_a",
+            "dataset_missing_b",
+        ],
+        # Prevent the empty IDs from being treated as the end of the data
+        "description": ["", "", "", "", "a", "b", "c", "d", "e", "f", "g", "h", "i"],
+    }
+)
+SAMPLE_SAMPLES_SHEET_DATA_WITH_REFERENCES = pd.DataFrame(
+    {
+        # Missing references to datasets
+        # References to donors, which are missing an ID column; contains empty cells
+        "donor_id": ["", "", "", "", "donor_b", "", "donor_a", "", "", "donor_b", "donor_b"],
+        # Prevent the empty IDs from being treated as the end of the data
+        "description": ["", "", "", "", "a", "b", "c", "d", "e", "f", "g"],
+    }
+)
 # Data to test automatic fixes
-SAMPLE_SHEET_DATA_WITH_FIXES = pd.DataFrame({
-    'manner_of_death': [
-        '', '', '', '', '1', 'unknown', 'not_applicable', '4', 'not applicable', 'not a manner of death',
-        'not_applicable',
-    ],
-})
+SAMPLE_SHEET_DATA_WITH_FIXES = pd.DataFrame(
+    {
+        "manner_of_death": [
+            "",
+            "",
+            "",
+            "",
+            "1",
+            "unknown",
+            "not_applicable",
+            "4",
+            "not applicable",
+            "not a manner of death",
+            "not_applicable",
+        ],
+    }
+)
 
 # Data to be compared with derived values
 SAMPLE_SHEET_DATA_WITH_CASTS_EXPECTED_NORMALIZATION = [
@@ -145,13 +192,13 @@ def _create_mock_spreadsheet_info(
         datasets_sheet_data = SAMPLE_SHEET_DATA if sheet_data is None else sheet_data
     if samples_sheet_data is not None and donors_sheet_data is None:
         donors_sheet_data = SAMPLE_SHEET_DATA
-    
+
     worksheets = [
         WorksheetInfo(
             data=datasets_sheet_data,
             worksheet_id=123,
             source_columns=list(datasets_sheet_data.columns),
-            source_rows_start_index=1
+            source_rows_start_index=1,
         )
     ]
     if donors_sheet_data is not None:
@@ -160,7 +207,7 @@ def _create_mock_spreadsheet_info(
                 data=donors_sheet_data,
                 worksheet_id=456,
                 source_columns=list(donors_sheet_data.columns),
-                source_rows_start_index=1
+                source_rows_start_index=1,
             )
         )
     if samples_sheet_data is not None:
@@ -169,20 +216,21 @@ def _create_mock_spreadsheet_info(
                 data=samples_sheet_data,
                 worksheet_id=789,
                 source_columns=list(samples_sheet_data.columns),
-                source_rows_start_index=1
+                source_rows_start_index=1,
             )
         )
-    
+
     return SpreadsheetInfo(
         spreadsheet_metadata=SpreadsheetMetadata(
             spreadsheet_title="Test Sheet Title",
             last_updated_date="2025-06-06T22:43:57.554Z",
             last_updated_by="foo",
             last_updated_email="foo@example.com",
-            can_edit=sheet_editable
+            can_edit=sheet_editable,
         ),
-        worksheets=worksheets
+        worksheets=worksheets,
     )
+
 
 def _test_validation_with_mock_sheets_response(
     validation_function,
@@ -195,8 +243,8 @@ def _test_validation_with_mock_sheets_response(
     samples_sheet_data=None,
     expect_read_call=True,
     expected_apis_parameter=None,
-    expected_error_code='validation_error',
-    additional_arguments={}
+    expected_error_code="validation_error",
+    additional_arguments={},
 ) -> SheetValidationResult:
     """Helper function for testing validation with service account access, for a validation function with a call
     signature like validate_google_sheet."""
@@ -206,14 +254,14 @@ def _test_validation_with_mock_sheets_response(
         sheet_data=sheet_data,
         datasets_sheet_data=datasets_sheet_data,
         donors_sheet_data=donors_sheet_data,
-        samples_sheet_data=samples_sheet_data
+        samples_sheet_data=samples_sheet_data,
     )
     mock_read_service_account.return_value = (
         mock_spreadsheet_info,
-        [MagicMock() for _ in mock_spreadsheet_info.worksheets]
+        [MagicMock() for _ in mock_spreadsheet_info.worksheets],
     )
 
-    entity_types = default_entity_types[:len(mock_spreadsheet_info.worksheets)]
+    entity_types = default_entity_types[: len(mock_spreadsheet_info.worksheets)]
 
     # Run validation
     validation_result = validation_function(
@@ -226,7 +274,7 @@ def _test_validation_with_mock_sheets_response(
     else:
         # Otherwise, verify sheet data was not read
         mock_read_service_account.assert_not_called()
-    
+
     # Verify metadata is returned
     assert validation_result.spreadsheet_metadata
     assert validation_result.spreadsheet_metadata.spreadsheet_title == "Test Sheet Title"
@@ -234,7 +282,7 @@ def _test_validation_with_mock_sheets_response(
     assert validation_result.spreadsheet_metadata.last_updated_by == "foo"
     assert validation_result.spreadsheet_metadata.last_updated_email == "foo@example.com"
     assert validation_result.error_code == expected_error_code
-    
+
     return validation_result
 
 
@@ -245,20 +293,22 @@ class TestReadSheetWithServiceAccount:
     def mock_env_with_credentials(self):
         """Fixture to mock environment with service account credentials."""
         original_env = os.environ.copy()
-        os.environ['GOOGLE_SERVICE_ACCOUNT'] = json.dumps({
-            "type": "service_account",
-            "project_id": "test-project",
-            "private_key_id": "test-key-id",
-            "private_key": (
-                "-----BEGIN PRIVATE KEY-----\nMOCK_PRIVATE_KEY_FOR_TESTING_ONLY\n-----END PRIVATE KEY-----\n"
-            ),
-            "client_email": "test@test-project.iam.gserviceaccount.com",
-            "client_id": "123456789",
-            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-            "token_uri": "https://oauth2.googleapis.com/token",
-            "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-            "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test%40test-project.iam.gserviceaccount.com"
-        })
+        os.environ["GOOGLE_SERVICE_ACCOUNT"] = json.dumps(
+            {
+                "type": "service_account",
+                "project_id": "test-project",
+                "private_key_id": "test-key-id",
+                "private_key": (
+                    "-----BEGIN PRIVATE KEY-----\nMOCK_PRIVATE_KEY_FOR_TESTING_ONLY\n-----END PRIVATE KEY-----\n"
+                ),
+                "client_email": "test@test-project.iam.gserviceaccount.com",
+                "client_id": "123456789",
+                "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                "token_uri": "https://oauth2.googleapis.com/token",
+                "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+                "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test%40test-project.iam.gserviceaccount.com",
+            }
+        )
         yield
         os.environ.clear()
         os.environ.update(original_env)
@@ -273,16 +323,18 @@ class TestReadSheetWithServiceAccount:
         # Mock the Drive API
         mock_get = MagicMock()
         mock_files = MagicMock()
-        
+
         # Mock spreadsheet.values_batch_get
         mock_data = {
-            "valueRanges": [{
-                "values": [
-                    ['header1', 'header2'],  # Headers
-                    ['value1', 'value3'],    # Row 1
-                    ['value2', 'value4']     # Row 2
-                ]
-            }]
+            "valueRanges": [
+                {
+                    "values": [
+                        ["header1", "header2"],  # Headers
+                        ["value1", "value3"],  # Row 1
+                        ["value2", "value4"],  # Row 2
+                    ]
+                }
+            ]
         }
         mock_sheet.values_batch_get.return_value = mock_data
         mock_worksheet.id = 123
@@ -296,22 +348,18 @@ class TestReadSheetWithServiceAccount:
         # Mock the Drive API response
         mock_get.execute.return_value = {
             "modifiedTime": "2025-06-06T22:43:57.554Z",
-            "lastModifyingUser": {
-                "displayName": "foo"
-            },
-            "capabilities": {
-                "canModifyContent": True
-            }
+            "lastModifyingUser": {"displayName": "foo"},
+            "capabilities": {"canModifyContent": True},
         }
         mock_files.get.return_value = mock_get
         mock_drive.files.return_value = mock_files
 
         return mock_sheet
 
-    @patch('googleapiclient.discovery.build')
-    @patch('hca_validation.entry_sheet_validator.validate_sheet.create_requests_session')
-    @patch('gspread.authorize')
-    @patch('google.oauth2.service_account.Credentials.from_service_account_info')
+    @patch("googleapiclient.discovery.build")
+    @patch("hca_validation.entry_sheet_validator.validate_sheet.create_requests_session")
+    @patch("gspread.authorize")
+    @patch("google.oauth2.service_account.Credentials.from_service_account_info")
     def test_with_service_account_credentials(
         self,
         mock_credentials,
@@ -343,7 +391,7 @@ class TestReadSheetWithServiceAccount:
         assert sheet_info.worksheet_id == 123
         assert sheet_info.source_columns == ["header1", "header2"]
         assert sheet_info.source_rows_start_index == 1
-        
+
         # Verify the mocks were called correctly
         mock_credentials.assert_called_once()
         mock_authorize.assert_called_once()
@@ -353,10 +401,10 @@ class TestReadSheetWithServiceAccount:
         # Expect values_batch_get to have been called with a range consisting of the quoted worksheet title
         mock_sheet.values_batch_get.assert_called_once_with(["'Test Worksheet'"])
 
-    @patch('googleapiclient.discovery.build')
-    @patch('hca_validation.entry_sheet_validator.validate_sheet.create_requests_session')
-    @patch('gspread.authorize')
-    @patch('google.oauth2.service_account.Credentials.from_service_account_info')
+    @patch("googleapiclient.discovery.build")
+    @patch("hca_validation.entry_sheet_validator.validate_sheet.create_requests_session")
+    @patch("gspread.authorize")
+    @patch("google.oauth2.service_account.Credentials.from_service_account_info")
     def test_pre_initialize_apis(
         self,
         mock_credentials,
@@ -388,51 +436,53 @@ class TestReadSheetWithServiceAccount:
     def test_without_service_account_credentials(self):
         """Test reading a sheet without service account credentials."""
         # Ensure no credentials are set
-        if 'GOOGLE_SERVICE_ACCOUNT' in os.environ:
-            del os.environ['GOOGLE_SERVICE_ACCOUNT']
+        if "GOOGLE_SERVICE_ACCOUNT" in os.environ:
+            del os.environ["GOOGLE_SERVICE_ACCOUNT"]
 
         # The function should raise a read error containing only 'auth_missing' code when no credentials are available
         with pytest.raises(SheetReadError) as error_info:
             read_sheet_with_service_account(PUBLIC_SHEET_ID)
-        assert error_info.value.error_code == 'auth_missing'
+        assert error_info.value.error_code == "auth_missing"
         assert error_info.value.spreadsheet_metadata is None
         assert error_info.value.worksheet_id is None
-        
+
     def test_with_unresolved_credentials(self):
         """Test reading a sheet with unresolved credentials from Secrets Manager."""
         # Set credentials to a string that looks like an unresolved secret reference
         original_env = os.environ.copy()
-        os.environ['GOOGLE_SERVICE_ACCOUNT'] = 'aws:secretsmanager:dev/hca-atlas-tracker/google-service-account'
+        os.environ["GOOGLE_SERVICE_ACCOUNT"] = "aws:secretsmanager:dev/hca-atlas-tracker/google-service-account"
 
         try:
             # The function should return read error containing only 'auth_unresolved' code when credentials weren't
             # resolved
             with pytest.raises(SheetReadError) as error_info:
                 read_sheet_with_service_account(PUBLIC_SHEET_ID)
-            assert error_info.value.error_code == 'auth_unresolved'
+            assert error_info.value.error_code == "auth_unresolved"
             assert error_info.value.spreadsheet_metadata is None
             assert error_info.value.worksheet_id is None
         finally:
             # Restore original environment
             os.environ.clear()
             os.environ.update(original_env)
-            
+
     def test_with_invalid_format_credentials(self):
         """Test reading a sheet with invalid format credentials."""
         # Set credentials to a valid JSON but missing required fields
         original_env = os.environ.copy()
-        os.environ['GOOGLE_SERVICE_ACCOUNT'] = json.dumps({
-            "type": "service_account",
-            "project_id": "test-project"
-            # Missing required fields: private_key, client_email, token_uri
-        })
+        os.environ["GOOGLE_SERVICE_ACCOUNT"] = json.dumps(
+            {
+                "type": "service_account",
+                "project_id": "test-project",
+                # Missing required fields: private_key, client_email, token_uri
+            }
+        )
 
         try:
             # The function should return read error containing only 'auth_invalid_format' code when credentials are
             # missing required fields
             with pytest.raises(SheetReadError) as error_info:
                 read_sheet_with_service_account(PUBLIC_SHEET_ID)
-            assert error_info.value.error_code == 'auth_invalid_format'
+            assert error_info.value.error_code == "auth_invalid_format"
             assert error_info.value.spreadsheet_metadata is None
             assert error_info.value.worksheet_id is None
         finally:
@@ -440,9 +490,9 @@ class TestReadSheetWithServiceAccount:
             os.environ.clear()
             os.environ.update(original_env)
 
-    @patch('hca_validation.entry_sheet_validator.validate_sheet.create_requests_session')
-    @patch('gspread.authorize')
-    @patch('google.oauth2.service_account.Credentials.from_service_account_info')
+    @patch("hca_validation.entry_sheet_validator.validate_sheet.create_requests_session")
+    @patch("gspread.authorize")
+    @patch("google.oauth2.service_account.Credentials.from_service_account_info")
     def test_sheet_not_found(
         self,
         mock_credentials,
@@ -459,17 +509,17 @@ class TestReadSheetWithServiceAccount:
         # The function should return read error containing only 'sheet_not_found' code when the sheet is not found
         with pytest.raises(SheetReadError) as error_info:
             read_sheet_with_service_account(NONEXISTENT_SHEET_ID)
-        assert error_info.value.error_code == 'sheet_not_found'
+        assert error_info.value.error_code == "sheet_not_found"
         assert error_info.value.spreadsheet_metadata is None
         assert error_info.value.worksheet_id is None
-        
+
         # Verify the mocks were called correctly
         mock_client.open_by_key.assert_called_once_with(NONEXISTENT_SHEET_ID)
 
-    @patch('googleapiclient.discovery.build')
-    @patch('hca_validation.entry_sheet_validator.validate_sheet.create_requests_session')
-    @patch('gspread.authorize')
-    @patch('google.oauth2.service_account.Credentials.from_service_account_info')
+    @patch("googleapiclient.discovery.build")
+    @patch("hca_validation.entry_sheet_validator.validate_sheet.create_requests_session")
+    @patch("gspread.authorize")
+    @patch("google.oauth2.service_account.Credentials.from_service_account_info")
     def test_worksheet_not_found(
         self,
         mock_credentials,
@@ -490,17 +540,17 @@ class TestReadSheetWithServiceAccount:
         # the worksheet is not found
         with pytest.raises(SheetReadError) as error_info:
             read_sheet_with_service_account(PUBLIC_SHEET_ID)
-        assert error_info.value.error_code == 'worksheet_not_found'
+        assert error_info.value.error_code == "worksheet_not_found"
         assert error_info.value.spreadsheet_metadata is not None
         assert error_info.value.worksheet_id is None
-        
+
         # Verify the mocks were called correctly
         mock_client.open_by_key.assert_called_once_with(PUBLIC_SHEET_ID)
         mock_sheet.worksheets.assert_called_once()
 
-    @patch('hca_validation.entry_sheet_validator.validate_sheet.create_requests_session')
-    @patch('gspread.authorize')
-    @patch('google.oauth2.service_account.Credentials.from_service_account_info')
+    @patch("hca_validation.entry_sheet_validator.validate_sheet.create_requests_session")
+    @patch("gspread.authorize")
+    @patch("google.oauth2.service_account.Credentials.from_service_account_info")
     def test_api_error(
         self,
         mock_credentials,
@@ -518,17 +568,17 @@ class TestReadSheetWithServiceAccount:
         # The function should return read error containing only 'api_error' code when an API error occurs
         with pytest.raises(SheetReadError) as error_info:
             read_sheet_with_service_account(PUBLIC_SHEET_ID)
-        assert error_info.value.error_code == 'api_error'
+        assert error_info.value.error_code == "api_error"
         assert error_info.value.spreadsheet_metadata is None
         assert error_info.value.worksheet_id is None
-        
+
         # Verify the mocks were called correctly
         mock_client.open_by_key.assert_called_once_with(PUBLIC_SHEET_ID)
 
-    @patch('googleapiclient.discovery.build')
-    @patch('hca_validation.entry_sheet_validator.validate_sheet.create_requests_session')
-    @patch('gspread.authorize')
-    @patch('google.oauth2.service_account.Credentials.from_service_account_info')
+    @patch("googleapiclient.discovery.build")
+    @patch("hca_validation.entry_sheet_validator.validate_sheet.create_requests_session")
+    @patch("gspread.authorize")
+    @patch("google.oauth2.service_account.Credentials.from_service_account_info")
     def test_generic_exception_with_metadata(
         self,
         mock_credentials,
@@ -548,10 +598,10 @@ class TestReadSheetWithServiceAccount:
         # The function should return read error containing 'api_error' code and spreadsheet metadata
         with pytest.raises(SheetReadError) as error_info:
             read_sheet_with_service_account(PUBLIC_SHEET_ID)
-        assert error_info.value.error_code == 'api_error'
+        assert error_info.value.error_code == "api_error"
         assert error_info.value.spreadsheet_metadata is not None
         assert error_info.value.worksheet_id is None
-        
+
         # Verify the mocks were called correctly
         mock_client.open_by_key.assert_called_once_with(PUBLIC_SHEET_ID)
         mock_sheet.worksheets.assert_called_once()
@@ -560,12 +610,12 @@ class TestReadSheetWithServiceAccount:
 class TestValidateGoogleSheet:
     """Tests for the validate_google_sheet function."""
 
-    @patch('hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account')
+    @patch("hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account")
     def test_service_account_access(self, mock_read_service_account):
         """Test validation with service account access."""
         _test_validation_with_mock_sheets_response(validate_google_sheet, mock_read_service_account)
 
-    @patch('hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account')
+    @patch("hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account")
     def test_service_account_access_with_bionetwork(self, mock_read_service_account):
         """Test validation using network-specific model."""
         result = _test_validation_with_mock_sheets_response(
@@ -575,15 +625,17 @@ class TestValidateGoogleSheet:
         # but not by the default model
         assert any(error.column == "doublet_detection" for error in result.errors)
 
-    @patch('hca_validation.validator.validate')
-    @patch('hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account')
+    @patch("hca_validation.validator.validate")
+    @patch("hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account")
     def test_row_normalization_before_validation(self, mock_read_service_account, mock_validate):
         """Test normalization of rows passed to the validation function."""
         # Store dicts that the validation function is called with
         validated_dicts = []
+
         def save_data(data, class_name):
             validated_dicts.append(data)
             return DEFAULT
+
         mock_validate.side_effect = save_data
         # Validate the mock sheet
         _test_validation_with_mock_sheets_response(
@@ -592,15 +644,18 @@ class TestValidateGoogleSheet:
         # Confirm that values were converted as expected
         assert validated_dicts == SAMPLE_SHEET_DATA_WITH_CASTS_EXPECTED_NORMALIZATION
 
-    @patch('hca_validation.validator.validate')
-    @patch('hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account')
+    @patch("hca_validation.validator.validate")
+    @patch("hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account")
     def test_int_normalization_before_validation(self, mock_read_service_account, mock_validate):
         """Test normalization of integer fields passed to the validation function."""
         # Store dicts that the validation function is called with
         validated_dicts = []
+
         def save_data(data, class_name):
-            if class_name.endswith("Sample"): validated_dicts.append(data)
+            if class_name.endswith("Sample"):
+                validated_dicts.append(data)
             return DEFAULT
+
         mock_validate.side_effect = save_data
         # Validate the mock sheet
         _test_validation_with_mock_sheets_response(
@@ -611,16 +666,19 @@ class TestValidateGoogleSheet:
         # Confirm that values were converted as expected
         assert validated_dicts == SAMPLE_SHEET_DATA_WITH_INTEGERS_EXPECTED_NORMALIZATION
 
-    @patch('hca_validation.validator.validate')
-    @patch('hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account')
+    @patch("hca_validation.validator.validate")
+    @patch("hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account")
     def test_valid_and_missing_int_normalization_before_validation(self, mock_read_service_account, mock_validate):
         """Test normalization of integer fields passed to the validation function, with only valid and missing
         integers."""
         # Store dicts that the validation function is called with
         validated_dicts = []
+
         def save_data(data, class_name):
-            if class_name.endswith("Sample"): validated_dicts.append(data)
+            if class_name.endswith("Sample"):
+                validated_dicts.append(data)
             return DEFAULT
+
         mock_validate.side_effect = save_data
         # Validate the mock sheet
         _test_validation_with_mock_sheets_response(
@@ -631,15 +689,17 @@ class TestValidateGoogleSheet:
         # Confirm that values were converted as expected
         assert validated_dicts == SAMPLE_SHEET_DATA_WITH_VALID_AND_MISSING_INTEGERS_EXPECTED_NORMALIZATION
 
-    @patch('hca_validation.validator.validate')
-    @patch('hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account')
+    @patch("hca_validation.validator.validate")
+    @patch("hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account")
     def test_class_name(self, mock_read_service_account, mock_validate):
         """Test that the correct class name is passed to the validation function."""
         # Store class name that the validation function was last called with
         last_class_name_info = {}
+
         def save_class_name(data, class_name):
             last_class_name_info["value"] = class_name
             return DEFAULT
+
         mock_validate.side_effect = save_class_name
         # Validate the mock sheet with default dataset model
         _test_validation_with_mock_sheets_response(validate_google_sheet, mock_read_service_account)
@@ -647,13 +707,11 @@ class TestValidateGoogleSheet:
         assert last_class_name_info["value"] == "Dataset"
         mock_read_service_account.reset_mock()
         # Validate the mock sheet with Gut Network dataset model
-        _test_validation_with_mock_sheets_response(
-            validate_google_sheet, mock_read_service_account, bionetwork="gut"
-        )
+        _test_validation_with_mock_sheets_response(validate_google_sheet, mock_read_service_account, bionetwork="gut")
         # Confirm that correct class was used
         assert last_class_name_info["value"] == "GutDataset"
 
-    @patch('hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account')
+    @patch("hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account")
     def test_duplicate_ids(self, mock_read_service_account):
         """Test validation of duplicate IDs."""
         result = _test_validation_with_mock_sheets_response(
@@ -671,7 +729,7 @@ class TestValidateGoogleSheet:
             for error in duplicate_id_errors
         )
 
-    @patch('hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account')
+    @patch("hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account")
     def test_referential_integrity(self, mock_read_service_account):
         """Test validation of referential integrity."""
         result = _test_validation_with_mock_sheets_response(
@@ -679,24 +737,22 @@ class TestValidateGoogleSheet:
             mock_read_service_account,
             datasets_sheet_data=SAMPLE_DATASETS_SHEET_DATA_WITH_REFERENCES,
             donors_sheet_data=SAMPLE_DONORS_SHEET_DATA_WITH_REFERENCES,
-            samples_sheet_data=SAMPLE_SAMPLES_SHEET_DATA_WITH_REFERENCES
+            samples_sheet_data=SAMPLE_SAMPLES_SHEET_DATA_WITH_REFERENCES,
         )
         # Based on the mock data, expect:
         # - Three missing reference errors for donors
         # - Four missing reference errors for samples, all for donor_id
         donors_reference_errors = [
-            error for error in result.errors
-            if error.entity_type == "donor" and "doesn't exist" in error.message
+            error for error in result.errors if error.entity_type == "donor" and "doesn't exist" in error.message
         ]
         samples_reference_errors = [
-            error for error in result.errors
-            if error.entity_type == "sample" and "doesn't exist" in error.message
+            error for error in result.errors if error.entity_type == "sample" and "doesn't exist" in error.message
         ]
         assert len(donors_reference_errors) == 3
         assert len(samples_reference_errors) == 4
         assert all(error.column == "donor_id" for error in samples_reference_errors)
 
-    @patch('hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account')
+    @patch("hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account")
     def test_available_fixes(self, mock_read_service_account):
         """Test that validate_google_sheet does not provide fixes on its own."""
         result = _test_validation_with_mock_sheets_response(
@@ -706,7 +762,7 @@ class TestValidateGoogleSheet:
         )
         assert all(error.input_fix is None for error in result.errors)
 
-    @patch('hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account')
+    @patch("hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account")
     def test_pre_initialized_apis(self, mock_read_service_account):
         """Test that pre-initialized APIs get passed to read_sheet_with_service_account."""
         mock_apis = MagicMock()
@@ -714,10 +770,10 @@ class TestValidateGoogleSheet:
             validate_google_sheet,
             mock_read_service_account,
             additional_arguments={"apis": mock_apis},
-            expected_apis_parameter=mock_apis
+            expected_apis_parameter=mock_apis,
         )
 
-    @patch('hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account')
+    @patch("hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account")
     def test_pre_loaded_sheet_data(self, mock_read_service_account):
         """Test validation of pre-loaded sheet data."""
         mock_sheet_info = _create_mock_spreadsheet_info()
@@ -725,31 +781,34 @@ class TestValidateGoogleSheet:
             validate_google_sheet,
             mock_read_service_account,
             additional_arguments={"sheet_read_result": mock_sheet_info},
-            expect_read_call=False
+            expect_read_call=False,
         )
 
-    @patch('hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account')
+    @patch("hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account")
     def test_service_account_access_failure(self, mock_read_service_account):
         """Test validation when service account access fails."""
         # Mock service account read failure
-        mock_read_service_account.side_effect = SheetReadError(error_code='auth_missing')
+        mock_read_service_account.side_effect = SheetReadError(error_code="auth_missing")
 
         # Run validation
         validation_result = validate_google_sheet(PUBLIC_SHEET_ID)
 
         # Verify service account method was used
         mock_read_service_account.assert_called_once_with(PUBLIC_SHEET_ID, ["dataset", "donor", "sample"], None)
-        
+
         # Verify that an error was reported
         assert len(validation_result.errors) > 0
         assert any("access" in error.message.lower() for error in validation_result.errors)
-        
+
         # Verify result, metadata, error code, and summary
         assert validation_result.successful is False
         assert validation_result.spreadsheet_metadata is None
-        assert validation_result.error_code == 'auth_missing'
+        assert validation_result.error_code == "auth_missing"
         assert validation_result.summary == {
-            "dataset_count": None, "donor_count": None, "sample_count": None, "error_count": 1
+            "dataset_count": None,
+            "donor_count": None,
+            "sample_count": None,
+            "error_count": 1,
         }
 
     def test_invalid_bionetwork(self):
@@ -758,8 +817,8 @@ class TestValidateGoogleSheet:
         # Run validation
         with pytest.raises(ValueError, match="'not-a-bionetwork' is not a valid bionetwork"):
             validate_google_sheet(PUBLIC_SHEET_ID, bionetwork="not-a-bionetwork")
-    
-    @patch('hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account')
+
+    @patch("hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account")
     def test_sheet_without_entities(self, mock_read_service_account):
         """Test that entity counts are still returned when an error is generated due to a sheet lacking rows to
         validate."""
@@ -768,17 +827,17 @@ class TestValidateGoogleSheet:
             mock_read_service_account,
             datasets_sheet_data=SAMPLE_SHEET_DATA_WITHOUT_ENTITIES,
             donors_sheet_data=SAMPLE_SHEET_DATA,
-            expected_error_code="no_data"
+            expected_error_code="no_data",
         )
         assert result.successful is False
         assert result.summary == {"dataset_count": 0, "donor_count": 2, "error_count": 1}
-        
+
 
 class TestProcessGoogleSheet:
     """Tests for the process_google_sheet function."""
 
-    @patch('hca_validation.entry_sheet_validator.process_sheet.init_apis')
-    @patch('hca_validation.entry_sheet_validator.process_sheet.read_sheet_with_service_account')
+    @patch("hca_validation.entry_sheet_validator.process_sheet.init_apis")
+    @patch("hca_validation.entry_sheet_validator.process_sheet.read_sheet_with_service_account")
     def test_available_fixes(self, mock_read_service_account, mock_init_apis):
         """Test that available fixes are present in error info for non-editable spreadsheet."""
         mock_apis = MagicMock()
@@ -787,7 +846,7 @@ class TestProcessGoogleSheet:
             process_google_sheet,
             mock_read_service_account,
             donors_sheet_data=SAMPLE_SHEET_DATA_WITH_FIXES,
-            expected_apis_parameter=mock_apis
+            expected_apis_parameter=mock_apis,
         )
         # Based on the mock data, expect three errors in the manner_of_death column, with appropriate input values
         # and fixed values (or lack thereof)
@@ -800,9 +859,9 @@ class TestProcessGoogleSheet:
         assert mod_errors[2].input == "not_applicable"
         assert mod_errors[2].input_fix == "not applicable"
 
-    @patch('hca_validation.entry_sheet_validator.process_sheet.init_apis')
-    @patch('hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account')
-    @patch('hca_validation.entry_sheet_validator.process_sheet.read_sheet_with_service_account')
+    @patch("hca_validation.entry_sheet_validator.process_sheet.init_apis")
+    @patch("hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account")
+    @patch("hca_validation.entry_sheet_validator.process_sheet.read_sheet_with_service_account")
     def test_application_of_fixes(self, mock_read_service_account_a, mock_read_service_account_b, mock_init_apis):
         """Test validation and updating of editable spreadsheet with fixes available."""
         mock_apis = MagicMock()
@@ -811,7 +870,7 @@ class TestProcessGoogleSheet:
         mock_donors_worksheet = MagicMock()
         mock_read_result = (
             _create_mock_spreadsheet_info(donors_sheet_data=SAMPLE_SHEET_DATA_WITH_FIXES, sheet_editable=True),
-            [mock_datasets_worksheet, mock_donors_worksheet]
+            [mock_datasets_worksheet, mock_donors_worksheet],
         )
         mock_read_service_account_a.return_value = mock_read_result
         mock_read_service_account_b.return_value = mock_read_result
@@ -824,18 +883,15 @@ class TestProcessGoogleSheet:
         mock_read_service_account_a.assert_called_once_with(PUBLIC_SHEET_ID, ["dataset", "donor"], mock_apis)
         mock_read_service_account_b.assert_called_once_with(PUBLIC_SHEET_ID, ["dataset", "donor"], mock_apis)
 
-    @patch('hca_validation.entry_sheet_validator.process_sheet.init_apis')
-    @patch('hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account')
-    @patch('hca_validation.entry_sheet_validator.process_sheet.read_sheet_with_service_account')
+    @patch("hca_validation.entry_sheet_validator.process_sheet.init_apis")
+    @patch("hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account")
+    @patch("hca_validation.entry_sheet_validator.process_sheet.read_sheet_with_service_account")
     def test_sheet_without_fixes(self, mock_read_service_account_a, mock_read_service_account_b, mock_init_apis):
         """Test processing of editable spreadsheet without fixes."""
         mock_apis = MagicMock()
         mock_init_apis.return_value = mock_apis
         mock_datasets_worksheet = MagicMock()
-        mock_read_result = (
-            _create_mock_spreadsheet_info(sheet_editable=True),
-            [mock_datasets_worksheet]
-        )
+        mock_read_result = (_create_mock_spreadsheet_info(sheet_editable=True), [mock_datasets_worksheet])
         mock_read_service_account_a.return_value = mock_read_result
         mock_read_service_account_b.return_value = mock_read_result
         process_google_sheet(PUBLIC_SHEET_ID, entity_types=["dataset"])
@@ -844,41 +900,44 @@ class TestProcessGoogleSheet:
         # Verify that spreadsheet was only read once
         mock_read_service_account_a.assert_called_once_with(PUBLIC_SHEET_ID, ["dataset"], mock_apis)
         mock_read_service_account_b.assert_not_called()
-    
-    @patch('hca_validation.entry_sheet_validator.process_sheet.init_apis')
-    @patch('hca_validation.entry_sheet_validator.process_sheet.read_sheet_with_service_account')
+
+    @patch("hca_validation.entry_sheet_validator.process_sheet.init_apis")
+    @patch("hca_validation.entry_sheet_validator.process_sheet.read_sheet_with_service_account")
     def test_early_read_error(self, mock_read_service_account, mock_init_apis):
         """Test that a validation result object is properly returned when the initial read call raises a
         SheetReadError."""
-        
+
         # Mock APIs
         mock_apis = MagicMock()
         mock_init_apis.return_value = mock_apis
 
         # Mock read failure
-        mock_read_service_account.side_effect = SheetReadError(error_code='sheet_not_found')
+        mock_read_service_account.side_effect = SheetReadError(error_code="sheet_not_found")
 
         # Run processing pipeline
         validation_result = process_google_sheet(PUBLIC_SHEET_ID)
 
         # Verify read function was called
         mock_read_service_account.assert_called_once_with(PUBLIC_SHEET_ID, ["dataset", "donor", "sample"], mock_apis)
-        
+
         # Verify that an error was reported
         assert len(validation_result.errors) > 0
         assert any("access" in error.message.lower() for error in validation_result.errors)
-        
+
         # Verify result, metadata, error code, and summary
         assert validation_result.successful is False
         assert validation_result.spreadsheet_metadata is None
-        assert validation_result.error_code == 'sheet_not_found'
+        assert validation_result.error_code == "sheet_not_found"
         assert validation_result.summary == {
-            "dataset_count": None, "donor_count": None, "sample_count": None, "error_count": 1
+            "dataset_count": None,
+            "donor_count": None,
+            "sample_count": None,
+            "error_count": 1,
         }
 
-    @patch('hca_validation.entry_sheet_validator.process_sheet.init_apis')
-    @patch('hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account')
-    @patch('hca_validation.entry_sheet_validator.process_sheet.read_sheet_with_service_account')
+    @patch("hca_validation.entry_sheet_validator.process_sheet.init_apis")
+    @patch("hca_validation.entry_sheet_validator.validate_sheet.read_sheet_with_service_account")
+    @patch("hca_validation.entry_sheet_validator.process_sheet.read_sheet_with_service_account")
     def test_google_error_while_applying_fixes(
         self, mock_read_service_account_a, mock_read_service_account_b, mock_init_apis
     ):
@@ -891,14 +950,10 @@ class TestProcessGoogleSheet:
         mock_update_response = MagicMock()
         mock_read_service_account_a.return_value = (
             _create_mock_spreadsheet_info(donors_sheet_data=SAMPLE_SHEET_DATA_WITH_FIXES, sheet_editable=True),
-            [mock_datasets_worksheet, mock_donors_worksheet]
+            [mock_datasets_worksheet, mock_donors_worksheet],
         )
         mock_update_response.json.return_value = {
-            "error": {
-                "code": 500,
-                "message": "Test error",
-                "status": "internal_server_error"
-            }
+            "error": {"code": 500, "message": "Test error", "status": "internal_server_error"}
         }
         mock_donors_worksheet.batch_update.side_effect = gspread.exceptions.APIError(mock_update_response)
 
@@ -916,8 +971,8 @@ class TestProcessGoogleSheet:
         assert validation_result.successful is False
         assert validation_result.spreadsheet_metadata is not None
         assert validation_result.spreadsheet_metadata.spreadsheet_title == "Test Sheet Title"
-        assert validation_result.error_code == 'api_error'
-        assert validation_result.summary  == {"dataset_count": None, "donor_count": None, "error_count": 1}
+        assert validation_result.error_code == "api_error"
+        assert validation_result.summary == {"dataset_count": None, "donor_count": None, "error_count": 1}
 
 
 # Integration tests that use actual Google Sheets
@@ -929,18 +984,19 @@ class TestIntegration:
     def test_read_actual_sheet_with_service_account(self):
         """Test reading an actual sheet with service account credentials."""
         # Load credentials from .env file if not already in environment
-        if not os.environ.get('GOOGLE_SERVICE_ACCOUNT'):
-            from dotenv import load_dotenv
+        if not os.environ.get("GOOGLE_SERVICE_ACCOUNT"):
             from pathlib import Path
-            
-            dotenv_path = Path(__file__).parent.parent.parent / '.env'
+
+            from dotenv import load_dotenv
+
+            dotenv_path = Path(__file__).parent.parent.parent / ".env"
             if dotenv_path.exists():
                 load_dotenv(dotenv_path=dotenv_path)
-        
+
         # Skip test if credentials are still not available
-        if not os.environ.get('GOOGLE_SERVICE_ACCOUNT'):
+        if not os.environ.get("GOOGLE_SERVICE_ACCOUNT"):
             pytest.skip("No service account credentials available for integration test")
-            
+
         sheet_read_result = read_sheet_with_service_account(PUBLIC_SHEET_ID)[0]
         assert isinstance(sheet_read_result, SpreadsheetInfo)
         assert isinstance(sheet_read_result.spreadsheet_metadata.spreadsheet_title, str)
@@ -958,68 +1014,70 @@ class TestIntegration:
     def test_validate_actual_sheet_with_service_account(self):
         """Test validating an actual sheet with service account credentials."""
         # Load credentials from .env file if not already in environment
-        if not os.environ.get('GOOGLE_SERVICE_ACCOUNT'):
-            from dotenv import load_dotenv
+        if not os.environ.get("GOOGLE_SERVICE_ACCOUNT"):
             from pathlib import Path
-            
-            dotenv_path = Path(__file__).parent.parent.parent / '.env'
+
+            from dotenv import load_dotenv
+
+            dotenv_path = Path(__file__).parent.parent.parent / ".env"
             if dotenv_path.exists():
                 load_dotenv(dotenv_path=dotenv_path)
-        
+
         # Skip test if credentials are still not available
-        if not os.environ.get('GOOGLE_SERVICE_ACCOUNT'):
+        if not os.environ.get("GOOGLE_SERVICE_ACCOUNT"):
             pytest.skip("No service account credentials available for integration test")
-        
+
         # Run validation
         validation_result = validate_google_sheet(PUBLIC_SHEET_ID)
-        
+
         # Verify that the metadata was returned
         assert validation_result.spreadsheet_metadata is not None
         assert isinstance(validation_result.spreadsheet_metadata.spreadsheet_title, str)
         assert isinstance(validation_result.spreadsheet_metadata.last_updated_date, str)
         assert isinstance(validation_result.spreadsheet_metadata.last_updated_by, str)
-        
+
         # We don't assert on the number of errors since the sheet content may change
         # Just verify that the function ran without exceptions
-        
+
         # For public sheets, we should get the default title
         spreadsheet_title = validation_result.spreadsheet_metadata.spreadsheet_title
         assert spreadsheet_title == "Title unavailable (public access)" or isinstance(spreadsheet_title, str)
-        
+
         # The actual function returns 'validation_error' if validation errors are found
         # or 'no_data' if no data is found to validate
-        assert validation_result.error_code in ['validation_error', 'no_data']
+        assert validation_result.error_code in ["validation_error", "no_data"]
 
         # Verify that a summary with the expected information was returned
         assert isinstance(validation_result.summary, dict)
-        assert 'dataset_count' in validation_result.summary
-        assert isinstance(validation_result.summary['dataset_count'], int)
-        assert 'donor_count' in validation_result.summary
-        assert isinstance(validation_result.summary['donor_count'], int)
-        assert 'sample_count' in validation_result.summary
-        assert isinstance(validation_result.summary['sample_count'], int)
-        assert 'error_count' in validation_result.summary
-        assert isinstance(validation_result.summary['error_count'], int)
+        assert "dataset_count" in validation_result.summary
+        assert isinstance(validation_result.summary["dataset_count"], int)
+        assert "donor_count" in validation_result.summary
+        assert isinstance(validation_result.summary["donor_count"], int)
+        assert "sample_count" in validation_result.summary
+        assert isinstance(validation_result.summary["sample_count"], int)
+        assert "error_count" in validation_result.summary
+        assert isinstance(validation_result.summary["error_count"], int)
 
     def test_read_private_sheet_with_credentials(self):
         """Test reading a private sheet with service account credentials."""
         # Try to load credentials from .env file if not in environment
-        if not os.environ.get('GOOGLE_SERVICE_ACCOUNT'):
+        if not os.environ.get("GOOGLE_SERVICE_ACCOUNT"):
             # Check if .env file exists
-            env_file = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), '.env')
+            env_file = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), ".env")
             if os.path.exists(env_file):
                 try:
                     # Load .env file
                     from dotenv import load_dotenv
+
                     load_dotenv(env_file)
                     print(f"Loaded credentials from {env_file}")
                 except ImportError:
                     print("python-dotenv not installed, skipping .env loading")
-        
+
         # Skip this test if no credentials are available after trying to load from .env
-        if not os.environ.get('GOOGLE_SERVICE_ACCOUNT'):
+        if not os.environ.get("GOOGLE_SERVICE_ACCOUNT"):
             pytest.skip("Service account credentials not available")
-            
+
         # This test only runs if GOOGLE_SERVICE_ACCOUNT is set
         sheet_read_result = read_sheet_with_service_account(PRIVATE_SHEET_ID)[0]
         assert isinstance(sheet_read_result, SpreadsheetInfo)

--- a/shared/tests/test_h5ad_storage.py
+++ b/shared/tests/test_h5ad_storage.py
@@ -28,20 +28,26 @@ def _make_file(path, *, with_raw=True, with_layer_int64=True):
     with h5py.File(path, "w") as f:
         _write_csr(
             f.create_group("X"),
-            shape=(3, 4), data=_DATA,
-            indices=_INDICES.astype("int32"), indptr=_INDPTR.astype("int32"),
+            shape=(3, 4),
+            data=_DATA,
+            indices=_INDICES.astype("int32"),
+            indptr=_INDPTR.astype("int32"),
         )
         if with_raw:
             _write_csr(
                 f.create_group("raw").create_group("X"),
-                shape=(3, 4), data=_DATA,
-                indices=_INDICES.astype("int32"), indptr=_INDPTR.astype("int32"),
+                shape=(3, 4),
+                data=_DATA,
+                indices=_INDICES.astype("int32"),
+                indptr=_INDPTR.astype("int32"),
             )
         if with_layer_int64:
             _write_csr(
                 f.create_group("layers").create_group("denoised"),
-                shape=(3, 4), data=_DATA,
-                indices=_INDICES.astype("int64"), indptr=_INDPTR.astype("int64"),
+                shape=(3, 4),
+                data=_DATA,
+                indices=_INDICES.astype("int64"),
+                indptr=_INDPTR.astype("int64"),
             )
 
 
@@ -68,8 +74,10 @@ def test_indices_and_indptr_dtypes_reported_separately(tmp_path):
     with h5py.File(path, "w") as f:
         _write_csr(
             f.create_group("X"),
-            shape=(3, 4), data=_DATA,
-            indices=_INDICES.astype("int32"), indptr=_INDPTR.astype("int64"),
+            shape=(3, 4),
+            data=_DATA,
+            indices=_INDICES.astype("int32"),
+            indptr=_INDPTR.astype("int64"),
         )
     x = get_matrix_storage(str(path))["X"]
     assert x["index_dtype"] == "int32"
@@ -117,8 +125,8 @@ def test_unrecognized_layer_node_is_filtered(tmp_path):
         f["layers"].create_group("not_a_matrix")
 
     layers = get_matrix_storage(str(path))["layers"]
-    assert "not_a_matrix" not in layers          # filtered out, no None value
-    assert "denoised" in layers                  # the real matrix survives
+    assert "not_a_matrix" not in layers  # filtered out, no None value
+    assert "denoised" in layers  # the real matrix survives
     assert all(v is not None for v in layers.values())
 
 
@@ -132,8 +140,8 @@ def test_malformed_sparse_node_degrades_to_none(tmp_path):
         f["X"].attrs["shape"] = np.int64(5)
 
     result = get_matrix_storage(str(path))
-    assert result["X"] is None                  # degraded, not raised
-    assert result["raw_X"] is not None          # other matrices still reported
+    assert result["X"] is None  # degraded, not raised
+    assert result["raw_X"] is not None  # other matrices still reported
     assert result["layers"]["denoised"] is not None
 
 
@@ -147,8 +155,8 @@ def test_incomplete_sparse_node_is_unrecognized(tmp_path):
         del f["X"]["indptr"]
 
     result = get_matrix_storage(str(path))
-    assert result["X"] is None                  # degraded, not raised
-    assert result["raw_X"] is not None          # other matrices still reported
+    assert result["X"] is None  # degraded, not raised
+    assert result["raw_X"] is not None  # other matrices still reported
     assert result["layers"]["denoised"] is not None
 
 

--- a/shared/tests/test_schema.py
+++ b/shared/tests/test_schema.py
@@ -1,24 +1,27 @@
 """
 Test script for schema functionality.
 """
-from hca_validation.schema_utils.schema_utils import schema_classes, load_schemaview
+
 import hca_validation.schema.generated.core as schema
+from hca_validation.schema_utils.schema_utils import load_schemaview, schema_classes
+
 
 def test_schemaview_classes():
-  """
-  Test that all classes in the mapping exist in the schema when loaded as a schemaview.
-  """
-  schemaview = load_schemaview()
-  print(schemaview)
-  for classes in schema_classes.values():
-    for class_name in classes.values():
-      print(class_name)
-      assert schemaview.get_class(class_name) is not None
+    """
+    Test that all classes in the mapping exist in the schema when loaded as a schemaview.
+    """
+    schemaview = load_schemaview()
+    print(schemaview)
+    for classes in schema_classes.values():
+        for class_name in classes.values():
+            print(class_name)
+            assert schemaview.get_class(class_name) is not None
+
 
 def test_generated_classes():
-  """
-  Test that all classes in the mapping exist in the exported Pydantic schema.
-  """
-  for classes in schema_classes.values():
-    for class_name in classes.values():
-      assert hasattr(schema, class_name)
+    """
+    Test that all classes in the mapping exist in the exported Pydantic schema.
+    """
+    for classes in schema_classes.values():
+        for class_name in classes.values():
+            assert hasattr(schema, class_name)

--- a/shared/tests/test_validator.py
+++ b/shared/tests/test_validator.py
@@ -3,8 +3,8 @@ Test script for the HCA validator module.
 
 This script demonstrates how to use the validator to validate HCA data.
 """
+
 import json
-import os
 from pathlib import Path
 
 import pytest
@@ -21,21 +21,21 @@ VOIBM_JSON_PATH = TEST_DIR / "valid_or_invalid_by_model_dataset.json"
 @pytest.fixture
 def valid_dataset():
     """Fixture to load the valid dataset."""
-    with open(VALID_JSON_PATH, 'r') as f:
+    with open(VALID_JSON_PATH, "r") as f:
         return json.load(f)
 
 
 @pytest.fixture
 def invalid_dataset():
     """Fixture to load the invalid dataset."""
-    with open(INVALID_JSON_PATH, 'r') as f:
+    with open(INVALID_JSON_PATH, "r") as f:
         return json.load(f)
 
 
 @pytest.fixture
 def voibm_dataset():
     """Fixture to load the valid-or-invalid-by-model dataset."""
-    with open(VOIBM_JSON_PATH, 'r') as f:
+    with open(VOIBM_JSON_PATH, "r") as f:
         return json.load(f)
 
 
@@ -63,6 +63,7 @@ def test_validate_invalid_dataset(invalid_dataset):
     assert "reference_genome" in error_fields, "Should have an error for reference_genome"
     assert "sequenced_fragment" in error_fields, "Should have an error for sequenced_fragment"
 
+
 def test_validate_valid_or_invalid_by_model_dataset(voibm_dataset):
     """Test validation of a dataset that is valid for the default model but invalid for a network-specific model."""
 
@@ -84,4 +85,3 @@ def test_validate_valid_or_invalid_by_model_dataset(voibm_dataset):
     # Check for specific validation errors
     assert "ambient_count_correction" in gut_error_fields, "Should have an error for ambient_count_correction"
     assert "doublet_detection" in gut_error_fields, "Should have an error for doublet_detection"
-


### PR DESCRIPTION
Closes #313.

## What changed
Brings the tree to a clean state under the current Ruff rule set (`E/F/I/W`) and wires enforcement into CI + pre-commit — so **lint** joins the test/typecheck gate added in #461.

**Mechanical** (`ruff format` + `ruff check --fix`):
- 75 files reformatted; whitespace-on-blank-lines, import sorting, redundant f-strings, and genuinely-unused imports removed.

**Hand-reviewed** (not auto-fixable — the real work):
- **40 F401** in `__init__.py` are intentional public-API re-exports (incl. the `hca-anndata-tools` lazy `__getattr__` + `TYPE_CHECKING` pattern) → `per-file-ignore` `"__init__.py" = ["F401"]`, the standard Ruff idiom.
- **E731**: converted a lambda assignment to a `def` (`validate_sheet.py`, real source).
- **F841 ×3**: removed dead `n = adata.n_obs` / `temp_dir` assignments in tests.
- **E402**: `# noqa` on an intentional post-`sys.path.insert` import in a test.
- **E501**: wrapped one 160-char test docstring.

**Enforcement:**
- `ci.yml`: new `lint` job — `ruff check` + `ruff format --check`, pinned `0.11.8` (matches pre-commit).
- `.pre-commit-config.yaml`: added the `ruff-format` hook.

## Why
Phase 1 CI (#461) deliberately deferred lint because the tree wasn't Ruff-clean (399 check + 75 format). This is that sweep, plus turning the gate on so it can't regress.

## Assumptions I made
- The removed imports are safe: **pyright (0 errors) and full `make test-all` both pass**, which is exactly what catches a wrongly-removed import.
- Excludes (`_vendored`, `schema/generated`, `anndata-tools/core.py`) left untouched — confirmed none appear in the diff.
- Widening the rule set toward the shared set (UP/B/SIM/C4/PIE/RET/PTH/RUF) is **out of scope**, tracked in #467 — it surfaces an unbounded new set of violations and would make this diff unreviewable.
- The diff is large and makes `git blame` noisy for one commit — unavoidable for a first format pass; #313 explicitly accepts this.

## How to verify
- **This PR self-verifies**: the new `lint` job runs on it — confirm `lint`, `typecheck`, and all `test (…)` jobs are green.
- Locally: `uvx ruff@0.11.8 check .` → "All checks passed!"; `uvx ruff@0.11.8 format --check .` → all formatted; `make typecheck` → 0 errors; `make test-all` → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)