### PR TITLE
style(ruff): enable flake8-bugbear (B) and fix violations (#467)

### DIFF
--- a/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
@@ -121,7 +121,7 @@ def read_var_gene_names(path: str) -> tuple[set[str], dict[str, str]]:
 
         gene_names = set(names)
 
-        eid_to_var_name = {_strip_ensembl_version(eid): name for eid, name in zip(index, names)}
+        eid_to_var_name = {_strip_ensembl_version(eid): name for eid, name in zip(index, names, strict=True)}
 
         return gene_names, eid_to_var_name
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -7,7 +7,7 @@ extend-exclude = [
 ]
 
 [lint]
-select = ["E", "F", "I", "W"]
+select = ["E", "F", "I", "W", "B"]
 
 [lint.per-file-ignores]
 # __init__.py files re-export their package's public API; the imports are

--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -996,7 +996,7 @@ def main() -> int:
         if exit_code == 0:
             logger.info("Dataset Validator completed successfully")
 
-        return exit_code
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/shared/src/hca_validation/entry_sheet_validator/apply_fixes.py
+++ b/shared/src/hca_validation/entry_sheet_validator/apply_fixes.py
@@ -84,7 +84,7 @@ def apply_fixes(
       gspread.exceptions.APIError:
         May be raised if a gspread operation fails
     """
-    worksheets_by_entity_type = dict(zip(entity_types, worksheets))
+    worksheets_by_entity_type = dict(zip(entity_types, worksheets, strict=True))
 
     value_ranges_by_entity_type = get_fix_value_ranges_by_entity_type(validation_result.errors, entity_types, sheet_id)
 

--- a/shared/src/hca_validation/entry_sheet_validator/validate_sheet.py
+++ b/shared/src/hca_validation/entry_sheet_validator/validate_sheet.py
@@ -307,7 +307,7 @@ def init_apis() -> ApiInstances:
             logger.info("Successfully created credentials object")
         except Exception as cred_error:
             logger.error(f"Error creating Google credentials object: {cred_error}")
-            raise SheetReadError(error_code="auth_error")
+            raise SheetReadError(error_code="auth_error") from cred_error
 
         # Authenticate with gspread
         logger.info("Authorizing with gspread...")
@@ -316,7 +316,7 @@ def init_apis() -> ApiInstances:
             logger.info("Successfully authorized with gspread")
         except Exception as auth_error:
             logger.error(f"Error authorizing with Google Sheets API: {auth_error}")
-            raise SheetReadError(error_code="auth_error")
+            raise SheetReadError(error_code="auth_error") from auth_error
 
         # Authenticate with Drive API
         logger.info("Authorizing with Drive API...")
@@ -325,34 +325,34 @@ def init_apis() -> ApiInstances:
             logger.info("Successfully authorized with Drive API")
         except Exception as auth_error:
             logger.error(f"Error authorizing with Google Drive API: {auth_error}")
-            raise SheetReadError(error_code="auth_error")
+            raise SheetReadError(error_code="auth_error") from auth_error
 
         return ApiInstances(gspread=gc, drive=drive)
 
     except json.JSONDecodeError as json_error:
         logger.error(f"Invalid JSON format in service account credentials: {json_error}")
-        raise SheetReadError(error_code="auth_invalid_format")
+        raise SheetReadError(error_code="auth_invalid_format") from json_error
     except gspread.exceptions.APIError as e:
         logger.error(f"Google Sheets API error: {e}")
         raise SheetReadError(
             error_code="api_error",
             error_message=f"Received error {e.code} from Google Sheets API: {e.error['message']}",
-        )
+        ) from e
     except GoogleHttpError as e:
         logger.error(f"Google API error: {e}")
         raise SheetReadError(
             error_code="api_error", error_message=f"Received error {e.status_code} from Google API: {e.reason}"
-        )
+        ) from e
     except requests.exceptions.RetryError as e:
         logger.error(f"Reached maximum configured API retries: {e}")
-        raise SheetReadError(error_code="max_api_retries")
-    except SheetReadError as e:
-        raise e
+        raise SheetReadError(error_code="max_api_retries") from e
+    except SheetReadError:
+        raise
     except Exception as e:
         logger.error(f"Unexpected error initializing APIs with service account: {e}")
         logger.error(f"Exception type: {type(e).__name__}")
         logger.error(f"Traceback: {traceback.format_exc()}")
-        raise SheetReadError(error_code="api_error")
+        raise SheetReadError(error_code="api_error") from e
 
 
 def read_worksheets(
@@ -391,7 +391,7 @@ def read_worksheets(
 
     worksheets_info = []
 
-    for sheet_index, worksheet, value_range in zip(sheet_indices, worksheets, api_result["valueRanges"]):
+    for sheet_index, worksheet, value_range in zip(sheet_indices, worksheets, api_result["valueRanges"], strict=True):
         data = gspread.utils.fill_gaps(value_range.get("values", [[]]))
         # Convert to DataFrame
         if len(data) >= 1:
@@ -423,7 +423,7 @@ def read_worksheets(
 
 def read_sheet_with_service_account(
     sheet_id: str,
-    entity_types: List[str] = ["dataset"],
+    entity_types: Optional[List[str]] = None,
     apis: Optional[ApiInstances] = None,
 ) -> tuple[SpreadsheetInfo, List[gspread.Worksheet]]:
     """
@@ -450,6 +450,9 @@ def read_sheet_with_service_account(
 
     # Configure logging
     logger = logging.getLogger(__name__)
+
+    if entity_types is None:
+        entity_types = ["dataset"]
 
     # Get sheet indices
     sheet_indices = [sheet_structure_by_entity_type[t]["sheet_index"] for t in entity_types]
@@ -504,42 +507,42 @@ def read_sheet_with_service_account(
 
             return SpreadsheetInfo(spreadsheet_metadata, sheets_info), gspread_worksheets
 
-        except gspread.exceptions.SpreadsheetNotFound:
+        except gspread.exceptions.SpreadsheetNotFound as e:
             logger.error(f"Sheet {sheet_id} not found. Check if the sheet ID is correct.")
             logger.error(
                 f"Error accessing Google Sheet with service account: Sheet {sheet_id} not found or not accessible "
                 "with provided credentials"
             )
-            raise SheetReadError(error_code="sheet_not_found", spreadsheet_metadata=spreadsheet_metadata)
+            raise SheetReadError(error_code="sheet_not_found", spreadsheet_metadata=spreadsheet_metadata) from e
         except PermissionError as e:
             logger.error(f"Permission denied accessing sheet {sheet_id}: {e}")
             logger.error("Make sure the service account has access to the sheet.")
-            raise SheetReadError(error_code="permission_denied", spreadsheet_metadata=spreadsheet_metadata)
+            raise SheetReadError(error_code="permission_denied", spreadsheet_metadata=spreadsheet_metadata) from e
         except gspread.exceptions.APIError as e:
             logger.error(f"Google Sheets API error: {e}")
             raise SheetReadError(
                 error_code="api_error",
                 error_message=f"Received error {e.code} from Google Sheets API: {e.error['message']}",
                 spreadsheet_metadata=spreadsheet_metadata,
-            )
+            ) from e
         except GoogleHttpError as e:
             logger.error(f"Google API error: {e}")
             raise SheetReadError(
                 error_code="api_error",
                 error_message=f"Received error {e.status_code} from Google API: {e.reason}",
                 spreadsheet_metadata=spreadsheet_metadata,
-            )
+            ) from e
         except requests.exceptions.RetryError as e:
             logger.error(f"Reached maximum configured API retries: {e}")
-            raise SheetReadError(error_code="max_api_retries", spreadsheet_metadata=spreadsheet_metadata)
+            raise SheetReadError(error_code="max_api_retries", spreadsheet_metadata=spreadsheet_metadata) from e
 
-    except SheetReadError as e:
-        raise e
+    except SheetReadError:
+        raise
     except Exception as e:
         logger.error(f"Unexpected error accessing Google Sheet with service account: {e}")
         logger.error(f"Exception type: {type(e).__name__}")
         logger.error(f"Traceback: {traceback.format_exc()}")
-        raise SheetReadError(error_code="api_error", spreadsheet_metadata=spreadsheet_metadata)
+        raise SheetReadError(error_code="api_error", spreadsheet_metadata=spreadsheet_metadata) from e
 
 
 def normalize_dataframe_values(df: pd.DataFrame, schemaview: SchemaView, class_name: str) -> pd.DataFrame:
@@ -740,7 +743,7 @@ def validate_google_sheet(
     # the original 1-based indices of the rows
     rows_to_validate_by_entity_type = {}
 
-    for entity_type, sheet_info in zip(entity_types, sheet_read_result.worksheets):
+    for entity_type, sheet_info in zip(entity_types, sheet_read_result.worksheets, strict=True):
         df = sheet_info.data
 
         # Skip the first column if it has no slot name
@@ -834,7 +837,7 @@ def validate_google_sheet(
 
     all_valid = True
 
-    for entity_type, sheet_info in zip(entity_types, sheet_read_result.worksheets):
+    for entity_type, sheet_info in zip(entity_types, sheet_read_result.worksheets, strict=True):
         # Determine schema class name to use for validation
         class_name = get_entity_class_name(entity_type, bionetwork)
         # Get normalized dataframe of rows to validate

--- a/shared/src/hca_validation/schema_utils/schema_utils.py
+++ b/shared/src/hca_validation/schema_utils/schema_utils.py
@@ -88,7 +88,7 @@ def coverage_classes(schemaview: SchemaView) -> List[str]:
     sample, dataset) regardless of bionetwork.
     """
     eligible = []
-    for entity_type, network_mapping in schema_classes.items():
+    for network_mapping in schema_classes.values():
         class_name = network_mapping["DEFAULT"]
         if any(True for _ in iter_coverage_slots(schemaview, class_name)):
             eligible.append(class_name)

--- a/shared/src/hca_validation/validator/validator.py
+++ b/shared/src/hca_validation/validator/validator.py
@@ -156,7 +156,9 @@ def validate_referential_integrity(
         # Add errors to list
         line_errors.extend(
             get_row_error_details(index, id_value, fk_value, fk_slot_name, fk_entity_type)
-            for (index, fk_value), id_value in zip(missing_ref_rows[fk_slot_name].items(), missing_ref_row_ids)
+            for (index, fk_value), id_value in zip(
+                missing_ref_rows[fk_slot_name].items(), missing_ref_row_ids, strict=True
+            )
         )
 
     if not line_errors:

--- a/shared/tests/test_entry_sheet_validator.py
+++ b/shared/tests/test_entry_sheet_validator.py
@@ -244,10 +244,13 @@ def _test_validation_with_mock_sheets_response(
     expect_read_call=True,
     expected_apis_parameter=None,
     expected_error_code="validation_error",
-    additional_arguments={},
+    additional_arguments=None,
 ) -> SheetValidationResult:
     """Helper function for testing validation with service account access, for a validation function with a call
     signature like validate_google_sheet."""
+
+    if additional_arguments is None:
+        additional_arguments = {}
 
     # Mock successful service account read
     mock_spreadsheet_info = _create_mock_spreadsheet_info(


### PR DESCRIPTION
Part of #467 — widen the Ruff `select` toward the shared rule set, one family per PR. This is **increment 1 of 8**: `B` (flake8-bugbear). Remaining: `UP`, `SIM`, `C4`, `PIE`, `RET`, `PTH`, `RUF`.

## What changed

Enabled `B` in `ruff.toml` (`select = ["E","F","I","W","B"]`) and fixed all 24 resulting violations across 8 files:

- **B904 (14)** — every `raise SheetReadError(...)` inside an `except` in `validate_sheet.py` now chains with `from <err>`. All are the same network/JSON→domain-error translation; chaining preserves the original cause on `__cause__` (purely additive).
- **B905 (6)** — `strict=True` on every `zip()`. Each site carries an equal-length invariant by construction (var columns are all `n_vars`; worksheets are built 1:1 with `entity_types`; Google's `batchGet` returns one `valueRange` per requested range).
- **B006 (2)** — mutable default args (`entity_types=["dataset"]`, a test helper's `additional_arguments={}`) converted to the `None`-sentinel idiom.
- **B012 (1)** — `dataset-validator/main.py`: `return exit_code` dedented out of a `finally` block.
- **B007 (1)** — `schema_utils.py`: iterate `schema_classes.values()` instead of binding an unused loop variable.
- Also simplified two adjacent `except SheetReadError as e: raise e` clauses to bare `raise` (surfaced by local review).

`ruff format` rewrapped one `validator.py` line that `strict=True` pushed past 120 chars.

## Why

Conformance check A6 flagged our `select` as narrower than the shared set. Bugbear is the highest-signal family (it catches likely bugs), so it goes first. Doing it as its own PR keeps the diff reviewable — each family surfaces its own violations to hand-fix.

## Assumptions I made

- **`strict=True` is the right call over `strict=False`.** Ruff's autofix would have chosen `strict=False` (behavior-preserving). I chose `strict=True` everywhere because each pair is provably equal-length, so a mismatch means a corrupt input or a caller bug — and silently zipping to the shorter sequence would quietly skip a worksheet's validation or a gene mapping. Turning that into a loud failure matches CLAUDE.md's "validate at trust boundaries, fail with a clear error." The only behavioral delta is fail-loud on malformed input, which is the intended direction.
- **`from <err>` (chain), never `from None` (suppress).** The original cause is already logged at each site; chaining keeps it on `__cause__` for anyone who catches the `SheetReadError` with a traceback. Nothing here needs the cause hidden.
- **B006 defaults were never mutated**, so the `None`-sentinel conversion is behavior-identical. This is the cited Effective Python idiom for dynamic defaults.
- **B012 dedent is behavior-identical** on every normal path: `main()`'s `except Exception` catches everything and the `finally` never mutates `exit_code`, and the three early `return exit_code` statements in the `try` already returned that same value. The only change is that `BaseException` (KeyboardInterrupt/SystemExit) now propagates instead of being swallowed by the in-`finally` return.

## How to verify

DoD items from #467, mapped to steps:

1. **Widen `select` incrementally** — `git show HEAD:ruff.toml` shows `select = ["E", "F", "I", "W", "B"]` (one family added, not a big-bang flip).
2. **Tree is clean under the new set** — `uvx ruff@0.11.8 check .` → "All checks passed!"; `uvx ruff@0.11.8 format --check .` → all formatted.
3. **Excludes preserved** — `ruff.toml` still lists `_vendored`, `schema/generated`, and the anndata `core.py` excludes (untouched).
4. **`target-version` unchanged** — still `py310` (repo minimum).
5. **No behavior regressions** — run the affected suites:
   - `cd shared && uv run pytest tests/ -m "not integration" -q` → 44 passed
   - `cd packages/hca-anndata-tools && uv run pytest tests/ -q` → 280 passed
   - `cd services/dataset-validator && uv run pytest tests/ -q --ignore=tests/test_docker_smoke.py` → 72 passed
   - `make typecheck` → 0 errors across all venvs

Closes #467 is intentionally **not** used — the issue tracks the full shared set, so it stays open until the remaining 7 families land.