### PR TITLE
docs: fix and complete the how-to-run-tests documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Note: `hca-anndata-tools` doesn't declare pyright as a dev dep — its files are
 make typecheck
 ```
 
-Pre-commit hook runs it on `git commit`. One-time setup: `pip install pre-commit && pre-commit install`.
+A pre-commit hook can run this (plus `ruff --fix` and formatting) on `git commit`, but it is opt-in — it does nothing until you install it: `pip install pre-commit && pre-commit install`.
 
 For Pylance to match in-editor, open the repo via `hca-validation-tools.code-workspace` (File → Open Workspace from File). Each package/service becomes its own root with its own uv `.venv/`, so imports resolve correctly per folder.
 

--- a/README.md
+++ b/README.md
@@ -120,8 +120,14 @@ uvx ruff@0.11.8 format --check . # formatting
 make typecheck                   # pyright
 ```
 
-A pre-commit hook runs these on `git commit` (one-time setup:
-`pip install pre-commit && pre-commit install`).
+Optionally install the pre-commit hook so equivalent checks run automatically on
+`git commit` — it applies `ruff --fix` and formatting and runs `make typecheck`
+(the auto-fixing counterparts of the read-only checks above). It is opt-in and
+does nothing until installed:
+
+```bash
+pip install pre-commit && pre-commit install
+```
 
 ### Deployment Commands
 

--- a/README.md
+++ b/README.md
@@ -10,33 +10,32 @@ This repository contains validation tools organized in a multi-service architect
 - **Data Dictionary Generator**: Creates data dictionaries from LinkML schema definitions
 - **Schema Validation**: Validates LinkML schemas and generates Python models
 
-## Project Structure
+## Repository Layout
 
-```
-hca-validation-tools/
-├── shared/                     # Shared library and schemas
-│   ├── src/hca_validation/     # Core validation package
-│   │   ├── entry_sheet_validator/  # Google Sheets validation
-│   │   ├── data_dictionary/        # Dictionary generation
-│   │   ├── validator/              # LinkML validation
-│   │   └── schemas/                # LinkML schema definitions
-│   └── tests/                  # Shared library tests
-├── services/                   # Microservices
-│   └── entry-sheet-validator/  # Lambda service for sheet validation
-│       ├── src/                # Lambda function code
-│       └── tests/              # Service-specific tests
-├── deployment/                 # AWS deployment configurations
-├── data_dictionaries/          # Generated data dictionaries
-└── docs/                      # Documentation
-```
+Top-level directories and their roles (each package/service has its own
+`pyproject.toml`, uv environment, and `tests/`):
+
+- **`shared/`** — core validation library (LinkML schemas, generated Pydantic models, entry-sheet logic) that the services depend on via a uv path dependency
+- **`packages/`** — publishable PyPI packages: `hca-schema-validator`, `hca-anndata-tools`, `hca-anndata-mcp`
+- **`services/`** — deployable services: `entry-sheet-validator` (Lambda), `dataset-validator` (Batch), and the `cellxgene-validator` / `hca-schema-validator` wrappers
+- **`deployment/`** — Dockerfiles and per-service deployment configs
+- **`data_dictionaries/`** — generated data dictionaries
 
 ## Quick Start
 
-This project uses uv for dependency management and Make for build automation:
+This project uses uv for dependency management and Make for build automation.
+
+Install uv first (it also provisions the required Python version, so you don't
+need to install Python yourself) — see the
+[uv install docs](https://docs.astral.sh/uv/getting-started/installation/):
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
 
 ```bash
 # Clone the repository
-git clone https://github.com/your-org/hca-validation-tools.git
+git clone https://github.com/clevercanary/hca-validation-tools.git
 cd hca-validation-tools
 
 # Build everything (schemas, data dictionaries, Docker images, run tests)
@@ -53,27 +52,88 @@ uv sync
 
 ### Build Commands
 ```bash
-make build-all          # Build everything and run tests
-make generate-schemas   # Generate Python models from LinkML schemas
-make validate-schema    # Validate all LinkML schema files
-make generate-data-dictionary  # Generate core data dictionary
-make build-lambda-container    # Build Lambda Docker container
+make build-all                 # Build shared lib + containers and run tests (needs Docker + AWS)
+make build-lambda-container    # Build the entry-sheet Lambda Docker image (needs PROFILE=excira)
+```
+
+Schema and data-dictionary generation live in the shared library's Makefile:
+
+```bash
+cd shared
+make gen-schema                # Generate Pydantic models from LinkML schemas
+make validate-schema           # Validate all LinkML schema files
+make generate-data-dictionary  # Generate the core data dictionary
+make build                     # All of the above in one step
 ```
 
 ### Test Commands
+
+Each package and service has its own uv environment, so tests are run per
+project with `uv run pytest`. Each line below is self-contained (run from the
+repo root):
+
 ```bash
-make test-all          # Run all tests
-make test-shared       # Run shared library tests only
-make test-integration  # Run integration tests only (requires credentials)
-make test-lambda-container     # Test Lambda container locally
+(cd shared                        && uv run pytest tests/ -m "not integration")  # shared library (unit)
+(cd packages/hca-anndata-tools    && uv run pytest tests/)
+(cd packages/hca-anndata-mcp      && uv run pytest tests/)
+(cd packages/hca-schema-validator && uv run pytest tests/)
+(cd services/dataset-validator    && uv run pytest tests/)
+(cd services/cellxgene-validator  && uv run pytest tests/)
+(cd services/hca-schema-validator && uv run pytest tests/)
 ```
 
-### Deployment Commands
+These seven suites are exactly what CI runs on every pull request. Type
+checking runs separately:
+
 ```bash
-make deploy-lambda-dev   # Deploy to development environment
-make deploy-lambda-prod  # Deploy to production environment
-make test-lambda-dev     # Test deployed Lambda in development
+make typecheck   # pyright across every typed project (one pass per venv)
 ```
+
+Integration tests (which hit live Google Sheets and need credentials in `.env`)
+are marked `integration` and skipped by default. Run only them with:
+
+```bash
+cd shared && uv run pytest tests/ -m integration
+```
+
+`make test-all` runs the shared and service suites in one go, **but note two
+gaps**: it invokes the entry-sheet container smoke test, so it **requires Docker
+and a built image** (and fails without them), and it **does not cover the
+`packages/` suites** — run those directly with the commands above.
+
+The **entry-sheet-validator container smoke test** is not part of the commands
+above; it boots the built Lambda image in Docker and needs credentials. See
+[deployment/entry-sheet-validator/README.md](deployment/entry-sheet-validator/README.md).
+
+### Checks (mirror CI)
+
+Before pushing, run the same lint, format, and type checks CI gates on. Ruff is
+pinned to match CI exactly:
+
+```bash
+uvx ruff@0.11.8 check .          # lint
+uvx ruff@0.11.8 format --check . # formatting
+make typecheck                   # pyright
+```
+
+A pre-commit hook runs these on `git commit` (one-time setup:
+`pip install pre-commit && pre-commit install`).
+
+### Deployment Commands
+
+The environment is selected with `ENV=dev` (default) or `ENV=prod`:
+
+```bash
+make deploy-lambda-container ENV=dev    # Deploy the entry-sheet Lambda (dev)
+make deploy-lambda-container ENV=prod   # Deploy the entry-sheet Lambda (prod)
+make invoke-lambda SHEET_ID=<id>        # Invoke the deployed Lambda
+
+# Dataset-validator Batch service
+make batch-publish-container ENV=dev    # Build, push to ECR, register the job def
+make batch-submit-job ENV=dev           # Submit a Batch validation job
+```
+
+See [CLAUDE.md](CLAUDE.md) for the full deployment and release workflow.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ git clone https://github.com/clevercanary/hca-validation-tools.git
 cd hca-validation-tools
 
 # Build everything (schemas, data dictionaries, Docker images, run tests)
-# Note: build-all builds the Lambda container, so it needs Docker running and
-# AWS credentials (it invokes the entry-sheet build with PROFILE=excira).
+# Note: build-all builds the Lambda container, so it needs Docker running and an
+# AWS profile with access to the Lambda Extension layer (passed as PROFILE=...).
 make build-all
 
 # Or just install the shared library (no Docker/AWS needed)
@@ -53,7 +53,7 @@ uv sync
 ### Build Commands
 ```bash
 make build-all                 # Build shared lib + containers and run tests (needs Docker + AWS)
-make build-lambda-container    # Build the entry-sheet Lambda Docker image (needs PROFILE=excira)
+make build-lambda-container PROFILE=<profile>  # Build the entry-sheet Lambda image (AWS profile with Extension-layer access)
 ```
 
 Schema and data-dictionary generation live in the shared library's Makefile:
@@ -90,7 +90,9 @@ make typecheck   # pyright across every typed project (one pass per venv)
 ```
 
 Integration tests (which hit live Google Sheets and need credentials in `.env`)
-are marked `integration` and skipped by default. Run only them with:
+are marked `integration`. The unit-test command above excludes them with
+`-m "not integration"`; a bare `pytest tests/` would run them. Run only the
+integration tests with:
 
 ```bash
 cd shared && uv run pytest tests/ -m integration
@@ -102,7 +104,9 @@ and a built image** (and fails without them), and it **does not cover the
 `packages/` suites** — run those directly with the commands above.
 
 The **entry-sheet-validator container smoke test** is not part of the commands
-above; it boots the built Lambda image in Docker and needs credentials. See
+above; it boots the built Lambda image in Docker (so it needs a built image),
+and its happy-path assertion additionally needs `GOOGLE_SERVICE_ACCOUNT` in the
+environment — without it that assertion skips. See
 [deployment/entry-sheet-validator/README.md](deployment/entry-sheet-validator/README.md).
 
 ### Checks (mirror CI)


### PR DESCRIPTION
## What changed

`README.md` only. Fixes and completes the human-facing "how to run tests" documentation, which had drifted since the Poetry→uv migration and the per-project split.

- **Test Commands** — replaced the stale block (which named the non-existent `make test-shared` / `make test-integration`) with the **seven per-project `uv run pytest` commands that mirror CI's matrix exactly**, each in a self-contained subshell so the lines are copy-paste-safe. Added the `integration`-marker split, `make typecheck`, and a pointer to the entry-sheet container smoke test. Documented `make test-all`'s two real gaps: it needs Docker + a built image, and it skips the `packages/` suites.
- **Checks (mirror CI)** — new section with the exact local gate commands (`uvx ruff@0.11.8 check .`, `format --check .`, `make typecheck`) and the pre-commit setup line.
- **Quick Start** — added the uv install prerequisite (noting uv provisions Python) and fixed the placeholder clone URL (`your-org` → `clevercanary`).
- **Build / Deployment sections** (scope expansion, see below) — corrected dead targets: schema/dict generation lives in `shared/`'s Makefile (`make gen-schema`, etc.); deploy is `make deploy-lambda-container ENV=dev|prod`; documented the Batch targets.
- **Repository Layout** — replaced the stale ASCII file-tree (missing `packages/` and three services) with a stable top-level role list.

## Why

A newcomer asked "is there a README that explains how to run these (and all) tests?" — and the honest answer was no: the documented targets didn't exist, and the `packages/` suites, typecheck, and local lint were undocumented. The only accurate reference lived in `CLAUDE.md` (agent instructions), which a human wouldn't find.

## Assumptions I made

- **Every command was verified against reality**, not copied from the old README: all 12 named make targets exist (checked against the root and `shared/` Makefiles), all 7 test-project directories have `tests/`, and the 7 test commands match `ci.yml`'s matrix (including `shared`'s `-m "not integration"`). Ruff is pinned to `0.11.8` to match the CI lint job.
- **Scope was expanded with approval** beyond #513's literal DoD (test commands + setup nits) to also fix the Build and Deployment sections, because they carried the same dead-target rot and fixing only the test section would leave the file half-honest.
- **`make test-all`'s behavioral gaps are documented, not fixed.** Whether to change `test-all` to cover `packages/` and drop the hard Docker dependency is DoD item 3, explicitly split out as its own (optional, behavioral) follow-up.
- The stale **Project Structure tree was replaced rather than updated** — a file-tree is the highest-drift, lowest-value kind of doc; a top-level role list keeps the orientation value without going stale on every file move.

## How to verify

Definition of done (from #513):

- [x] **README Test Commands accurate** — no dead targets; per-project `uv run pytest` for `shared/`, the three `packages/`, and the services; `make typecheck` documented; the `-m "not integration"` / `-m integration` split noted; container smoke test points at `deployment/entry-sheet-validator/README.md`.
- [x] **`make test-all`'s real coverage noted** (needs Docker; skips `packages/`).
- [x] **Quick Start** gains the uv prerequisite and the corrected clone URL.
- [x] **Local lint/format/typecheck commands** documented, mirroring the CI gates.

To check: read the rendered README and run any command — e.g.
```
(cd shared && uv run pytest tests/ -m "not integration")
uvx ruff@0.11.8 check . && uvx ruff@0.11.8 format --check .
make typecheck
```
Each should run as written. Cross-check the target names against the root `Makefile`, `shared/Makefile`, and `.github/workflows/ci.yml`.

Docs-only change: no code, tests, or types affected (diff touches only `README.md`).

Closes #513
