### PR TITLE
style(ruff): enable PTH (pathlib) and migrate os.path → pathlib (closes #467)

### DIFF
--- a/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/label.py
+++ b/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/label.py
@@ -1,6 +1,6 @@
 """MCP wrapper for hca_schema_validator.HCALabeler."""
 
-import os
+from pathlib import Path
 
 from hca_anndata_tools._io import open_h5ad
 from hca_anndata_tools.write import make_edit_entry, resolve_latest, write_h5ad
@@ -58,7 +58,7 @@ def label_h5ad(path: str) -> dict:
     """
     try:
         path = resolve_latest(path)
-        if not os.path.isfile(path):
+        if not Path(path).is_file():
             return {"error": f"File not found: {path}"}
 
         # backed="r": the labeler only mutates obs/var/raw.var (all in-memory

--- a/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/populate.py
+++ b/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/populate.py
@@ -21,7 +21,7 @@ is the thin file-I/O shim around it:
    edit-log entry, return the new ``output_path``.
 """
 
-import os
+from pathlib import Path
 
 from hca_anndata_tools import has_edit_log_operation
 from hca_anndata_tools._io import open_h5ad
@@ -53,7 +53,7 @@ def populate_labels(path: str) -> dict:
     """
     try:
         path = resolve_latest(path)
-        if not os.path.isfile(path):
+        if not Path(path).is_file():
             return {"error": f"File not found: {path}"}
 
         # backed="r": populator only mutates obs/var/raw.var (all

--- a/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/validate.py
+++ b/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/validate.py
@@ -1,6 +1,6 @@
 """MCP wrappers for hca_schema_validator validators."""
 
-import os
+from pathlib import Path
 
 from hca_anndata_tools.write import resolve_latest
 from hca_schema_validator import HCACellAnnotationValidator, HCAValidator
@@ -24,7 +24,7 @@ def validate_schema(path: str) -> dict:
     """
     try:
         path = resolve_latest(path)
-        if not os.path.isfile(path):
+        if not Path(path).is_file():
             return {"error": f"File not found: {path}"}
         v = HCAValidator()
         try:
@@ -33,9 +33,9 @@ def validate_schema(path: str) -> dict:
             # Vendored cellxgene code exits on unrecoverable read failures.
             # Surface a generic error if no validator errors were captured.
             if not v.errors:
-                return {"error": f"Validator could not read {os.path.basename(path)}"}
+                return {"error": f"Validator could not read {Path(path).name}"}
         return {
-            "filename": os.path.basename(path),
+            "filename": Path(path).name,
             "is_valid": v.is_valid,
             "error_count": len(v.errors),
             "warning_count": len(v.warnings),
@@ -73,12 +73,12 @@ def validate_cell_annotation(path: str) -> dict:
     """
     try:
         path = resolve_latest(path)
-        if not os.path.isfile(path):
+        if not Path(path).is_file():
             return {"error": f"File not found: {path}"}
         v = HCACellAnnotationValidator()
         is_valid = v.validate_adata(path)
         return {
-            "filename": os.path.basename(path),
+            "filename": Path(path).name,
             "is_valid": is_valid,
             "error_count": len(v.errors),
             "warning_count": len(v.warnings),

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/compress.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/compress.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-import os
+from pathlib import Path
 from typing import Literal
 
 import h5py
@@ -67,7 +67,7 @@ def compress_h5ad(
                 "current_compression": current_filter,
             }
 
-        size_before = os.path.getsize(path)
+        size_before = Path(path).stat().st_size
 
         entry = make_edit_entry(
             operation="compress_h5ad",
@@ -92,7 +92,7 @@ def compress_h5ad(
         if "error" in result:
             return result
 
-        size_after = os.path.getsize(result["output_path"])
+        size_after = Path(result["output_path"]).stat().st_size
         ratio = round(size_before / size_after, 2) if size_after else None
 
         # Backfill size_after/ratio into the edit log entry we just wrote. We

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/convert.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/convert.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import contextlib
-import os
 import re
 import shutil
 import tempfile
+from pathlib import Path
 
 import anndata as ad
 import h5py
@@ -156,8 +156,8 @@ def convert_cellxgene_to_hca(
         slug = _slugify(title)
         timestamp = generate_timestamp()
         out_filename = f"{slug}-edit-{timestamp}.h5ad"
-        directory = output_dir if output_dir is not None else os.path.dirname(path)
-        output_path = os.path.join(directory, out_filename)
+        directory = Path(output_dir) if output_dir is not None else Path(path).parent
+        output_path = str(directory / out_filename)
 
         entry = make_edit_entry(
             operation="import_cellxgene",
@@ -184,7 +184,7 @@ def convert_cellxgene_to_hca(
 
         # --- Step 4: Copy source + transplant via h5py ---
         with tempfile.TemporaryDirectory() as tmpdir:
-            temp_path = os.path.join(tmpdir, "convert_temp.h5ad")
+            temp_path = str(Path(tmpdir) / "convert_temp.h5ad")
             temp_adata.write_h5ad(temp_path)
             del temp_adata
 
@@ -229,18 +229,18 @@ def convert_cellxgene_to_hca(
             # --- Step 5: Verify transplant ---
             verify_err = verify_obs_transplant(temp_path, output_path, obs_cols_added)
             if verify_err:
-                os.remove(output_path)
+                Path(output_path).unlink()
                 return {"error": verify_err}
 
         return {
             "output_path": output_path,
-            "source": os.path.basename(path),
+            "source": Path(path).name,
             "title": title,
             "conversions": conversions,
         }
 
     except Exception as e:
-        if output_path and os.path.isfile(output_path):
+        if output_path and Path(output_path).is_file():
             with contextlib.suppress(OSError):
-                os.remove(output_path)
+                Path(output_path).unlink()
         return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import contextlib
-import os
 import shutil
 import tempfile
 from collections.abc import Mapping
+from pathlib import Path
 from typing import Any
 
 import anndata as ad
@@ -309,7 +309,7 @@ def copy_cap_annotations(
         temp_uns: dict[str, Any] = {CAP_METADATA_KEY: source_cap_block}
         uns_keys_added = [CAP_METADATA_KEY]
 
-        source_basename = os.path.basename(source_path)
+        source_basename = Path(source_path).name
         source_sha256 = _compute_sha256(source_path)
         target_sha256 = _compute_sha256(target_path)
 
@@ -346,7 +346,7 @@ def copy_cap_annotations(
         output_path = generate_output_path(target_path)
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            temp_path = os.path.join(tmpdir, "cap_temp.h5ad")
+            temp_path = str(Path(tmpdir) / "cap_temp.h5ad")
             temp_adata.write_h5ad(temp_path)
             del temp_adata
 
@@ -388,7 +388,7 @@ def copy_cap_annotations(
             # --- Step 5: Verify transplant — full column comparison ---
             verify_err = verify_obs_transplant(temp_path, output_path, obs_cols_to_copy)
             if verify_err:
-                os.remove(output_path)
+                Path(output_path).unlink()
                 return {"error": verify_err}
 
         # --- Step 6: Cleanup + validate marker genes ---
@@ -408,7 +408,7 @@ def copy_cap_annotations(
         }
 
     except Exception as e:
-        if output_path and os.path.isfile(output_path):
+        if output_path and Path(output_path).is_file():
             with contextlib.suppress(OSError):
-                os.remove(output_path)
+                Path(output_path).unlink()
         return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import contextlib
 import json
-import os
 import shutil
 import types
 import typing
+from pathlib import Path
 
 import h5py
 import numpy as np
@@ -115,7 +115,7 @@ def list_uns_fields(path: str) -> dict:
             extra_uns_keys = sorted(k for k in adata.uns if k not in schema_keys)
 
             return {
-                "filename": os.path.basename(path),
+                "filename": Path(path).name,
                 "fields": fields,
                 "set_count": sum(1 for f in fields if f["is_set"]),
                 "missing_required": missing_required,
@@ -146,7 +146,7 @@ def view_edit_log(path: str) -> dict:
             entries = json.loads(read_edit_log_h5py(f))
 
         result = {
-            "filename": os.path.basename(path),
+            "filename": Path(path).name,
             "edit_count": len(entries),
             "entries": entries,
         }
@@ -256,8 +256,8 @@ def set_uns(
 
         return {
             **result,
-            "editing": os.path.basename(path),
-            "wrote": os.path.basename(result["output_path"]),
+            "editing": Path(path).name,
+            "wrote": Path(result["output_path"]).name,
             "field": field,
             "old_value": old_value,
             "new_value": make_serializable(validated_value),
@@ -412,7 +412,7 @@ def replace_placeholder_values(
         }
 
     except Exception as e:
-        if output_path and os.path.isfile(output_path):
+        if output_path and Path(output_path).is_file():
             with contextlib.suppress(OSError):
-                os.remove(output_path)
+                Path(output_path).unlink()
         return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/inspect.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/inspect.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import os
+from pathlib import Path
 
 import h5py
 import numpy as np
@@ -74,7 +74,7 @@ def _classify_x_at_path(path: str, sample_size: int) -> dict:
             nonzero_max = float(finite.max())
 
     return {
-        "filename": os.path.basename(path),
+        "filename": Path(path).name,
         "dtype": dtype,
         "sample_size": int(sample.size),
         "nonzero_count": nonzero_count,
@@ -164,12 +164,12 @@ def check_schema_type(path: str) -> dict:
             version = _read_schema_version(f)
         if version:
             return {
-                "filename": os.path.basename(path),
+                "filename": Path(path).name,
                 "schema": "cellxgene",
                 "schema_version": version,
             }
         return {
-            "filename": os.path.basename(path),
+            "filename": Path(path).name,
             "schema": "hca",
             "schema_version": None,
         }

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/storage.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/storage.py
@@ -1,6 +1,6 @@
 """HDF5 storage details for an AnnData file."""
 
-import os
+from pathlib import Path
 
 import h5py
 
@@ -55,7 +55,7 @@ def get_storage_info(path: str) -> dict:
             return {"error": "Only .h5ad files supported (not zarr)"}
 
         path = resolve_latest(path)
-        file_bytes = os.path.getsize(path)
+        file_bytes = Path(path).stat().st_size
         result = {
             "file_size_bytes": file_bytes,
             "file_size_mb": round(file_bytes / (1024 * 1024), 1),

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/strip.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/strip.py
@@ -16,8 +16,8 @@ truth.
 from __future__ import annotations
 
 import contextlib
-import os
 import shutil
+from pathlib import Path
 
 import h5py
 
@@ -105,7 +105,7 @@ def strip_forbidden_obs_columns(path: str) -> dict:
     output_path = None
     try:
         path = resolve_latest(path)
-        if not os.path.isfile(path):
+        if not Path(path).is_file():
             return {"error": f"File not found: {path}"}
 
         # Peek first: layout check + presence check. Both via h5py so we
@@ -165,7 +165,7 @@ def strip_forbidden_obs_columns(path: str) -> dict:
                 write_edit_log_h5py(f_out, log_result["json"])
 
         if log_error is not None:
-            os.remove(output_path)
+            Path(output_path).unlink()
             return log_error
 
         cleanup_previous_version(path, output_path)
@@ -176,7 +176,7 @@ def strip_forbidden_obs_columns(path: str) -> dict:
         }
 
     except Exception as e:
-        if output_path and os.path.isfile(output_path):
+        if output_path and Path(output_path).is_file():
             with contextlib.suppress(OSError):
-                os.remove(output_path)
+                Path(output_path).unlink()
         return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
@@ -6,9 +6,9 @@ import contextlib
 import glob
 import hashlib
 import json
-import os
 import re
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 from . import __version__
@@ -26,7 +26,7 @@ _REQUIRED_ENTRY_KEYS = {"timestamp", "tool", "tool_version", "operation", "descr
 def _compute_sha256(path: str) -> str:
     """Compute SHA-256 hex digest of a file."""
     h = hashlib.sha256()
-    with open(path, "rb") as f:
+    with Path(path).open("rb") as f:
         for chunk in iter(lambda: f.read(_HASH_CHUNK_SIZE), b""):
             h.update(chunk)
     return h.hexdigest()
@@ -46,7 +46,7 @@ def strip_timestamp(filename: str) -> str:
 
 def _base_stem(path: str) -> str:
     """Extract the base stem (no timestamp, no extension) from an h5ad path."""
-    return strip_timestamp(os.path.basename(path)).removesuffix(".h5ad")
+    return strip_timestamp(Path(path).name).removesuffix(".h5ad")
 
 
 def generate_timestamp() -> str:
@@ -64,7 +64,7 @@ def generate_output_path(source_path: str) -> str:
         Path string in the same directory as source_path.
     """
     stem = _base_stem(source_path)
-    return os.path.join(os.path.dirname(source_path), f"{stem}-edit-{generate_timestamp()}.h5ad")
+    return str(Path(source_path).parent / f"{stem}-edit-{generate_timestamp()}.h5ad")
 
 
 def resolve_latest(path: str) -> str:
@@ -80,24 +80,23 @@ def resolve_latest(path: str) -> str:
     Returns:
         Path to the latest timestamped version, or the original if none exist.
     """
-    directory = os.path.dirname(path) or "."
+    directory = Path(path).parent
     stem = _base_stem(path)
 
     # Glob for timestamped variants, then strict regex filter on full basename
-    pattern = os.path.join(directory, f"{glob.escape(stem)}-edit-*-*-*-*-*-*.h5ad")
     full_re = re.compile(rf"^{re.escape(stem)}-edit-\d{{4}}-\d{{2}}-\d{{2}}-\d{{2}}-\d{{2}}-\d{{2}}\.h5ad$")
-    candidates = [f for f in glob.glob(pattern) if full_re.match(os.path.basename(f))]
+    candidates = [f for f in directory.glob(f"{glob.escape(stem)}-edit-*-*-*-*-*-*.h5ad") if full_re.match(f.name)]
 
     if not candidates:
         return path
 
     # Timestamps are lexicographically ordered
-    return os.path.normpath(max(candidates))
+    return str(max(candidates))
 
 
 def _is_timestamped(path: str) -> bool:
     """Check if a path has a timestamp suffix (i.e. it's an edit, not the original)."""
-    return bool(_TIMESTAMP_PATTERN.search(os.path.basename(path)))
+    return bool(_TIMESTAMP_PATTERN.search(Path(path).name))
 
 
 def has_edit_log_operation(adata, operation: str) -> bool:
@@ -205,7 +204,7 @@ def build_edit_log(
             return {"error": f"edit_entries[{i}] missing required keys: {sorted(missing)}"}
 
     sha256 = source_sha256 if source_sha256 is not None else _compute_sha256(source_path)
-    source_filename = os.path.basename(source_path)
+    source_filename = Path(source_path).name
 
     stamped_entries = [{**entry, "source_file": source_filename, "source_sha256": sha256} for entry in edit_entries]
 
@@ -235,9 +234,9 @@ def cleanup_previous_version(source_path: str, output_path: str) -> None:
     Never deletes the original (non-timestamped) file. Skips if output
     overwrote source in place (same-second write).
     """
-    if _is_timestamped(source_path) and source_path != output_path and os.path.isfile(source_path):
+    if _is_timestamped(source_path) and source_path != output_path and Path(source_path).is_file():
         with contextlib.suppress(OSError):
-            os.remove(source_path)  # write succeeded; stale file is harmless
+            Path(source_path).unlink()  # write succeeded; stale file is harmless
 
 
 def write_h5ad(
@@ -279,7 +278,7 @@ def write_h5ad(
         if not source_path.endswith(".h5ad"):
             return {"error": f"Source path must be a .h5ad file, got: {source_path}"}
 
-        if not os.path.isfile(source_path):
+        if not Path(source_path).is_file():
             return {"error": f"Source file not found: {source_path}"}
 
         provenance = adata.uns.get("provenance", {})

--- a/packages/hca-anndata-tools/tests/test_convert.py
+++ b/packages/hca-anndata-tools/tests/test_convert.py
@@ -1,8 +1,8 @@
 """Tests for convert_cellxgene_to_hca."""
 
 import json
-import os
 import re
+from pathlib import Path
 
 import anndata as ad
 
@@ -96,7 +96,7 @@ def test_convert_label_columns_preserved(cellxgene_h5ad):
 
 def test_convert_output_named_from_title(cellxgene_h5ad):
     result = convert_cellxgene_to_hca(str(cellxgene_h5ad))
-    basename = os.path.basename(result["output_path"])
+    basename = Path(result["output_path"]).name
 
     assert basename.startswith("snrna-seq-of-human-retina-test-subset-edit-")
     assert re.search(r"\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}\.h5ad$", basename)

--- a/packages/hca-anndata-tools/tests/test_strip.py
+++ b/packages/hca-anndata-tools/tests/test_strip.py
@@ -1,7 +1,7 @@
 """Tests for strip_forbidden_obs_columns."""
 
 import json
-import os
+from pathlib import Path
 
 import anndata as ad
 import pandas as pd
@@ -72,7 +72,7 @@ def test_strip_no_op_when_neither_present(sample_h5ad_for_write):
     assert result.get("skipped") is True
     assert "reason" in result
     # No timestamped snapshot should appear in the source directory.
-    siblings = os.listdir(os.path.dirname(sample_h5ad_for_write))
+    siblings = [p.name for p in Path(sample_h5ad_for_write).parent.iterdir()]
     assert not any("-edit-" in name for name in siblings)
 
 
@@ -86,7 +86,7 @@ def test_strip_refuses_cellxgene_layout(cellxgene_h5ad):
     assert "CellxGENE-layout" in result["error"]
     assert "convert_cellxgene_to_hca" in result["error"]
     # No timestamped snapshot should appear in the source directory.
-    siblings = os.listdir(os.path.dirname(cellxgene_h5ad))
+    siblings = [p.name for p in Path(cellxgene_h5ad).parent.iterdir()]
     assert not any("-edit-" in name for name in siblings)
 
 

--- a/packages/hca-anndata-tools/tests/test_write.py
+++ b/packages/hca-anndata-tools/tests/test_write.py
@@ -2,8 +2,8 @@
 
 import hashlib
 import json
-import os
 import re
+from pathlib import Path
 
 import anndata as ad
 
@@ -67,7 +67,7 @@ def test_generate_output_path_strips_existing_timestamp(tmp_path):
     source.touch()
     result = generate_output_path(str(source))
     # Should have base "data" with a NEW timestamp, not double-stamped
-    basename = os.path.basename(result)
+    basename = Path(result).name
     assert basename.startswith("data-")
     # Exactly one timestamp (no double-stamping) — use unanchored pattern
     ts_pattern = r"\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}"
@@ -76,7 +76,7 @@ def test_generate_output_path_strips_existing_timestamp(tmp_path):
 
 def test_generate_output_path_format(sample_h5ad_for_write):
     result = generate_output_path(str(sample_h5ad_for_write))
-    basename = os.path.basename(result)
+    basename = Path(result).name
     assert TIMESTAMP_RE.search(basename)
     assert basename.startswith("test-dataset-")
 
@@ -91,7 +91,7 @@ def test_write_h5ad_basic(sample_h5ad_for_write):
     assert "error" not in result
     assert "output_path" in result
 
-    assert os.path.isfile(result["output_path"])
+    assert Path(result["output_path"]).is_file()
     assert TIMESTAMP_RE.search(result["output_path"])
 
 
@@ -129,7 +129,7 @@ def test_write_h5ad_preserves_existing_log(sample_h5ad_for_write):
 def test_write_h5ad_sha256_correct(sample_h5ad_for_write):
     # Compute expected hash independently
     h = hashlib.sha256()
-    with open(sample_h5ad_for_write, "rb") as f:
+    with Path(sample_h5ad_for_write).open("rb") as f:
         for chunk in iter(lambda: f.read(8192), b""):
             h.update(chunk)
     expected_sha = h.hexdigest()
@@ -149,7 +149,7 @@ def test_write_h5ad_source_file_is_basename(sample_h5ad_for_write):
     written = ad.read_h5ad(result["output_path"])
     log = json.loads(written.uns["provenance"][EDIT_LOG_KEY])
     source_file = log[0]["source_file"]
-    assert source_file == os.path.basename(source_file)
+    assert source_file == Path(source_file).name
     assert source_file == "test-dataset.h5ad"
 
 
@@ -257,7 +257,7 @@ def test_write_h5ad_custom_output_path(sample_h5ad_for_write, tmp_path):
 
     assert "error" not in result
     assert result["output_path"] == custom
-    assert os.path.isfile(custom)
+    assert Path(custom).is_file()
 
 
 # --- resolve_latest ---
@@ -305,14 +305,14 @@ def test_write_h5ad_deletes_previous_timestamped(sample_h5ad_for_write):
     # First write: original → timestamped
     r1 = write_h5ad(adata, str(sample_h5ad_for_write), [_make_entry(description="first")])
     assert "error" not in r1
-    assert os.path.isfile(str(sample_h5ad_for_write))  # original still there
+    assert Path(sample_h5ad_for_write).is_file()  # original still there
 
     # Second write: timestamped → new timestamped
     adata2 = ad.read_h5ad(r1["output_path"])
     r2 = write_h5ad(adata2, r1["output_path"], [_make_entry(description="second")])
     assert "error" not in r2
-    assert os.path.isfile(str(sample_h5ad_for_write))  # original still there
-    assert os.path.isfile(r2["output_path"])  # latest version exists
+    assert Path(sample_h5ad_for_write).is_file()  # original still there
+    assert Path(r2["output_path"]).is_file()  # latest version exists
 
     # Count h5ad files in directory — should be original + one timestamped
     d = sample_h5ad_for_write.parent
@@ -325,13 +325,13 @@ def test_write_h5ad_never_deletes_original(sample_h5ad_for_write):
     adata = ad.read_h5ad(str(sample_h5ad_for_write))
     r1 = write_h5ad(adata, str(sample_h5ad_for_write), [_make_entry()])
     assert "error" not in r1
-    assert os.path.isfile(str(sample_h5ad_for_write))
+    assert Path(sample_h5ad_for_write).is_file()
 
     # Write again from original
     adata2 = ad.read_h5ad(str(sample_h5ad_for_write))
     r2 = write_h5ad(adata2, str(sample_h5ad_for_write), [_make_entry()])
     assert "error" not in r2
-    assert os.path.isfile(str(sample_h5ad_for_write))
+    assert Path(sample_h5ad_for_write).is_file()
 
 
 # --- has_edit_log_operation ---

--- a/packages/hca-schema-validator/src/hca_schema_validator/labeler.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/labeler.py
@@ -61,7 +61,7 @@ def _organism_for_feature(feature_id: str):
 class HCALabeler(AnnDataLabelAppender):
     def __init__(self, adata):
         super().__init__(adata)
-        with open(_SCHEMA_PATH) as f:
+        with _SCHEMA_PATH.open() as f:
             self.schema_def = yaml.safe_load(f)
         self._preflight_done = False
 

--- a/packages/hca-schema-validator/src/hca_schema_validator/validator.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/validator.py
@@ -18,7 +18,7 @@ from .labeler import HCA_DERIVED_OBS_LABELS
 
 # GENCODE version info (loaded once at module level)
 _GENE_INFO_PATH = Path(__file__).parent / "_vendored" / "cellxgene_schema" / "gencode_files" / "gene_info.yml"
-with open(_GENE_INFO_PATH) as _f:
+with _GENE_INFO_PATH.open() as _f:
     _gene_info = yaml.safe_load(_f)
 
 # Schema file constants
@@ -61,7 +61,7 @@ class HCAValidator(Validator):
             # Load HCA-specific schema
             schema_path = Path(__file__).parent / SCHEMA_DIR / SCHEMA_FILENAME
 
-            with open(schema_path) as fp:
+            with schema_path.open() as fp:
                 self.schema_def = yaml.safe_load(fp)
 
     def validate_adata(self, h5ad_path=None):
@@ -432,7 +432,7 @@ def _collect_curie_exceptions(source_def):
 @functools.lru_cache(maxsize=1)
 def _load_default_schema_def():
     schema_path = Path(__file__).parent / SCHEMA_DIR / SCHEMA_FILENAME
-    with open(schema_path) as fp:
+    with schema_path.open() as fp:
         return yaml.safe_load(fp)
 
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -7,7 +7,7 @@ extend-exclude = [
 ]
 
 [lint]
-select = ["E", "F", "I", "W", "B", "C4", "PIE", "RET", "RUF", "SIM", "UP"]
+select = ["E", "F", "I", "W", "B", "C4", "PIE", "PTH", "RET", "RUF", "SIM", "UP"]
 
 [lint.per-file-ignores]
 # __init__.py files re-export their package's public API; the imports are

--- a/services/dataset-validator/src/dataset_validator/main.py
+++ b/services/dataset-validator/src/dataset_validator/main.py
@@ -311,7 +311,7 @@ def compute_sha256(file_path: Path) -> str:
     logger.debug("Computing SHA256 for: %s", file_path)
     sha256_hash = hashlib.sha256()
 
-    with open(file_path, "rb") as f:
+    with file_path.open("rb") as f:
         # Read file in 64KB chunks to handle large files efficiently
         for chunk in iter(lambda: f.read(65536), b""):
             sha256_hash.update(chunk)
@@ -751,7 +751,7 @@ def validate_environment() -> tuple[dict[str, str | None], list[str]]:
     # In local file mode, all fields get defaults; only the file must exist
     if local_file:
         missing_vars = []
-        if not os.path.isfile(local_file):
+        if not Path(local_file).is_file():
             missing_vars.append(f"LOCAL_FILE={local_file} (file does not exist)")
         return env_vars, missing_vars
 

--- a/services/entry-sheet-validator/src/entry_sheet_validator_lambda/test_lambda.py
+++ b/services/entry-sheet-validator/src/entry_sheet_validator_lambda/test_lambda.py
@@ -34,9 +34,9 @@ def main():
 
     # Load service account credentials if provided
     if args.creds_file:
-        if os.path.exists(args.creds_file):
+        if Path(args.creds_file).exists():
             print(f"Loading service account credentials from {args.creds_file}")
-            with open(args.creds_file) as f:
+            with Path(args.creds_file).open() as f:
                 credentials = f.read()
                 os.environ["GOOGLE_SERVICE_ACCOUNT"] = credentials
         else:
@@ -44,7 +44,7 @@ def main():
 
     # Load from .env file if provided
     elif args.env_file:
-        if os.path.exists(args.env_file):
+        if Path(args.env_file).exists():
             print(f"Loading environment variables from {args.env_file}")
             load_dotenv(args.env_file)
         else:

--- a/shared/src/hca_validation/data_dictionary/generate_dictionary.py
+++ b/shared/src/hca_validation/data_dictionary/generate_dictionary.py
@@ -153,7 +153,7 @@ def generate_dictionary(schema_path=None, output_path=None):
         output_path = data_dict_dir / f"{schema_name}_data_dictionary.json"
 
     # Write to file
-    with open(output_path, "w", encoding="utf-8") as fh:
+    with Path(output_path).open("w", encoding="utf-8") as fh:
         json.dump(data_dict, fh, indent=2)
     print(f"Data dictionary written to {output_path}")
 

--- a/shared/src/hca_validation/entry_sheet_validator/validate_sheet.py
+++ b/shared/src/hca_validation/entry_sheet_validator/validate_sheet.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import json
-import os
 import re
 import sys
 from collections.abc import Mapping
@@ -913,9 +912,7 @@ def validate_google_sheet(
             all_valid = False
             logger.warning(f"Validation found errors in some of the {len(rows_to_validate)} {entity_type} rows.")
             logger.warning("Please check the schema requirements and update the data accordingly.")
-            logger.info(
-                f"Schema location: {os.path.join(os.path.dirname(__file__), f'../../schema/{entity_type}.yaml')}"
-            )
+            logger.info(f"Schema location: {Path(__file__).parent / f'../../schema/{entity_type}.yaml'}")
 
     # Summary
     if all_valid:

--- a/shared/src/hca_validation/schema_utils/schema_utils.py
+++ b/shared/src/hca_validation/schema_utils/schema_utils.py
@@ -1,5 +1,5 @@
-import os
 from collections.abc import Iterator
+from pathlib import Path
 
 import jsonasobj2
 from linkml_runtime import SchemaView
@@ -28,8 +28,8 @@ entity_types_by_class = {
 
 def load_schemaview():
     # Get the schema path
-    module_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    schema_path = os.path.join(module_dir, "schema/core.yaml")
+    module_dir = Path(__file__).parent.parent
+    schema_path = module_dir / "schema/core.yaml"
     # Create a schemaview
     return SchemaView(schema_path)
 

--- a/shared/tests/test_entry_sheet_validator.py
+++ b/shared/tests/test_entry_sheet_validator.py
@@ -10,6 +10,7 @@ This script tests the functionality of the entry sheet validator, including:
 
 import json
 import os
+from pathlib import Path
 from unittest.mock import DEFAULT, MagicMock, patch
 
 import gspread
@@ -1065,8 +1066,8 @@ class TestIntegration:
         # Try to load credentials from .env file if not in environment
         if not os.environ.get("GOOGLE_SERVICE_ACCOUNT"):
             # Check if .env file exists
-            env_file = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), ".env")
-            if os.path.exists(env_file):
+            env_file = Path(__file__).parent.parent / ".env"
+            if env_file.exists():
                 try:
                     # Load .env file
                     from dotenv import load_dotenv

--- a/shared/tests/test_validator.py
+++ b/shared/tests/test_validator.py
@@ -21,21 +21,21 @@ VOIBM_JSON_PATH = TEST_DIR / "valid_or_invalid_by_model_dataset.json"
 @pytest.fixture
 def valid_dataset():
     """Fixture to load the valid dataset."""
-    with open(VALID_JSON_PATH) as f:
+    with VALID_JSON_PATH.open() as f:
         return json.load(f)
 
 
 @pytest.fixture
 def invalid_dataset():
     """Fixture to load the invalid dataset."""
-    with open(INVALID_JSON_PATH) as f:
+    with INVALID_JSON_PATH.open() as f:
         return json.load(f)
 
 
 @pytest.fixture
 def voibm_dataset():
     """Fixture to load the valid-or-invalid-by-model dataset."""
-    with open(VOIBM_JSON_PATH) as f:
+    with VOIBM_JSON_PATH.open() as f:
         return json.load(f)
 
 


### PR DESCRIPTION
## What changed

Enables the **`PTH`** (flake8-use-pathlib) Ruff rule family — the final family in the #467 widening — and migrates all **88 flagged sites across 24 files** from `os.path` / `open()` / `os.remove` to `pathlib.Path` equivalents. PTH has **no autofixes** in ruff 0.11.8, so every site was converted by hand.

With this, `ruff.toml`'s `select` is the full agreed shared set: `E/F/I/W/B/C4/PIE/PTH/RET/RUF/SIM/UP`.

Conversions: `os.path.join`→`/`, `dirname`→`.parent`, `basename`→`.name`, `abspath`→(see below), `exists`/`isfile`→`.exists()`/`.is_file()`, `getsize`→`.stat().st_size`, `listdir`/`glob`→`.iterdir()`/`.glob()`, `os.remove`→`.unlink()`, `open(p)`→`Path(p).open()`. 10 now-unused `import os` lines dropped.

## Why

Part of #467 (A6 — widen Ruff toward the shared rule set). PTH was deliberately sequenced **last** because it's a semantic migration, not a syntax swap. **This PR closes #467**: once merged, the full shared set (E/W/F/I/UP/B/SIM/C4/PIE/RET/PTH/RUF) is enforced in CI.

## Assumptions I made

- **`str`-returning public contracts are preserved.** `write.py`'s `generate_output_path`/`resolve_latest` and `convert.py`/`copy_cap.py`'s `output_path`/`temp_path` still return `str` (wrapped `str(Path(...))` at the boundary), because callers and ~280 anndata-tools tests assert on `str` paths. The migration is internal-only for those functions.
- **`resolve_latest` glob rewrite is winner-identical.** `glob.glob(os.path.join(dir, pat))` → `dir.glob(pat)`; `str(max(candidates))` selects the same file because all candidates share one parent directory (lexical order is decided by the timestamp in the basename). `os.path.normpath` was dropped — pathlib already normalizes `./` and `.`; the only divergence is uncollapsed `..`, which real h5ad paths never contain, and no caller compares the returned string. `glob.escape` output is fnmatch-compatible with `Path.glob`.
- **`schema_utils.load_schemaview` uses `Path(__file__).parent.parent`, not `.resolve()`.** `os.path.abspath` does not follow symlinks; `Path.resolve()` does. Since `__file__` is absolute on 3.9+, `.parent.parent` reproduces the old `dirname(dirname(abspath(...)))` behavior exactly without introducing symlink resolution. (Same reasoning applied to the identical spot in `test_entry_sheet_validator.py`.)
- **`os.listdir` → `[p.name for p in ...iterdir()]`** in `test_strip.py` — kept elements as filename `str`s so the `"-edit-" in name` membership check still works (raw `iterdir()` yields `Path`s).
- **Boundaries that want `str` keep `str`.** `Path(local_file).is_file()` in dataset-validator's env-check, but the user-facing error message keeps the raw `local_file` string; temp paths handed to `write_h5ad`/`h5py.File`/`verify_obs_transplant` stay `str`.

## How to verify

Definition of done (from #505 / #467):

- [x] **Add `PTH` to `select` in `ruff.toml`.** → see the one-line `ruff.toml` change.
- [x] **Convert or `# noqa` each site; keep `str` at external boundaries.** → 88 sites converted, **zero `# noqa`** added.
- [x] **`ruff check .` + `format --check .` clean.**
      ```
      uvx ruff@0.11.8 check . && uvx ruff@0.11.8 format --check .
      ```
      → `All checks passed!` / all files formatted.
- [x] **All affected suites + `make typecheck` green.**
      ```
      make typecheck                                              # 0 errors, 4 venvs
      cd shared && uv run pytest tests/ -m "not integration" -q   # 44
      cd packages/hca-anndata-tools && uv run pytest tests/ -q    # 280
      cd packages/hca-schema-validator && uv run pytest tests/ -q # 121
      cd services/dataset-validator && uv run pytest tests/ -q    # 78
      cd services/hca-schema-validator && uv run pytest tests/ -q # 11
      cd packages/hca-anndata-mcp && uv run pytest tests/ -q      # 41
      ```
- [x] **CI `lint` job green.** → the pushed branch runs `ci.yml` (lint + typecheck + test).
- [x] **Closes #467** — full shared rule set now enforced.

**Live runtime check (behavior-preservation on real data, MANUAL_TESTS):** all three reproduce the recorded baseline —
1. Entry-sheet validation on a real Google Sheet → `successful=False`, `error_count=206`, title `Test Copy of AgaceHelmsley_HCA_tier 1_metadata` (exercises the changed `load_schemaview` + `validate_sheet`).
2. h5ad metadata + storage read on a 285M file → `34934×35477`, 39 coverage entries, X csr nnz=`56435142` (exercises the rewritten `resolve_latest` + `storage.py`).
3. HCA schema validation on the same file → `is_valid=False`, 5 errors, 3 warnings (exercises the changed `validator.py`/`labeler.py` opens).

Closes #467
