### PR TITLE
feat(anndata-tools): add drop_obs_columns for removing obs columns by name

### DIFF
--- a/packages/hca-anndata-mcp/src/hca_anndata_mcp/server.py
+++ b/packages/hca-anndata-mcp/src/hca_anndata_mcp/server.py
@@ -2,6 +2,7 @@
 
 from fastmcp import FastMCP
 
+from hca_anndata_mcp.tools.drop import drop_obs_columns
 from hca_anndata_mcp.tools.label import label_h5ad
 from hca_anndata_mcp.tools.plot import plot_embedding_mcp
 from hca_anndata_mcp.tools.populate import populate_labels
@@ -44,6 +45,11 @@ mcp = FastMCP(
         "the file is already HCA-layout and the SRE columns survived from "
         "upstream; on CellxGENE-layout files convert_cellxgene_to_hca strips "
         "them automatically as a side-effect, "
+        "drop_obs_columns to remove caller-named obs columns — use this for "
+        "producer columns the schema doesn't name, such as ethnicity under a "
+        "non-canonical name (ethnicity_verbatim, race, ...) or derived labels "
+        "under a non-canonical name (cell_type_label, ...); it refuses any "
+        "column the HCA schema names and drops all or nothing, "
         "validate_marker_genes to check CAP marker genes against var, "
         "copy_cap_annotations to copy CAP annotations from a source into an HCA target file, "
         "replace_placeholder_values to replace banned placeholder values with NaN in obs columns, "
@@ -78,6 +84,7 @@ mcp.tool()(list_uns_fields)
 mcp.tool()(set_uns)
 mcp.tool()(convert_cellxgene_to_hca)
 mcp.tool()(strip_forbidden_obs_columns)
+mcp.tool()(drop_obs_columns)
 mcp.tool()(validate_marker_genes)
 mcp.tool()(copy_cap_annotations)
 mcp.tool()(replace_placeholder_values)

--- a/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/drop.py
+++ b/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/drop.py
@@ -1,0 +1,12 @@
+"""MCP wrapper for hca_anndata_tools.drop_obs_columns.
+
+Thin re-export to keep parity with the other MCP tools (each gets its
+own wrapper file). The underlying function in hca-anndata-tools already
+returns a dict-shaped result; this module exists so future wrapper-only
+behavior (e.g. path normalization, MCP-side logging) lands here without
+touching the tools layer.
+"""
+
+from hca_anndata_tools import drop_obs_columns
+
+__all__ = ["drop_obs_columns"]

--- a/packages/hca-anndata-mcp/tests/test_drop.py
+++ b/packages/hca-anndata-mcp/tests/test_drop.py
@@ -1,0 +1,47 @@
+"""Unit tests for the drop_obs_columns MCP wrapper."""
+
+import anndata as ad
+import pandas as pd
+
+from hca_anndata_mcp.tools.drop import drop_obs_columns
+
+
+def test_drop_missing_file():
+    result = drop_obs_columns("/nonexistent/file.h5ad", ["race"])
+    assert "error" in result
+    assert "File not found" in result["error"]
+
+
+def test_drop_removes_producer_column(tmp_path):
+    """Happy path through the wrapper: a column the HCA schema does not name
+    drops cleanly."""
+    from hca_anndata_tools.testing import create_sample_h5ad
+
+    path = tmp_path / "test.h5ad"
+    create_sample_h5ad(path)
+    adata = ad.read_h5ad(path)
+    adata.obs["ethnicity_verbatim"] = pd.Categorical(["unknown"] * adata.n_obs)
+    adata.write_h5ad(path)
+
+    result = drop_obs_columns(str(path), ["ethnicity_verbatim"])
+
+    assert "error" not in result
+    assert result["obs_columns_dropped"] == ["ethnicity_verbatim"]
+    assert "ethnicity_verbatim" not in ad.read_h5ad(result["output_path"]).obs.columns
+
+
+def test_drop_refuses_schema_column_through_wrapper(tmp_path):
+    """The guard must be in force via the wrapper too — it lives in the tools
+    layer, not the MCP layer, so this pins that the wrapper does not bypass it."""
+    from hca_anndata_tools.testing import create_sample_h5ad
+
+    path = tmp_path / "test.h5ad"
+    create_sample_h5ad(path)
+    adata = ad.read_h5ad(path)
+    adata.obs["donor_id"] = pd.Categorical(["D1"] * adata.n_obs)
+    adata.write_h5ad(path)
+
+    result = drop_obs_columns(str(path), ["donor_id"])
+
+    assert "error" in result
+    assert "donor_id" in ad.read_h5ad(path).obs.columns

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/__init__.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/__init__.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
     from .compress import compress_h5ad
     from .convert import convert_cellxgene_to_hca
     from .copy_cap import copy_cap_annotations
+    from .drop import drop_obs_columns
     from .edit import (
         list_uns_fields,
         replace_placeholder_values,
@@ -60,6 +61,7 @@ _LAZY_IMPORTS = {
     "compress_h5ad": ".compress",
     "normalize_raw": ".normalize",
     "strip_forbidden_obs_columns": ".strip",
+    "drop_obs_columns": ".drop",
     "check_x_normalization": ".inspect",
     "check_schema_type": ".inspect",
 }

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/drop.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/drop.py
@@ -197,11 +197,31 @@ def drop_obs_columns(path: str, columns: list[str]) -> dict:
     """
     output_path = None
     try:
-        if not columns:
+        # Shape-check the argument before anything reads it. This is an
+        # MCP-exposed tool, so `columns` arrives as decoded JSON and may hold
+        # numbers or nulls, and every check below assumes strings. Without
+        # this, a non-string entry raises inside `"/" in c` and surfaces as
+        # "argument of type 'int' is not iterable" — safe, since nothing has
+        # been written yet, but it breaks the promise that one error reports
+        # every problem.
+        if isinstance(columns, str):
+            return {
+                "error": (
+                    "columns must be a list of column names, not a single string — "
+                    "a bare string iterates as individual characters."
+                )
+            }
+        try:
+            # Dedupe, preserving caller order. A repeated name is harmless, so
+            # it isn't worth reporting as a problem.
+            requested = list(dict.fromkeys(columns))
+        except TypeError:
+            return {"error": "columns must be a list of column names."}
+        if not requested:
             return {"error": "No columns given — name the obs columns to drop."}
-        # Dedupe, preserving caller order. A repeated name is harmless, so it
-        # isn't worth reporting as a problem.
-        requested = list(dict.fromkeys(columns))
+        non_str = [c for c in requested if not isinstance(c, str)]
+        if non_str:
+            return {"error": f"columns must contain only strings; got: {non_str}"}
 
         path = resolve_latest(path)
         if not Path(path).is_file():

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/drop.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/drop.py
@@ -143,7 +143,7 @@ def _validate_request(obs: h5py.Group, uns: h5py.Group | None, columns: list[str
     return problems
 
 
-def drop_obs_columns(path: str, columns: list[str]) -> dict:
+def drop_obs_columns(path: str, columns: list[str] | tuple[str, ...]) -> dict:
     """Drop the named obs columns from an h5ad file.
 
     All-or-nothing: the whole request is validated before anything is written,
@@ -188,7 +188,11 @@ def drop_obs_columns(path: str, columns: list[str]) -> dict:
             ``strip_forbidden_obs_columns``, this makes no CellxGENE-layout
             refusal, because removing an arbitrary column is layout-agnostic.
         columns: Obs column names to drop. Duplicates are ignored; order is
-            preserved in the result.
+            preserved in the result. Annotated as list-or-tuple rather than
+            ``Sequence[str]`` deliberately: ``str`` satisfies ``Sequence[str]``,
+            so the looser annotation would stop a type checker from catching
+            ``columns="one_name"`` — a slip the runtime has to guard anyway
+            because MCP callers are not type-checked at all.
 
     Returns:
         Dict with ``output_path``, ``obs_columns_dropped`` and

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/drop.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/drop.py
@@ -1,0 +1,277 @@
+"""Drop caller-named obs columns from an h5ad file.
+
+The general-purpose sibling of :mod:`hca_anndata_tools.strip`. That module
+encodes *policy* — the two HCA-forbidden privacy column names are baked in and
+it takes no arguments — and ``convert_cellxgene_to_hca`` imports its constant
+for exactly that purpose. This module holds no policy at all: the caller names
+the columns, and the only opinion it enforces is refusing to remove something
+the HCA schema names (see :func:`drop_obs_columns`).
+
+That split exists because producers ship the same information under names no
+fixed list can anticipate: the breast-v1 source datasets carry ethnicity as
+``ethnicity_verbatim``, ``ethnicity_grouped``, ``reported_ethnicity``, ``race``
+and ``self_reported_ethnicity_label`` across seven files, and carry derived
+ontology labels as ``cell_type_label``, ``assay_label`` and friends that differ
+per dataset.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import shutil
+from pathlib import Path
+
+import h5py
+
+from ._io import (
+    _decode_bytes,
+    read_edit_log_h5py,
+    update_column_order,
+    write_edit_log_h5py,
+)
+from .schema.helpers import obs_column_tiers
+from .write import (
+    build_edit_log,
+    cleanup_previous_version,
+    generate_output_path,
+    make_edit_entry,
+    resolve_latest,
+)
+
+
+def _read_batch_condition(uns: h5py.Group | None) -> list[str]:
+    """Read ``uns['batch_condition']`` as a list of obs column names.
+
+    The HCA schema types it ``element_type: match_obs_columns``, so every entry
+    must name an obs column. Returns an empty list when absent or unreadable —
+    an unreadable value is the validator's problem to report, not a reason for
+    this tool to refuse a drop.
+    """
+    if uns is None or "batch_condition" not in uns:
+        return []
+    try:
+        raw = uns["batch_condition"][()]  # pyright: ignore[reportIndexIssue]
+    except (OSError, TypeError, ValueError):
+        return []
+    if isinstance(raw, bytes | str):
+        return [_decode_bytes(raw)]
+    try:
+        return [_decode_bytes(v) for v in raw]
+    except TypeError:
+        return []
+
+
+def _validate_request(obs: h5py.Group, uns: h5py.Group | None, columns: list[str]) -> list[str]:
+    """Collect every reason the requested columns cannot be dropped.
+
+    Returns a list of human-readable problems, empty when the request is good.
+    All checks run to completion rather than short-circuiting: a caller who
+    mistyped two names should learn about both in one round trip.
+    """
+    problems: list[str] = []
+    required_named, optional_named = obs_column_tiers()
+
+    # h5py resolves a name containing '/' as an HDF5 link path, not as a dict
+    # key: a leading slash resolves from the file root, and inner slashes
+    # traverse subgroups. So `"/X" in obs` is True whenever the file has a root
+    # X, and `del obs["/X"]` unlinks the expression matrix. Rejecting these
+    # up front is what keeps every check below — which compares plain strings —
+    # from disagreeing with what the delete would actually do.
+    malformed = [c for c in columns if "/" in c or not c.strip()]
+    if malformed:
+        problems.append(f"not valid obs column names (a column name cannot contain '/' or be blank): {malformed}")
+
+    # The index is a dataset in the obs group like any column, so a caller can
+    # name it. Deleting it destroys the file's cell identities.
+    index_name = _decode_bytes(obs.attrs.get("_index", "_index"))
+    if index_name in columns:
+        problems.append(f"'{index_name}' is the obs index, not a column — deleting it would destroy the file")
+
+    required = sorted(c for c in columns if c in required_named)
+    if required:
+        problems.append(f"HCA schema-required obs columns cannot be dropped: {required}")
+
+    optional = sorted(c for c in columns if c in optional_named)
+    if optional:
+        problems.append(
+            f"schema-described obs columns cannot be dropped: {optional} — "
+            f"these are optional per the HCA schema but hold producer data that "
+            f"cannot be recovered once removed"
+        )
+
+    # Columns that something in uns *references*. A dropped column leaves the
+    # reference dangling and turns a valid file invalid, so these are refused
+    # rather than repaired — repairing either of them would mean rewriting a
+    # claim the file makes, which is a curation decision and not this tool's
+    # to take. Contrast `uns['<col>_colors']`, which the column *owns* and which
+    # is therefore deleted alongside it (see :func:`drop_obs_columns`).
+    batched = sorted(set(columns) & set(_read_batch_condition(uns)))
+    if batched:
+        problems.append(
+            f"referenced by uns['batch_condition']: {batched} — that list declares "
+            f"which columns define the experiment's batches, so dropping one changes "
+            f"the declaration. Edit uns['batch_condition'] first if that is intended"
+        )
+
+    # CAP annotation sets declare themselves in uns['cap_metadata'] and require
+    # obs columns named '<set>--<suffix>'. Those names are not schema-named, so
+    # nothing above catches them, and dropping one leaves the declared set
+    # broken. Keyed on the '--' convention rather than on parsing cap_metadata,
+    # which may be stored as either a group or a JSON string: over-refusing a
+    # '--' name in a CAP file is the safe direction, and no column this tool
+    # targets uses that separator.
+    if uns is not None and "cap_metadata" in uns:
+        cap_cols = sorted(c for c in columns if "--" in c)
+        if cap_cols:
+            problems.append(
+                f"look like CAP annotation-set columns: {cap_cols} — the set is declared "
+                f"in uns['cap_metadata'], which would still require them. Remove the "
+                f"annotation set instead of its columns"
+            )
+
+    # Membership against the group's direct children, not `c in obs` — the
+    # latter would resolve link paths and so accept names that point outside
+    # obs entirely (see the malformed check above).
+    #
+    # Reported last: a caller reading the error wants the schema verdict on the
+    # names they meant more than the spelling of the ones they fumbled.
+    members = set(obs.keys())
+    absent = [c for c in columns if c not in members]
+    if absent:
+        problems.append(f"not present in obs: {absent}")
+
+    return problems
+
+
+def drop_obs_columns(path: str, columns: list[str]) -> dict:
+    """Drop the named obs columns from an h5ad file.
+
+    All-or-nothing: the whole request is validated before anything is written,
+    and if any column fails any check the file is left untouched and every
+    problem is reported together. There is no partial drop and no ``skipped``
+    state — unlike :func:`~hca_anndata_tools.strip.strip_forbidden_obs_columns`,
+    whose built-in column list makes "neither present" a normal outcome. Here
+    the caller named the columns, so a name that isn't there is a mistake worth
+    failing on.
+
+    Refuses to drop any column the HCA schema names, whether required or
+    optional, as well as the obs index. Dropping a required column would leave
+    an invalid file, and dropping an optional one would discard producer data
+    that cannot be reconstructed; this tool deliberately offers no way to do
+    either. Columns the schema does not name — producer extras, privacy columns
+    under non-canonical names, derived labels under non-canonical names — are
+    the intended targets and drop freely.
+
+    Derived label columns under their *canonical* names (``cell_type``,
+    ``tissue``, ``assay``, ``sex``, ``disease``, ``organism``,
+    ``development_stage``) are not guarded: they are outputs that
+    ``populate_labels`` regenerates from the matching ``*_ontology_term_id``
+    columns, so removing one loses nothing permanently.
+
+    Deletes ``uns['<column>_colors']`` alongside each dropped column. scanpy
+    writes that key for any categorical it plots, and the palette belongs to the
+    column rather than standing on its own — leaving it behind would orphan it,
+    which the validator reports as "Colors field uns[...] does not have a
+    corresponding categorical field in obs". Removing it is finishing the
+    deletion the caller asked for. Anything that merely *references* a column
+    is treated the other way and refuses the request outright; see
+    :func:`_validate_request`.
+
+    Note this does not shrink the file. HDF5 does not reclaim freed space
+    in place, so the output is the same size as the input even with columns
+    gone; ``compress_h5ad`` repacks and is meant to run last in a curation
+    sequence anyway.
+
+    Args:
+        path: Path to an .h5ad file. Auto-resolves to the latest timestamped
+            edit snapshot before operating. Either layout is fine — unlike
+            ``strip_forbidden_obs_columns``, this makes no CellxGENE-layout
+            refusal, because removing an arbitrary column is layout-agnostic.
+        columns: Obs column names to drop. Duplicates are ignored; order is
+            preserved in the result.
+
+    Returns:
+        Dict with ``output_path``, ``obs_columns_dropped`` and
+        ``uns_keys_dropped`` on success, or ``{"error": ...}`` if the request
+        was rejected or the write failed.
+    """
+    output_path = None
+    try:
+        if not columns:
+            return {"error": "No columns given — name the obs columns to drop."}
+        # Dedupe, preserving caller order. A repeated name is harmless, so it
+        # isn't worth reporting as a problem.
+        requested = list(dict.fromkeys(columns))
+
+        path = resolve_latest(path)
+        if not Path(path).is_file():
+            return {"error": f"File not found: {path}"}
+
+        with h5py.File(path, "r") as f_in:
+            obs = f_in.get("obs")
+            if obs is None:
+                return {"error": "File has no obs group"}
+            if not isinstance(obs, h5py.Group):
+                return {"error": "obs is not a group — the file predates the modern h5ad layout"}
+            uns = f_in.get("uns")
+            if not isinstance(uns, h5py.Group):
+                uns = None
+            problems = _validate_request(obs, uns, requested)
+            # Palettes to remove with their columns. Resolved here, from the
+            # same read that validated, so the write phase does no discovery.
+            owned_uns_keys = [k for c in requested if (k := f"{c}_colors") in (uns or {})]
+
+        if problems:
+            return {"error": "Refusing to drop: " + "; ".join(problems)}
+
+        output_path = generate_output_path(path)
+        shutil.copy2(path, output_path)
+
+        # Defer the malformed-log cleanup until after the with-block closes the
+        # output file, matching strip_forbidden_obs_columns: unlinking an open
+        # HDF5 handle works on POSIX but raises on Windows, and the context
+        # __exit__ flush would hit a removed inode either way.
+        log_error = None
+        with h5py.File(output_path, "a") as f_out:
+            for col in requested:
+                del f_out["obs"][col]
+            update_column_order(f_out, [], set(requested))
+            for key in owned_uns_keys:
+                del f_out["uns"][key]
+
+            described = f"Dropped obs columns: {requested}"
+            if owned_uns_keys:
+                described += f" (and the palettes they own: {owned_uns_keys})"
+            entry = make_edit_entry(
+                operation="drop_obs_columns",
+                description=described,
+                details={
+                    "obs_columns_dropped": requested,
+                    "uns_keys_dropped": owned_uns_keys,
+                },
+            )
+
+            existing_log = read_edit_log_h5py(f_out)
+            log_result = build_edit_log(existing_log, [entry], path)
+            if "error" in log_result:
+                log_error = log_result
+            else:
+                write_edit_log_h5py(f_out, log_result["json"])
+
+        if log_error is not None:
+            Path(output_path).unlink()
+            return log_error
+
+        cleanup_previous_version(path, output_path)
+
+        return {
+            "output_path": output_path,
+            "obs_columns_dropped": requested,
+            "uns_keys_dropped": owned_uns_keys,
+        }
+
+    except Exception as e:
+        if output_path and Path(output_path).is_file():
+            with contextlib.suppress(OSError):
+                Path(output_path).unlink()
+        return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/drop.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/drop.py
@@ -135,8 +135,13 @@ def _validate_request(obs: h5py.Group, uns: h5py.Group | None, columns: list[str
     #
     # Reported last: a caller reading the error wants the schema verdict on the
     # names they meant more than the spelling of the ones they fumbled.
+    #
+    # Malformed names are excluded so each bad name is reported once. A name like
+    # "/X" is necessarily absent from `obs.keys()` too, and listing it under both
+    # problems implied its only fault was being missing — which would have sent a
+    # caller looking for a typo rather than reading the path-name rule above.
     members = set(obs.keys())
-    absent = [c for c in columns if c not in members]
+    absent = [c for c in columns if c not in members and c not in malformed]
     if absent:
         problems.append(f"not present in obs: {absent}")
 

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/schema/helpers.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/schema/helpers.py
@@ -7,25 +7,47 @@ from typing import Any
 
 from .core import (
     AdiposeDataset,
-    AdiposeSample,
     Cell,
     Dataset,
     Donor,
     GutDataset,
-    GutSample,
     MusculoskeletalDataset,
     Sample,
 )
 
 _BIONETWORK_CLASSES = [AdiposeDataset, GutDataset, MusculoskeletalDataset]
 
-# Every class contributing obs-located fields. Unlike uns — which lives
-# entirely on Dataset — obs fields are spread across the entity classes:
-# Dataset carries the per-library sequencing fields, Donor and Sample the
-# per-donor and per-sample ones. Bionetwork subclasses are included because
-# a field one of them marks required is still required for files in that
-# bionetwork.
-_OBS_CLASSES = [Dataset, Donor, Sample, Cell, AdiposeSample, GutSample, *_BIONETWORK_CLASSES]
+# The four HCA entity types. Bionetwork variants are subclasses of these.
+_ENTITY_BASE_CLASSES = [Dataset, Donor, Sample, Cell]
+
+
+def _entity_classes() -> list[type]:
+    """Every entity class, derived by walking subclasses rather than listed.
+
+    Obs fields are spread across the entity classes — Dataset carries the
+    per-library sequencing fields, Donor and Sample the per-donor and
+    per-sample ones — and each bionetwork subclasses those to add or tighten
+    requirements. A field one bionetwork marks required is still required for
+    files in that bionetwork, so all of them count.
+
+    Derived deliberately, not enumerated: ``allowed_bionetwork_names`` in
+    ``shared`` already declares 18 bionetworks against the 3 that currently
+    have schema classes, so this list would silently go stale the first time
+    one of the other 15 gains a subclass — and going stale here means a
+    required column quietly losing its guard in ``drop_obs_columns``. There
+    are already three hand-maintained bionetwork maps in ``shared`` that
+    disagree with each other; this is not a fourth.
+    """
+    seen: list[type] = []
+    stack = list(_ENTITY_BASE_CLASSES)
+    while stack:
+        cls = stack.pop()
+        if cls in seen:
+            continue
+        seen.append(cls)
+        stack.extend(cls.__subclasses__())
+    return seen
+
 
 # Fields that LinkML's Dataset model claims live in uns but that are not
 # actually uns fields per HCA Tier 1 / CELLxGENE. See issue #343. Dropping
@@ -142,7 +164,7 @@ def build_obs_column_tiers() -> tuple[frozenset[str], frozenset[str]]:
     """Collect obs column names the HCA schema names, split by requiredness.
 
     Returns ``(required, optional)`` as a union across every class in
-    ``_OBS_CLASSES``. Consumers get the two tiers separately rather than one
+    every entity class. Consumers get the two tiers separately rather than one
     combined set so they can say *which* tier a column offended — see
     :func:`~hca_anndata_tools.drop.drop_obs_columns`, whose guard refuses both
     but reports them apart.
@@ -158,7 +180,7 @@ def build_obs_column_tiers() -> tuple[frozenset[str], frozenset[str]]:
     """
     required: set[str] = set()
     optional: set[str] = set()
-    for cls in _OBS_CLASSES:
+    for cls in _entity_classes():
         for name, fi in cls.model_fields.items():
             if _get_ann_data_location(fi) != "obs":
                 continue

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/schema/helpers.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/schema/helpers.py
@@ -1,13 +1,31 @@
-"""Introspection helpers for extracting uns field metadata from Pydantic models."""
+"""Introspection helpers for extracting uns and obs field metadata from Pydantic models."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Any
 
-from .core import AdiposeDataset, Dataset, GutDataset, MusculoskeletalDataset
+from .core import (
+    AdiposeDataset,
+    AdiposeSample,
+    Cell,
+    Dataset,
+    Donor,
+    GutDataset,
+    GutSample,
+    MusculoskeletalDataset,
+    Sample,
+)
 
 _BIONETWORK_CLASSES = [AdiposeDataset, GutDataset, MusculoskeletalDataset]
+
+# Every class contributing obs-located fields. Unlike uns — which lives
+# entirely on Dataset — obs fields are spread across the entity classes:
+# Dataset carries the per-library sequencing fields, Donor and Sample the
+# per-donor and per-sample ones. Bionetwork subclasses are included because
+# a field one of them marks required is still required for files in that
+# bionetwork.
+_OBS_CLASSES = [Dataset, Donor, Sample, Cell, AdiposeSample, GutSample, *_BIONETWORK_CLASSES]
 
 # Fields that LinkML's Dataset model claims live in uns but that are not
 # actually uns fields per HCA Tier 1 / CELLxGENE. See issue #343. Dropping
@@ -118,3 +136,45 @@ def uns_field_registry() -> dict[str, UnsFieldInfo]:
     if _UNS_REGISTRY is None:
         _UNS_REGISTRY = get_uns_field_registry()
     return _UNS_REGISTRY
+
+
+def build_obs_column_tiers() -> tuple[frozenset[str], frozenset[str]]:
+    """Collect obs column names the HCA schema names, split by requiredness.
+
+    Returns ``(required, optional)`` as a union across every class in
+    ``_OBS_CLASSES``. Consumers get the two tiers separately rather than one
+    combined set so they can say *which* tier a column offended — see
+    :func:`~hca_anndata_tools.drop.drop_obs_columns`, whose guard refuses both
+    but reports them apart.
+
+    Deliberately does not track which entity owns a column. The question these
+    sets answer is "does the schema name this?", and for that the union across
+    entities is the right granularity.
+
+    Note this is not the same question the coverage machinery in
+    ``shared/schema_utils`` answers: ``iter_coverage_slots`` excludes identifier
+    and foreign-key slots, which would drop ``donor_id`` and ``sample_id`` —
+    exactly the columns a delete guard most needs to protect.
+    """
+    required: set[str] = set()
+    optional: set[str] = set()
+    for cls in _OBS_CLASSES:
+        for name, fi in cls.model_fields.items():
+            if _get_ann_data_location(fi) != "obs":
+                continue
+            (required if fi.is_required() else optional).add(name)
+    # A column required by any entity is required, even if another class
+    # declares it optional — the stricter tier wins.
+    return frozenset(required), frozenset(optional - required)
+
+
+# Cached at module level — schema is static
+_OBS_TIERS: tuple[frozenset[str], frozenset[str]] | None = None
+
+
+def obs_column_tiers() -> tuple[frozenset[str], frozenset[str]]:
+    """Return the cached ``(required, optional)`` obs column tiers."""
+    global _OBS_TIERS
+    if _OBS_TIERS is None:
+        _OBS_TIERS = build_obs_column_tiers()
+    return _OBS_TIERS

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/schema/helpers.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/schema/helpers.py
@@ -163,8 +163,8 @@ def uns_field_registry() -> dict[str, UnsFieldInfo]:
 def build_obs_column_tiers() -> tuple[frozenset[str], frozenset[str]]:
     """Collect obs column names the HCA schema names, split by requiredness.
 
-    Returns ``(required, optional)`` as a union across every class in
-    every entity class. Consumers get the two tiers separately rather than one
+    Returns ``(required, optional)`` as a union across every entity class.
+    Consumers get the two tiers separately rather than one
     combined set so they can say *which* tier a column offended — see
     :func:`~hca_anndata_tools.drop.drop_obs_columns`, whose guard refuses both
     but reports them apart.

--- a/packages/hca-anndata-tools/tests/test_drop.py
+++ b/packages/hca-anndata-tools/tests/test_drop.py
@@ -1,0 +1,413 @@
+"""Tests for drop_obs_columns."""
+
+import json
+from pathlib import Path
+
+import anndata as ad
+import h5py
+import numpy as np
+import pandas as pd
+
+from hca_anndata_tools._io import _decode_bytes, read_obs_column_names
+from hca_anndata_tools.drop import drop_obs_columns
+from hca_anndata_tools.write import EDIT_LOG_KEY, make_edit_entry
+
+
+def _add_obs_cols(path, *names):
+    """Add categorical obs columns to the fixture file, in place.
+
+    Deliberately does *not* touch ``uns['schema_version']``: the fixture sets
+    it, which is the marker ``strip_forbidden_obs_columns`` refuses on, so
+    leaving it proves drop makes no such refusal (R6).
+    """
+    adata = ad.read_h5ad(path)
+    for name in names:
+        adata.obs[name] = pd.Categorical(["value"] * adata.n_obs)
+    adata.write_h5ad(path)
+
+
+def _no_snapshot_written(path):
+    """True when no timestamped edit snapshot appeared beside the source."""
+    return not any("-edit-" in p.name for p in Path(path).parent.iterdir())
+
+
+# --- R1: all-or-nothing ------------------------------------------------------
+
+
+def test_drop_absent_column_errors_and_writes_nothing(sample_h5ad_for_write):
+    """A name that isn't in obs is a mistake, not a no-op. Nothing is written."""
+    result = drop_obs_columns(str(sample_h5ad_for_write), ["nonexistent_column"])
+
+    assert "error" in result
+    assert "not present in obs" in result["error"]
+    assert "nonexistent_column" in result["error"]
+    assert _no_snapshot_written(sample_h5ad_for_write)
+
+
+def test_drop_is_atomic_across_valid_and_invalid(sample_h5ad_for_write):
+    """The load-bearing R1 case: one bad name in a list of good ones drops
+    nothing at all. A partial drop would silently half-curate a file."""
+    _add_obs_cols(sample_h5ad_for_write, "ethnicity_verbatim")
+    before = Path(sample_h5ad_for_write).read_bytes()
+
+    result = drop_obs_columns(
+        str(sample_h5ad_for_write),
+        ["ethnicity_verbatim", "typo_column"],
+    )
+
+    assert "error" in result
+    assert _no_snapshot_written(sample_h5ad_for_write)
+    # The source file must be untouched, not merely un-snapshotted.
+    assert Path(sample_h5ad_for_write).read_bytes() == before
+    assert "ethnicity_verbatim" in ad.read_h5ad(sample_h5ad_for_write).obs.columns
+
+
+def test_drop_reports_every_problem_at_once(sample_h5ad_for_write):
+    """A caller who names two bad columns learns about both in one round trip."""
+    result = drop_obs_columns(str(sample_h5ad_for_write), ["donor_id", "typo_column"])
+
+    assert "error" in result
+    # donor_id is schema-required *and* absent from the fixture; the schema
+    # verdict is what matters, but the absent list must still be populated by
+    # the other name rather than short-circuited away.
+    assert "required" in result["error"]
+    assert "typo_column" in result["error"]
+
+
+def test_drop_empty_column_list_errors(sample_h5ad_for_write):
+    result = drop_obs_columns(str(sample_h5ad_for_write), [])
+
+    assert "error" in result
+    assert "No columns given" in result["error"]
+    assert _no_snapshot_written(sample_h5ad_for_write)
+
+
+def test_drop_dedupes_repeated_names(sample_h5ad_for_write):
+    """A repeated name is harmless — it drops once and reports once."""
+    _add_obs_cols(sample_h5ad_for_write, "ethnicity_verbatim")
+
+    result = drop_obs_columns(
+        str(sample_h5ad_for_write),
+        ["ethnicity_verbatim", "ethnicity_verbatim"],
+    )
+
+    assert "error" not in result
+    assert result["obs_columns_dropped"] == ["ethnicity_verbatim"]
+
+
+# --- R1: names must be plain column names, not HDF5 link paths ---------------
+
+
+def test_drop_refuses_names_containing_a_slash(sample_h5ad_for_write):
+    """h5py resolves '/X' from the file root and 'a/b' into subgroups, so an
+    unguarded `c in obs` check accepts names pointing outside obs and the
+    delete then unlinks them. Every other check here compares plain strings, so
+    a path-shaped name would otherwise slip past all of them."""
+    for name in ("/X", "/raw/X", "/var", "/uns", "/obsm/X_umap", "raw/X"):
+        result = drop_obs_columns(str(sample_h5ad_for_write), [name])
+
+        assert "error" in result, f"{name!r} must be refused"
+        assert "cannot contain" in result["error"]
+        assert _no_snapshot_written(sample_h5ad_for_write)
+
+    # The matrix and the other top-level groups are still there.
+    with h5py.File(sample_h5ad_for_write, "r") as f:
+        assert "X" in f
+        assert "var" in f
+        assert "uns" in f
+
+
+def test_drop_slash_path_cannot_bypass_the_schema_guard(sample_h5ad_for_write):
+    """'/obs/donor_id' resolves to the same dataset as 'donor_id' but would not
+    match the schema-required name set, so it must be refused by the path check
+    rather than sliding past the tier comparison."""
+    _add_obs_cols(sample_h5ad_for_write, "donor_id")
+
+    result = drop_obs_columns(str(sample_h5ad_for_write), ["/obs/donor_id"])
+
+    assert "error" in result
+    assert "donor_id" in ad.read_h5ad(sample_h5ad_for_write).obs.columns
+
+
+def test_drop_slash_path_cannot_erase_provenance(sample_h5ad_for_write):
+    """The edit log lives at uns/provenance/edit_history. Reaching it through a
+    link path would let a caller replace an audit trail with a fresh one that
+    records only its own operation."""
+    adata = ad.read_h5ad(sample_h5ad_for_write)
+    adata.uns.setdefault("provenance", {})[EDIT_LOG_KEY] = json.dumps(
+        [
+            {
+                **make_edit_entry(operation="prior_op", description="seed", details={}),
+                "source_file": "seed.h5ad",
+                "source_sha256": "0" * 64,
+            }
+        ]
+    )
+    adata.write_h5ad(sample_h5ad_for_write)
+
+    result = drop_obs_columns(str(sample_h5ad_for_write), [f"/uns/provenance/{EDIT_LOG_KEY}"])
+
+    assert "error" in result
+    log = json.loads(ad.read_h5ad(sample_h5ad_for_write).uns["provenance"][EDIT_LOG_KEY])
+    assert [e["operation"] for e in log] == ["prior_op"]
+
+
+def test_drop_refuses_blank_names(sample_h5ad_for_write):
+    result = drop_obs_columns(str(sample_h5ad_for_write), ["  "])
+
+    assert "error" in result
+    assert "cannot contain" in result["error"]
+
+
+# --- R2: guard tiers ---------------------------------------------------------
+
+
+def test_drop_refuses_schema_required_column(sample_h5ad_for_write):
+    """donor_id is required; dropping it would leave an invalid file."""
+    _add_obs_cols(sample_h5ad_for_write, "donor_id")
+
+    result = drop_obs_columns(str(sample_h5ad_for_write), ["donor_id"])
+
+    assert "error" in result
+    assert "required" in result["error"]
+    assert "donor_id" in result["error"]
+    assert _no_snapshot_written(sample_h5ad_for_write)
+
+
+def test_drop_refuses_schema_optional_column(sample_h5ad_for_write):
+    """author_batch_notes is optional per the schema but holds producer data
+    that cannot be reconstructed, so it is refused too."""
+    _add_obs_cols(sample_h5ad_for_write, "author_batch_notes")
+
+    result = drop_obs_columns(str(sample_h5ad_for_write), ["author_batch_notes"])
+
+    assert "error" in result
+    assert "author_batch_notes" in result["error"]
+    # Reported as the optional tier, not the required one — the distinction is
+    # the seam a future force flag would use.
+    assert "optional" in result["error"]
+    assert "required" not in result["error"]
+    assert _no_snapshot_written(sample_h5ad_for_write)
+
+
+def test_drop_refuses_obs_index(sample_h5ad_for_write):
+    """The index is a dataset in the obs group like any column, so a caller can
+    name it. Deleting it would destroy the file's cell identities."""
+    with h5py.File(sample_h5ad_for_write, "r") as f:
+        index_name = _decode_bytes(f["obs"].attrs.get("_index", "_index"))
+
+    result = drop_obs_columns(str(sample_h5ad_for_write), [index_name])
+
+    assert "error" in result
+    assert "obs index" in result["error"]
+    assert _no_snapshot_written(sample_h5ad_for_write)
+
+
+# --- R3: derived labels are not guarded --------------------------------------
+
+
+def test_drop_allows_canonical_derived_labels(sample_h5ad_for_write):
+    """cell_type/sex/tissue are outputs populate_labels regenerates from the
+    matching *_ontology_term_id columns, so they carry no guard."""
+    result = drop_obs_columns(str(sample_h5ad_for_write), ["cell_type", "sex", "tissue"])
+
+    assert "error" not in result
+    written = ad.read_h5ad(result["output_path"])
+    for col in ("cell_type", "sex", "tissue"):
+        assert col not in written.obs.columns
+
+
+# --- R4: the guard must not block the use case the tool exists for -----------
+
+
+def test_drop_removes_ethnicity_under_noncanonical_names(sample_h5ad_for_write):
+    """The reason this tool exists. These five names are how the breast-v1
+    source datasets carry ethnicity; none is a schema field, so none is
+    guarded. If this test fails the tool cannot do its job."""
+    aliases = [
+        "self_reported_ethnicity_label",
+        "ethnicity_verbatim",
+        "ethnicity_grouped",
+        "reported_ethnicity",
+        "race",
+    ]
+    _add_obs_cols(sample_h5ad_for_write, *aliases)
+
+    result = drop_obs_columns(str(sample_h5ad_for_write), aliases)
+
+    assert "error" not in result
+    assert result["obs_columns_dropped"] == aliases
+    written = ad.read_h5ad(result["output_path"])
+    for col in aliases:
+        assert col not in written.obs.columns
+
+
+def test_drop_removes_producer_label_columns(sample_h5ad_for_write):
+    """The other target class: derived labels under non-canonical names, which
+    differ per dataset and so cannot be a fixed list in code."""
+    labels = ["cell_type_label", "assay_label", "tissue_label"]
+    _add_obs_cols(sample_h5ad_for_write, *labels)
+
+    result = drop_obs_columns(str(sample_h5ad_for_write), labels)
+
+    assert "error" not in result
+    written = ad.read_h5ad(result["output_path"])
+    for col in labels:
+        assert col not in written.obs.columns
+
+
+# --- uns references: delete what the column owns, refuse what references it --
+
+
+def test_drop_deletes_the_palette_the_column_owns(sample_h5ad_for_write):
+    """scanpy stores a categorical's colours at uns['<col>_colors']. The palette
+    belongs to the column, so it goes with it — left behind it is orphaned, and
+    the validator rejects a colors field with no matching obs column."""
+    _add_obs_cols(sample_h5ad_for_write, "cell_type_label")
+    adata = ad.read_h5ad(sample_h5ad_for_write)
+    adata.uns["cell_type_label_colors"] = np.array(["#111111", "#222222"])
+    adata.uns["unrelated_colors"] = np.array(["#333333"])
+    adata.write_h5ad(sample_h5ad_for_write)
+
+    result = drop_obs_columns(str(sample_h5ad_for_write), ["cell_type_label"])
+
+    assert "error" not in result
+    assert result["uns_keys_dropped"] == ["cell_type_label_colors"]
+    written = ad.read_h5ad(result["output_path"])
+    assert "cell_type_label_colors" not in written.uns
+    # A palette belonging to some other column is none of our business.
+    assert "unrelated_colors" in written.uns
+
+
+def test_drop_reports_no_uns_keys_when_there_is_no_palette(sample_h5ad_for_write):
+    _add_obs_cols(sample_h5ad_for_write, "race")
+
+    result = drop_obs_columns(str(sample_h5ad_for_write), ["race"])
+
+    assert result["uns_keys_dropped"] == []
+
+
+def test_drop_refuses_column_referenced_by_batch_condition(sample_h5ad_for_write):
+    """uns['batch_condition'] is typed match_obs_columns, so its entries must
+    name obs columns. It declares which columns define the experiment's
+    batches — rewriting that claim is a curation decision, not cleanup."""
+    _add_obs_cols(sample_h5ad_for_write, "producer_batch")
+    adata = ad.read_h5ad(sample_h5ad_for_write)
+    adata.uns["batch_condition"] = np.array(["producer_batch"])
+    adata.write_h5ad(sample_h5ad_for_write)
+
+    result = drop_obs_columns(str(sample_h5ad_for_write), ["producer_batch"])
+
+    assert "error" in result
+    assert "batch_condition" in result["error"]
+    assert "producer_batch" in ad.read_h5ad(sample_h5ad_for_write).obs.columns
+
+
+def test_drop_allows_column_absent_from_batch_condition(sample_h5ad_for_write):
+    """The batch_condition check must key on membership, not on the key merely
+    existing — otherwise any file with batches becomes undroppable."""
+    _add_obs_cols(sample_h5ad_for_write, "producer_batch", "race")
+    adata = ad.read_h5ad(sample_h5ad_for_write)
+    adata.uns["batch_condition"] = np.array(["producer_batch"])
+    adata.write_h5ad(sample_h5ad_for_write)
+
+    result = drop_obs_columns(str(sample_h5ad_for_write), ["race"])
+
+    assert "error" not in result
+
+
+def test_drop_refuses_cap_annotation_set_columns(sample_h5ad_for_write):
+    """CAP set columns are named '<set>--<suffix>' and are not schema-named, so
+    nothing else catches them. uns['cap_metadata'] would still declare the set,
+    leaving it broken — the set has to go, not its columns."""
+    _add_obs_cols(sample_h5ad_for_write, "myset--cell_type")
+    adata = ad.read_h5ad(sample_h5ad_for_write)
+    adata.uns["cap_metadata"] = {"cellannotation_schema_version": "1.0.0"}
+    adata.write_h5ad(sample_h5ad_for_write)
+
+    result = drop_obs_columns(str(sample_h5ad_for_write), ["myset--cell_type"])
+
+    assert "error" in result
+    assert "cap_metadata" in result["error"]
+    assert "myset--cell_type" in ad.read_h5ad(sample_h5ad_for_write).obs.columns
+
+
+def test_drop_allows_double_dash_when_no_cap_metadata(sample_h5ad_for_write):
+    """Without a CAP declaration there is no set to break, so the '--' shape is
+    just a column name."""
+    _add_obs_cols(sample_h5ad_for_write, "odd--name")
+
+    result = drop_obs_columns(str(sample_h5ad_for_write), ["odd--name"])
+
+    assert "error" not in result
+
+
+# --- R5/R6: result shape and mechanics ---------------------------------------
+
+
+def test_drop_preserves_caller_order_and_leaves_other_columns(sample_h5ad_for_write):
+    _add_obs_cols(sample_h5ad_for_write, "race", "ethnicity_verbatim")
+
+    result = drop_obs_columns(str(sample_h5ad_for_write), ["race", "ethnicity_verbatim"])
+
+    assert result["obs_columns_dropped"] == ["race", "ethnicity_verbatim"]
+    written = ad.read_h5ad(result["output_path"])
+    # Untouched columns survive, including the numeric one.
+    for col in ("sex", "tissue", "cell_type", "n_counts"):
+        assert col in written.obs.columns
+
+
+def test_drop_succeeds_on_cellxgene_layout(cellxgene_h5ad):
+    """Unlike strip_forbidden_obs_columns, this makes no layout refusal —
+    removing an arbitrary column is layout-agnostic."""
+    _add_obs_cols(cellxgene_h5ad, "ethnicity_verbatim")
+
+    result = drop_obs_columns(str(cellxgene_h5ad), ["ethnicity_verbatim"])
+
+    assert "error" not in result
+    assert "ethnicity_verbatim" not in ad.read_h5ad(result["output_path"]).obs.columns
+
+
+def test_drop_updates_column_order(sample_h5ad_for_write):
+    """column-order must lose exactly the dropped names and keep the survivors
+    in their original relative order, or the file stops round-tripping."""
+    _add_obs_cols(sample_h5ad_for_write, "race")
+    before = read_obs_column_names(str(sample_h5ad_for_write))
+
+    result = drop_obs_columns(str(sample_h5ad_for_write), ["race", "cell_type"])
+    after = read_obs_column_names(result["output_path"])
+
+    assert "race" not in after
+    assert "cell_type" not in after
+    assert after == [c for c in before if c not in ("race", "cell_type")]
+
+
+def test_drop_preserves_existing_edit_log(sample_h5ad_for_write):
+    """An h5ad already carrying edit-log entries must get the new entry
+    appended, not replacing history."""
+    adata = ad.read_h5ad(sample_h5ad_for_write)
+    adata.obs["race"] = pd.Categorical(["value"] * adata.n_obs)
+    prior_entry = make_edit_entry(
+        operation="prior_synthetic_op",
+        description="Synthetic prior entry to verify the drop tool appends.",
+        details={"shape_before": [adata.n_obs, adata.n_vars]},
+    )
+    seed_log = json.dumps([{**prior_entry, "source_file": "synthetic-seed.h5ad", "source_sha256": "0" * 64}])
+    adata.uns.setdefault("provenance", {})[EDIT_LOG_KEY] = seed_log
+    adata.write_h5ad(sample_h5ad_for_write)
+
+    result = drop_obs_columns(str(sample_h5ad_for_write), ["race"])
+    assert "error" not in result
+
+    log = json.loads(ad.read_h5ad(result["output_path"]).uns["provenance"][EDIT_LOG_KEY])
+    assert len(log) == 2, f"Expected 2 entries (prior + drop), got {len(log)}"
+    assert log[0]["operation"] == "prior_synthetic_op"
+    assert log[1]["operation"] == "drop_obs_columns"
+    assert log[1]["details"]["obs_columns_dropped"] == ["race"]
+
+
+def test_drop_missing_file():
+    result = drop_obs_columns("/nonexistent/path/file.h5ad", ["race"])
+
+    assert "error" in result
+    assert "File not found" in result["error"]

--- a/packages/hca-anndata-tools/tests/test_drop.py
+++ b/packages/hca-anndata-tools/tests/test_drop.py
@@ -199,6 +199,23 @@ def test_drop_refuses_blank_names(sample_h5ad_for_write):
     assert "cannot contain" in result["error"]
 
 
+def test_drop_reports_each_bad_name_once(sample_h5ad_for_write):
+    """A malformed name is necessarily absent from obs too, so it would appear
+    under both problems unless the absent check excludes it.
+
+    Listing '/X' as merely "not present in obs" implied its only fault was a typo
+    and sent the reader past the path-name rule that actually explains it.
+    """
+    result = drop_obs_columns(str(sample_h5ad_for_write), ["/X", "definitely_not_here"])
+
+    error = result["error"]
+    assert error.count("/X") == 1, error
+    # The genuinely-absent name is still reported, and under the right problem.
+    absent_part = error.split("not present in obs:")[1]
+    assert "definitely_not_here" in absent_part
+    assert "/X" not in absent_part
+
+
 # --- R2: guard tiers ---------------------------------------------------------
 
 

--- a/packages/hca-anndata-tools/tests/test_drop.py
+++ b/packages/hca-anndata-tools/tests/test_drop.py
@@ -303,6 +303,25 @@ def test_drop_refuses_column_referenced_by_batch_condition(sample_h5ad_for_write
     assert "producer_batch" in ad.read_h5ad(sample_h5ad_for_write).obs.columns
 
 
+def test_drop_reads_scalar_batch_condition(sample_h5ad_for_write):
+    """A bare string lands on disk as a scalar bytes dataset rather than an
+    array, so iterating it would yield individual characters. Covers the
+    scalar branch of _read_batch_condition, which the array-valued tests
+    above never reach."""
+    _add_obs_cols(sample_h5ad_for_write, "producer_batch")
+    adata = ad.read_h5ad(sample_h5ad_for_write)
+    adata.uns["batch_condition"] = "producer_batch"
+    adata.write_h5ad(sample_h5ad_for_write)
+
+    with h5py.File(sample_h5ad_for_write, "r") as f:
+        assert f["uns"]["batch_condition"].shape == (), "fixture must produce a scalar, not an array"
+
+    result = drop_obs_columns(str(sample_h5ad_for_write), ["producer_batch"])
+
+    assert "error" in result
+    assert "batch_condition" in result["error"]
+
+
 def test_drop_allows_column_absent_from_batch_condition(sample_h5ad_for_write):
     """The batch_condition check must key on membership, not on the key merely
     existing — otherwise any file with batches becomes undroppable."""

--- a/packages/hca-anndata-tools/tests/test_drop.py
+++ b/packages/hca-anndata-tools/tests/test_drop.py
@@ -243,6 +243,93 @@ def test_drop_refuses_obs_index(sample_h5ad_for_write):
     assert _no_snapshot_written(sample_h5ad_for_write)
 
 
+# --- R2: the columns #538 made visible to the guard --------------------------
+#
+# These four were invisible to annDataLocation-walking until #538 (PR #545), so an
+# earlier revision of this tool deleted all of them without complaint. The LinkML
+# schema was the real defect: `Cell` was a bare `pass` with nowhere for the cell
+# annotation to live, and two `Sample` slots carried no annotation. A hardcoded
+# column list here was considered and rejected — the premise of #531 is that such
+# lists rot.
+#
+# Pinned here because the guard's coverage of them is a property of *this* tool,
+# and nothing else in this suite would notice if a future schema regeneration
+# silently dropped an annotation.
+
+
+def test_drop_refuses_the_columns_538_made_visible(sample_h5ad_for_write):
+    """All three at once, and the error must name every one of them.
+
+    Refusing two of three would be worse than refusing none: the caller would see
+    an error, assume nothing happened, and the tool's all-or-nothing contract (R1)
+    is what makes that assumption safe.
+    """
+    columns = ["cell_type_ontology_term_id", "is_primary_data", "sample_collection_method"]
+    _add_obs_cols(sample_h5ad_for_write, *columns)
+
+    result = drop_obs_columns(str(sample_h5ad_for_write), columns)
+
+    assert "error" in result
+    for column in columns:
+        assert column in result["error"], f"{column} fell through the guard"
+    assert _no_snapshot_written(sample_h5ad_for_write)
+
+
+def test_drop_splits_the_538_columns_across_tiers(sample_h5ad_for_write):
+    """`sample_collection_method` is schema-required; the other two are optional.
+
+    The tiers are reported apart because that seam is what a future `--force` flag
+    would act on, so a column landing in the wrong tier would become droppable
+    once that flag exists.
+    """
+    columns = ["cell_type_ontology_term_id", "is_primary_data", "sample_collection_method"]
+    _add_obs_cols(sample_h5ad_for_write, *columns)
+
+    error = drop_obs_columns(str(sample_h5ad_for_write), columns)["error"]
+
+    required_part, _, optional_part = error.partition("; ")
+    assert "required" in required_part
+    assert "sample_collection_method" in required_part
+    assert "optional" in optional_part
+    assert "cell_type_ontology_term_id" in optional_part
+    assert "is_primary_data" in optional_part
+
+
+def test_drop_refuses_cell_type_ontology_term_id(sample_h5ad_for_write):
+    """The worst of the four to lose: it is unrecoverable.
+
+    `populate_labels` derives `cell_type` *from* this column, not the reverse, so
+    once it is gone the file's cell annotation cannot be reconstructed from
+    anything else in the file. It is schema-*optional* (matching the h5ad
+    validator's `requirement_level`), which is exactly why the guard has to refuse
+    the optional tier too rather than only the required one.
+    """
+    _add_obs_cols(sample_h5ad_for_write, "cell_type_ontology_term_id")
+
+    result = drop_obs_columns(str(sample_h5ad_for_write), ["cell_type_ontology_term_id"])
+
+    assert "error" in result
+    assert "cell_type_ontology_term_id" in result["error"]
+    assert "optional" in result["error"]
+    assert _no_snapshot_written(sample_h5ad_for_write)
+
+
+def test_drop_refuses_author_cell_type(sample_h5ad_for_write):
+    """#538 gave `Cell` this slot too, so it is now guarded.
+
+    Deliberate: it holds the author's own cell-type naming, which no other column
+    can reconstruct once removed. Distinct from the derived labels below, which are
+    unguarded precisely because they are regenerable.
+    """
+    _add_obs_cols(sample_h5ad_for_write, "author_cell_type")
+
+    result = drop_obs_columns(str(sample_h5ad_for_write), ["author_cell_type"])
+
+    assert "error" in result
+    assert "author_cell_type" in result["error"]
+    assert _no_snapshot_written(sample_h5ad_for_write)
+
+
 # --- R3: derived labels are not guarded --------------------------------------
 
 

--- a/packages/hca-anndata-tools/tests/test_drop.py
+++ b/packages/hca-anndata-tools/tests/test_drop.py
@@ -152,6 +152,41 @@ def test_drop_slash_path_cannot_erase_provenance(sample_h5ad_for_write):
     assert [e["operation"] for e in log] == ["prior_op"]
 
 
+def test_drop_refuses_a_bare_string_for_columns(sample_h5ad_for_write):
+    """columns="race" instead of ["race"] would iterate as characters and report
+    'not present in obs: [r, a, c, e]' — a plausible slip from an MCP client
+    with a useless error, so it is named explicitly."""
+    result = drop_obs_columns(str(sample_h5ad_for_write), "race")  # pyright: ignore[reportArgumentType]
+
+    assert "error" in result
+    assert "not a single string" in result["error"]
+    assert _no_snapshot_written(sample_h5ad_for_write)
+
+
+def test_drop_refuses_non_string_entries(sample_h5ad_for_write):
+    """This is an MCP-exposed tool, so columns arrives as decoded JSON and may
+    hold numbers or nulls. Every check downstream assumes strings, so they are
+    rejected up front with a message that says so rather than surfacing
+    "argument of type 'int' is not iterable"."""
+    for bad in ([123], [None], ["race", 123]):
+        result = drop_obs_columns(str(sample_h5ad_for_write), bad)  # pyright: ignore[reportArgumentType]
+
+        assert "error" in result
+        assert "only strings" in result["error"], f"{bad!r} gave: {result['error']}"
+        assert _no_snapshot_written(sample_h5ad_for_write)
+
+
+def test_drop_accepts_a_tuple_of_names(sample_h5ad_for_write):
+    """Nothing depends on the argument being a list specifically, so a tuple
+    from a caller that built one should not be an error."""
+    _add_obs_cols(sample_h5ad_for_write, "race")
+
+    result = drop_obs_columns(str(sample_h5ad_for_write), ("race",))  # pyright: ignore[reportArgumentType]
+
+    assert "error" not in result
+    assert result["obs_columns_dropped"] == ["race"]
+
+
 def test_drop_refuses_blank_names(sample_h5ad_for_write):
     result = drop_obs_columns(str(sample_h5ad_for_write), ["  "])
 

--- a/packages/hca-anndata-tools/tests/test_drop.py
+++ b/packages/hca-anndata-tools/tests/test_drop.py
@@ -155,7 +155,11 @@ def test_drop_slash_path_cannot_erase_provenance(sample_h5ad_for_write):
 def test_drop_refuses_a_bare_string_for_columns(sample_h5ad_for_write):
     """columns="race" instead of ["race"] would iterate as characters and report
     'not present in obs: [r, a, c, e]' — a plausible slip from an MCP client
-    with a useless error, so it is named explicitly."""
+    with a useless error, so it is named explicitly.
+
+    The ignore is deliberate and must stay: the annotation already rejects this
+    statically, and the point of the test is the runtime guard that protects
+    MCP callers, who get no type checking at all."""
     result = drop_obs_columns(str(sample_h5ad_for_write), "race")  # pyright: ignore[reportArgumentType]
 
     assert "error" in result
@@ -178,10 +182,11 @@ def test_drop_refuses_non_string_entries(sample_h5ad_for_write):
 
 def test_drop_accepts_a_tuple_of_names(sample_h5ad_for_write):
     """Nothing depends on the argument being a list specifically, so a tuple
-    from a caller that built one should not be an error."""
+    from a caller that built one should not be an error — and the annotation
+    says so, which is why this call needs no type-checker exemption."""
     _add_obs_cols(sample_h5ad_for_write, "race")
 
-    result = drop_obs_columns(str(sample_h5ad_for_write), ("race",))  # pyright: ignore[reportArgumentType]
+    result = drop_obs_columns(str(sample_h5ad_for_write), ("race",))
 
     assert "error" not in result
     assert result["obs_columns_dropped"] == ["race"]

--- a/packages/hca-anndata-tools/tests/test_schema_helpers.py
+++ b/packages/hca-anndata-tools/tests/test_schema_helpers.py
@@ -1,0 +1,125 @@
+"""Tests for the schema introspection helpers in schema/helpers.py.
+
+These assert membership rather than exact set sizes. A hard count would turn
+any upstream LinkML change into a red test with no explanation of what moved,
+whereas these fail only when something meaningful changed — and the
+non-membership assertions below are load-bearing safety properties, not
+incidental facts.
+"""
+
+from hca_anndata_tools.schema.helpers import (
+    build_obs_column_tiers,
+    obs_column_tiers,
+    uns_field_registry,
+)
+
+
+def _required():
+    return obs_column_tiers()[0]
+
+
+def _optional():
+    return obs_column_tiers()[1]
+
+
+# How the breast-v1 source datasets carry ethnicity. None is a schema field.
+_ETHNICITY_ALIASES = (
+    "self_reported_ethnicity_label",
+    "ethnicity_verbatim",
+    "ethnicity_grouped",
+    "reported_ethnicity",
+    "race",
+)
+
+# Columns HCA forbids outright for privacy — schema-*forbidden*, so they appear
+# in neither tier.
+_FORBIDDEN = (
+    "self_reported_ethnicity",
+    "self_reported_ethnicity_ontology_term_id",
+)
+
+# Derived label outputs, regenerable by populate_labels from the matching
+# *_ontology_term_id column.
+_DERIVED_LABELS = (
+    "tissue",
+    "cell_type",
+    "assay",
+    "disease",
+    "sex",
+    "organism",
+    "development_stage",
+)
+
+
+def test_required_tier_contains_known_required_columns():
+    required = _required()
+    for col in (
+        "donor_id",
+        "sample_id",
+        "library_id",
+        "library_sequencing_run",
+        "organism_ontology_term_id",
+        "tissue_ontology_term_id",
+    ):
+        assert col in required, f"{col} should be schema-required"
+
+
+def test_optional_tier_contains_known_optional_columns():
+    optional = _optional()
+    for col in ("author_batch_notes", "tissue_free_text", "sequencing_platform"):
+        assert col in optional, f"{col} should be schema-optional"
+
+
+def test_tiers_are_disjoint():
+    """A column required by any entity is required, even where another class
+    declares it optional — the stricter tier wins."""
+    assert not (_required() & _optional())
+
+
+def test_bionetwork_only_required_columns_are_collected():
+    """ambient_count_correction and doublet_detection live on the bionetwork
+    Dataset subclasses, not base Dataset. If _OBS_CLASSES stopped walking the
+    subclasses these would silently vanish from the guard."""
+    required = _required()
+    assert "ambient_count_correction" in required
+    assert "doublet_detection" in required
+
+
+def test_ethnicity_aliases_are_in_neither_tier():
+    """The safety property drop_obs_columns depends on: if any alias were
+    schema-named, the guard would refuse the drop this tool exists to perform."""
+    named = _required() | _optional()
+    for col in _ETHNICITY_ALIASES:
+        assert col not in named, f"{col} must not be schema-named"
+
+
+def test_forbidden_privacy_columns_are_in_neither_tier():
+    """HCA forbids these outright, so they are absent from the schema rather
+    than declared optional — meaning the guard cannot block stripping them."""
+    named = _required() | _optional()
+    for col in _FORBIDDEN:
+        assert col not in named, f"{col} is forbidden, not schema-named"
+
+
+def test_derived_label_columns_are_in_neither_tier():
+    """Derived labels carry no guard because they are regenerable. That holds
+    only while they stay absent from both tiers."""
+    named = _required() | _optional()
+    for col in _DERIVED_LABELS:
+        assert col not in named, f"{col} is a derived label, not a schema obs field"
+
+
+def test_obs_tiers_and_uns_registry_do_not_overlap():
+    """A field is obs or uns by its annDataLocation, never both. An overlap
+    would mean the introspection is misreading the annotation."""
+    named_obs = _required() | _optional()
+    assert not (named_obs & set(uns_field_registry()))
+
+
+def test_tiers_are_cached():
+    """The builder walks model_fields across nine Pydantic classes, so the
+    result is cached. Identity, not equality — two equal frozensets built
+    fresh each call would pass an equality check while losing the cache."""
+    assert obs_column_tiers() is obs_column_tiers()
+    # The uncached builder is what the cache wraps; it must agree with it.
+    assert build_obs_column_tiers() == obs_column_tiers()

--- a/packages/hca-anndata-tools/tests/test_schema_helpers.py
+++ b/packages/hca-anndata-tools/tests/test_schema_helpers.py
@@ -7,7 +7,10 @@ non-membership assertions below are load-bearing safety properties, not
 incidental facts.
 """
 
+from pydantic import BaseModel
+
 from hca_anndata_tools.schema.helpers import (
+    _entity_classes,
     build_obs_column_tiers,
     obs_column_tiers,
     uns_field_registry,
@@ -76,9 +79,34 @@ def test_tiers_are_disjoint():
     assert not (_required() & _optional())
 
 
+def test_entity_classes_are_derived_not_enumerated():
+    """`allowed_bionetwork_names` in shared declares 18 bionetworks against the 3
+    that currently have schema classes. A hardcoded class list would silently go
+    stale the first time one of the other 15 gains a subclass, and stale here
+    means a required column quietly losing its guard in drop_obs_columns.
+
+    Pins that the walk reaches every entity class in the module, so adding a
+    bionetwork needs no change here."""
+    from hca_anndata_tools.schema import core
+
+    derived = {c.__name__ for c in _entity_classes()}
+    # Every model class in core.py that subclasses one of the four entity bases
+    # must be reachable. Compare against an independent scan of the module.
+    bases = {"Dataset", "Donor", "Sample", "Cell"}
+    expected = {
+        name
+        for name, obj in vars(core).items()
+        if isinstance(obj, type)
+        and issubclass(obj, BaseModel)
+        and (name in bases or bases & {b.__name__ for b in obj.__mro__})
+        and name not in ("ConfiguredBaseModel", "BaseModel")
+    }
+    assert derived == expected, f"unreachable entity classes: {expected - derived}"
+
+
 def test_bionetwork_only_required_columns_are_collected():
     """ambient_count_correction and doublet_detection live on the bionetwork
-    Dataset subclasses, not base Dataset. If _OBS_CLASSES stopped walking the
+    Dataset subclasses, not base Dataset. If the subclass walk stopped reaching
     subclasses these would silently vanish from the guard."""
     required = _required()
     assert "ambient_count_correction" in required

--- a/packages/hca-anndata-tools/tests/test_schema_helpers.py
+++ b/packages/hca-anndata-tools/tests/test_schema_helpers.py
@@ -73,6 +73,36 @@ def test_optional_tier_contains_known_optional_columns():
         assert col in optional, f"{col} should be schema-optional"
 
 
+def test_columns_538_made_visible_are_tiered():
+    """#538 (PR #545) added the LinkML declarations these four depend on.
+
+    Before it, `Cell` was a bare `pass` and two `Sample` slots carried no
+    `annDataLocation`, so all four were invisible to this walk and `drop_obs_columns`
+    deleted them without complaint. Asserted here as well as in test_drop because the
+    two failures look different: here it means the bundled model went stale, there it
+    means the guard stopped consulting it.
+
+    `sample_collection_method` is required; the Cell pair and `is_primary_data` are
+    optional, matching the h5ad validator's requirement levels.
+    """
+    assert "sample_collection_method" in _required()
+    for col in ("cell_type_ontology_term_id", "author_cell_type", "is_primary_data"):
+        assert col in _optional(), f"{col} should be schema-optional"
+
+
+def test_cell_entity_contributes_obs_columns():
+    """The `Cell` class is reachable from the entity walk and contributes columns.
+
+    `Cell` was empty until #538, so this is the first thing that would break if a
+    regeneration lost the class or the walk stopped reaching it — a silent failure
+    otherwise, since the tiers would simply come back two columns lighter.
+    """
+    from hca_anndata_tools.schema.core import Cell
+
+    assert Cell in _entity_classes()
+    assert {"author_cell_type", "cell_type_ontology_term_id"} <= _optional()
+
+
 def test_tiers_are_disjoint():
     """A column required by any entity is required, even where another class
     declares it optional — the stricter tier wins."""


### PR DESCRIPTION
Closes #531

> **Blocked by #538 — held as a draft so it cannot be merged first.** Three obs columns the HCA schema defines —
> `cell_type_ontology_term_id`, `is_primary_data`, `sample_collection_method` — are
> invisible to the `annDataLocation` discovery this guard derives its tiers from, so they
> currently drop. `cell_type_ontology_term_id` is unrecoverable (`populate_labels` derives
> `cell_type` *from* it). Fixing that is a schema change with `metadata_coverage`
> wire-format consequences, so it lands separately. A supplementary hardcoded list here was
> considered and rejected — hardcoded column lists rotting is the premise of this issue.

## What changed

A new `drop_obs_columns(path, columns)` in `packages/hca-anndata-tools`, exposed as MCP
tool 24.

- **`drop.py`** (new) — the tool. Validates the whole request before touching anything,
  then copies the file, deletes the named obs datasets via h5py, repairs
  `obs['column-order']`, and appends an edit-log entry.
- **`schema/helpers.py`** — `build_obs_column_tiers()` walks the nine obs-bearing model
  classes for `annDataLocation == "obs"`, splitting on `is_required()`, cached behind
  `obs_column_tiers()`. Mirrors the existing `get_uns_field_registry` / `uns_field_registry`
  pair.
- **`__init__.py`** — lazy-import wiring, matching `strip_forbidden_obs_columns`.
- **`hca-anndata-mcp/tools/drop.py`** (new) — thin re-export, same shape as `tools/strip.py`.
- **`server.py`** — import, registration, one sentence in the instructions string.
- Tests: `test_drop.py` (27), `test_schema_helpers.py` (9, the first tests for that
  module), `hca-anndata-mcp/tests/test_drop.py` (3).

## Why

`strip_forbidden_obs_columns` can only remove two hardcoded canonical privacy column
names. Producers ship the same information under names no fixed list anticipates:

| What | How it actually appears |
|---|---|
| ethnicity | `self_reported_ethnicity_label`, `ethnicity_verbatim`, `ethnicity_grouped`, `reported_ethnicity`, `race` — five names across seven breast-v1 files, none matching the hardcoded pair |
| derived ontology labels | `cell_type_label`, `assay_label`, … — redundant once `populate_labels` has run, and a different set per dataset |

So `strip` returns `{"skipped": true}` on every one of those files while the data is still
there. This tool holds **no policy** — the caller names the columns — and its only opinion
is refusing to remove what the file cannot afford to lose.

## Assumptions I made

**The request is all-or-nothing, and there is no `skipped` state.** Every check runs to
completion and a single error reports every problem, so one mistyped name cannot
half-curate a file. This is a deliberate divergence from `strip`, which *chose* its own
column names and so treats "neither present" as a normal outcome; here the caller named
them, making absence a mistake. Practical consequence: **one union column list cannot be
reused across the seven breast files** — `race` exists only in nee2023 — so each file needs
its own exact list, read from the evaluate step.

**Any column the schema names is refused, optional as well as required.** Optional columns
hold producer data that cannot be reconstructed, and this tool deliberately offers no way
to damage a file. A `force` flag could later permit the optional tier; it must never permit
the required tier, which is why the error reports the two tiers separately. Verified that
this blocks nothing we need: none of the ethnicity aliases or producer `*_label` columns
appear in either tier, and the schema-*forbidden* `self_reported_ethnicity*` columns are in
neither, so the guard cannot block a privacy strip.

**Canonical derived labels carry no guard.** `cell_type`, `tissue`, `assay`, `sex`,
`disease`, `organism`, `development_stage` are outputs `populate_labels` regenerates from
the matching `*_ontology_term_id` columns, so dropping one loses nothing permanently —
categorically different from `donor_id`. Also unavoidable: `HCA_DERIVED_OBS_LABELS` lives in
`hca-schema-validator`, which `hca-anndata-tools` does not depend on.

**Names containing `/` are rejected before anything else.** h5py resolves them as HDF5 link
paths, not dict keys — a leading slash resolves from the file root and inner slashes
traverse subgroups — so `"/X" in obs` is `True` whenever the file has a root `X`, and
`del obs["/X"]` unlinks the expression matrix. Every other check compares plain strings, so
without this they would disagree with what the delete actually does. The existence check
also moved to `set(obs.keys())` for the same reason. Found by the security pass and verified
by exploit before and after.

**`uns` references split by ownership.** `uns['<col>_colors']` *belongs to* the column —
scanpy writes it for any categorical it plots, including the producer label columns this
tool targets — so it is deleted alongside, and orphaning it is a hard validator error
(`Colors field uns[...] does not have a corresponding categorical field in obs`). By
contrast `uns['batch_condition']` (typed `match_obs_columns`) and CAP annotation sets
declared in `uns['cap_metadata']` merely *reference* the column, and repairing either would
rewrite a claim the file makes — a curation decision, not cleanup — so those refuse. The CAP
check keys on the `--` naming convention rather than parsing `cap_metadata`, which may be a
group or a JSON string; over-refusing is the safe direction and no targeted column uses that
separator.

**The schema tiers are derived, not hardcoded** — that is the whole point, since a
hardcoded list is what rotted in `strip`. This cannot reuse `shared/schema_utils`:
`hca-anndata-tools` does not depend on `hca-validation-shared`, and `iter_coverage_slots`
excludes identifier and foreign-key slots, so `donor_id` and `sample_id` would fall out of
the guard entirely.

**The file does not shrink.** HDF5 does not reclaim freed space in place, so the output is
the same size as the input. Acceptable because `compress_h5ad` repacks and runs last in a
curation sequence; documented in the docstring so it is not reported as a bug. Note the
corollary: dropped PII remains recoverable in the output file's bytes until a repack. That
is inherited from `strip`, not new here, but it means **`compress_h5ad` is not optional
after a privacy drop**.

**No CellxGENE-layout refusal.** `strip` refuses because `convert_cellxgene_to_hca`
supersedes it; removing an arbitrary column is layout-agnostic.

**Known pre-existing hazard, not fixed here:** a same-second `generate_output_path`
collision makes `copy2` raise `SameFileError`, after which the cleanup handler unlinks the
*input*. That is #437, which affects `strip.py` identically; I commented there with the
verification and a note that its proposed counter-suffix fix would produce filenames
`resolve_latest`'s regex rejects.

## How to verify

Definition of done from #531, mapped to steps.

**Setup**

```bash
cd packages/hca-anndata-tools && uv sync
```

**R1 — all-or-nothing, no partial drops, no `skipped` state**

```bash
uv run pytest tests/test_drop.py -k "atomic or absent or empty or dedupe or every_problem" -v
```
Expect 5 passing. The load-bearing one is `test_drop_is_atomic_across_valid_and_invalid`:
it hashes the source file before a mixed valid/invalid call and asserts the bytes are
unchanged, not merely that no snapshot appeared.

**R2 — guard tiers: required, optional, obs index all refused**

```bash
uv run pytest tests/test_drop.py -k "refuses_schema or refuses_obs_index" -v
```
Expect 3 passing. The optional case asserts the message says `optional` and *not*
`required`, so the tiers cannot silently collapse into one message.

**R3 — canonical derived labels are droppable**

```bash
uv run pytest tests/test_drop.py -k canonical_derived -v
```

**R4 — the guard does not block the job the tool exists for**

```bash
uv run pytest tests/test_drop.py -k "noncanonical or producer_label" -v
uv run pytest tests/test_schema_helpers.py -v
```
The registry tests pin that the ethnicity aliases, the forbidden privacy columns, and the
seven derived labels are all in neither tier. Membership assertions rather than the counts
25/11 — a hard count would go red on any upstream LinkML change with no explanation of what
moved.

**R5/R6/R7 — result shape, mechanics, layout-agnosticism**

```bash
uv run pytest tests/test_drop.py tests/test_schema_helpers.py -v
cd ../hca-anndata-mcp && uv run pytest tests/test_drop.py -v
```
Expect 36 + 3 passing. `test_drop_succeeds_on_cellxgene_layout` proves R6 by succeeding on
the fixture, which sets `uns['schema_version']` — the exact marker `strip` refuses on.

**Manual check on a real file** (nothing is mutated in place; a timestamped snapshot is
written beside the input):

```bash
# 1. See what non-schema columns a file carries
#    (MCP: get_summary, or read obs.columns)
# 2. Drop two ethnicity aliases, naming them exactly
#    MCP: drop_obs_columns(path, ["ethnicity_verbatim", "ethnicity_grouped"])
#    Expect: {"output_path": "<stem>-edit-<ts>.h5ad",
#             "obs_columns_dropped": ["ethnicity_verbatim", "ethnicity_grouped"],
#             "uns_keys_dropped": []}
# 3. Confirm the guard bites
#    MCP: drop_obs_columns(path, ["donor_id"])
#    Expect an error naming the required tier, and no new snapshot on disk
# 4. Confirm a typo fails loudly rather than partially
#    MCP: drop_obs_columns(path, ["ethnicity_verbatim", "ethnicty_grouped"])
#    Expect one error listing the misspelling, and the file untouched
# 5. Confirm the path guard
#    MCP: drop_obs_columns(path, ["/X"])
#    Expect refusal; the matrix must still be present afterwards
```

**Gate**

```bash
make typecheck        # 0 errors across all four roots
```
316 `hca-anndata-tools` tests, 44 `hca-anndata-mcp` tests, ruff check and format clean.

## Out of scope

- Editing obs *values* — #236 (`set_obs`)
- Detecting *which* columns are redundant — #523 and #525; this only removes what it is told to
- Validating the file after the drop — `validate_schema` exists
- Adding the tool to `curate-h5ad`'s Bucket A, which the skill declares a closed set — that
  belongs with #522/#529, which already touch that skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)
