### PR TITLE
style(ruff): enable RET/SIM/C4/PIE/RUF small families (#503)

### DIFF
--- a/packages/hca-anndata-tools/src/hca_anndata_tools/_gencode.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/_gencode.py
@@ -22,11 +22,10 @@ def load_gencode_reference() -> tuple[dict[str, str], dict[str, list[str]]]:
     name_to_ids: dict[str, list[str]] = defaultdict(list)
 
     ref = resources.files("hca_anndata_tools") / "reference_data" / "genes_homo_sapiens.csv.gz"
-    with resources.as_file(ref) as path:
-        with gzip.open(path, "rt") as f:
-            for row in csv.reader(f):
-                ensembl_id, gene_name = row[0], row[1]
-                id_to_name[ensembl_id] = gene_name
-                name_to_ids[gene_name].append(ensembl_id)
+    with resources.as_file(ref) as path, gzip.open(path, "rt") as f:
+        for row in csv.reader(f):
+            ensembl_id, gene_name = row[0], row[1]
+            id_to_name[ensembl_id] = gene_name
+            name_to_ids[gene_name].append(ensembl_id)
 
     return id_to_name, dict(name_to_ids)

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/convert.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/convert.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import os
 import re
 import shutil
@@ -240,8 +241,6 @@ def convert_cellxgene_to_hca(
 
     except Exception as e:
         if output_path and os.path.isfile(output_path):
-            try:
+            with contextlib.suppress(OSError):
                 os.remove(output_path)
-            except OSError:
-                pass
         return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import os
 import shutil
 import tempfile
@@ -49,7 +50,7 @@ _SKIP_SETS = {"sex", "development_stage", "self_reported_ethnicity"}
 # replaced wholesale on overwrite.
 _OVERWRITE_UNS_KEYS = {CAP_METADATA_KEY}
 
-# Maximum percent (0–100) of cells on either side that may be absent from the
+# Maximum percent (0-100) of cells on either side that may be absent from the
 # other. Applied to both `missing_from_hca.pct` and `missing_from_cap.pct`.
 _MAX_MISSING_PCT = 5.0
 
@@ -57,7 +58,7 @@ _MAX_MISSING_PCT = 5.0
 def _compute_axis_overlap(cap_ids: set[str], hca_ids: set[str]) -> dict:
     """Compare CAP and HCA ID sets along one axis (cells or genes).
 
-    Percentages are 0–100, computed as a share of the side the missing IDs
+    Percentages are 0-100, computed as a share of the side the missing IDs
     came from: `missing_from_hca.pct = 100 * missing_from_hca.n / n_cap`,
     and symmetrically for `missing_from_cap`. Rounded to one decimal place
     for readability — exact ratios can be recomputed from the integer
@@ -101,7 +102,7 @@ def _get_annotation_sets(cap_block: Mapping[str, Any]) -> list[str]:
     """Get annotation sets defined in the CAP block's cellannotation_metadata."""
     meta = cap_block.get("cellannotation_metadata", {})
     if isinstance(meta, dict):
-        return [s for s in meta.keys() if s not in _SKIP_SETS]
+        return [s for s in meta if s not in _SKIP_SETS]
     return []
 
 
@@ -408,8 +409,6 @@ def copy_cap_annotations(
 
     except Exception as e:
         if output_path and os.path.isfile(output_path):
-            try:
+            with contextlib.suppress(OSError):
                 os.remove(output_path)
-            except OSError:
-                pass
         return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import shutil
@@ -111,7 +112,7 @@ def list_uns_fields(path: str) -> dict:
 
             # Extra uns keys not in the HCA schema
             schema_keys = set(registry.keys()) | {"provenance"}
-            extra_uns_keys = sorted(k for k in adata.uns.keys() if k not in schema_keys)
+            extra_uns_keys = sorted(k for k in adata.uns if k not in schema_keys)
 
             return {
                 "filename": os.path.basename(path),
@@ -412,8 +413,6 @@ def replace_placeholder_values(
 
     except Exception as e:
         if output_path and os.path.isfile(output_path):
-            try:
+            with contextlib.suppress(OSError):
                 os.remove(output_path)
-            except OSError:
-                pass
         return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/plot.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/plot.py
@@ -56,14 +56,14 @@ def plot_embedding(
             basis = embedding.replace("X_", "")
             plot_title = title or f"{color} — {embedding}"
 
-            kwargs = dict(
-                color=color,
-                basis=basis,
-                title=plot_title,
-                legend_loc=legend_loc,
-                frameon=frameon,
-                show=False,
-            )
+            kwargs = {
+                "color": color,
+                "basis": basis,
+                "title": plot_title,
+                "legend_loc": legend_loc,
+                "frameon": frameon,
+                "show": False,
+            }
             if palette:
                 kwargs["palette"] = palette
 

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/storage.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/storage.py
@@ -36,7 +36,7 @@ def _inspect_item(f: h5py.File, name: str) -> dict | None:
     item = f[name]
     if isinstance(item, h5py.Dataset):
         return _dataset_info(item)
-    elif isinstance(item, h5py.Group):
+    if isinstance(item, h5py.Group):
         return _group_info(item)
     return None
 

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/strip.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/strip.py
@@ -15,6 +15,7 @@ truth.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import shutil
 
@@ -176,8 +177,6 @@ def strip_forbidden_obs_columns(path: str) -> dict:
 
     except Exception as e:
         if output_path and os.path.isfile(output_path):
-            try:
+            with contextlib.suppress(OSError):
                 os.remove(output_path)
-            except OSError:
-                pass
         return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/summary.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/summary.py
@@ -51,17 +51,17 @@ def get_summary(path: str) -> dict:
                 "var_columns": [{"name": col, "dtype": str(adata.var[col].dtype)} for col in adata.var.columns],
                 "obsm_keys": [
                     {"key": k, "type": _type_name(adata.obsm[k]), "shape": _shape_str(adata.obsm[k])}
-                    for k in adata.obsm.keys()
+                    for k in adata.obsm
                 ],
                 "varm_keys": [
                     {"key": k, "type": _type_name(adata.varm[k]), "shape": _shape_str(adata.varm[k])}
-                    for k in adata.varm.keys()
+                    for k in adata.varm
                 ],
-                "obsp_keys": [{"key": k, "type": _type_name(adata.obsp[k])} for k in adata.obsp.keys()],
-                "varp_keys": [{"key": k, "type": _type_name(adata.varp[k])} for k in adata.varp.keys()],
+                "obsp_keys": [{"key": k, "type": _type_name(adata.obsp[k])} for k in adata.obsp],
+                "varp_keys": [{"key": k, "type": _type_name(adata.varp[k])} for k in adata.varp],
                 "layers": [
                     {"name": k, "type": _type_name(adata.layers[k]), "dtype": _dtype_str(adata.layers[k])}
-                    for k in adata.layers.keys()
+                    for k in adata.layers
                 ],
                 "uns_keys": list(adata.uns.keys()),
                 "has_raw": adata.raw is not None,

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/view.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/view.py
@@ -61,12 +61,11 @@ def view_data(
 
             if isinstance(attr_obj, pd.DataFrame):
                 return _view_dataframe(attr_obj, columns, row_start, row_end)
-            elif hasattr(attr_obj, "shape") and len(getattr(attr_obj, "shape", ())) >= 1:
+            if hasattr(attr_obj, "shape") and len(getattr(attr_obj, "shape", ())) >= 1:
                 return _view_array(attr_obj, row_start, row_end, col_start, col_end)
-            elif isinstance(attr_obj, dict):
+            if isinstance(attr_obj, dict):
                 return _view_dict(attr_obj)
-            else:
-                return {"data": str(attr_obj), "type": type(attr_obj).__name__}
+            return {"data": str(attr_obj), "type": type(attr_obj).__name__}
 
     except Exception as e:
         return {"error": str(e)}
@@ -99,10 +98,7 @@ def _view_dataframe(
 def _view_array(arr, row_start: int, row_end: int, col_start: int, col_end: int) -> dict:
     """View a slice of an array-like object."""
     shape = arr.shape
-    if len(shape) == 1:
-        sliced = arr[row_start:row_end]
-    else:
-        sliced = arr[row_start:row_end, col_start:col_end]
+    sliced = arr[row_start:row_end] if len(shape) == 1 else arr[row_start:row_end, col_start:col_end]
 
     if hasattr(sliced, "toarray"):
         sliced = sliced.toarray()

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import glob
 import hashlib
 import json
@@ -235,10 +236,8 @@ def cleanup_previous_version(source_path: str, output_path: str) -> None:
     overwrote source in place (same-second write).
     """
     if _is_timestamped(source_path) and source_path != output_path and os.path.isfile(source_path):
-        try:
-            os.remove(source_path)
-        except OSError:
-            pass  # write succeeded; stale file is harmless
+        with contextlib.suppress(OSError):
+            os.remove(source_path)  # write succeeded; stale file is harmless
 
 
 def write_h5ad(

--- a/packages/hca-schema-validator/src/hca_schema_validator/__init__.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/__init__.py
@@ -12,10 +12,10 @@ from .populator import populate_in_memory
 from .validator import HCAValidator, check_cosmetic_labels
 
 __all__ = [
-    "HCAValidator",
+    "HCA_DERIVED_OBS_LABELS",
     "HCACellAnnotationValidator",
     "HCALabeler",
-    "HCA_DERIVED_OBS_LABELS",
+    "HCAValidator",
     "check_cosmetic_labels",
     "populate_in_memory",
 ]

--- a/packages/hca-schema-validator/src/hca_schema_validator/validator.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/validator.py
@@ -137,7 +137,8 @@ class HCAValidator(Validator):
         """
         df_definition = self.schema_def["components"].get(df_name, {})
         if "columns" not in df_definition:
-            return super()._validate_dataframe(df_name)
+            super()._validate_dataframe(df_name)
+            return
 
         # Capture the full schema column set before requirement_level
         # extraction below strips optional / strongly_recommended / forbidden
@@ -275,7 +276,7 @@ class HCAValidator(Validator):
         if organism == "NCBITaxon:9606":
             v = _gene_info["human"]["version"]
             return f"GENCODE v{v} (Ensembl 114)"
-        elif organism == "NCBITaxon:10090":
+        if organism == "NCBITaxon:10090":
             v = _gene_info["mouse"]["version"]
             return f"GENCODE {v} (Ensembl 114)"
         return "GENCODE reference (Ensembl 114)"
@@ -295,8 +296,7 @@ class HCAValidator(Validator):
             if not organism:
                 self.warnings.append(f"Feature ID '{feature_id}' in '{df_name}' not found in {version_label}.")
                 continue
-            else:
-                organism_ontology_id = organism.value
+            organism_ontology_id = organism.value
 
             valid_gene_id = get_gene_checker(organism).is_valid_id(feature_id)
 

--- a/packages/hca-schema-validator/tests/test_labeler.py
+++ b/packages/hca-schema-validator/tests/test_labeler.py
@@ -36,7 +36,7 @@ def _replace_first_feature_id(adata, new_id):
     Both indexes are updated together so they stay aligned (otherwise the
     labeler's raw.var mirror would target a different gene).
     """
-    new_ids = [new_id] + list(adata.var.index[1:])
+    new_ids = [new_id, *list(adata.var.index[1:])]
     adata.var.index = pd.Index(new_ids)
     raw = adata.raw.to_adata()
     raw.var.index = pd.Index(new_ids)

--- a/packages/hca-schema-validator/tests/test_populator.py
+++ b/packages/hca-schema-validator/tests/test_populator.py
@@ -272,7 +272,7 @@ def test_error_message_distinguishes_unknown_ensembl(tmp_path):
     # Replace var.index with a fake Ensembl ID GENCODE won't know, then
     # claim a feature_name for that row. Triggers the NaN-canonical
     # mismatch path.
-    fake_ids = ["ENSG99999999999"] + list(adata.var.index[1:])
+    fake_ids = ["ENSG99999999999", *list(adata.var.index[1:])]
     adata.var.index = pd.Index(fake_ids)
     adata.var["feature_name"] = pd.Categorical(["FAKE_SYMBOL"] * adata.n_vars)
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -7,7 +7,7 @@ extend-exclude = [
 ]
 
 [lint]
-select = ["E", "F", "I", "W", "B"]
+select = ["E", "F", "I", "W", "B", "C4", "PIE", "RET", "RUF", "SIM"]
 
 [lint.per-file-ignores]
 # __init__.py files re-export their package's public API; the imports are

--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -339,9 +339,8 @@ def verify_file_integrity(file_path: Path, expected_sha256: str) -> bool:
     if computed_sha256.lower() == expected_sha256.lower():
         logger.info("File integrity verified successfully")
         return True
-    else:
-        logger.error("File integrity check failed - computed: %s, expected: %s", computed_sha256, expected_sha256)
-        return False
+    logger.error("File integrity check failed - computed: %s, expected: %s", computed_sha256, expected_sha256)
+    return False
 
 
 def get_column_unique_values_if_present(df: pd.DataFrame, name: str, map_value=str):
@@ -407,7 +406,7 @@ def _read_shape(f: h5py.File, obs: pd.DataFrame) -> Tuple[int, int]:
                 node = var[index_name]
                 if isinstance(node, h5py.Dataset):
                     n_vars = int(node.shape[0])
-    return int(len(obs)), n_vars
+    return len(obs), n_vars
 
 
 def _read_metadata_inputs(file_path: Path) -> Tuple[pd.DataFrame, dict, int, int]:
@@ -415,7 +414,7 @@ def _read_metadata_inputs(file_path: Path) -> Tuple[pd.DataFrame, dict, int, int
 
     Uses targeted ``read_elem`` of obs/uns plus the X header for shape — never
     opens X/raw/layers. This replaces ``read_h5ad(path, backed="r")``, whose
-    backed mode is X-only and eagerly materializes ``layers`` + ``raw`` (15–24+ GB
+    backed mode is X-only and eagerly materializes ``layers`` + ``raw`` (15-24+ GB
     on large files). See hca-validation-tools#447.
     """
     with h5py.File(file_path, "r") as f:
@@ -834,8 +833,10 @@ def main() -> int:
             error_msg = f"Missing required environment variables: {', '.join(missing_vars)}"
             logger.error(error_msg)
             validation_message = create_failure_message(env_vars, error_msg, start_time)
+            # exit_code must be assigned (not inlined as `return 1`): the finally
+            # block reads it for SNS status and completion logging on the way out.
             exit_code = 1
-            return exit_code
+            return exit_code  # noqa: RET504
 
         # Required env vars are guaranteed non-None after the missing_vars check above
         file_id = env_vars["file_id"]
@@ -886,7 +887,7 @@ def main() -> int:
                 validation_message.integrity_status = INTEGRITY_ERROR
                 validation_message.error_message = error_msg
                 exit_code = 1
-                return exit_code
+                return exit_code  # noqa: RET504
 
             # Compute downloaded file SHA256
             downloaded_sha256 = compute_sha256(local_file)
@@ -901,7 +902,7 @@ def main() -> int:
                 validation_message.integrity_status = INTEGRITY_INVALID
                 validation_message.error_message = error_msg
                 exit_code = 1
-                return exit_code
+                return exit_code  # noqa: RET504
 
             validation_message.integrity_status = INTEGRITY_VALID
 

--- a/services/entry-sheet-validator/src/entry_sheet_validator_lambda/handler.py
+++ b/services/entry-sheet-validator/src/entry_sheet_validator_lambda/handler.py
@@ -100,7 +100,7 @@ def extract_validation_errors(sheet_id: str, bionetwork: Optional[str] = None) -
 
     except Exception as e:
         # If there's an error in the validation process itself
-        error_msg = f"Error in validation process: {str(e)}"
+        error_msg = f"Error in validation process: {e!s}"
         error_info = SheetErrorInfo(entity_type=None, worksheet_id=None, message=error_msg)
         return (
             SheetValidationResult(
@@ -154,18 +154,15 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         if "body" in event:
             try:
                 # Parse the body if it's a string (from API Gateway)
-                if isinstance(event["body"], str):
-                    body = json.loads(event["body"])
-                else:
-                    body = event["body"]
+                body = json.loads(event["body"]) if isinstance(event["body"], str) else event["body"]
 
                 sheet_id = body.get("sheet_id")
                 bionetwork = body.get("bionetwork")
             except Exception as e:
-                logger.warning(f"Error parsing request body: {str(e)}")
+                logger.warning(f"Error parsing request body: {e!s}")
                 return {
                     "statusCode": HTTPStatus.BAD_REQUEST.value,
-                    "body": json.dumps({"error": f"Invalid request body: {str(e)}"}),
+                    "body": json.dumps({"error": f"Invalid request body: {e!s}"}),
                     "headers": {"Content-Type": "application/json", "Access-Control-Allow-Origin": "*"},
                 }
         else:
@@ -226,12 +223,11 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                 "body": json.dumps(response_data),
                 "headers": {"Content-Type": "application/json", "Access-Control-Allow-Origin": "*"},
             }
-        else:
-            # Direct Lambda invocation
-            return response_data
+        # Direct Lambda invocation
+        return response_data
     except Exception as e:
         # Log the error
-        logger.error(f"Error: {str(e)}")
+        logger.error(f"Error: {e!s}")
         logger.error(traceback.format_exc())
 
         # Prepare error response
@@ -244,9 +240,8 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                 "body": json.dumps(error_response),
                 "headers": {"Content-Type": "application/json", "Access-Control-Allow-Origin": "*"},
             }
-        else:
-            # Direct Lambda invocation
-            return error_response
+        # Direct Lambda invocation
+        return error_response
 
 
 # For local testing

--- a/shared/src/hca_validation/entry_sheet_validator/validate_sheet.py
+++ b/shared/src/hca_validation/entry_sheet_validator/validate_sheet.py
@@ -927,15 +927,14 @@ def validate_google_sheet(
             summary=validation_summary,
             errors=validation_errors,
         )
-    else:
-        logger.warning(f"Validation found errors in some of the {len(entity_types)} entity types.")
-        return SheetValidationResult(
-            successful=False,
-            spreadsheet_metadata=sheet_read_result.spreadsheet_metadata,
-            error_code="validation_error",
-            summary=validation_summary,
-            errors=validation_errors,
-        )
+    logger.warning(f"Validation found errors in some of the {len(entity_types)} entity types.")
+    return SheetValidationResult(
+        successful=False,
+        spreadsheet_metadata=sheet_read_result.spreadsheet_metadata,
+        error_code="validation_error",
+        summary=validation_summary,
+        errors=validation_errors,
+    )
 
 
 if __name__ == "__main__":

--- a/shared/src/hca_validation/h5ad_storage/h5ad_storage.py
+++ b/shared/src/hca_validation/h5ad_storage/h5ad_storage.py
@@ -121,10 +121,10 @@ def get_matrix_storage(path: str) -> dict:
     with h5py.File(path, "r") as f:
         if "X" in f:
             result["X"] = _matrix_info(f["X"])
-        raw = f["raw"] if "raw" in f else None
+        raw = f.get("raw")
         if isinstance(raw, h5py.Group) and "X" in raw:
             result["raw_X"] = _matrix_info(raw["X"])
-        layers_group = f["layers"] if "layers" in f else None
+        layers_group = f.get("layers")
         if isinstance(layers_group, h5py.Group) and len(layers_group):
             # Only keep recognizable matrices so the documented shape
             # ({name: {...}}) holds — _matrix_info returns None for anything

--- a/shared/src/hca_validation/metadata_coverage/metadata_coverage.py
+++ b/shared/src/hca_validation/metadata_coverage/metadata_coverage.py
@@ -57,7 +57,7 @@ def compute_metadata_coverage(adata: Any, schemaview: SchemaView) -> Dict[str, A
     obs: pd.DataFrame = adata.obs.replace(r"^\s*$", pd.NA, regex=True)
     uns = adata.uns
 
-    entities: Dict[str, Dict[str, int]] = {"obs": {"record_count": int(len(obs))}}
+    entities: Dict[str, Dict[str, int]] = {"obs": {"record_count": len(obs)}}
     field_coverage: List[Dict[str, Any]] = []
 
     for class_name in coverage_classes(schemaview):

--- a/shared/src/hca_validation/schema_utils/schema_utils.py
+++ b/shared/src/hca_validation/schema_utils/schema_utils.py
@@ -19,11 +19,11 @@ schema_classes = {
 }
 
 # Derive mapping from class name to entity type
-entity_types_by_class = dict(
-    (class_name, entity_type)
+entity_types_by_class = {
+    class_name: entity_type
     for entity_type, network_mapping in schema_classes.items()
     for _, class_name in network_mapping.items()
-)
+}
 
 
 def load_schemaview():


### PR DESCRIPTION
Part of #467 — widen Ruff toward the shared rule set, one grouped PR at a time. **Increment 2 of 4** (after `B` in #502): the five small families **`RET`, `SIM`, `C4`, `PIE`, `RUF`**. Remaining after this: `UP` (#504), `PTH` (#505).

## What changed

Added `RET`, `SIM`, `C4`, `PIE`, `RUF` to `select` in `ruff.toml` and fixed all 47 resulting violations across 21 files (net −13 lines).

**Mechanical (ruff --fix or trivial):**
- RET505/507 — collapsed `else`/`elif` after `return`/`continue`.
- SIM118 — dropped `.keys()` from membership/iteration over dict-likes.
- SIM401 — `f["k"] if "k" in f else None` → `f.get("k")` (h5py; also one fewer link lookup).
- SIM105 — `try/except OSError: pass` → `contextlib.suppress(OSError)` (added `import contextlib` to 5 `hca-anndata-tools` files).
- SIM117 — combined nested `with` in `_gencode.py`.
- SIM108 — if/else → ternary in `view.py` and `handler.py`.
- C402/C408 — generator→dict-comprehension, `dict()`→literal.
- RUF010 `str(x)`→`{x!s}`, RUF022 sort `__all__`, RUF046 drop redundant `int(len(...))`, RUF005 `[x] + list(...)`→`[x, *list(...)]`.

**Judgment calls:**
- **RET504 ×3** in `dataset-validator/main.py` — **not fixed; `# noqa: RET504`.** Ruff wants to drop `exit_code = 1` before `return exit_code`, but `main()`'s `finally` block reads `exit_code` for SNS status + completion logging on the way out; inlining `return 1` would decouple the returned value from the variable the `finally` inspects. Full rationale at the first site, bare noqa at the other two.
- **RET503 ×2** in `hca-schema-validator/validator.py` — fixed at the root: `_validate_dataframe` now returns `None` uniformly (`super()._validate_dataframe(df_name); return`) instead of propagating the base's value from one branch while other branches fall through. The vendored base is `:rtype None` and both call sites discard the return, so this is behavior-identical and clears both RET503s with one change.
- **RUF002/003 ×3** — ambiguous en-dashes (`–`) in prose comments/docstrings replaced with `-`.
- **PIE** — zero violations; enabled purely as a regression guard.

## Why

Conformance A6 (#467) — adopt the shared Ruff rule set. Grouping the small, low-churn families into one PR keeps review cycles sane while isolating the two big mechanical families (`UP`, `PTH`) into their own PRs.

## Assumptions I made

- **`strict`-equivalent behavior is preserved everywhere.** Every rewrite was checked to be behavior-identical: `contextlib.suppress(OSError)` catches exactly `OSError` like the old `except OSError: pass`; the combined `with` enters context managers left-to-right so `path` is bound before `gzip.open(path)` evaluates; `f.get("raw")` returns the object or `None` like the old contains+index.
- **The RET504 assignments are load-bearing**, not redundant — verified `exit_code` is read by the `finally` block. This is the one place Ruff's suggestion is wrong, hence the noqa.
- **The RET503 base method is void** — verified the vendored `cellxgene_schema` `_validate_dataframe` has no value return and both callers discard the result.
- **`RUF100` must run under the full rule set.** Two live `# noqa` directives (`F401` in `test_dependency_imports.py`, `E402` in `test_cell_annotation.py`) were transiently stripped when RUF100 ran under a narrow `--select RUF` (where those rules weren't active) and restored once the full lint confirmed they're needed. The committed state keeps both.

## How to verify

DoD items from #503, mapped to steps:

1. **Five families enabled** — `git show HEAD:ruff.toml` shows `select = ["E","F","I","W","B","C4","PIE","RET","RUF","SIM"]`.
2. **Tree clean under the new set** — `uvx ruff@0.11.8 check .` → "All checks passed!"; `uvx ruff@0.11.8 format --check .` → all formatted.
3. **Excludes preserved / target unchanged** — `ruff.toml` still lists the three excludes; `target-version` still `py310`.
4. **No behavior regressions** — run the affected suites:
   - `cd packages/hca-anndata-tools && uv run pytest tests/ -q` → 280 passed
   - `cd packages/hca-schema-validator && uv run pytest tests/ -q` → 121 passed
   - `cd shared && uv run pytest tests/ -m "not integration" -q` → 44 passed
   - `cd services/dataset-validator && uv run pytest tests/ -q --ignore=tests/test_docker_smoke.py` → 72 passed
   - `make typecheck` → 0 errors across all venvs
5. **RET504 sites** — read `dataset-validator/main.py` around the three `# noqa: RET504`; confirm each keeps `exit_code = 1` before `return exit_code` and the `finally` block still reads `exit_code`.

**Coverage gap:** `entry-sheet-validator/handler.py` got RUF010 + SIM108 + RET505 edits but its only test needs Docker + AWS + the Google secret, so it isn't run locally or in PR CI. All three edits are behavior-identical transforms.

Part of #467 (not `Closes`) — #467 closes when #505 (PTH) lands.