### PR TITLE
style(ruff): enable UP (pyupgrade) and apply autofixes (part of #467)

### DIFF
--- a/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
@@ -157,7 +157,7 @@ def write_edit_log_h5py(f: h5py.File, log_json: str) -> None:
     ds.attrs["encoding-version"] = "0.2.0"
 
 
-def read_categorical_data(item: h5py.Group) -> tuple[pd.Index, "np.ndarray"]:
+def read_categorical_data(item: h5py.Group) -> tuple[pd.Index, np.ndarray]:
     """Read categories and codes from a categorical h5py group.
 
     Args:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/_serialize.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/_serialize.py
@@ -5,13 +5,13 @@ import numpy as np
 
 def make_serializable(obj):
     """Recursively convert numpy types to JSON-serializable Python types."""
-    if isinstance(obj, (np.integer,)):
+    if isinstance(obj, np.integer):
         return int(obj)
-    if isinstance(obj, (np.floating,)):
+    if isinstance(obj, np.floating):
         return float(obj)
-    if isinstance(obj, (np.bool_,)):
+    if isinstance(obj, np.bool_):
         return bool(obj)
-    if isinstance(obj, (np.str_, np.bytes_)):
+    if isinstance(obj, np.str_ | np.bytes_):
         return str(obj)
     if isinstance(obj, np.ndarray):
         return obj.tolist()
@@ -19,6 +19,6 @@ def make_serializable(obj):
         return obj.decode("utf-8", errors="replace")
     if isinstance(obj, dict):
         return {k: make_serializable(v) for k, v in obj.items()}
-    if isinstance(obj, (list, tuple)):
+    if isinstance(obj, list | tuple):
         return [make_serializable(v) for v in obj]
     return obj

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/view.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/view.py
@@ -119,13 +119,13 @@ def _view_dict(d: dict) -> dict:
     """View a dict (uns entries), summarizing large values."""
     result = {}
     for k, v in d.items():
-        if isinstance(v, (str, int, float, bool)):
+        if isinstance(v, str | int | float | bool):
             result[k] = v
         elif isinstance(v, np.ndarray):
             result[k] = f"ndarray shape={v.shape} dtype={v.dtype}"
         elif isinstance(v, dict):
             result[k] = f"dict with {len(v)} keys: {list(v.keys())[:10]}"
-        elif isinstance(v, (list, tuple)):
+        elif isinstance(v, list | tuple):
             result[k] = f"{type(v).__name__} with {len(v)} items"
         elif isinstance(v, pd.DataFrame):
             result[k] = f"DataFrame shape={v.shape}"

--- a/packages/hca-schema-validator/src/hca_schema_validator/cell_annotation_validator.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/cell_annotation_validator.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
-from typing import List, Optional
 
 import anndata as ad
 import semver
@@ -72,8 +71,8 @@ class HCACellAnnotationValidator:
     """
 
     def __init__(self) -> None:
-        self.errors: List[str] = []
-        self.warnings: List[str] = []
+        self.errors: list[str] = []
+        self.warnings: list[str] = []
 
     def _error(self, message: str) -> None:
         self.errors.append(message)
@@ -109,7 +108,7 @@ class HCACellAnnotationValidator:
 
         return not self.errors
 
-    def _resolve_cap_metadata(self, uns) -> Optional[Mapping]:
+    def _resolve_cap_metadata(self, uns) -> Mapping | None:
         """Return the canonical ``uns['cap_metadata']`` mapping, or None.
 
         Strict: CAP metadata must live under ``uns['cap_metadata']``. Any
@@ -152,7 +151,7 @@ class HCACellAnnotationValidator:
                 f"semver string (e.g. '0.1.0'); got {value!r}."
             )
 
-    def _check_metadata(self, cap) -> List[str]:
+    def _check_metadata(self, cap) -> list[str]:
         if "cellannotation_metadata" not in cap:
             self._error(NO_SETS_ERROR)
             return []
@@ -169,7 +168,7 @@ class HCACellAnnotationValidator:
             self._error(NO_SETS_ERROR)
             return []
 
-        annotation_sets: List[str] = []
+        annotation_sets: list[str] = []
         for set_name, set_meta in metadata.items():
             if not isinstance(set_meta, dict):
                 self._error(

--- a/packages/hca-schema-validator/src/hca_schema_validator/labeler.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/labeler.py
@@ -1,8 +1,8 @@
 """HCA labeler: NaN-tolerant AnnDataLabelAppender with HCA preflight checks."""
 
 import functools
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable, Dict, List
 
 import pandas as pd
 import yaml
@@ -66,7 +66,7 @@ class HCALabeler(AnnDataLabelAppender):
         self._preflight_done = False
 
     def _preflight(self) -> None:
-        issues: List[str] = []
+        issues: list[str] = []
         for component_name in ("obs", "var", "raw.var"):
             df = getattr_anndata(self.adata, component_name)
             if df is None:
@@ -141,7 +141,7 @@ class HCALabeler(AnnDataLabelAppender):
             raise ValueError("HCALabeler preflight failed:\n  - " + "\n  - ".join(issues))
 
     @staticmethod
-    def _reserved_collisions(df, component_name: str, add_labels_def: List[Dict]) -> List[str]:
+    def _reserved_collisions(df, component_name: str, add_labels_def: list[dict]) -> list[str]:
         """Return one error string per ``add_labels`` target already on ``df``.
 
         Mirrors the vendored validator's reserved-column wording so curators
@@ -152,7 +152,7 @@ class HCALabeler(AnnDataLabelAppender):
         need a different membership check and are intentionally out of
         scope; the HCA schema doesn't use them.
         """
-        issues: List[str] = []
+        issues: list[str] = []
         for label_def in add_labels_def:
             target = label_def.get("to_column")
             if target is not None and target in df.columns:
@@ -183,10 +183,10 @@ class HCALabeler(AnnDataLabelAppender):
 
     def _map_by_organism(
         self,
-        ids: List[str],
+        ids: list[str],
         fn: Callable[[str, SupportedOrganisms], object],
-    ) -> Dict[str, object]:
-        out: Dict[str, object] = {}
+    ) -> dict[str, object]:
+        out: dict[str, object] = {}
         for i in ids:
             organism = _organism_for_feature(i)
             out[i] = pd.NA if organism is None else fn(i, organism)

--- a/ruff.toml
+++ b/ruff.toml
@@ -7,7 +7,7 @@ extend-exclude = [
 ]
 
 [lint]
-select = ["E", "F", "I", "W", "B", "C4", "PIE", "RET", "RUF", "SIM"]
+select = ["E", "F", "I", "W", "B", "C4", "PIE", "RET", "RUF", "SIM", "UP"]
 
 [lint.per-file-ignores]
 # __init__.py files re-export their package's public API; the imports are

--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -14,11 +14,12 @@ import resource
 import shutil
 import subprocess
 import sys
+from collections.abc import Callable
 from dataclasses import asdict, dataclass, fields
 from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Callable, List, Optional, Tuple, cast
+from typing import cast
 
 import boto3
 import h5py
@@ -91,10 +92,10 @@ class MetadataSummary:
     """Summary of metadata from a dataset file."""
 
     title: str
-    assay: List[str]
-    suspension_type: List[str]
-    tissue: List[str]
-    disease: List[str]
+    assay: list[str]
+    suspension_type: list[str]
+    tissue: list[str]
+    disease: list[str]
     cell_count: int
     gene_count: int
 
@@ -104,8 +105,8 @@ class ValidationToolReport:
     """Validation report and metadata of a run of an individual validation tool."""
 
     valid: bool
-    errors: List[str]
-    warnings: List[str]
+    errors: list[str]
+    warnings: list[str]
     started_at: str
     finished_at: str
 
@@ -142,17 +143,15 @@ class ValidationMessage(ValidationMessagePointer):
     carries only the ValidationMessagePointer subset (see to_pointer)."""
 
     # Optional fields
-    batch_job_name: Optional[str] = None  # Job definition name (for context)
-    downloaded_sha256: Optional[str] = None  # SHA256 computed from downloaded file
-    source_sha256: Optional[str] = None  # SHA256 from S3 metadata
-    integrity_status: Optional[str] = None  # "valid", "invalid", "error"
-    metadata_summary: Optional[MetadataSummary] = None  # Metadata from the file
-    tool_reports: Optional[  # Reports for individual validation tools
-        dict[str, ValidationToolReport]
-    ] = None
-    metadata_coverage: Optional[dict] = None  # Per-field completeness summary (#405)
-    matrix_storage: Optional[dict] = None  # Per-matrix/layer shape + size, from HDF5 header (#447)
-    error_message: Optional[str] = None  # Human-readable error description
+    batch_job_name: str | None = None  # Job definition name (for context)
+    downloaded_sha256: str | None = None  # SHA256 computed from downloaded file
+    source_sha256: str | None = None  # SHA256 from S3 metadata
+    integrity_status: str | None = None  # "valid", "invalid", "error"
+    metadata_summary: MetadataSummary | None = None  # Metadata from the file
+    tool_reports: dict[str, ValidationToolReport] | None = None  # Reports for individual validation tools
+    metadata_coverage: dict | None = None  # Per-field completeness summary (#405)
+    matrix_storage: dict | None = None  # Per-matrix/layer shape + size, from HDF5 header (#447)
+    error_message: str | None = None  # Human-readable error description
 
     def to_pointer(self) -> ValidationMessagePointer:
         """Project to the pointer-only payload published to SNS."""
@@ -378,7 +377,7 @@ def _get_schemaview():
     return load_schemaview()
 
 
-def _read_shape(f: h5py.File, obs: pd.DataFrame) -> Tuple[int, int]:
+def _read_shape(f: h5py.File, obs: pd.DataFrame) -> tuple[int, int]:
     """Derive (n_obs, n_vars) from the X header, falling back to obs/var length.
 
     X carries a ``shape`` attr when sparse; when dense it's a 2-D dataset.
@@ -409,7 +408,7 @@ def _read_shape(f: h5py.File, obs: pd.DataFrame) -> Tuple[int, int]:
     return len(obs), n_vars
 
 
-def _read_metadata_inputs(file_path: Path) -> Tuple[pd.DataFrame, dict, int, int]:
+def _read_metadata_inputs(file_path: Path) -> tuple[pd.DataFrame, dict, int, int]:
     """Read (obs, uns, n_obs, n_vars) from an h5ad without loading matrices.
 
     Uses targeted ``read_elem`` of obs/uns plus the X header for shape — never
@@ -429,7 +428,7 @@ def _read_metadata_inputs(file_path: Path) -> Tuple[pd.DataFrame, dict, int, int
 
 def read_file_metadata(
     file_path: Path,
-) -> Tuple[MetadataSummary, Optional[dict], Optional[dict]]:
+) -> tuple[MetadataSummary, dict | None, dict | None]:
     """Read metadata once and return (summary, coverage, matrix_storage).
 
     Only obs + uns (+ matrix headers) are read — never the matrices themselves —
@@ -789,7 +788,7 @@ def create_failure_message(env_vars: dict[str, str | None], error: str, start_ti
     )
 
 
-def cleanup_files(work_dir: Optional[Path] = None) -> None:
+def cleanup_files(work_dir: Path | None = None) -> None:
     """
     Clean up work directory after validation.
 
@@ -815,9 +814,9 @@ def main() -> int:
 
     # Initialize validation tracking variables
     start_time = datetime.now(timezone.utc)
-    validation_message: Optional[ValidationMessage] = None
+    validation_message: ValidationMessage | None = None
     exit_code = 1  # Default to failure
-    work_dir: Optional[Path] = None
+    work_dir: Path | None = None
     local_mode = False
     env_vars: dict[str, str | None] = {}
 

--- a/services/dataset-validator/tests/test_dataset_validator.py
+++ b/services/dataset-validator/tests/test_dataset_validator.py
@@ -7,7 +7,6 @@ import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Dict
 from unittest.mock import MagicMock, patch
 
 import boto3
@@ -110,7 +109,7 @@ def env_manager():
     """Fixture that provides environment variable management utilities."""
     original_env = {}
 
-    def set_env(env_vars: Dict[str, str]):
+    def set_env(env_vars: dict[str, str]):
         """Set environment variables and save originals for cleanup."""
         for key, value in env_vars.items():
             original_env[key] = os.environ.get(key)

--- a/services/dataset-validator/tests/test_metadata_coverage.py
+++ b/services/dataset-validator/tests/test_metadata_coverage.py
@@ -5,7 +5,7 @@ and `.uns` (dict) are needed by compute_metadata_coverage.
 """
 
 from types import SimpleNamespace
-from typing import Any, Dict, List
+from typing import Any
 
 import pandas as pd
 import pytest
@@ -20,11 +20,11 @@ def schemaview():
     return load_schemaview()
 
 
-def make_adata(obs: pd.DataFrame, uns: Dict[str, Any] | None = None):
+def make_adata(obs: pd.DataFrame, uns: dict[str, Any] | None = None):
     return SimpleNamespace(obs=obs, uns=uns or {})
 
 
-def field_entry(result: Dict[str, Any], entity_class: str, field: str) -> Dict[str, Any]:
+def field_entry(result: dict[str, Any], entity_class: str, field: str) -> dict[str, Any]:
     for entry in result["field_coverage"]:
         if entry["entity_class"] == entity_class and entry["field"] == field:
             return entry
@@ -265,7 +265,7 @@ class TestInvariant:
 
     def test_violation_raises(self):
         entities = {"donor": {"record_count": 10}}
-        bad: List[Dict[str, Any]] = [
+        bad: list[dict[str, Any]] = [
             {"entity_class": "donor", "field": "x", "complete": 5, "missing": 4, "inconsistent": 0}
         ]
         with pytest.raises(RuntimeError, match="invariant violated"):

--- a/services/entry-sheet-validator/src/entry_sheet_validator_lambda/handler.py
+++ b/services/entry-sheet-validator/src/entry_sheet_validator_lambda/handler.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """
 AWS Lambda function for validating Google Sheets using the HCA entry sheet validator.
@@ -15,7 +14,7 @@ import os
 import traceback
 from dataclasses import asdict
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Tuple
+from typing import Any
 
 import psutil
 
@@ -53,7 +52,7 @@ ERROR_TO_STATUS: dict[str, HTTPStatus] = {
 }
 
 
-def extract_validation_errors(sheet_id: str, bionetwork: Optional[str] = None) -> Tuple[SheetValidationResult, int]:
+def extract_validation_errors(sheet_id: str, bionetwork: str | None = None) -> tuple[SheetValidationResult, int]:
     """
     Extract validation errors from a Google Sheet.
 
@@ -133,7 +132,7 @@ def get_memory_usage():
     }
 
 
-def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     """
     AWS Lambda handler function for validating HCA entry sheets in Google Sheets format.
 

--- a/services/entry-sheet-validator/src/entry_sheet_validator_lambda/test_lambda.py
+++ b/services/entry-sheet-validator/src/entry_sheet_validator_lambda/test_lambda.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """
 Test script for the HCA Entry Sheet Validator Lambda function.
@@ -37,7 +36,7 @@ def main():
     if args.creds_file:
         if os.path.exists(args.creds_file):
             print(f"Loading service account credentials from {args.creds_file}")
-            with open(args.creds_file, "r") as f:
+            with open(args.creds_file) as f:
                 credentials = f.read()
                 os.environ["GOOGLE_SERVICE_ACCOUNT"] = credentials
         else:

--- a/services/hca-schema-validator/src/hca_schema_validator_service/_log_capture.py
+++ b/services/hca-schema-validator/src/hca_schema_validator_service/_log_capture.py
@@ -10,13 +10,13 @@ service expects.
 from __future__ import annotations
 
 import logging
-from typing import Callable, List, Optional
+from collections.abc import Callable
 
 
 class ListHandler(logging.Handler):
     """Capture warning and error log records into lists."""
 
-    def __init__(self, warning_list: List[str], error_list: List[str]) -> None:
+    def __init__(self, warning_list: list[str], error_list: list[str]) -> None:
         super().__init__()
         self.warning_list = warning_list
         self.error_list = error_list
@@ -34,7 +34,7 @@ def run_with_captured_logs(
     logger_name: str,
     validate: Callable[[str], bool],
     unexpected_error_prefix: str,
-    postprocess_warnings: Optional[Callable[[List[str]], List[str]]] = None,
+    postprocess_warnings: Callable[[list[str]], list[str]] | None = None,
 ) -> dict:
     """Invoke ``validate(file_path)`` with warnings/errors captured from ``logger_name``.
 
@@ -44,8 +44,8 @@ def run_with_captured_logs(
     """
     logger = logging.getLogger(logger_name)
     logger.setLevel(logging.WARNING)
-    warning_messages: List[str] = []
-    error_messages: List[str] = []
+    warning_messages: list[str] = []
+    error_messages: list[str] = []
     handler = ListHandler(warning_messages, error_messages)
     logger.addHandler(handler)
 

--- a/shared/src/hca_validation/data_dictionary/generate_dictionary.py
+++ b/shared/src/hca_validation/data_dictionary/generate_dictionary.py
@@ -10,7 +10,7 @@ By default, the dictionary is saved to the 'data_dictionaries' directory in the 
 import json
 import sys
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 import jsonasobj2
 from linkml_runtime import SchemaView
@@ -18,7 +18,7 @@ from linkml_runtime import SchemaView
 from hca_validation.schema_utils import get_class_entity_type
 
 
-def transform_schema_to_data_dictionary(schemaview: SchemaView) -> Dict[str, Any]:
+def transform_schema_to_data_dictionary(schemaview: SchemaView) -> dict[str, Any]:
     """
     Transform the LinkML schema into the requested data dictionary format.
 

--- a/shared/src/hca_validation/entry_sheet_validator/apply_fixes.py
+++ b/shared/src/hca_validation/entry_sheet_validator/apply_fixes.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import gspread
 
 from hca_validation.entry_sheet_validator.validate_sheet import SheetErrorInfo, SheetValidationResult
@@ -22,7 +20,7 @@ def get_fix_value_range(a1: str, value: str):
     return {"range": a1, "values": [[value]]}
 
 
-def get_fix_value_ranges_by_entity_type(errors: List[SheetErrorInfo], entity_types: List[str], sheet_id: str):
+def get_fix_value_ranges_by_entity_type(errors: list[SheetErrorInfo], entity_types: list[str], sheet_id: str):
     """
     Create value range dicts to be passed to gspread in order to fix the given errors, organized by entity type
 
@@ -59,8 +57,8 @@ def get_fix_value_ranges_by_entity_type(errors: List[SheetErrorInfo], entity_typ
 
 def apply_fixes(
     validation_result: SheetValidationResult,
-    entity_types: List[str],
-    worksheets: List[gspread.Worksheet],
+    entity_types: list[str],
+    worksheets: list[gspread.Worksheet],
     sheet_id: str,
 ) -> bool:
     """

--- a/shared/src/hca_validation/entry_sheet_validator/find_fixes.py
+++ b/shared/src/hca_validation/entry_sheet_validator/find_fixes.py
@@ -1,5 +1,4 @@
 import dataclasses
-from typing import List, Optional
 
 from linkml_runtime import SchemaView
 from linkml_runtime.linkml_model.meta import ClassDefinition
@@ -21,9 +20,7 @@ sheet_value_fix_map = {
 }
 
 
-def get_fixed_value(
-    entity_type: str, entity_induced_class: ClassDefinition, slot_name: str, value: str
-) -> Optional[str]:
+def get_fixed_value(entity_type: str, entity_induced_class: ClassDefinition, slot_name: str, value: str) -> str | None:
     # We only need to check `attributes`, since an induced class has nothing in `slots`
     if slot_name not in entity_induced_class.attributes:
         return None
@@ -31,7 +28,7 @@ def get_fixed_value(
 
 
 def add_fix_to_error_if_available(
-    error: SheetErrorInfo, bionetwork: Optional[str], schemaview: SchemaView
+    error: SheetErrorInfo, bionetwork: str | None, schemaview: SchemaView
 ) -> SheetErrorInfo:
     # If the error doesn't have the required values, return it unchanged
     # Require string input value to avoid values that consist of the entire input row
@@ -44,7 +41,7 @@ def add_fix_to_error_if_available(
     return dataclasses.replace(error, input_fix=input_fix)
 
 
-def add_fixes_to_errors(errors: List[SheetErrorInfo], bionetwork: Optional[str]) -> List[SheetErrorInfo]:
+def add_fixes_to_errors(errors: list[SheetErrorInfo], bionetwork: str | None) -> list[SheetErrorInfo]:
     """
     Identify fixes for the given errors where possible, and return copies of the error objects with fixed values
     specified.

--- a/shared/src/hca_validation/entry_sheet_validator/process_sheet.py
+++ b/shared/src/hca_validation/entry_sheet_validator/process_sheet.py
@@ -1,5 +1,4 @@
 import dataclasses
-from typing import List, Optional
 
 import gspread
 
@@ -20,8 +19,8 @@ from .validate_sheet import (
 def process_google_sheet(
     sheet_id: str,
     *,
-    entity_types: List[str] = default_entity_types,
-    bionetwork: Optional[str] = None,
+    entity_types: list[str] = default_entity_types,
+    bionetwork: str | None = None,
 ) -> SheetValidationResult:
     """
     Process a Google Sheet by:

--- a/shared/src/hca_validation/entry_sheet_validator/validate_sheet.py
+++ b/shared/src/hca_validation/entry_sheet_validator/validate_sheet.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 import json
 import os
 import re
 import sys
+from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Any, List, Mapping, Optional
+from typing import Any
 
 # Import libraries for Google API access
 import gspread
@@ -42,7 +42,7 @@ class WorksheetInfo:
 
     data: pd.DataFrame
     worksheet_id: int
-    source_columns: List[Any]
+    source_columns: list[Any]
     source_rows_start_index: int
 
     def get_a1(self, row, column):
@@ -59,7 +59,7 @@ class SpreadsheetMetadata:
     spreadsheet_title: str
     last_updated_date: str
     last_updated_by: str
-    last_updated_email: Optional[str]
+    last_updated_email: str | None
     can_edit: bool
 
 
@@ -68,7 +68,7 @@ class SpreadsheetInfo:
     """Container for Google Sheet data and metadata."""
 
     spreadsheet_metadata: SpreadsheetMetadata
-    worksheets: List[WorksheetInfo]
+    worksheets: list[WorksheetInfo]
 
 
 @dataclass
@@ -76,24 +76,24 @@ class SheetReadError(Exception):
     """Exception raised when reading a Google Sheet fails."""
 
     error_code: str
-    error_message: Optional[str] = None
-    spreadsheet_metadata: Optional[SpreadsheetMetadata] = None
-    worksheet_id: Optional[int] = None
+    error_message: str | None = None
+    spreadsheet_metadata: SpreadsheetMetadata | None = None
+    worksheet_id: int | None = None
 
 
 @dataclass
 class SheetErrorInfo:
     """Container for info regarding an error that occurred while reading and validating a Google Sheet."""
 
-    entity_type: Optional[str]
-    worksheet_id: Optional[int]
+    entity_type: str | None
+    worksheet_id: int | None
     message: str
-    row: Optional[int] = None
-    column: Optional[Any] = None
-    cell: Optional[str] = None
-    primary_key: Optional[str] = None
-    input: Optional[Any] = None
-    input_fix: Optional[str] = None
+    row: int | None = None
+    column: Any | None = None
+    cell: str | None = None
+    primary_key: str | None = None
+    input: Any | None = None
+    input_fix: str | None = None
 
 
 @dataclass
@@ -101,10 +101,10 @@ class SheetValidationResult:
     """Container for general info on the outcome of a Google Sheet validation."""
 
     successful: bool
-    spreadsheet_metadata: Optional[SpreadsheetMetadata]
-    error_code: Optional[str]
+    spreadsheet_metadata: SpreadsheetMetadata | None
+    error_code: str | None
     summary: Mapping[str, int | None]
-    errors: List[SheetErrorInfo]
+    errors: list[SheetErrorInfo]
 
 
 # Custom sentinel value used to detect missing parameters
@@ -356,8 +356,8 @@ def init_apis() -> ApiInstances:
 
 
 def read_worksheets(
-    sheet_id: str, spreadsheet_metadata: SpreadsheetMetadata, spreadsheet: gspread.Spreadsheet, sheet_indices: List[int]
-) -> tuple[List[WorksheetInfo], List[gspread.Worksheet]]:
+    sheet_id: str, spreadsheet_metadata: SpreadsheetMetadata, spreadsheet: gspread.Spreadsheet, sheet_indices: list[int]
+) -> tuple[list[WorksheetInfo], list[gspread.Worksheet]]:
     import logging
 
     logger = logging.getLogger(__name__)
@@ -365,7 +365,7 @@ def read_worksheets(
     # Get list of worksheets
 
     all_worksheets = spreadsheet.worksheets()
-    worksheets: List[gspread.Worksheet] = []
+    worksheets: list[gspread.Worksheet] = []
 
     logger.info(
         f"Attempting to get worksheets of spreadsheet {sheet_id} at indices: {', '.join(str(i) for i in sheet_indices)}"
@@ -423,9 +423,9 @@ def read_worksheets(
 
 def read_sheet_with_service_account(
     sheet_id: str,
-    entity_types: Optional[List[str]] = None,
-    apis: Optional[ApiInstances] = None,
-) -> tuple[SpreadsheetInfo, List[gspread.Worksheet]]:
+    entity_types: list[str] | None = None,
+    apis: ApiInstances | None = None,
+) -> tuple[SpreadsheetInfo, list[gspread.Worksheet]]:
     """
     Read data from a Google Sheet using a service account for authentication.
 
@@ -590,7 +590,7 @@ def normalize_dataframe_values(df: pd.DataFrame, schemaview: SchemaView, class_n
 
 
 def make_summary_without_entities(
-    error_count: int, entity_types: List[str] = default_entity_types
+    error_count: int, entity_types: list[str] = default_entity_types
 ) -> dict[str, int | None]:
     return {**{f"{entity_type}_count": None for entity_type in entity_types}, "error_count": error_count}
 
@@ -598,12 +598,12 @@ def make_summary_without_entities(
 def make_validation_result_for_whole_sheet_error(
     *,
     sheet_id: str,
-    entity_types: List[str],
+    entity_types: list[str],
     error_code: str,
-    error_message: Optional[str] = None,
-    spreadsheet_metadata: Optional[SpreadsheetMetadata] = None,
-    worksheet_id: Optional[int] = None,
-    entity_type: Optional[str] = None,
+    error_message: str | None = None,
+    spreadsheet_metadata: SpreadsheetMetadata | None = None,
+    worksheet_id: int | None = None,
+    entity_type: str | None = None,
 ) -> SheetValidationResult:
     error_msg = error_message or f"Error processing sheet {sheet_id} (Error: {error_code})"
     error_info = SheetErrorInfo(entity_type=entity_type, worksheet_id=worksheet_id, message=error_msg)
@@ -617,7 +617,7 @@ def make_validation_result_for_whole_sheet_error(
 
 
 def make_read_error_validation_result(
-    sheet_id: str, entity_types: List[str], read_error: SheetReadError
+    sheet_id: str, entity_types: list[str], read_error: SheetReadError
 ) -> SheetValidationResult:
     import logging
 
@@ -644,11 +644,11 @@ def handle_validation_error(
     validation_error: ValidationError,
     *,
     validation_summary: dict[str, int],
-    validation_errors_list: List[SheetErrorInfo],
+    validation_errors_list: list[SheetErrorInfo],
     entity_type: str,
     sheet_info: WorksheetInfo,
     row_index: int | MissingSentinel = MISSING,
-    row_id: Optional[Any] | MissingSentinel = MISSING,
+    row_id: Any | MissingSentinel = MISSING,
 ):
     for error in validation_error.errors():
         # Update error count
@@ -689,10 +689,10 @@ def handle_validation_error(
 def validate_google_sheet(
     sheet_id: str,
     *,
-    entity_types: List[str] = default_entity_types,
-    bionetwork: Optional[str] = None,
-    sheet_read_result: Optional[SpreadsheetInfo] = None,
-    apis: Optional[ApiInstances] = None,
+    entity_types: list[str] = default_entity_types,
+    bionetwork: str | None = None,
+    sheet_read_result: SpreadsheetInfo | None = None,
+    apis: ApiInstances | None = None,
 ) -> SheetValidationResult:
     """
     Validate data from a Google Sheet starting at row 6 until the first empty row.

--- a/shared/src/hca_validation/h5ad_storage/h5ad_storage.py
+++ b/shared/src/hca_validation/h5ad_storage/h5ad_storage.py
@@ -15,7 +15,7 @@ hca-validation-tools#447.
 
 from __future__ import annotations
 
-from typing import Any, Optional, cast
+from typing import Any, cast
 
 import h5py
 import numpy as np
@@ -32,7 +32,7 @@ def _storage_size(dataset: h5py.Dataset) -> int:
     return int(dataset.id.get_storage_size())
 
 
-def _matrix_info(node: Any) -> Optional[dict]:
+def _matrix_info(node: Any) -> dict | None:
     """Storage facts for one matrix node (sparse group or dense dataset).
 
     Returns ``None`` for anything that isn't a recognizable matrix, or that
@@ -46,7 +46,7 @@ def _matrix_info(node: Any) -> Optional[dict]:
         return None
 
 
-def _parse_matrix_node(node: Any) -> Optional[dict]:
+def _parse_matrix_node(node: Any) -> dict | None:
     """Parse one matrix node into storage facts. May raise on malformed input;
     callers go through :func:`_matrix_info`, which degrades that to ``None``."""
     encoding = _decode(node.attrs.get("encoding-type", ""))

--- a/shared/src/hca_validation/metadata_coverage/metadata_coverage.py
+++ b/shared/src/hca_validation/metadata_coverage/metadata_coverage.py
@@ -23,7 +23,7 @@ Invariant: for every emitted entry,
   complete + missing + inconsistent == entities[entity_class].record_count.
 """
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 import pandas as pd
 from linkml_runtime import SchemaView
@@ -39,7 +39,7 @@ from hca_validation.schema_utils import (
 SCHEMA_NAME = "tier_1"
 
 
-def compute_metadata_coverage(adata: Any, schemaview: SchemaView) -> Dict[str, Any]:
+def compute_metadata_coverage(adata: Any, schemaview: SchemaView) -> dict[str, Any]:
     """Build the `metadata_coverage` payload for one AnnData file.
 
     Parameters
@@ -57,8 +57,8 @@ def compute_metadata_coverage(adata: Any, schemaview: SchemaView) -> Dict[str, A
     obs: pd.DataFrame = adata.obs.replace(r"^\s*$", pd.NA, regex=True)
     uns = adata.uns
 
-    entities: Dict[str, Dict[str, int]] = {"obs": {"record_count": len(obs)}}
-    field_coverage: List[Dict[str, Any]] = []
+    entities: dict[str, dict[str, int]] = {"obs": {"record_count": len(obs)}}
+    field_coverage: list[dict[str, Any]] = []
 
     for class_name in coverage_classes(schemaview):
         entity_class = get_class_entity_type(class_name)
@@ -104,7 +104,7 @@ def compute_metadata_coverage(adata: Any, schemaview: SchemaView) -> Dict[str, A
     }
 
 
-def _entry(entity_class: str, field: str, complete: int, *, missing: int = 0, inconsistent: int = 0) -> Dict[str, Any]:
+def _entry(entity_class: str, field: str, complete: int, *, missing: int = 0, inconsistent: int = 0) -> dict[str, Any]:
     return {
         "entity_class": entity_class,
         "field": field,
@@ -136,14 +136,14 @@ def _entity_record_count(
     return int(obs[identifier.name].dropna().nunique())
 
 
-def _obs_identifier_entry(slot_name: str, obs: pd.DataFrame) -> Dict[str, Any]:
+def _obs_identifier_entry(slot_name: str, obs: pd.DataFrame) -> dict[str, Any]:
     if slot_name not in obs.columns:
         return _entry("obs", slot_name, complete=0, missing=len(obs))
     complete = int(obs[slot_name].notna().sum())
     return _entry("obs", slot_name, complete, missing=len(obs) - complete)
 
 
-def _uns_entry(entity_class: str, slot_name: str, uns: Any) -> Dict[str, Any]:
+def _uns_entry(entity_class: str, slot_name: str, uns: Any) -> dict[str, Any]:
     value = uns.get(slot_name)
     complete = 1 if _is_value_populated(value) else 0
     return _entry(entity_class, slot_name, complete, missing=1 - complete)
@@ -154,9 +154,9 @@ def _obs_entry(
     entity_class: str,
     slot_name: str,
     obs: pd.DataFrame,
-    grouped: Optional[Any],
+    grouped: Any | None,
     record_count: int,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     # Always emit an entry. Skipping any (entity_class, slot) looks like schema
     # drift to the tracker; emit `complete=0, missing=record_count` so the
     # invariant holds (when record_count is 0, both sides are 0).
@@ -180,7 +180,7 @@ def _obs_entry(
     )
 
 
-def _bucket_single_group(series: pd.Series) -> Tuple[int, int, int]:
+def _bucket_single_group(series: pd.Series) -> tuple[int, int, int]:
     """Bucket a Dataset-class obs slot. The whole obs table is one entity."""
     non_null = series.dropna()
     if non_null.empty:
@@ -193,7 +193,7 @@ def _bucket_single_group(series: pd.Series) -> Tuple[int, int, int]:
     return 1, 0, 0
 
 
-def _bucket_groups(grouped: Any, slot_name: str) -> Tuple[int, int, int]:
+def _bucket_groups(grouped: Any, slot_name: str) -> tuple[int, int, int]:
     """Bucket entity instances using a pre-built groupby on the identifier.
 
     Vectorized via `.agg(['size', 'count', 'nunique'])`:
@@ -236,8 +236,8 @@ def _is_value_populated(value: Any) -> bool:
 
 
 def _assert_invariant(
-    entities: Dict[str, Dict[str, int]],
-    field_coverage: List[Dict[str, Any]],
+    entities: dict[str, dict[str, int]],
+    field_coverage: list[dict[str, Any]],
 ) -> None:
     for entry in field_coverage:
         entity_class = entry["entity_class"]

--- a/shared/src/hca_validation/schema_utils/schema_utils.py
+++ b/shared/src/hca_validation/schema_utils/schema_utils.py
@@ -1,5 +1,5 @@
 import os
-from typing import Iterator, List, Optional, Tuple
+from collections.abc import Iterator
 
 import jsonasobj2
 from linkml_runtime import SchemaView
@@ -34,7 +34,7 @@ def load_schemaview():
     return SchemaView(schema_path)
 
 
-def get_entity_class_name(schema_type: str, bionetwork: Optional[str] = None) -> str:
+def get_entity_class_name(schema_type: str, bionetwork: str | None = None) -> str:
     # Validate schema type
     if schema_type not in schema_classes:
         raise ValueError(
@@ -58,7 +58,7 @@ def get_class_identifier_name(schemaview: SchemaView, class_name: str) -> str:
     raise ValueError(f"No identifier slot found for class {class_name}")
 
 
-def get_slot_anndata_location(slot: SlotDefinition) -> Optional[str]:
+def get_slot_anndata_location(slot: SlotDefinition) -> str | None:
     if not slot.annotations:
         return None
     for name, info in jsonasobj2.items(slot.annotations):
@@ -76,7 +76,7 @@ def is_deprecated_slot(schemaview: SchemaView, slot: SlotDefinition) -> bool:
     return False
 
 
-def coverage_classes(schemaview: SchemaView) -> List[str]:
+def coverage_classes(schemaview: SchemaView) -> list[str]:
     """DEFAULT LinkML class names eligible for metadata coverage reporting.
 
     Returns the canonical (non-bionetwork-specific) class for each entity type
@@ -95,7 +95,7 @@ def coverage_classes(schemaview: SchemaView) -> List[str]:
     return eligible
 
 
-def iter_coverage_slots(schemaview: SchemaView, class_name: str) -> Iterator[Tuple[str, str]]:
+def iter_coverage_slots(schemaview: SchemaView, class_name: str) -> Iterator[tuple[str, str]]:
     """Yield (slot_name, annDataLocation) for slots of `class_name` that participate
     in coverage reporting at entity grain.
 

--- a/shared/src/hca_validation/validator/validator.py
+++ b/shared/src/hca_validation/validator/validator.py
@@ -5,7 +5,7 @@ This module provides the main validation functionality for HCA data using Pydant
 """
 
 import itertools
-from typing import Any, Dict, Optional
+from typing import Any
 
 import pandas as pd
 from linkml_runtime import SchemaView
@@ -28,7 +28,7 @@ schema_classes = {
 }
 
 
-def validate(data: Dict[str, Any], *, class_name: str) -> Optional[ValidationError]:
+def validate(data: dict[str, Any], *, class_name: str) -> ValidationError | None:
     """
     Validate HCA data against a schema using Pydantic models.
 
@@ -53,7 +53,7 @@ def validate(data: Dict[str, Any], *, class_name: str) -> Optional[ValidationErr
         return e
 
 
-def validate_id_uniqueness(data: pd.DataFrame, schemaview: SchemaView, class_name: str) -> Optional[ValidationError]:
+def validate_id_uniqueness(data: pd.DataFrame, schemaview: SchemaView, class_name: str) -> ValidationError | None:
     """
     Validate that no entities in the given data have duplicate IDs.
 

--- a/shared/tests/conftest.py
+++ b/shared/tests/conftest.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """Shared test configuration for HCA validation tools."""
 

--- a/shared/tests/test_entry_sheet_validator.py
+++ b/shared/tests/test_entry_sheet_validator.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """Test script for the HCA entry sheet validator module.
 

--- a/shared/tests/test_validator.py
+++ b/shared/tests/test_validator.py
@@ -21,21 +21,21 @@ VOIBM_JSON_PATH = TEST_DIR / "valid_or_invalid_by_model_dataset.json"
 @pytest.fixture
 def valid_dataset():
     """Fixture to load the valid dataset."""
-    with open(VALID_JSON_PATH, "r") as f:
+    with open(VALID_JSON_PATH) as f:
         return json.load(f)
 
 
 @pytest.fixture
 def invalid_dataset():
     """Fixture to load the invalid dataset."""
-    with open(INVALID_JSON_PATH, "r") as f:
+    with open(INVALID_JSON_PATH) as f:
         return json.load(f)
 
 
 @pytest.fixture
 def voibm_dataset():
     """Fixture to load the valid-or-invalid-by-model dataset."""
-    with open(VOIBM_JSON_PATH, "r") as f:
+    with open(VOIBM_JSON_PATH) as f:
         return json.load(f)
 
 


### PR DESCRIPTION
**Part of #467** (A6 — widen Ruff toward the shared rule set). PR 2 of 3 in the agreed grouping.

## What changed
- Added `"UP"` to `select` in `ruff.toml`.
- Applied the pyupgrade autofixes across 23 files (172 violations, zero `# noqa` needed):
  - `Optional[X]`/`Union[X, Y]` → `X | None` / `X | Y`
  - `typing.List/Dict/Tuple` → builtin generics; deprecated `typing` imports removed or moved to `collections.abc`
  - 4 single-element-tuple `isinstance` unwraps + 3 PEP-604 `isinstance` unions
  - dropped 5 `# -*- coding: utf-8 -*-` declarations; `open(path, "r")` → `open(path)` in 2 test files
- Two hand-fixes on touched hunks (found in local review):
  - `dataset-validator/main.py`: restored the `tool_reports` inline comment that the `Optional[...]` collapse silently dropped — every sibling field in that dataclass block keeps one.
  - `validate_sheet.py`: `row_id: Any | None | MissingSentinel` → `Any | MissingSentinel` (`Any` already subsumes `None`).

## Why
Move the repo toward the full shared Ruff rule set. `UP` is the largest of the three remaining families but the lowest-risk per fix — the changes are mechanical modern-syntax rewrites for our `py310` target.

## Assumptions I made
- **`py310` runtime safety without `from __future__ import annotations`.** `X | None` and PEP-604 `isinstance` unions evaluate at runtime on 3.10, so the dataclass files that lack the future import (`dataset-validator/main.py`, `validate_sheet.py`) are unaffected — an import-time failure would fail every test, and all suites pass.
- **Generated/vendored files stay excluded.** `schema/generated/*`, anndata-tools `core.py`, and `_vendored/*` are `extend-exclude`d and were not rewritten (verified empty diff against those paths); the exclusion is load-bearing (they still contain `Optional[`/`List[`).
- **UP038 union form is acceptable here.** The 3 `X | Y` isinstance rewrites sit in metadata-scale paths (`make_serializable` over JSON-ish uns, `_view_dict` over uns entries), not per-cell/per-row hot loops, so the tuple form's marginal speed edge doesn't matter.
- **entry-sheet-validator isn't in pyright's coverage** and its only test is the Docker smoke (needs Docker + creds), so `handler.py`/`test_lambda.py`'s type-only changes rest on the mechanical-rewrite guarantee, not a run. (`test_lambda.py` is the orphaned manual script slated for deletion in #507.)

## How to verify
Definition of done from #504, mapped to steps:
- [ ] **`UP` added to `select`** → `grep UP ruff.toml` shows it in the list.
- [ ] **Autofix applied + reviewed, nothing force-fit** → `uvx ruff@0.11.8 check . --select UP` prints "All checks passed!"; `git grep -n "noqa: UP"` returns nothing.
- [ ] **Full lint + format clean** → `uvx ruff@0.11.8 check .` and `uvx ruff@0.11.8 format --check .` both clean.
- [ ] **Affected suites + typecheck green** → from repo root `make typecheck` (0 errors, 4 venvs); then `cd shared && uv run pytest tests/ -m "not integration"` (44), `packages/hca-anndata-tools` (280), `packages/hca-schema-validator` (121), `services/dataset-validator` (78), `services/hca-schema-validator` (11).
- [ ] **CI `lint` job green** on this PR.

PR references "Part of #467" (not `Closes`) — #467 is closed by the final family (#505, `PTH`).