### PR TITLE
build: source the entry-sheet Lambda build profile from .env.make

### DIFF
--- a/.env.make.example
+++ b/.env.make.example
@@ -1,6 +1,13 @@
 # Example environment overrides for Makefile
 # Copy this file to `.env.make` and replace the placeholder values.
 
+# ------- Lambda image build -------
+# AWS CLI profile used to build the Lambda image (needs access to fetch the
+# AWS-Parameters-and-Secrets Lambda Extension layer). Env-agnostic — the build
+# produces one image — so it's a single profile. Used by
+# `make build-lambda-container` / `make build-all`.
+LAMBDA_PROFILE=your-aws-profile
+
 # ------- Development environment -------
 DEV_AWS_ACCOUNT_ID=000000000000
 DEV_REPO_NAME=your-dev-ecr-repo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,8 +60,9 @@ For Pylance to match in-editor, open the repo via `hca-validation-tools.code-wor
 
 ```bash
 # Lambda (Entry Sheet Validator) - ENV=dev by default, use ENV=prod for production
-# PROFILE=excira is required for build (fetches AWS Lambda Extension layer via AWS API)
-make build-lambda-container PROFILE=excira
+# The build needs an AWS profile that can fetch the Lambda Extension layer; it
+# comes from LAMBDA_PROFILE in .env.make (override with PROFILE=... if needed).
+make build-lambda-container
 make deploy-lambda-container ENV=dev
 make invoke-lambda SHEET_ID=<google-sheet-id>
 

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,12 @@ AWS_REGION       ?= $(DEV_AWS_REGION)
 LAMBDA_ROLE      ?= $(DEV_LAMBDA_ROLE)
 endif
 
+# AWS CLI profile for the entry-sheet Lambda build (fetches the Extension
+# layer). The build is env-agnostic — it produces one image — so this is a
+# single profile, not dev/prod. From LAMBDA_PROFILE in .env.make; override
+# with PROFILE=... .
+PROFILE ?= $(LAMBDA_PROFILE)
+
 # ----- Batch environment settings (mapped from .env.make) -----
 ifeq ($(ENV),prod)
 BATCH_PROFILE        ?= $(PROD_BATCH_PROFILE)
@@ -188,7 +194,7 @@ invoke-lambda:
 build-all:
 	@echo "Running full multi-service build & test chain..."
 	@$(MAKE) -C shared build
-	@$(MAKE) -C services/entry-sheet-validator build-lambda-container PROFILE=excira
+	@$(MAKE) -C services/entry-sheet-validator build-lambda-container PROFILE=$(PROFILE)
 	@$(MAKE) -C services/dataset-validator build
 	@$(MAKE) test-all
 	@echo "✓ All services built and tested successfully"

--- a/README.md
+++ b/README.md
@@ -148,8 +148,23 @@ See [CLAUDE.md](CLAUDE.md) for the full deployment and release workflow.
 ## Configuration
 
 ### Environment Files
+Both are **gitignored** — keep credentials and machine-specific values out of the repo.
+
 - **`.env`** - Contains `GOOGLE_SERVICE_ACCOUNT` credentials for Google Sheets API
-- **`.env.make`** - Contains AWS deployment variables (account IDs, regions, etc.)
+- **`.env.make`** - AWS deployment variables (account IDs, regions, roles) and the
+  AWS CLI profile used to build the Lambda image
+
+One-time AWS setup — copy the committed template and fill in your values:
+
+```bash
+cp .env.make.example .env.make
+# then edit .env.make: set LAMBDA_PROFILE to an AWS CLI profile that can fetch
+# the Lambda Extension layer (and fill in the account/region/role vars for deploy)
+```
+
+With `.env.make` in place, `make build-lambda-container` and `make build-all`
+pick up the profile automatically — no `PROFILE=` argument needed (pass
+`PROFILE=<name>` only to override).
 
 ### Google Sheets Integration
 To run integration tests or use the validator with private sheets:

--- a/deployment/entry-sheet-validator/README.md
+++ b/deployment/entry-sheet-validator/README.md
@@ -52,7 +52,7 @@ skips rather than passing on an auth failure.
 Build the image first (the target refuses to run if it is missing):
 
 ```bash
-make build-lambda-container PROFILE=excira   # produces hca-entry-sheet-validator:latest
+make build-lambda-container   # produces hca-entry-sheet-validator:latest (AWS profile from .env.make)
 make test-lambda-container
 ```
 

--- a/deployment/entry-sheet-validator/README.md
+++ b/deployment/entry-sheet-validator/README.md
@@ -96,9 +96,17 @@ This generates test files and provides instructions for testing the Lambda conta
 
 ### Deploying to AWS
 
-AWS_PROFILE=excira make build-lambda-container
-AWS_PROFILE=excira make deploy-lambda-container ENV=dev
-AWS_PROFILE=hca-prod-lambda-deploy make deploy-lambda-container ENV=prod
+The build profile comes from `LAMBDA_PROFILE` in `.env.make` (see the repo-root
+README), so the build needs no profile on the command line. The **deploy**
+profile is still supplied via the `AWS_PROFILE` env var — dev and prod use
+different profiles. Sourcing the deploy profile from `.env.make` too is tracked
+in #517.
+
+```bash
+make build-lambda-container                                       # profile from .env.make
+AWS_PROFILE=<dev-profile>  make deploy-lambda-container ENV=dev
+AWS_PROFILE=<prod-profile> make deploy-lambda-container ENV=prod
+```
 
 ## API Request Format
 

--- a/services/entry-sheet-validator/Makefile
+++ b/services/entry-sheet-validator/Makefile
@@ -25,7 +25,7 @@ help:
 test-lambda-container:
 	@docker image inspect hca-entry-sheet-validator:latest >/dev/null 2>&1 || { \
 		echo "Error: image hca-entry-sheet-validator:latest not found."; \
-		echo "Build it first: make build-lambda-container PROFILE=excira"; \
+		echo "Build it first: make build-lambda-container (from repo root)"; \
 		exit 1; \
 	}
 	@echo "Running pytest smoke test against Lambda container..."

--- a/services/entry-sheet-validator/Makefile
+++ b/services/entry-sheet-validator/Makefile
@@ -18,7 +18,7 @@ help:
 	@echo "  deploy-lambda-container - Deploy the Lambda container image to AWS"
 
 # Test Lambda function locally.
-# Requires the image (build it first: `make build-lambda-container PROFILE=excira`)
+# Requires the image (build it first: `make build-lambda-container` from repo root)
 # and loads the repo-root .env so GOOGLE_SERVICE_ACCOUNT is present for the
 # happy-path assertion (without creds the happy-path test skips).
 .PHONY: test-lambda-container


### PR DESCRIPTION
## What changed

The entry-sheet **Lambda build** now reads its AWS profile from the gitignored `.env.make`, the way the **Batch** build already does — instead of requiring `PROFILE=` on the command line and hardcoding a specific profile name.

- **`Makefile`** — new `PROFILE ?= $(LAMBDA_PROFILE)` (sourced from `.env.make`); removed the hardcoded `PROFILE=excira` from `build-all`. CLI `PROFILE=` still overrides.
- **`.env.make.example`** — added a single `LAMBDA_PROFILE` in a "Lambda image build" section.
- **`README.md`** — one-time `.env.make` setup instructions; notes both env files are gitignored and the build picks up the profile with no `PROFILE=` argument.
- **`CLAUDE.md`** — dropped the hardcoded `excira`; the build profile comes from `LAMBDA_PROFILE`.
- **`deployment/entry-sheet-validator/README.md` + `services/entry-sheet-validator/Makefile`** — the entry-sheet build hints/instructions no longer name a profile.

## Why

The hardcoded profile name doesn't exist on other machines, shouldn't be committed, and made the Lambda build inconsistent with the Batch build (which already sources `BATCH_PROFILE` from `.env.make`). This closes the source of the profile-name leak (the README was made generic in #514; this removes it from the Makefile/build path entirely).

## Assumptions I made

- **Single `LAMBDA_PROFILE`, not `DEV_`/`PROD_`.** The build produces one image and only needs a profile that can fetch the AWS Parameters & Secrets Extension layer — it's env-agnostic. dev/prod only matters at *deploy* (a separate mechanism, tracked in #517). So I deliberately did **not** mirror the dev/prod split the deploy vars use.
- **Make precedence:** `PROFILE ?= $(LAMBDA_PROFILE)` lets a command-line `PROFILE=` override (command-line vars beat `?=`), and a fresh clone with no `.env.make` leaves `PROFILE` empty → the build script passes no `--profile` → the AWS default credential chain is used (graceful, same as the old no-arg behavior).
- **Batch is untouched.** The Batch orchestrator targets explicitly pass `PROFILE=$(BATCH_PROFILE)` to the dataset-validator sub-make, so the new root-level `PROFILE` default does not leak into Batch.
- **Deploy is out of scope.** The Lambda *deploy* path still uses an inline `AWS_PROFILE` env var and hardcodes profile names in the deploy docs + the dataset-validator Batch example strings — a distinct mechanism, filed as **#517**.

## How to verify

Definition of done (from #516):

- [x] **`make build-lambda-container` / `make build-all` build using the `.env.make` profile, no `PROFILE=` on the CLI, no profile name committed.**
  - Set `LAMBDA_PROFILE=<your-profile>` in `.env.make` (copy from `.env.make.example`), then:
    ```
    make build-lambda-container        # builds hca-entry-sheet-validator:latest, no PROFILE= needed
    make -n build-all | grep PROFILE   # shows PROFILE=<your-profile>, not a hardcoded name
    ```
  - `git grep excira` shows no match in the entry-sheet **build** path (Makefile/build docs).
  - *Verified in this session:* `make build-lambda-container` (no `PROFILE=`) built the image, fetching the Extension layer via the profile resolved from `.env.make`.
- [x] **`.env.make.example` documents the Lambda profile var; README/CLAUDE.md explain the one-time `.env.make` setup.**
- [x] **Batch flow unchanged** — `make -n batch-publish-container` still forwards `PROFILE=$(BATCH_PROFILE)`.

Closes #516
