### PR TITLE
test(entry-sheet): close local-testing gaps for the Lambda secrets extension

### DIFF
--- a/deployment/entry-sheet-validator/README.md
+++ b/deployment/entry-sheet-validator/README.md
@@ -40,26 +40,25 @@ Usage:
 make build-lambda-container
 ```
 
-### `test_lambda_container_locally.sh`
+### Local container smoke test
 
-Tests the Lambda container locally by running it in Docker and invoking it with a test event:
+`make test-lambda-container` (in `services/entry-sheet-validator/`) starts the
+built image in Docker and drives it through the Lambda Runtime Interface
+Emulator with `pytest tests/test_lambda_container_smoke.py`. It loads the
+repo-root `.env` so `GOOGLE_SERVICE_ACCOUNT` is present; with credentials the
+happy-path test asserts a `200` and a boolean `valid`, and without them it
+skips rather than passing on an auth failure.
 
-1. Creates a temporary directory for test files
-2. Generates a test event with a Google Sheet ID
-3. Creates a script to run the Lambda container
-4. Copies these files to the `output` directory
-
-Usage:
+Build the image first (the target refuses to run if it is missing):
 
 ```bash
+make build-lambda-container PROFILE=excira   # produces hca-entry-sheet-validator:latest
 make test-lambda-container
 ```
 
-After running this script, you can test the Lambda function locally with:
-
-```bash
-cd deployment/entry-sheet-validator/output && ./run_lambda.sh
-```
+The real Secrets-Extension → Secrets-Manager credential path is an AWS
+integration that only runs inside the deployed Lambda; verify it post-deploy
+with `make invoke-lambda ENV=dev`, not locally.
 
 ### `test_api_endpoint.sh`
 

--- a/services/entry-sheet-validator/Makefile
+++ b/services/entry-sheet-validator/Makefile
@@ -12,16 +12,24 @@ TAG ?= $(SHA)
 .PHONY: help
 help:
 	@echo "Entry Sheet Validator Service Tasks:"
-	@echo "  test-lambda-container  - Test the Lambda container locally (uses .env for credentials)"
+	@echo "  test-lambda-container  - Test the Lambda container locally (loads root .env for credentials; needs a built image)"
 	@echo "  test-lambda            - Alias for test-lambda-container"
 	@echo "  build-lambda-container - Build the entry sheet validator Lambda container image"
 	@echo "  deploy-lambda-container - Deploy the Lambda container image to AWS"
 
-# Test Lambda function locally
+# Test Lambda function locally.
+# Requires the image (build it first: `make build-lambda-container PROFILE=excira`)
+# and loads the repo-root .env so GOOGLE_SERVICE_ACCOUNT is present for the
+# happy-path assertion (without creds the happy-path test skips).
 .PHONY: test-lambda-container
 test-lambda-container:
+	@docker image inspect hca-entry-sheet-validator:latest >/dev/null 2>&1 || { \
+		echo "Error: image hca-entry-sheet-validator:latest not found."; \
+		echo "Build it first: make build-lambda-container PROFILE=excira"; \
+		exit 1; \
+	}
 	@echo "Running pytest smoke test against Lambda container..."
-	@$(UV) pytest tests/test_lambda_container_smoke.py -v
+	@$(UV) --env-file ../../.env pytest tests/test_lambda_container_smoke.py -v
 
 # Test Lambda function locally
 .PHONY: test-lambda

--- a/services/entry-sheet-validator/tests/test_lambda_container_smoke.py
+++ b/services/entry-sheet-validator/tests/test_lambda_container_smoke.py
@@ -41,53 +41,33 @@ def lambda_container():
 
 
 def test_lambda_container_smoke(lambda_container):
-    """Basic smoke test: POSTs a minimal event to the Lambda container and checks for a valid response."""
+    """Basic smoke: the container boots and returns a well-formed response (a `valid` result or an `error`).
+
+    Deliberately credential-agnostic — this only proves the container serves the endpoint; the credentialed
+    happy path is asserted in test_lambda_happy_path.
+    """
     event = {"sheet_id": "1oPFb6qb0Y2HeoQqjSGRe_TlsZPRLwq-HUlVF0iqtVlY"}
     response = requests.post("http://localhost:9000/2015-03-31/functions/function/invocations", json=event, timeout=10)
     assert response.status_code in (200, 400, 401)
     data = response.json()
-    # Accept both direct and API Gateway-style responses
-    if "body" in data:
-        body_data = json.loads(data["body"])
-        assert "valid" in body_data
-        # Optionally: assert body_data["valid"] is True
-    else:
-        assert "valid" in data
+    # Accept both direct and API Gateway-style (body is a JSON string) responses.
+    body_data = json.loads(data["body"]) if "body" in data else data
+    assert "valid" in body_data or "error" in body_data
 
 
 def test_lambda_happy_path(lambda_container):
-    """Test Lambda container with a valid public sheet_id (happy path)."""
+    """Happy path: with credentials present, a valid public sheet_id must return 200 and a boolean `valid`.
+
+    Without credentials the read cannot authenticate, so the happy path is untestable and the test skips
+    rather than passing on an auth failure (the weakness this replaced).
+    """
+    if not os.environ.get("GOOGLE_SERVICE_ACCOUNT"):
+        pytest.skip("GOOGLE_SERVICE_ACCOUNT not set (load the root .env); happy path needs credentials")
+
     event = {"sheet_id": "1oPFb6qb0Y2HeoQqjSGRe_TlsZPRLwq-HUlVF0iqtVlY"}
     response = requests.post("http://localhost:9000/2015-03-31/functions/function/invocations", json=event, timeout=10)
-    assert response.status_code in (200, 400, 401)
+    assert response.status_code == 200
     data = response.json()
-    # Handle API Gateway-style response
-    if "body" in data:
-        body_data = json.loads(data["body"])
-        assert "valid" in body_data
-        # Optionally: assert body_data["valid"] is True
-    else:
-        assert "valid" in data
-
-    """
-    Smoke test: POST a test event to the running Lambda container via RIE and check the response.
-    Assumes the container is running on localhost:9000.
-    """
-    event = {"queryStringParameters": {"sheet_id": "1Gp2yocEq9OWECfDgCVbExIgzYfM7s6nJV5ftyn-SMXQ"}}
-    try:
-        response = requests.post(
-            "http://localhost:9000/2015-03-31/functions/function/invocations", json=event, timeout=10
-        )
-    except Exception as e:
-        pytest.fail(f"Failed to contact Lambda container: {e}")
-    assert response.status_code in (200, 400, 401)
-    data = response.json()
-    # Handle API Gateway-style response (body is a JSON string)
-    if "body" in data:
-        try:
-            body_data = json.loads(data["body"])
-        except Exception:
-            body_data = {}
-        assert "valid" in body_data or "error" in body_data
-    else:
-        assert "valid" in data or "error" in data
+    # Handle both direct and API Gateway-style (body is a JSON string) responses.
+    body_data = json.loads(data["body"]) if "body" in data else data
+    assert isinstance(body_data.get("valid"), bool)

--- a/shared/tests/test_entry_sheet_validator.py
+++ b/shared/tests/test_entry_sheet_validator.py
@@ -468,6 +468,102 @@ class TestReadSheetWithServiceAccount:
             os.environ.clear()
             os.environ.update(original_env)
 
+    # Valid service-account JSON used as the extension's SecretString payload.
+    _EXTENSION_SECRET_JSON = json.dumps(
+        {
+            "type": "service_account",
+            "project_id": "extension-project",
+            "private_key_id": "ext-key-id",
+            "private_key": (
+                "-----BEGIN PRIVATE KEY-----\nMOCK_PRIVATE_KEY_FOR_TESTING_ONLY\n-----END PRIVATE KEY-----\n"
+            ),
+            "client_email": "extension@extension-project.iam.gserviceaccount.com",
+            "client_id": "987654321",
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://oauth2.googleapis.com/token",
+        }
+    )
+
+    @patch("requests.get")
+    @patch("googleapiclient.discovery.build")
+    @patch("hca_validation.entry_sheet_validator.validate_sheet.create_requests_session")
+    @patch("gspread.authorize")
+    @patch("google.oauth2.service_account.Credentials.from_service_account_info")
+    def test_with_extension_resolved_credentials(
+        self,
+        mock_credentials,
+        mock_authorize,
+        mock_create_requests_session,
+        mock_build,
+        mock_requests_get,
+    ):
+        """In a Lambda env, credentials come from the Secrets Extension (localhost:2773), not the env fallback.
+
+        This is the only path that exercises the HTTP body of get_secret_from_extension; every other test runs
+        outside Lambda and short-circuits at the `AWS_LAMBDA_FUNCTION_NAME` guard. GOOGLE_SERVICE_ACCOUNT is
+        deliberately set to an unresolved `aws:secretsmanager:` reference so that if the fallback were taken
+        instead of the extension, init_apis would raise `auth_unresolved` and this test would fail.
+        """
+        original_env = os.environ.copy()
+        os.environ["AWS_LAMBDA_FUNCTION_NAME"] = "hca-entry-sheet-validator"
+        os.environ["AWS_SESSION_TOKEN"] = "test-session-token"
+        # Pin ENVIRONMENT: init_apis derives the secret id from it (default "dev"), and the URL
+        # assertion below expects "dev/..."; without pinning, a runner with ENVIRONMENT=prod fails spuriously.
+        os.environ["ENVIRONMENT"] = "dev"
+        os.environ["GOOGLE_SERVICE_ACCOUNT"] = "aws:secretsmanager:dev/hca-atlas-tracker/google-service-account"
+
+        # Mock the extension's HTTP response: raise_for_status is a no-op, json() carries the SecretString.
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"SecretString": self._EXTENSION_SECRET_JSON}
+        mock_requests_get.return_value = mock_response
+
+        # Mock the downstream Google clients so the read proceeds without real network.
+        mock_client = MagicMock()
+        mock_authorize.return_value = mock_client
+        mock_drive = MagicMock()
+        mock_build.return_value = mock_drive
+        self._mock_api_outputs(mock_client, mock_drive)
+
+        try:
+            sheet_read_result = read_sheet_with_service_account(PUBLIC_SHEET_ID)[0]
+            assert isinstance(sheet_read_result, SpreadsheetInfo)
+
+            # The extension was queried with the session token and the environment-derived secret id.
+            mock_requests_get.assert_called_once()
+            call = mock_requests_get.call_args
+            assert "dev/hca-atlas-tracker/google-service-account" in call.args[0]
+            assert call.kwargs["headers"]["X-Aws-Parameters-Secrets-Token"] == "test-session-token"
+
+            # The credentials handed to Google came from the extension's SecretString, not the env fallback.
+            mock_credentials.assert_called_once()
+            assert (
+                mock_credentials.call_args.args[0]["client_email"]
+                == "extension@extension-project.iam.gserviceaccount.com"
+            )
+        finally:
+            os.environ.clear()
+            os.environ.update(original_env)
+
+    @patch("requests.get")
+    def test_with_extension_request_failure(self, mock_requests_get):
+        """If the extension call fails in a Lambda env, get_secret_from_extension returns None and init_apis
+        falls back to GOOGLE_SERVICE_ACCOUNT — here an unresolved reference, yielding `auth_unresolved`."""
+        original_env = os.environ.copy()
+        os.environ["AWS_LAMBDA_FUNCTION_NAME"] = "hca-entry-sheet-validator"
+        os.environ["AWS_SESSION_TOKEN"] = "test-session-token"
+        os.environ["GOOGLE_SERVICE_ACCOUNT"] = "aws:secretsmanager:dev/hca-atlas-tracker/google-service-account"
+
+        mock_requests_get.side_effect = RuntimeError("extension unreachable")
+
+        try:
+            with pytest.raises(SheetReadError) as error_info:
+                read_sheet_with_service_account(PUBLIC_SHEET_ID)
+            assert error_info.value.error_code == "auth_unresolved"
+            mock_requests_get.assert_called_once()
+        finally:
+            os.environ.clear()
+            os.environ.update(original_env)
+
     def test_with_invalid_format_credentials(self):
         """Test reading a sheet with invalid format credentials."""
         # Set credentials to a valid JSON but missing required fields


### PR DESCRIPTION
## What changed

Closes the entry-sheet-validator local-testing gaps surfaced in #507 (three self-contained items).

**1. Unit-test the AWS Secrets-Extension caller** (`shared/tests/test_entry_sheet_validator.py`, +2 tests → 33 total). `get_secret_from_extension` (the `localhost:2773` call) was **dead to the suite**: every test runs outside a Lambda env, so the `if "AWS_LAMBDA_FUNCTION_NAME" not in os.environ: return None` guard short-circuits before the HTTP call. The new tests set the Lambda env and mock `requests.get`:
- `test_with_extension_resolved_credentials` — extension returns a valid `SecretString`; asserts the read proceeds **and** the credentials handed to Google came from the extension, not the env fallback (proven by setting `GOOGLE_SERVICE_ACCOUNT` to an unresolved `aws:secretsmanager:` ref — if the fallback were taken, it'd raise `auth_unresolved`). Also checks the request carried the session-token header and the env-derived secret id.
- `test_with_extension_request_failure` — `requests.get` raises → `get_secret_from_extension` returns `None` → fallback to the unresolved ref → `auth_unresolved`. Exercises the `except` handler.

**2. Smoke-test hygiene** (`services/entry-sheet-validator`):
- `Makefile` `test-lambda-container` now runs `uv run --env-file ../../.env pytest …` (its help text always claimed "uses .env" but never loaded it) and guards on a built image with an actionable error.
- `test_lambda_container_smoke.py`: the happy path asserts **`200` + a boolean `valid`** and **skips** when no creds are present (instead of passing on an auth failure via the old `status_code in (200,400,401)`); the basic test stays a credential-agnostic well-formedness check. Removed a dead trailing block that re-requested a private sheet with a mismatched event shape.

**3. Removed the rotted harness.** Deleted the gitignored local scratch (`deployment/entry-sheet-validator/output/run_lambda.sh` + siblings) that shelled to a never-committed `test_extension.py` mock and carried a mangled cred literal, and rewrote the deployment README section that pointed at it to describe the real pytest flow.

## Why

Entry-sheet changes (e.g. `handler.py` edits in #503) were landing with no local or CI coverage of the Lambda's credential handling. The validation *logic* is well covered (31 tests); these items close the holes around the Secrets-Extension caller and the container smoke test, and remove a misleading dead harness.

## Assumptions I made

- **`@patch("requests.get")` is the right seam.** `get_secret_from_extension` does a function-local `import requests`; that rebinds the name to the already-loaded module in `sys.modules`, so patching the module's `get` attribute intercepts the call. The downstream Google clients (`gspread.authorize`, `create_requests_session`, `build`, `Credentials.from_service_account_info`) are mocked, so the extension call is the only `requests.get` in the path (`assert_called_once()` holds).
- **`ENVIRONMENT` is pinned in the asserting test.** `init_apis` derives the secret id from `ENVIRONMENT` (default `"dev"`); the test sets it explicitly so the URL assertion doesn't depend on ambient env. The broader sweep of the class's manual env save/restore to `monkeypatch` is tracked separately as #510 (low priority).
- **The happy-path smoke test skips without creds** because a real `200` requires real Google auth — skipping is honest, versus the old assertion that passed on auth failure. The extension code path itself is now covered by the unit tests, so nothing is lost.
- **`make test-lambda-container` now requires a local root `.env` and a built image.** `uv run --env-file` fails if `.env` is absent and the guard fails if the image is missing — both are correct for a local dev/integration target, and both print an actionable message.
- **Item 3 produced no code deletion in the diff**: `deployment/entry-sheet-validator/output/` is gitignored, so `run_lambda.sh` was untracked; it's deleted from the working tree and the committable part is the README fix.

## How to verify

Definition of done (from #507):

- [x] **Unit-test `get_secret_from_extension` (happy + failure).**
  ```
  cd shared && uv run pytest tests/test_entry_sheet_validator.py -k extension -v   # 2 passed
  cd shared && uv run pytest tests/test_entry_sheet_validator.py -q                # 33 passed
  ```
  No Docker, no AWS, no extension binary — CI runs these on every PR.
- [x] **Smoke-test loads `.env` + strict happy-path assertion + build prerequisite.** Inspect `services/entry-sheet-validator/Makefile` (`--env-file ../../.env`, `docker image inspect` guard, truthful help) and `tests/test_lambda_container_smoke.py` (skip-without-creds, `== 200` + boolean `valid`, dead block removed). To run it (needs Docker + creds):
  ```
  cd services/entry-sheet-validator
  make build-lambda-container PROFILE=excira
  make test-lambda-container          # loads root .env → happy path asserts 200 + valid
  ```
  Not run in CI (needs Docker + the GOOGLE_SERVICE_ACCOUNT secret) — out of scope per the issue.
- [x] **Rotted harness removed.** `deployment/entry-sheet-validator/output/run_lambda.sh` is gone locally; the README no longer references it and describes the real flow + post-deploy `invoke-lambda` verification.

Closes #507
