### PR TITLE
fix(schema): make three obs columns visible to annDataLocation discovery

### DIFF
--- a/data_dictionaries/core_data_dictionary.json
+++ b/data_dictionaries/core_data_dictionary.json
@@ -460,10 +460,17 @@
         {
           "name": "is_primary_data",
           "title": "Is Primary Data",
-          "description": "Deprecated placeholder indicating whether sample represents primary data.",
-          "range": "string",
+          "description": "Whether the sample represents the primary data for these cells, as opposed to a re-analysis of data published elsewhere.",
+          "range": "boolean",
           "required": false,
-          "multivalued": false
+          "multivalued": false,
+          "example": "true",
+          "annotations": {
+            "annDataLocation": "obs",
+            "tier": "Tier 1",
+            "cxg": "is_primary_data"
+          },
+          "rationale": "Required by the h5ad validator and by the published Tier 1 dictionary, but left optional here until entry sheets carry the column \u2014 LinkML's `required` is enforced against entry sheet rows, so flipping it fails every sheet without it. See #544. Lives on Sample to match the published Tier 1 dictionary, which places it there even though CELLxGENE treats it as a per-cell flag. Consequence: coverage buckets it by sample_id, so an integrated object whose cells disagree within one sample (duplicate copies marked false, canonical ones true) reports that sample as inconsistent. That is accurate reporting of a genuinely mixed value, not a validation failure \u2014 the h5ad validator accepts such a file."
         },
         {
           "name": "library_id",
@@ -528,6 +535,10 @@
           "range": "SampleCollectionMethod",
           "required": true,
           "multivalued": false,
+          "annotations": {
+            "annDataLocation": "obs",
+            "tier": "Tier 1"
+          },
           "values": "brush; scraping; biopsy; surgical resection; blood draw; body fluid; other"
         },
         {
@@ -700,7 +711,38 @@
       "title": "Cell",
       "description": "A single cell derived from a sample",
       "name": "cell",
-      "attributes": []
+      "attributes": [
+        {
+          "name": "author_cell_type",
+          "title": "Author Cell Type",
+          "description": "Cell type label as assigned by the data author, in their own vocabulary.",
+          "range": "string",
+          "required": false,
+          "multivalued": false,
+          "example": "alveolar macrophage; luminal progenitor",
+          "annotations": {
+            "annDataLocation": "obs",
+            "tier": "Tier 1"
+          },
+          "rationale": "The author's own naming, retained alongside the ontology term so the original annotation is not lost when terms are mapped to CL"
+        },
+        {
+          "name": "cell_type_ontology_term_id",
+          "title": "Cell Type Ontology Term ID",
+          "description": "Cell type, as an ontology term.",
+          "range": "string",
+          "required": false,
+          "multivalued": false,
+          "example": "CL:0000583",
+          "annotations": {
+            "annDataLocation": "obs",
+            "tier": "Tier 1",
+            "cxg": "cell_type_ontology_term_id"
+          },
+          "rationale": "Optional to match the validator's requirement_level, but unrecoverable once dropped \u2014 populate_labels derives cell_type from this column, not the reverse",
+          "values": "A CL term, or \"unknown\". ZFA, FBbt, and WBbt terms are allowed depending on the organism. \"na\" is allowed if tissue_type is \"cell line\"."
+        }
+      ]
     }
   ],
   "prefixes": {

--- a/data_dictionaries/core_data_dictionary.json
+++ b/data_dictionaries/core_data_dictionary.json
@@ -470,7 +470,7 @@
             "tier": "Tier 1",
             "cxg": "is_primary_data"
           },
-          "rationale": "Required by the h5ad validator and by the published Tier 1 dictionary, but left optional here until entry sheets carry the column \u2014 LinkML's `required` is enforced against entry sheet rows, so flipping it fails every sheet without it. See #544. Lives on Sample to match the published Tier 1 dictionary, which places it there even though CELLxGENE treats it as a per-cell flag. Consequence: coverage buckets it by sample_id, so an integrated object whose cells disagree within one sample (duplicate copies marked false, canonical ones true) reports that sample as inconsistent. That is accurate reporting of a genuinely mixed value, not a validation failure \u2014 the h5ad validator accepts such a file."
+          "rationale": "Required by the h5ad validator and by the published Tier 1 dictionary, but left optional here until entry sheets carry the column \u2014 LinkML's `required` is enforced against entry sheet rows, so flipping it fails every sheet without it. See #544.\nLives on Sample to match the published Tier 1 dictionary, which places it there even though CELLxGENE treats it as a per-cell flag. Consequence: coverage buckets it by sample_id, so an integrated object whose cells disagree within one sample (duplicate copies marked false, canonical ones true) reports that sample as inconsistent. That is accurate reporting of a genuinely mixed value, not a validation failure \u2014 the h5ad validator accepts such a file."
         },
         {
           "name": "library_id",

--- a/data_dictionaries/core_data_dictionary.json
+++ b/data_dictionaries/core_data_dictionary.json
@@ -460,17 +460,16 @@
         {
           "name": "is_primary_data",
           "title": "Is Primary Data",
-          "description": "Whether the sample represents the primary data for these cells, as opposed to a re-analysis of data published elsewhere.",
-          "range": "boolean",
+          "description": "Deprecated placeholder indicating whether sample represents primary data.",
+          "range": "string",
           "required": false,
           "multivalued": false,
-          "example": "true",
           "annotations": {
             "annDataLocation": "obs",
             "tier": "Tier 1",
             "cxg": "is_primary_data"
           },
-          "rationale": "Required by the h5ad validator and by the published Tier 1 dictionary, but left optional here until entry sheets carry the column \u2014 LinkML's `required` is enforced against entry sheet rows, so flipping it fails every sheet without it. See #544.\nLives on Sample to match the published Tier 1 dictionary, which places it there even though CELLxGENE treats it as a per-cell flag. Consequence: coverage buckets it by sample_id, so an integrated object whose cells disagree within one sample (duplicate copies marked false, canonical ones true) reports that sample as inconsistent. That is accurate reporting of a genuinely mixed value, not a validation failure \u2014 the h5ad validator accepts such a file."
+          "rationale": "Kept as a deprecated placeholder on purpose. The annotation is the only thing added here, because annotations are inert for validation: they tell annDataLocation-walking consumers such as drop_obs_columns that this obs column exists and must not be deleted, without altering what the entry sheet validator accepts. Restoring it to a real `range: boolean` slot would start type-checking the column on entry sheets, where it is currently an unconstrained string that tolerates any value including \"na\" \u2014 sheets that validate today would begin failing. See #544.\nThe real modelling question is deferred, not answered. CELLxGENE defines this in obs as a per-cell bool, and the published Tier 1 dictionary describes it as \"the canonical instance of this cellular observation\" \u2014 per-observation semantics \u2014 while filing it under `sample`. A sample's cells can legitimately disagree, so Sample is the wrong grain for it and this placeholder deliberately makes no semantic claim. Moving it to Cell is its own change: slots are global by name in LinkML, so it needs a slot_usage override rather than a move, and removing it from Sample outright would make sheets carrying the column fail with extra_forbidden."
         },
         {
           "name": "library_id",
@@ -535,10 +534,12 @@
           "range": "SampleCollectionMethod",
           "required": true,
           "multivalued": false,
+          "example": "biopsy; brush; surgical resection",
           "annotations": {
             "annDataLocation": "obs",
             "tier": "Tier 1"
           },
+          "rationale": "Main contributor to batch effects",
           "values": "brush; scraping; biopsy; surgical resection; blood draw; body fluid; other"
         },
         {
@@ -715,32 +716,32 @@
         {
           "name": "author_cell_type",
           "title": "Author Cell Type",
-          "description": "Cell type label as assigned by the data author, in their own vocabulary.",
+          "description": "Encoding of author intuition of cellular annotation in the dataset.",
           "range": "string",
           "required": false,
           "multivalued": false,
-          "example": "alveolar macrophage; luminal progenitor",
+          "example": "Goblet cell; microglia",
           "annotations": {
             "annDataLocation": "obs",
             "tier": "Tier 1"
           },
-          "rationale": "The author's own naming, retained alongside the ontology term so the original annotation is not lost when terms are mapped to CL"
+          "rationale": "Encoding of author intuition of cellular annotation in their dataset.\nRetained alongside the ontology term so the author's original naming is not lost when terms are mapped to CL."
         },
         {
           "name": "cell_type_ontology_term_id",
           "title": "Cell Type Ontology Term ID",
-          "description": "Cell type, as an ontology term.",
+          "description": "Cell Ontology (CL) term.",
           "range": "string",
           "required": false,
           "multivalued": false,
-          "example": "CL:0000583",
+          "example": "CL:0001204",
           "annotations": {
             "annDataLocation": "obs",
             "tier": "Tier 1",
             "cxg": "cell_type_ontology_term_id"
           },
-          "rationale": "Optional to match the validator's requirement_level, but unrecoverable once dropped \u2014 populate_labels derives cell_type from this column, not the reverse",
-          "values": "A CL term, or \"unknown\". ZFA, FBbt, and WBbt terms are allowed depending on the organism. \"na\" is allowed if tissue_type is \"cell line\"."
+          "rationale": "Encoding of cell type to help alignment with other datasets.\nUnrecoverable once dropped \u2014 populate_labels derives cell_type from this column, not the reverse. Optional here to match the h5ad validator's requirement_level.",
+          "values": "This must be a Cell Ontology (CL) term (http://www.ebi.ac.uk/ols4/ontologies/cl).\n\nIf no appropriate high-level term can be found or the cell type is unknown, then it is strongly recommended to use 'unknown'.\n\nThe following terms must not be used: \"CL:0000255\" for eukaryotic cell; \"CL:0000257\" for Eumycetozoan cell; \"CL:0000548\" for animal cell.\n\nZFA, FBbt, and WBbt terms are allowed depending on the organism, and \"na\" is allowed if tissue_type is \"cell line\" \u2014 per the h5ad validator's curie_constraints."
         }
       ]
     }

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/schema/core.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/schema/core.py
@@ -1,13 +1,33 @@
 # Bundled copy of shared/src/hca_validation/schema/generated/core.py
 # Generated from LinkML schemas via `cd shared && make gen-schema`.
 # To refresh: copy the generated file here after regeneration.
-from __future__ import annotations
+from __future__ import annotations 
 
-from decimal import Decimal
-from enum import Enum
-from typing import Any, ClassVar, Optional, Union
+import re
+import sys
+from datetime import (
+    date,
+    datetime,
+    time
+)
+from decimal import Decimal 
+from enum import Enum 
+from typing import (
+    Any,
+    ClassVar,
+    Literal,
+    Optional,
+    Union
+)
 
-from pydantic import BaseModel, ConfigDict, Field, RootModel
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    RootModel,
+    field_validator
+)
+
 
 metamodel_version = "None"
 version = "0.1.0"
@@ -819,7 +839,24 @@ class Sample(ConfiguredBaseModel):
                       'other factors differ.'],
          'domain_of': ['Sample'],
          'examples': [{'value': 'EMBL-EBI; Genome Institute of Singapore'}]} })
-    is_primary_data: Optional[str] = Field(default=None, title="Is Primary Data", description="""Deprecated placeholder indicating whether sample represents primary data.""", json_schema_extra = { "linkml_meta": {'alias': 'is_primary_data', 'domain_of': ['Sample'], 'is_a': 'deprecated_slot'} })
+    is_primary_data: Optional[bool] = Field(default=None, title="Is Primary Data", description="""Whether the sample represents the primary data for these cells, as opposed to a re-analysis of data published elsewhere.""", json_schema_extra = { "linkml_meta": {'alias': 'is_primary_data',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'is_primary_data'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Required by the h5ad validator and by the published Tier 1 '
+                      'dictionary, but left optional here until entry sheets carry the '
+                      "column — LinkML's `required` is enforced against entry sheet "
+                      'rows, so flipping it fails every sheet without it. See #544. '
+                      'Lives on Sample to match the published Tier 1 dictionary, which '
+                      'places it there even though CELLxGENE treats it as a per-cell '
+                      'flag. Consequence: coverage buckets it by sample_id, so an '
+                      'integrated object whose cells disagree within one sample '
+                      '(duplicate copies marked false, canonical ones true) reports '
+                      'that sample as inconsistent. That is accurate reporting of a '
+                      'genuinely mixed value, not a validation failure — the h5ad '
+                      'validator accepts such a file.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'true'}]} })
     library_id: str = Field(default=..., title="Library ID", description="""The unique ID that is used to track libraries in the investigator's institution (should align with the publication).""", json_schema_extra = { "linkml_meta": {'alias': 'library_id',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
@@ -847,6 +884,8 @@ class Sample(ConfiguredBaseModel):
          'domain_of': ['Sample'],
          'examples': [{'value': 'run1; NV0087'}]} })
     sample_collection_method: SampleCollectionMethod = Field(default=..., title="Sample Collection Method", description="""The method the sample was physically obtained from the donor.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_method',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
          'domain_of': ['Sample'],
          'notes': ['brush; scraping; biopsy; surgical resection; blood draw; body '
                    'fluid; other']} })
@@ -1046,7 +1085,24 @@ class AdiposeSample(Sample):
                       'other factors differ.'],
          'domain_of': ['Sample'],
          'examples': [{'value': 'EMBL-EBI; Genome Institute of Singapore'}]} })
-    is_primary_data: Optional[str] = Field(default=None, title="Is Primary Data", description="""Deprecated placeholder indicating whether sample represents primary data.""", json_schema_extra = { "linkml_meta": {'alias': 'is_primary_data', 'domain_of': ['Sample'], 'is_a': 'deprecated_slot'} })
+    is_primary_data: Optional[bool] = Field(default=None, title="Is Primary Data", description="""Whether the sample represents the primary data for these cells, as opposed to a re-analysis of data published elsewhere.""", json_schema_extra = { "linkml_meta": {'alias': 'is_primary_data',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'is_primary_data'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Required by the h5ad validator and by the published Tier 1 '
+                      'dictionary, but left optional here until entry sheets carry the '
+                      "column — LinkML's `required` is enforced against entry sheet "
+                      'rows, so flipping it fails every sheet without it. See #544. '
+                      'Lives on Sample to match the published Tier 1 dictionary, which '
+                      'places it there even though CELLxGENE treats it as a per-cell '
+                      'flag. Consequence: coverage buckets it by sample_id, so an '
+                      'integrated object whose cells disagree within one sample '
+                      '(duplicate copies marked false, canonical ones true) reports '
+                      'that sample as inconsistent. That is accurate reporting of a '
+                      'genuinely mixed value, not a validation failure — the h5ad '
+                      'validator accepts such a file.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'true'}]} })
     library_id: str = Field(default=..., title="Library ID", description="""The unique ID that is used to track libraries in the investigator's institution (should align with the publication).""", json_schema_extra = { "linkml_meta": {'alias': 'library_id',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
@@ -1074,6 +1130,8 @@ class AdiposeSample(Sample):
          'domain_of': ['Sample'],
          'examples': [{'value': 'run1; NV0087'}]} })
     sample_collection_method: SampleCollectionMethod = Field(default=..., title="Sample Collection Method", description="""The method the sample was physically obtained from the donor.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_method',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
          'domain_of': ['Sample'],
          'notes': ['brush; scraping; biopsy; surgical resection; blood draw; body '
                    'fluid; other']} })
@@ -1274,7 +1332,24 @@ class GutSample(Sample):
                       'other factors differ.'],
          'domain_of': ['Sample'],
          'examples': [{'value': 'EMBL-EBI; Genome Institute of Singapore'}]} })
-    is_primary_data: Optional[str] = Field(default=None, title="Is Primary Data", description="""Deprecated placeholder indicating whether sample represents primary data.""", json_schema_extra = { "linkml_meta": {'alias': 'is_primary_data', 'domain_of': ['Sample'], 'is_a': 'deprecated_slot'} })
+    is_primary_data: Optional[bool] = Field(default=None, title="Is Primary Data", description="""Whether the sample represents the primary data for these cells, as opposed to a re-analysis of data published elsewhere.""", json_schema_extra = { "linkml_meta": {'alias': 'is_primary_data',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'is_primary_data'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Required by the h5ad validator and by the published Tier 1 '
+                      'dictionary, but left optional here until entry sheets carry the '
+                      "column — LinkML's `required` is enforced against entry sheet "
+                      'rows, so flipping it fails every sheet without it. See #544. '
+                      'Lives on Sample to match the published Tier 1 dictionary, which '
+                      'places it there even though CELLxGENE treats it as a per-cell '
+                      'flag. Consequence: coverage buckets it by sample_id, so an '
+                      'integrated object whose cells disagree within one sample '
+                      '(duplicate copies marked false, canonical ones true) reports '
+                      'that sample as inconsistent. That is accurate reporting of a '
+                      'genuinely mixed value, not a validation failure — the h5ad '
+                      'validator accepts such a file.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'true'}]} })
     library_id: str = Field(default=..., title="Library ID", description="""The unique ID that is used to track libraries in the investigator's institution (should align with the publication).""", json_schema_extra = { "linkml_meta": {'alias': 'library_id',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
@@ -1302,6 +1377,8 @@ class GutSample(Sample):
          'domain_of': ['Sample'],
          'examples': [{'value': 'run1; NV0087'}]} })
     sample_collection_method: SampleCollectionMethod = Field(default=..., title="Sample Collection Method", description="""The method the sample was physically obtained from the donor.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_method',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
          'domain_of': ['Sample'],
          'notes': ['brush; scraping; biopsy; surgical resection; blood draw; body '
                    'fluid; other']} })
@@ -1549,7 +1626,26 @@ class Cell(ConfiguredBaseModel):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/cell'})
 
-    pass
+    author_cell_type: Optional[str] = Field(default=None, title="Author Cell Type", description="""Cell type label as assigned by the data author, in their own vocabulary.""", json_schema_extra = { "linkml_meta": {'alias': 'author_cell_type',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ["The author's own naming, retained alongside the ontology term "
+                      'so the original annotation is not lost when terms are mapped to '
+                      'CL'],
+         'domain_of': ['Cell'],
+         'examples': [{'value': 'alveolar macrophage; luminal progenitor'}]} })
+    cell_type_ontology_term_id: Optional[str] = Field(default=None, title="Cell Type Ontology Term ID", description="""Cell type, as an ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'cell_type_ontology_term_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'cell_type_ontology_term_id'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ["Optional to match the validator's requirement_level, but "
+                      'unrecoverable once dropped — populate_labels derives cell_type '
+                      'from this column, not the reverse'],
+         'domain_of': ['Cell'],
+         'examples': [{'value': 'CL:0000583'}],
+         'notes': ['A CL term, or "unknown". ZFA, FBbt, and WBbt terms are allowed '
+                   'depending on the organism. "na" is allowed if tissue_type is "cell '
+                   'line".']} })
 
 
 # Model rebuild

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/schema/core.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/schema/core.py
@@ -839,24 +839,33 @@ class Sample(ConfiguredBaseModel):
                       'other factors differ.'],
          'domain_of': ['Sample'],
          'examples': [{'value': 'EMBL-EBI; Genome Institute of Singapore'}]} })
-    is_primary_data: Optional[bool] = Field(default=None, title="Is Primary Data", description="""Whether the sample represents the primary data for these cells, as opposed to a re-analysis of data published elsewhere.""", json_schema_extra = { "linkml_meta": {'alias': 'is_primary_data',
+    is_primary_data: Optional[str] = Field(default=None, title="Is Primary Data", description="""Deprecated placeholder indicating whether sample represents primary data.""", json_schema_extra = { "linkml_meta": {'alias': 'is_primary_data',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'cxg': {'tag': 'cxg', 'value': 'is_primary_data'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
-         'comments': ['Required by the h5ad validator and by the published Tier 1 '
-                      'dictionary, but left optional here until entry sheets carry the '
-                      "column — LinkML's `required` is enforced against entry sheet "
-                      'rows, so flipping it fails every sheet without it. See #544.',
-                      'Lives on Sample to match the published Tier 1 dictionary, which '
-                      'places it there even though CELLxGENE treats it as a per-cell '
-                      'flag. Consequence: coverage buckets it by sample_id, so an '
-                      'integrated object whose cells disagree within one sample '
-                      '(duplicate copies marked false, canonical ones true) reports '
-                      'that sample as inconsistent. That is accurate reporting of a '
-                      'genuinely mixed value, not a validation failure — the h5ad '
-                      'validator accepts such a file.'],
+         'comments': ['Kept as a deprecated placeholder on purpose. The annotation is '
+                      'the only thing added here, because annotations are inert for '
+                      'validation: they tell annDataLocation-walking consumers such as '
+                      'drop_obs_columns that this obs column exists and must not be '
+                      'deleted, without altering what the entry sheet validator '
+                      'accepts. Restoring it to a real `range: boolean` slot would '
+                      'start type-checking the column on entry sheets, where it is '
+                      'currently an unconstrained string that tolerates any value '
+                      'including "na" — sheets that validate today would begin '
+                      'failing. See #544.',
+                      'The real modelling question is deferred, not answered. '
+                      'CELLxGENE defines this in obs as a per-cell bool, and the '
+                      'published Tier 1 dictionary describes it as "the canonical '
+                      'instance of this cellular observation" — per-observation '
+                      "semantics — while filing it under `sample`. A sample's cells "
+                      'can legitimately disagree, so Sample is the wrong grain for it '
+                      'and this placeholder deliberately makes no semantic claim. '
+                      'Moving it to Cell is its own change: slots are global by name '
+                      'in LinkML, so it needs a slot_usage override rather than a '
+                      'move, and removing it from Sample outright would make sheets '
+                      'carrying the column fail with extra_forbidden.'],
          'domain_of': ['Sample'],
-         'examples': [{'value': 'true'}]} })
+         'is_a': 'deprecated_slot'} })
     library_id: str = Field(default=..., title="Library ID", description="""The unique ID that is used to track libraries in the investigator's institution (should align with the publication).""", json_schema_extra = { "linkml_meta": {'alias': 'library_id',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
@@ -886,7 +895,9 @@ class Sample(ConfiguredBaseModel):
     sample_collection_method: SampleCollectionMethod = Field(default=..., title="Sample Collection Method", description="""The method the sample was physically obtained from the donor.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_method',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Main contributor to batch effects'],
          'domain_of': ['Sample'],
+         'examples': [{'value': 'biopsy; brush; surgical resection'}],
          'notes': ['brush; scraping; biopsy; surgical resection; blood draw; body '
                    'fluid; other']} })
     sample_collection_year: Optional[str] = Field(default=None, title="Sample Collection Year", description="""Year of sample collection. Should not be detailed further (to exact month and day), to prevent identifiability.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_year',
@@ -1085,24 +1096,33 @@ class AdiposeSample(Sample):
                       'other factors differ.'],
          'domain_of': ['Sample'],
          'examples': [{'value': 'EMBL-EBI; Genome Institute of Singapore'}]} })
-    is_primary_data: Optional[bool] = Field(default=None, title="Is Primary Data", description="""Whether the sample represents the primary data for these cells, as opposed to a re-analysis of data published elsewhere.""", json_schema_extra = { "linkml_meta": {'alias': 'is_primary_data',
+    is_primary_data: Optional[str] = Field(default=None, title="Is Primary Data", description="""Deprecated placeholder indicating whether sample represents primary data.""", json_schema_extra = { "linkml_meta": {'alias': 'is_primary_data',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'cxg': {'tag': 'cxg', 'value': 'is_primary_data'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
-         'comments': ['Required by the h5ad validator and by the published Tier 1 '
-                      'dictionary, but left optional here until entry sheets carry the '
-                      "column — LinkML's `required` is enforced against entry sheet "
-                      'rows, so flipping it fails every sheet without it. See #544.',
-                      'Lives on Sample to match the published Tier 1 dictionary, which '
-                      'places it there even though CELLxGENE treats it as a per-cell '
-                      'flag. Consequence: coverage buckets it by sample_id, so an '
-                      'integrated object whose cells disagree within one sample '
-                      '(duplicate copies marked false, canonical ones true) reports '
-                      'that sample as inconsistent. That is accurate reporting of a '
-                      'genuinely mixed value, not a validation failure — the h5ad '
-                      'validator accepts such a file.'],
+         'comments': ['Kept as a deprecated placeholder on purpose. The annotation is '
+                      'the only thing added here, because annotations are inert for '
+                      'validation: they tell annDataLocation-walking consumers such as '
+                      'drop_obs_columns that this obs column exists and must not be '
+                      'deleted, without altering what the entry sheet validator '
+                      'accepts. Restoring it to a real `range: boolean` slot would '
+                      'start type-checking the column on entry sheets, where it is '
+                      'currently an unconstrained string that tolerates any value '
+                      'including "na" — sheets that validate today would begin '
+                      'failing. See #544.',
+                      'The real modelling question is deferred, not answered. '
+                      'CELLxGENE defines this in obs as a per-cell bool, and the '
+                      'published Tier 1 dictionary describes it as "the canonical '
+                      'instance of this cellular observation" — per-observation '
+                      "semantics — while filing it under `sample`. A sample's cells "
+                      'can legitimately disagree, so Sample is the wrong grain for it '
+                      'and this placeholder deliberately makes no semantic claim. '
+                      'Moving it to Cell is its own change: slots are global by name '
+                      'in LinkML, so it needs a slot_usage override rather than a '
+                      'move, and removing it from Sample outright would make sheets '
+                      'carrying the column fail with extra_forbidden.'],
          'domain_of': ['Sample'],
-         'examples': [{'value': 'true'}]} })
+         'is_a': 'deprecated_slot'} })
     library_id: str = Field(default=..., title="Library ID", description="""The unique ID that is used to track libraries in the investigator's institution (should align with the publication).""", json_schema_extra = { "linkml_meta": {'alias': 'library_id',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
@@ -1132,7 +1152,9 @@ class AdiposeSample(Sample):
     sample_collection_method: SampleCollectionMethod = Field(default=..., title="Sample Collection Method", description="""The method the sample was physically obtained from the donor.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_method',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Main contributor to batch effects'],
          'domain_of': ['Sample'],
+         'examples': [{'value': 'biopsy; brush; surgical resection'}],
          'notes': ['brush; scraping; biopsy; surgical resection; blood draw; body '
                    'fluid; other']} })
     sample_collection_year: Optional[str] = Field(default=None, title="Sample Collection Year", description="""Year of sample collection. Should not be detailed further (to exact month and day), to prevent identifiability.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_year',
@@ -1332,24 +1354,33 @@ class GutSample(Sample):
                       'other factors differ.'],
          'domain_of': ['Sample'],
          'examples': [{'value': 'EMBL-EBI; Genome Institute of Singapore'}]} })
-    is_primary_data: Optional[bool] = Field(default=None, title="Is Primary Data", description="""Whether the sample represents the primary data for these cells, as opposed to a re-analysis of data published elsewhere.""", json_schema_extra = { "linkml_meta": {'alias': 'is_primary_data',
+    is_primary_data: Optional[str] = Field(default=None, title="Is Primary Data", description="""Deprecated placeholder indicating whether sample represents primary data.""", json_schema_extra = { "linkml_meta": {'alias': 'is_primary_data',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'cxg': {'tag': 'cxg', 'value': 'is_primary_data'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
-         'comments': ['Required by the h5ad validator and by the published Tier 1 '
-                      'dictionary, but left optional here until entry sheets carry the '
-                      "column — LinkML's `required` is enforced against entry sheet "
-                      'rows, so flipping it fails every sheet without it. See #544.',
-                      'Lives on Sample to match the published Tier 1 dictionary, which '
-                      'places it there even though CELLxGENE treats it as a per-cell '
-                      'flag. Consequence: coverage buckets it by sample_id, so an '
-                      'integrated object whose cells disagree within one sample '
-                      '(duplicate copies marked false, canonical ones true) reports '
-                      'that sample as inconsistent. That is accurate reporting of a '
-                      'genuinely mixed value, not a validation failure — the h5ad '
-                      'validator accepts such a file.'],
+         'comments': ['Kept as a deprecated placeholder on purpose. The annotation is '
+                      'the only thing added here, because annotations are inert for '
+                      'validation: they tell annDataLocation-walking consumers such as '
+                      'drop_obs_columns that this obs column exists and must not be '
+                      'deleted, without altering what the entry sheet validator '
+                      'accepts. Restoring it to a real `range: boolean` slot would '
+                      'start type-checking the column on entry sheets, where it is '
+                      'currently an unconstrained string that tolerates any value '
+                      'including "na" — sheets that validate today would begin '
+                      'failing. See #544.',
+                      'The real modelling question is deferred, not answered. '
+                      'CELLxGENE defines this in obs as a per-cell bool, and the '
+                      'published Tier 1 dictionary describes it as "the canonical '
+                      'instance of this cellular observation" — per-observation '
+                      "semantics — while filing it under `sample`. A sample's cells "
+                      'can legitimately disagree, so Sample is the wrong grain for it '
+                      'and this placeholder deliberately makes no semantic claim. '
+                      'Moving it to Cell is its own change: slots are global by name '
+                      'in LinkML, so it needs a slot_usage override rather than a '
+                      'move, and removing it from Sample outright would make sheets '
+                      'carrying the column fail with extra_forbidden.'],
          'domain_of': ['Sample'],
-         'examples': [{'value': 'true'}]} })
+         'is_a': 'deprecated_slot'} })
     library_id: str = Field(default=..., title="Library ID", description="""The unique ID that is used to track libraries in the investigator's institution (should align with the publication).""", json_schema_extra = { "linkml_meta": {'alias': 'library_id',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
@@ -1379,7 +1410,9 @@ class GutSample(Sample):
     sample_collection_method: SampleCollectionMethod = Field(default=..., title="Sample Collection Method", description="""The method the sample was physically obtained from the donor.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_method',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Main contributor to batch effects'],
          'domain_of': ['Sample'],
+         'examples': [{'value': 'biopsy; brush; surgical resection'}],
          'notes': ['brush; scraping; biopsy; surgical resection; blood draw; body '
                    'fluid; other']} })
     sample_collection_year: Optional[str] = Field(default=None, title="Sample Collection Year", description="""Year of sample collection. Should not be detailed further (to exact month and day), to prevent identifiability.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_year',
@@ -1626,26 +1659,37 @@ class Cell(ConfiguredBaseModel):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/cell'})
 
-    author_cell_type: Optional[str] = Field(default=None, title="Author Cell Type", description="""Cell type label as assigned by the data author, in their own vocabulary.""", json_schema_extra = { "linkml_meta": {'alias': 'author_cell_type',
+    author_cell_type: Optional[str] = Field(default=None, title="Author Cell Type", description="""Encoding of author intuition of cellular annotation in the dataset.""", json_schema_extra = { "linkml_meta": {'alias': 'author_cell_type',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
-         'comments': ["The author's own naming, retained alongside the ontology term "
-                      'so the original annotation is not lost when terms are mapped to '
-                      'CL'],
+         'comments': ['Encoding of author intuition of cellular annotation in their '
+                      'dataset.',
+                      "Retained alongside the ontology term so the author's original "
+                      'naming is not lost when terms are mapped to CL.'],
          'domain_of': ['Cell'],
-         'examples': [{'value': 'alveolar macrophage; luminal progenitor'}]} })
-    cell_type_ontology_term_id: Optional[str] = Field(default=None, title="Cell Type Ontology Term ID", description="""Cell type, as an ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'cell_type_ontology_term_id',
+         'examples': [{'value': 'Goblet cell; microglia'}]} })
+    cell_type_ontology_term_id: Optional[str] = Field(default=None, title="Cell Type Ontology Term ID", description="""Cell Ontology (CL) term.""", json_schema_extra = { "linkml_meta": {'alias': 'cell_type_ontology_term_id',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'cxg': {'tag': 'cxg', 'value': 'cell_type_ontology_term_id'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
-         'comments': ["Optional to match the validator's requirement_level, but "
-                      'unrecoverable once dropped — populate_labels derives cell_type '
-                      'from this column, not the reverse'],
+         'comments': ['Encoding of cell type to help alignment with other datasets.',
+                      'Unrecoverable once dropped — populate_labels derives cell_type '
+                      'from this column, not the reverse. Optional here to match the '
+                      "h5ad validator's requirement_level."],
          'domain_of': ['Cell'],
-         'examples': [{'value': 'CL:0000583'}],
-         'notes': ['A CL term, or "unknown". ZFA, FBbt, and WBbt terms are allowed '
-                   'depending on the organism. "na" is allowed if tissue_type is "cell '
-                   'line".']} })
+         'examples': [{'value': 'CL:0001204'}],
+         'notes': ['This must be a Cell Ontology (CL) term '
+                   '(http://www.ebi.ac.uk/ols4/ontologies/cl).\n'
+                   '\n'
+                   'If no appropriate high-level term can be found or the cell type is '
+                   "unknown, then it is strongly recommended to use 'unknown'.\n"
+                   '\n'
+                   'The following terms must not be used: "CL:0000255" for eukaryotic '
+                   'cell; "CL:0000257" for Eumycetozoan cell; "CL:0000548" for animal '
+                   'cell.\n',
+                   'ZFA, FBbt, and WBbt terms are allowed depending on the organism, '
+                   'and "na" is allowed if tissue_type is "cell line" — per the h5ad '
+                   "validator's curie_constraints."]} })
 
 
 # Model rebuild

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/schema/core.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/schema/core.py
@@ -846,7 +846,7 @@ class Sample(ConfiguredBaseModel):
          'comments': ['Required by the h5ad validator and by the published Tier 1 '
                       'dictionary, but left optional here until entry sheets carry the '
                       "column — LinkML's `required` is enforced against entry sheet "
-                      'rows, so flipping it fails every sheet without it. See #544. '
+                      'rows, so flipping it fails every sheet without it. See #544.',
                       'Lives on Sample to match the published Tier 1 dictionary, which '
                       'places it there even though CELLxGENE treats it as a per-cell '
                       'flag. Consequence: coverage buckets it by sample_id, so an '
@@ -1092,7 +1092,7 @@ class AdiposeSample(Sample):
          'comments': ['Required by the h5ad validator and by the published Tier 1 '
                       'dictionary, but left optional here until entry sheets carry the '
                       "column — LinkML's `required` is enforced against entry sheet "
-                      'rows, so flipping it fails every sheet without it. See #544. '
+                      'rows, so flipping it fails every sheet without it. See #544.',
                       'Lives on Sample to match the published Tier 1 dictionary, which '
                       'places it there even though CELLxGENE treats it as a per-cell '
                       'flag. Consequence: coverage buckets it by sample_id, so an '
@@ -1339,7 +1339,7 @@ class GutSample(Sample):
          'comments': ['Required by the h5ad validator and by the published Tier 1 '
                       'dictionary, but left optional here until entry sheets carry the '
                       "column — LinkML's `required` is enforced against entry sheet "
-                      'rows, so flipping it fails every sheet without it. See #544. '
+                      'rows, so flipping it fails every sheet without it. See #544.',
                       'Lives on Sample to match the published Tier 1 dictionary, which '
                       'places it there even though CELLxGENE treats it as a per-cell '
                       'flag. Consequence: coverage buckets it by sample_id, so an '

--- a/services/dataset-validator/tests/test_metadata_coverage.py
+++ b/services/dataset-validator/tests/test_metadata_coverage.py
@@ -310,14 +310,32 @@ class TestFieldCoverageEnumeration:
         assert {e["entity_class"] for e in result["field_coverage"]} <= {"obs", "dataset", "donor", "sample"}
 
     def test_cell_entity_class_absent_in_v0(self, schemaview):
-        # The Cell LinkML class has no slots in v0, so no entity_class == "cell"
-        # entries should appear and entities["cell"] should not be emitted.
-        # If someone adds a Cell slot, this test fires and forces a wire-format
-        # review (cell.record_count denominator, etc.).
+        # Cell gained slots in #538, so this exclusion is now deliberate rather than a
+        # side effect of the class being empty: coverage_classes() skips Cell by name,
+        # and the rationale lives there.
+        #
+        # What that comment does not cover, because it is a wire-format concern rather
+        # than a schema one: when the exclusion is lifted, cell.record_count needs a
+        # denominator decision (n_obs, presumably) before this test can be deleted.
         obs = pd.DataFrame({"donor_id": ["D1"], "sample_id": ["S1"]})
         result = compute_metadata_coverage(make_adata(obs), schemaview)
         assert "cell" not in result["entities"]
         assert all(e["entity_class"] != "cell" for e in result["field_coverage"])
+
+    def test_newly_annotated_sample_slots_emit_at_sample_grain(self, schemaview):
+        # #538 gave `is_primary_data` and `sample_collection_method` an
+        # `annDataLocation: obs` annotation, which makes them coverage-eligible for the
+        # first time. `is_primary_data` additionally stopped being a deprecated slot,
+        # and deprecated slots are filtered out of coverage — so both changes were
+        # needed for it to appear here.
+        #
+        # This is an additive wire-format change: two new sample-grain rows, shifting
+        # the denominator for anyone computing percentages over the set. "sample" is
+        # already in the tracker's allowlist, so nothing rejects it.
+        obs = pd.DataFrame({"donor_id": ["D1"], "sample_id": ["S1"]})
+        result = compute_metadata_coverage(make_adata(obs), schemaview)
+        sample_fields = {e["field"] for e in result["field_coverage"] if e["entity_class"] == "sample"}
+        assert {"is_primary_data", "sample_collection_method"} <= sample_fields
 
     def test_library_slots_emit_at_sample_grain(self, schemaview):
         # PRD-documented v0 contract: library_* slots are declared on the Sample

--- a/services/dataset-validator/tests/test_metadata_coverage.py
+++ b/services/dataset-validator/tests/test_metadata_coverage.py
@@ -323,19 +323,24 @@ class TestFieldCoverageEnumeration:
         assert all(e["entity_class"] != "cell" for e in result["field_coverage"])
 
     def test_newly_annotated_sample_slots_emit_at_sample_grain(self, schemaview):
-        # #538 gave `is_primary_data` and `sample_collection_method` an
-        # `annDataLocation: obs` annotation, which makes them coverage-eligible for the
-        # first time. `is_primary_data` additionally stopped being a deprecated slot,
-        # and deprecated slots are filtered out of coverage — so both changes were
-        # needed for it to appear here.
+        # #538 gave both `sample_collection_method` and `is_primary_data` an
+        # `annDataLocation: obs` annotation, but only the former becomes
+        # coverage-eligible: `is_primary_data` is still `is_a: deprecated_slot`, and
+        # deprecated slots are filtered out of coverage.
         #
-        # This is an additive wire-format change: two new sample-grain rows, shifting
-        # the denominator for anyone computing percentages over the set. "sample" is
-        # already in the tracker's allowlist, so nothing rejects it.
+        # That asymmetry is deliberate, not an oversight. `is_primary_data` stays a
+        # deprecated placeholder so entry sheet validation is untouched — the annotation
+        # alone is enough for annDataLocation-walking consumers like drop_obs_columns.
+        # See the slot's comments and #544.
+        #
+        # Net wire-format change is therefore ONE new sample-grain row, which shifts the
+        # denominator for anyone computing percentages. "sample" is already in the
+        # tracker's allowlist, so nothing rejects it.
         obs = pd.DataFrame({"donor_id": ["D1"], "sample_id": ["S1"]})
         result = compute_metadata_coverage(make_adata(obs), schemaview)
         sample_fields = {e["field"] for e in result["field_coverage"] if e["entity_class"] == "sample"}
-        assert {"is_primary_data", "sample_collection_method"} <= sample_fields
+        assert "sample_collection_method" in sample_fields
+        assert "is_primary_data" not in sample_fields
 
     def test_library_slots_emit_at_sample_grain(self, schemaview):
         # PRD-documented v0 contract: library_* slots are declared on the Sample

--- a/shared/src/hca_validation/schema/cell.yaml
+++ b/shared/src/hca_validation/schema/cell.yaml
@@ -26,10 +26,9 @@ classes:
 slots:
   author_cell_type:
     title: Author Cell Type
-    description: >-
-      Cell type label as assigned by the data author, in their own vocabulary.
+    description: Encoding of author intuition of cellular annotation in the dataset.
     examples:
-      - value: alveolar macrophage; luminal progenitor
+      - value: Goblet cell; microglia
     annotations:
       annDataLocation: obs
       tier: Tier 1
@@ -37,15 +36,16 @@ slots:
     required: false
     multivalued: false
     comments:
+      - Encoding of author intuition of cellular annotation in their dataset.
       - >-
-        The author's own naming, retained alongside the ontology term so the original
-        annotation is not lost when terms are mapped to CL
+        Retained alongside the ontology term so the author's original naming is not lost
+        when terms are mapped to CL.
 
   cell_type_ontology_term_id:
     title: Cell Type Ontology Term ID
-    description: Cell type, as an ontology term.
+    description: Cell Ontology (CL) term.
     examples:
-      - value: CL:0000583
+      - value: CL:0001204
     annotations:
       annDataLocation: obs
       tier: Tier 1
@@ -54,10 +54,17 @@ slots:
     required: false
     multivalued: false
     notes:
+      - |
+        This must be a Cell Ontology (CL) term (http://www.ebi.ac.uk/ols4/ontologies/cl).
+
+        If no appropriate high-level term can be found or the cell type is unknown, then it is strongly recommended to use 'unknown'.
+
+        The following terms must not be used: "CL:0000255" for eukaryotic cell; "CL:0000257" for Eumycetozoan cell; "CL:0000548" for animal cell.
       - >-
-        A CL term, or "unknown". ZFA, FBbt, and WBbt terms are allowed depending on the
-        organism. "na" is allowed if tissue_type is "cell line".
+        ZFA, FBbt, and WBbt terms are allowed depending on the organism, and "na" is
+        allowed if tissue_type is "cell line" — per the h5ad validator's curie_constraints.
     comments:
+      - Encoding of cell type to help alignment with other datasets.
       - >-
-        Optional to match the validator's requirement_level, but unrecoverable once
-        dropped — populate_labels derives cell_type from this column, not the reverse
+        Unrecoverable once dropped — populate_labels derives cell_type from this column,
+        not the reverse. Optional here to match the h5ad validator's requirement_level.

--- a/shared/src/hca_validation/schema/cell.yaml
+++ b/shared/src/hca_validation/schema/cell.yaml
@@ -19,4 +19,42 @@ classes:
   Cell:
     description: >-
       A single cell derived from a sample
+    slots:
+      - author_cell_type
+      - cell_type_ontology_term_id
 
+slots:
+  author_cell_type:
+    title: Author Cell Type
+    description: >-
+      Cell type label as assigned by the data author, in their own vocabulary.
+    examples:
+      - value: alveolar macrophage; luminal progenitor
+    annotations:
+      annDataLocation: obs
+      tier: Tier 1
+    range: string
+    required: false
+    multivalued: false
+    comments: >-
+      The author's own naming, retained alongside the ontology term so the original
+      annotation is not lost when terms are mapped to CL
+
+  cell_type_ontology_term_id:
+    title: Cell Type Ontology Term ID
+    description: Cell type, as an ontology term.
+    examples:
+      - value: CL:0000583
+    annotations:
+      annDataLocation: obs
+      tier: Tier 1
+      cxg: cell_type_ontology_term_id
+    range: string
+    required: false
+    multivalued: false
+    notes: >-
+      A CL term, or "unknown". ZFA, FBbt, and WBbt terms are allowed depending on the
+      organism. "na" is allowed if tissue_type is "cell line".
+    comments: >-
+      Optional to match the validator's requirement_level, but unrecoverable once
+      dropped — populate_labels derives cell_type from this column, not the reverse

--- a/shared/src/hca_validation/schema/cell.yaml
+++ b/shared/src/hca_validation/schema/cell.yaml
@@ -36,9 +36,10 @@ slots:
     range: string
     required: false
     multivalued: false
-    comments: >-
-      The author's own naming, retained alongside the ontology term so the original
-      annotation is not lost when terms are mapped to CL
+    comments:
+      - >-
+        The author's own naming, retained alongside the ontology term so the original
+        annotation is not lost when terms are mapped to CL
 
   cell_type_ontology_term_id:
     title: Cell Type Ontology Term ID
@@ -52,9 +53,11 @@ slots:
     range: string
     required: false
     multivalued: false
-    notes: >-
-      A CL term, or "unknown". ZFA, FBbt, and WBbt terms are allowed depending on the
-      organism. "na" is allowed if tissue_type is "cell line".
-    comments: >-
-      Optional to match the validator's requirement_level, but unrecoverable once
-      dropped — populate_labels derives cell_type from this column, not the reverse
+    notes:
+      - >-
+        A CL term, or "unknown". ZFA, FBbt, and WBbt terms are allowed depending on the
+        organism. "na" is allowed if tissue_type is "cell line".
+    comments:
+      - >-
+        Optional to match the validator's requirement_level, but unrecoverable once
+        dropped — populate_labels derives cell_type from this column, not the reverse

--- a/shared/src/hca_validation/schema/generated/core.py
+++ b/shared/src/hca_validation/schema/generated/core.py
@@ -843,7 +843,7 @@ class Sample(ConfiguredBaseModel):
          'comments': ['Required by the h5ad validator and by the published Tier 1 '
                       'dictionary, but left optional here until entry sheets carry the '
                       "column — LinkML's `required` is enforced against entry sheet "
-                      'rows, so flipping it fails every sheet without it. See #544. '
+                      'rows, so flipping it fails every sheet without it. See #544.',
                       'Lives on Sample to match the published Tier 1 dictionary, which '
                       'places it there even though CELLxGENE treats it as a per-cell '
                       'flag. Consequence: coverage buckets it by sample_id, so an '
@@ -1089,7 +1089,7 @@ class AdiposeSample(Sample):
          'comments': ['Required by the h5ad validator and by the published Tier 1 '
                       'dictionary, but left optional here until entry sheets carry the '
                       "column — LinkML's `required` is enforced against entry sheet "
-                      'rows, so flipping it fails every sheet without it. See #544. '
+                      'rows, so flipping it fails every sheet without it. See #544.',
                       'Lives on Sample to match the published Tier 1 dictionary, which '
                       'places it there even though CELLxGENE treats it as a per-cell '
                       'flag. Consequence: coverage buckets it by sample_id, so an '
@@ -1336,7 +1336,7 @@ class GutSample(Sample):
          'comments': ['Required by the h5ad validator and by the published Tier 1 '
                       'dictionary, but left optional here until entry sheets carry the '
                       "column — LinkML's `required` is enforced against entry sheet "
-                      'rows, so flipping it fails every sheet without it. See #544. '
+                      'rows, so flipping it fails every sheet without it. See #544.',
                       'Lives on Sample to match the published Tier 1 dictionary, which '
                       'places it there even though CELLxGENE treats it as a per-cell '
                       'flag. Consequence: coverage buckets it by sample_id, so an '

--- a/shared/src/hca_validation/schema/generated/core.py
+++ b/shared/src/hca_validation/schema/generated/core.py
@@ -836,7 +836,24 @@ class Sample(ConfiguredBaseModel):
                       'other factors differ.'],
          'domain_of': ['Sample'],
          'examples': [{'value': 'EMBL-EBI; Genome Institute of Singapore'}]} })
-    is_primary_data: Optional[str] = Field(default=None, title="Is Primary Data", description="""Deprecated placeholder indicating whether sample represents primary data.""", json_schema_extra = { "linkml_meta": {'alias': 'is_primary_data', 'domain_of': ['Sample'], 'is_a': 'deprecated_slot'} })
+    is_primary_data: Optional[bool] = Field(default=None, title="Is Primary Data", description="""Whether the sample represents the primary data for these cells, as opposed to a re-analysis of data published elsewhere.""", json_schema_extra = { "linkml_meta": {'alias': 'is_primary_data',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'is_primary_data'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Required by the h5ad validator and by the published Tier 1 '
+                      'dictionary, but left optional here until entry sheets carry the '
+                      "column — LinkML's `required` is enforced against entry sheet "
+                      'rows, so flipping it fails every sheet without it. See #544. '
+                      'Lives on Sample to match the published Tier 1 dictionary, which '
+                      'places it there even though CELLxGENE treats it as a per-cell '
+                      'flag. Consequence: coverage buckets it by sample_id, so an '
+                      'integrated object whose cells disagree within one sample '
+                      '(duplicate copies marked false, canonical ones true) reports '
+                      'that sample as inconsistent. That is accurate reporting of a '
+                      'genuinely mixed value, not a validation failure — the h5ad '
+                      'validator accepts such a file.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'true'}]} })
     library_id: str = Field(default=..., title="Library ID", description="""The unique ID that is used to track libraries in the investigator's institution (should align with the publication).""", json_schema_extra = { "linkml_meta": {'alias': 'library_id',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
@@ -864,6 +881,8 @@ class Sample(ConfiguredBaseModel):
          'domain_of': ['Sample'],
          'examples': [{'value': 'run1; NV0087'}]} })
     sample_collection_method: SampleCollectionMethod = Field(default=..., title="Sample Collection Method", description="""The method the sample was physically obtained from the donor.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_method',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
          'domain_of': ['Sample'],
          'notes': ['brush; scraping; biopsy; surgical resection; blood draw; body '
                    'fluid; other']} })
@@ -1063,7 +1082,24 @@ class AdiposeSample(Sample):
                       'other factors differ.'],
          'domain_of': ['Sample'],
          'examples': [{'value': 'EMBL-EBI; Genome Institute of Singapore'}]} })
-    is_primary_data: Optional[str] = Field(default=None, title="Is Primary Data", description="""Deprecated placeholder indicating whether sample represents primary data.""", json_schema_extra = { "linkml_meta": {'alias': 'is_primary_data', 'domain_of': ['Sample'], 'is_a': 'deprecated_slot'} })
+    is_primary_data: Optional[bool] = Field(default=None, title="Is Primary Data", description="""Whether the sample represents the primary data for these cells, as opposed to a re-analysis of data published elsewhere.""", json_schema_extra = { "linkml_meta": {'alias': 'is_primary_data',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'is_primary_data'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Required by the h5ad validator and by the published Tier 1 '
+                      'dictionary, but left optional here until entry sheets carry the '
+                      "column — LinkML's `required` is enforced against entry sheet "
+                      'rows, so flipping it fails every sheet without it. See #544. '
+                      'Lives on Sample to match the published Tier 1 dictionary, which '
+                      'places it there even though CELLxGENE treats it as a per-cell '
+                      'flag. Consequence: coverage buckets it by sample_id, so an '
+                      'integrated object whose cells disagree within one sample '
+                      '(duplicate copies marked false, canonical ones true) reports '
+                      'that sample as inconsistent. That is accurate reporting of a '
+                      'genuinely mixed value, not a validation failure — the h5ad '
+                      'validator accepts such a file.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'true'}]} })
     library_id: str = Field(default=..., title="Library ID", description="""The unique ID that is used to track libraries in the investigator's institution (should align with the publication).""", json_schema_extra = { "linkml_meta": {'alias': 'library_id',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
@@ -1091,6 +1127,8 @@ class AdiposeSample(Sample):
          'domain_of': ['Sample'],
          'examples': [{'value': 'run1; NV0087'}]} })
     sample_collection_method: SampleCollectionMethod = Field(default=..., title="Sample Collection Method", description="""The method the sample was physically obtained from the donor.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_method',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
          'domain_of': ['Sample'],
          'notes': ['brush; scraping; biopsy; surgical resection; blood draw; body '
                    'fluid; other']} })
@@ -1291,7 +1329,24 @@ class GutSample(Sample):
                       'other factors differ.'],
          'domain_of': ['Sample'],
          'examples': [{'value': 'EMBL-EBI; Genome Institute of Singapore'}]} })
-    is_primary_data: Optional[str] = Field(default=None, title="Is Primary Data", description="""Deprecated placeholder indicating whether sample represents primary data.""", json_schema_extra = { "linkml_meta": {'alias': 'is_primary_data', 'domain_of': ['Sample'], 'is_a': 'deprecated_slot'} })
+    is_primary_data: Optional[bool] = Field(default=None, title="Is Primary Data", description="""Whether the sample represents the primary data for these cells, as opposed to a re-analysis of data published elsewhere.""", json_schema_extra = { "linkml_meta": {'alias': 'is_primary_data',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'is_primary_data'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Required by the h5ad validator and by the published Tier 1 '
+                      'dictionary, but left optional here until entry sheets carry the '
+                      "column — LinkML's `required` is enforced against entry sheet "
+                      'rows, so flipping it fails every sheet without it. See #544. '
+                      'Lives on Sample to match the published Tier 1 dictionary, which '
+                      'places it there even though CELLxGENE treats it as a per-cell '
+                      'flag. Consequence: coverage buckets it by sample_id, so an '
+                      'integrated object whose cells disagree within one sample '
+                      '(duplicate copies marked false, canonical ones true) reports '
+                      'that sample as inconsistent. That is accurate reporting of a '
+                      'genuinely mixed value, not a validation failure — the h5ad '
+                      'validator accepts such a file.'],
+         'domain_of': ['Sample'],
+         'examples': [{'value': 'true'}]} })
     library_id: str = Field(default=..., title="Library ID", description="""The unique ID that is used to track libraries in the investigator's institution (should align with the publication).""", json_schema_extra = { "linkml_meta": {'alias': 'library_id',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
@@ -1319,6 +1374,8 @@ class GutSample(Sample):
          'domain_of': ['Sample'],
          'examples': [{'value': 'run1; NV0087'}]} })
     sample_collection_method: SampleCollectionMethod = Field(default=..., title="Sample Collection Method", description="""The method the sample was physically obtained from the donor.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_method',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
          'domain_of': ['Sample'],
          'notes': ['brush; scraping; biopsy; surgical resection; blood draw; body '
                    'fluid; other']} })
@@ -1566,7 +1623,26 @@ class Cell(ConfiguredBaseModel):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/cell'})
 
-    pass
+    author_cell_type: Optional[str] = Field(default=None, title="Author Cell Type", description="""Cell type label as assigned by the data author, in their own vocabulary.""", json_schema_extra = { "linkml_meta": {'alias': 'author_cell_type',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ["The author's own naming, retained alongside the ontology term "
+                      'so the original annotation is not lost when terms are mapped to '
+                      'CL'],
+         'domain_of': ['Cell'],
+         'examples': [{'value': 'alveolar macrophage; luminal progenitor'}]} })
+    cell_type_ontology_term_id: Optional[str] = Field(default=None, title="Cell Type Ontology Term ID", description="""Cell type, as an ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'cell_type_ontology_term_id',
+         'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
+                         'cxg': {'tag': 'cxg', 'value': 'cell_type_ontology_term_id'},
+                         'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ["Optional to match the validator's requirement_level, but "
+                      'unrecoverable once dropped — populate_labels derives cell_type '
+                      'from this column, not the reverse'],
+         'domain_of': ['Cell'],
+         'examples': [{'value': 'CL:0000583'}],
+         'notes': ['A CL term, or "unknown". ZFA, FBbt, and WBbt terms are allowed '
+                   'depending on the organism. "na" is allowed if tissue_type is "cell '
+                   'line".']} })
 
 
 # Model rebuild

--- a/shared/src/hca_validation/schema/generated/core.py
+++ b/shared/src/hca_validation/schema/generated/core.py
@@ -836,24 +836,33 @@ class Sample(ConfiguredBaseModel):
                       'other factors differ.'],
          'domain_of': ['Sample'],
          'examples': [{'value': 'EMBL-EBI; Genome Institute of Singapore'}]} })
-    is_primary_data: Optional[bool] = Field(default=None, title="Is Primary Data", description="""Whether the sample represents the primary data for these cells, as opposed to a re-analysis of data published elsewhere.""", json_schema_extra = { "linkml_meta": {'alias': 'is_primary_data',
+    is_primary_data: Optional[str] = Field(default=None, title="Is Primary Data", description="""Deprecated placeholder indicating whether sample represents primary data.""", json_schema_extra = { "linkml_meta": {'alias': 'is_primary_data',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'cxg': {'tag': 'cxg', 'value': 'is_primary_data'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
-         'comments': ['Required by the h5ad validator and by the published Tier 1 '
-                      'dictionary, but left optional here until entry sheets carry the '
-                      "column — LinkML's `required` is enforced against entry sheet "
-                      'rows, so flipping it fails every sheet without it. See #544.',
-                      'Lives on Sample to match the published Tier 1 dictionary, which '
-                      'places it there even though CELLxGENE treats it as a per-cell '
-                      'flag. Consequence: coverage buckets it by sample_id, so an '
-                      'integrated object whose cells disagree within one sample '
-                      '(duplicate copies marked false, canonical ones true) reports '
-                      'that sample as inconsistent. That is accurate reporting of a '
-                      'genuinely mixed value, not a validation failure — the h5ad '
-                      'validator accepts such a file.'],
+         'comments': ['Kept as a deprecated placeholder on purpose. The annotation is '
+                      'the only thing added here, because annotations are inert for '
+                      'validation: they tell annDataLocation-walking consumers such as '
+                      'drop_obs_columns that this obs column exists and must not be '
+                      'deleted, without altering what the entry sheet validator '
+                      'accepts. Restoring it to a real `range: boolean` slot would '
+                      'start type-checking the column on entry sheets, where it is '
+                      'currently an unconstrained string that tolerates any value '
+                      'including "na" — sheets that validate today would begin '
+                      'failing. See #544.',
+                      'The real modelling question is deferred, not answered. '
+                      'CELLxGENE defines this in obs as a per-cell bool, and the '
+                      'published Tier 1 dictionary describes it as "the canonical '
+                      'instance of this cellular observation" — per-observation '
+                      "semantics — while filing it under `sample`. A sample's cells "
+                      'can legitimately disagree, so Sample is the wrong grain for it '
+                      'and this placeholder deliberately makes no semantic claim. '
+                      'Moving it to Cell is its own change: slots are global by name '
+                      'in LinkML, so it needs a slot_usage override rather than a '
+                      'move, and removing it from Sample outright would make sheets '
+                      'carrying the column fail with extra_forbidden.'],
          'domain_of': ['Sample'],
-         'examples': [{'value': 'true'}]} })
+         'is_a': 'deprecated_slot'} })
     library_id: str = Field(default=..., title="Library ID", description="""The unique ID that is used to track libraries in the investigator's institution (should align with the publication).""", json_schema_extra = { "linkml_meta": {'alias': 'library_id',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
@@ -883,7 +892,9 @@ class Sample(ConfiguredBaseModel):
     sample_collection_method: SampleCollectionMethod = Field(default=..., title="Sample Collection Method", description="""The method the sample was physically obtained from the donor.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_method',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Main contributor to batch effects'],
          'domain_of': ['Sample'],
+         'examples': [{'value': 'biopsy; brush; surgical resection'}],
          'notes': ['brush; scraping; biopsy; surgical resection; blood draw; body '
                    'fluid; other']} })
     sample_collection_year: Optional[str] = Field(default=None, title="Sample Collection Year", description="""Year of sample collection. Should not be detailed further (to exact month and day), to prevent identifiability.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_year',
@@ -1082,24 +1093,33 @@ class AdiposeSample(Sample):
                       'other factors differ.'],
          'domain_of': ['Sample'],
          'examples': [{'value': 'EMBL-EBI; Genome Institute of Singapore'}]} })
-    is_primary_data: Optional[bool] = Field(default=None, title="Is Primary Data", description="""Whether the sample represents the primary data for these cells, as opposed to a re-analysis of data published elsewhere.""", json_schema_extra = { "linkml_meta": {'alias': 'is_primary_data',
+    is_primary_data: Optional[str] = Field(default=None, title="Is Primary Data", description="""Deprecated placeholder indicating whether sample represents primary data.""", json_schema_extra = { "linkml_meta": {'alias': 'is_primary_data',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'cxg': {'tag': 'cxg', 'value': 'is_primary_data'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
-         'comments': ['Required by the h5ad validator and by the published Tier 1 '
-                      'dictionary, but left optional here until entry sheets carry the '
-                      "column — LinkML's `required` is enforced against entry sheet "
-                      'rows, so flipping it fails every sheet without it. See #544.',
-                      'Lives on Sample to match the published Tier 1 dictionary, which '
-                      'places it there even though CELLxGENE treats it as a per-cell '
-                      'flag. Consequence: coverage buckets it by sample_id, so an '
-                      'integrated object whose cells disagree within one sample '
-                      '(duplicate copies marked false, canonical ones true) reports '
-                      'that sample as inconsistent. That is accurate reporting of a '
-                      'genuinely mixed value, not a validation failure — the h5ad '
-                      'validator accepts such a file.'],
+         'comments': ['Kept as a deprecated placeholder on purpose. The annotation is '
+                      'the only thing added here, because annotations are inert for '
+                      'validation: they tell annDataLocation-walking consumers such as '
+                      'drop_obs_columns that this obs column exists and must not be '
+                      'deleted, without altering what the entry sheet validator '
+                      'accepts. Restoring it to a real `range: boolean` slot would '
+                      'start type-checking the column on entry sheets, where it is '
+                      'currently an unconstrained string that tolerates any value '
+                      'including "na" — sheets that validate today would begin '
+                      'failing. See #544.',
+                      'The real modelling question is deferred, not answered. '
+                      'CELLxGENE defines this in obs as a per-cell bool, and the '
+                      'published Tier 1 dictionary describes it as "the canonical '
+                      'instance of this cellular observation" — per-observation '
+                      "semantics — while filing it under `sample`. A sample's cells "
+                      'can legitimately disagree, so Sample is the wrong grain for it '
+                      'and this placeholder deliberately makes no semantic claim. '
+                      'Moving it to Cell is its own change: slots are global by name '
+                      'in LinkML, so it needs a slot_usage override rather than a '
+                      'move, and removing it from Sample outright would make sheets '
+                      'carrying the column fail with extra_forbidden.'],
          'domain_of': ['Sample'],
-         'examples': [{'value': 'true'}]} })
+         'is_a': 'deprecated_slot'} })
     library_id: str = Field(default=..., title="Library ID", description="""The unique ID that is used to track libraries in the investigator's institution (should align with the publication).""", json_schema_extra = { "linkml_meta": {'alias': 'library_id',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
@@ -1129,7 +1149,9 @@ class AdiposeSample(Sample):
     sample_collection_method: SampleCollectionMethod = Field(default=..., title="Sample Collection Method", description="""The method the sample was physically obtained from the donor.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_method',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Main contributor to batch effects'],
          'domain_of': ['Sample'],
+         'examples': [{'value': 'biopsy; brush; surgical resection'}],
          'notes': ['brush; scraping; biopsy; surgical resection; blood draw; body '
                    'fluid; other']} })
     sample_collection_year: Optional[str] = Field(default=None, title="Sample Collection Year", description="""Year of sample collection. Should not be detailed further (to exact month and day), to prevent identifiability.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_year',
@@ -1329,24 +1351,33 @@ class GutSample(Sample):
                       'other factors differ.'],
          'domain_of': ['Sample'],
          'examples': [{'value': 'EMBL-EBI; Genome Institute of Singapore'}]} })
-    is_primary_data: Optional[bool] = Field(default=None, title="Is Primary Data", description="""Whether the sample represents the primary data for these cells, as opposed to a re-analysis of data published elsewhere.""", json_schema_extra = { "linkml_meta": {'alias': 'is_primary_data',
+    is_primary_data: Optional[str] = Field(default=None, title="Is Primary Data", description="""Deprecated placeholder indicating whether sample represents primary data.""", json_schema_extra = { "linkml_meta": {'alias': 'is_primary_data',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'cxg': {'tag': 'cxg', 'value': 'is_primary_data'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
-         'comments': ['Required by the h5ad validator and by the published Tier 1 '
-                      'dictionary, but left optional here until entry sheets carry the '
-                      "column — LinkML's `required` is enforced against entry sheet "
-                      'rows, so flipping it fails every sheet without it. See #544.',
-                      'Lives on Sample to match the published Tier 1 dictionary, which '
-                      'places it there even though CELLxGENE treats it as a per-cell '
-                      'flag. Consequence: coverage buckets it by sample_id, so an '
-                      'integrated object whose cells disagree within one sample '
-                      '(duplicate copies marked false, canonical ones true) reports '
-                      'that sample as inconsistent. That is accurate reporting of a '
-                      'genuinely mixed value, not a validation failure — the h5ad '
-                      'validator accepts such a file.'],
+         'comments': ['Kept as a deprecated placeholder on purpose. The annotation is '
+                      'the only thing added here, because annotations are inert for '
+                      'validation: they tell annDataLocation-walking consumers such as '
+                      'drop_obs_columns that this obs column exists and must not be '
+                      'deleted, without altering what the entry sheet validator '
+                      'accepts. Restoring it to a real `range: boolean` slot would '
+                      'start type-checking the column on entry sheets, where it is '
+                      'currently an unconstrained string that tolerates any value '
+                      'including "na" — sheets that validate today would begin '
+                      'failing. See #544.',
+                      'The real modelling question is deferred, not answered. '
+                      'CELLxGENE defines this in obs as a per-cell bool, and the '
+                      'published Tier 1 dictionary describes it as "the canonical '
+                      'instance of this cellular observation" — per-observation '
+                      "semantics — while filing it under `sample`. A sample's cells "
+                      'can legitimately disagree, so Sample is the wrong grain for it '
+                      'and this placeholder deliberately makes no semantic claim. '
+                      'Moving it to Cell is its own change: slots are global by name '
+                      'in LinkML, so it needs a slot_usage override rather than a '
+                      'move, and removing it from Sample outright would make sheets '
+                      'carrying the column fail with extra_forbidden.'],
          'domain_of': ['Sample'],
-         'examples': [{'value': 'true'}]} })
+         'is_a': 'deprecated_slot'} })
     library_id: str = Field(default=..., title="Library ID", description="""The unique ID that is used to track libraries in the investigator's institution (should align with the publication).""", json_schema_extra = { "linkml_meta": {'alias': 'library_id',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
@@ -1376,7 +1407,9 @@ class GutSample(Sample):
     sample_collection_method: SampleCollectionMethod = Field(default=..., title="Sample Collection Method", description="""The method the sample was physically obtained from the donor.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_method',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
+         'comments': ['Main contributor to batch effects'],
          'domain_of': ['Sample'],
+         'examples': [{'value': 'biopsy; brush; surgical resection'}],
          'notes': ['brush; scraping; biopsy; surgical resection; blood draw; body '
                    'fluid; other']} })
     sample_collection_year: Optional[str] = Field(default=None, title="Sample Collection Year", description="""Year of sample collection. Should not be detailed further (to exact month and day), to prevent identifiability.""", json_schema_extra = { "linkml_meta": {'alias': 'sample_collection_year',
@@ -1623,26 +1656,37 @@ class Cell(ConfiguredBaseModel):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://github.com/clevercanary/hca-validation-tools/schema/cell'})
 
-    author_cell_type: Optional[str] = Field(default=None, title="Author Cell Type", description="""Cell type label as assigned by the data author, in their own vocabulary.""", json_schema_extra = { "linkml_meta": {'alias': 'author_cell_type',
+    author_cell_type: Optional[str] = Field(default=None, title="Author Cell Type", description="""Encoding of author intuition of cellular annotation in the dataset.""", json_schema_extra = { "linkml_meta": {'alias': 'author_cell_type',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
-         'comments': ["The author's own naming, retained alongside the ontology term "
-                      'so the original annotation is not lost when terms are mapped to '
-                      'CL'],
+         'comments': ['Encoding of author intuition of cellular annotation in their '
+                      'dataset.',
+                      "Retained alongside the ontology term so the author's original "
+                      'naming is not lost when terms are mapped to CL.'],
          'domain_of': ['Cell'],
-         'examples': [{'value': 'alveolar macrophage; luminal progenitor'}]} })
-    cell_type_ontology_term_id: Optional[str] = Field(default=None, title="Cell Type Ontology Term ID", description="""Cell type, as an ontology term.""", json_schema_extra = { "linkml_meta": {'alias': 'cell_type_ontology_term_id',
+         'examples': [{'value': 'Goblet cell; microglia'}]} })
+    cell_type_ontology_term_id: Optional[str] = Field(default=None, title="Cell Type Ontology Term ID", description="""Cell Ontology (CL) term.""", json_schema_extra = { "linkml_meta": {'alias': 'cell_type_ontology_term_id',
          'annotations': {'annDataLocation': {'tag': 'annDataLocation', 'value': 'obs'},
                          'cxg': {'tag': 'cxg', 'value': 'cell_type_ontology_term_id'},
                          'tier': {'tag': 'tier', 'value': 'Tier 1'}},
-         'comments': ["Optional to match the validator's requirement_level, but "
-                      'unrecoverable once dropped — populate_labels derives cell_type '
-                      'from this column, not the reverse'],
+         'comments': ['Encoding of cell type to help alignment with other datasets.',
+                      'Unrecoverable once dropped — populate_labels derives cell_type '
+                      'from this column, not the reverse. Optional here to match the '
+                      "h5ad validator's requirement_level."],
          'domain_of': ['Cell'],
-         'examples': [{'value': 'CL:0000583'}],
-         'notes': ['A CL term, or "unknown". ZFA, FBbt, and WBbt terms are allowed '
-                   'depending on the organism. "na" is allowed if tissue_type is "cell '
-                   'line".']} })
+         'examples': [{'value': 'CL:0001204'}],
+         'notes': ['This must be a Cell Ontology (CL) term '
+                   '(http://www.ebi.ac.uk/ols4/ontologies/cl).\n'
+                   '\n'
+                   'If no appropriate high-level term can be found or the cell type is '
+                   "unknown, then it is strongly recommended to use 'unknown'.\n"
+                   '\n'
+                   'The following terms must not be used: "CL:0000255" for eukaryotic '
+                   'cell; "CL:0000257" for Eumycetozoan cell; "CL:0000548" for animal '
+                   'cell.\n',
+                   'ZFA, FBbt, and WBbt terms are allowed depending on the organism, '
+                   'and "na" is allowed if tissue_type is "cell line" — per the h5ad '
+                   "validator's curie_constraints."]} })
 
 
 # Model rebuild

--- a/shared/src/hca_validation/schema/sample.yaml
+++ b/shared/src/hca_validation/schema/sample.yaml
@@ -142,32 +142,33 @@ slots:
       To be able to link to other studies from the same institution as sometimes samples from different labs in the same institute are processed via similar core facilities. Thus batch effects may be smaller for datasets from the same institute even if other factors differ.
 
   is_primary_data:
+    is_a: deprecated_slot
     title: Is Primary Data
-    description: >-
-      Whether the sample represents the primary data for these cells, as opposed to
-      a re-analysis of data published elsewhere.
-    examples:
-      - value: "true"
+    description: Deprecated placeholder indicating whether sample represents primary data.
     annotations:
       annDataLocation: obs
       tier: Tier 1
       cxg: is_primary_data
-    range: boolean
-    required: false
-    multivalued: false
     comments:
       - >-
-        Required by the h5ad validator and by the published Tier 1 dictionary, but left
-        optional here until entry sheets carry the column — LinkML's `required` is
-        enforced against entry sheet rows, so flipping it fails every sheet without it.
-        See #544.
+        Kept as a deprecated placeholder on purpose. The annotation is the only thing
+        added here, because annotations are inert for validation: they tell
+        annDataLocation-walking consumers such as drop_obs_columns that this obs column
+        exists and must not be deleted, without altering what the entry sheet validator
+        accepts. Restoring it to a real `range: boolean` slot would start type-checking
+        the column on entry sheets, where it is currently an unconstrained string that
+        tolerates any value including "na" — sheets that validate today would begin
+        failing. See #544.
       - >-
-        Lives on Sample to match the published Tier 1 dictionary, which places it there
-        even though CELLxGENE treats it as a per-cell flag. Consequence: coverage buckets
-        it by sample_id, so an integrated object whose cells disagree within one sample
-        (duplicate copies marked false, canonical ones true) reports that sample as
-        inconsistent. That is accurate reporting of a genuinely mixed value, not a
-        validation failure — the h5ad validator accepts such a file.
+        The real modelling question is deferred, not answered. CELLxGENE defines this in
+        obs as a per-cell bool, and the published Tier 1 dictionary describes it as "the
+        canonical instance of this cellular observation" — per-observation semantics —
+        while filing it under `sample`. A sample's cells can legitimately disagree, so
+        Sample is the wrong grain for it and this placeholder deliberately makes no
+        semantic claim. Moving it to Cell is its own change: slots are global by name in
+        LinkML, so it needs a slot_usage override rather than a move, and removing it
+        from Sample outright would make sheets carrying the column fail with
+        extra_forbidden.
 
   library_id:
     title: Library ID
@@ -403,12 +404,16 @@ slots:
   sample_collection_method:
     title: Sample Collection Method
     description: The method the sample was physically obtained from the donor.
+    examples:
+      - value: biopsy; brush; surgical resection
     annotations:
       annDataLocation: obs
       tier: Tier 1
     range: SampleCollectionMethod
     required: true
     notes: "brush; scraping; biopsy; surgical resection; blood draw; body fluid; other"
+    comments:
+      - Main contributor to batch effects
 
   tissue_ontology_term:
     is_a: deprecated_slot

--- a/shared/src/hca_validation/schema/sample.yaml
+++ b/shared/src/hca_validation/schema/sample.yaml
@@ -155,16 +155,19 @@ slots:
     range: boolean
     required: false
     multivalued: false
-    comments: >-
-      Required by the h5ad validator and by the published Tier 1 dictionary, but left
-      optional here until entry sheets carry the column — LinkML's `required` is
-      enforced against entry sheet rows, so flipping it fails every sheet without it. See #544.
-      Lives on Sample to match the published Tier 1 dictionary, which places it there
-      even though CELLxGENE treats it as a per-cell flag. Consequence: coverage buckets
-      it by sample_id, so an integrated object whose cells disagree within one sample
-      (duplicate copies marked false, canonical ones true) reports that sample as
-      inconsistent. That is accurate reporting of a genuinely mixed value, not a
-      validation failure — the h5ad validator accepts such a file.
+    comments:
+      - >-
+        Required by the h5ad validator and by the published Tier 1 dictionary, but left
+        optional here until entry sheets carry the column — LinkML's `required` is
+        enforced against entry sheet rows, so flipping it fails every sheet without it.
+        See #544.
+      - >-
+        Lives on Sample to match the published Tier 1 dictionary, which places it there
+        even though CELLxGENE treats it as a per-cell flag. Consequence: coverage buckets
+        it by sample_id, so an integrated object whose cells disagree within one sample
+        (duplicate copies marked false, canonical ones true) reports that sample as
+        inconsistent. That is accurate reporting of a genuinely mixed value, not a
+        validation failure — the h5ad validator accepts such a file.
 
   library_id:
     title: Library ID

--- a/shared/src/hca_validation/schema/sample.yaml
+++ b/shared/src/hca_validation/schema/sample.yaml
@@ -142,9 +142,29 @@ slots:
       To be able to link to other studies from the same institution as sometimes samples from different labs in the same institute are processed via similar core facilities. Thus batch effects may be smaller for datasets from the same institute even if other factors differ.
 
   is_primary_data:
-    is_a: deprecated_slot
     title: Is Primary Data
-    description: Deprecated placeholder indicating whether sample represents primary data.
+    description: >-
+      Whether the sample represents the primary data for these cells, as opposed to
+      a re-analysis of data published elsewhere.
+    examples:
+      - value: "true"
+    annotations:
+      annDataLocation: obs
+      tier: Tier 1
+      cxg: is_primary_data
+    range: boolean
+    required: false
+    multivalued: false
+    comments: >-
+      Required by the h5ad validator and by the published Tier 1 dictionary, but left
+      optional here until entry sheets carry the column — LinkML's `required` is
+      enforced against entry sheet rows, so flipping it fails every sheet without it. See #544.
+      Lives on Sample to match the published Tier 1 dictionary, which places it there
+      even though CELLxGENE treats it as a per-cell flag. Consequence: coverage buckets
+      it by sample_id, so an integrated object whose cells disagree within one sample
+      (duplicate copies marked false, canonical ones true) reports that sample as
+      inconsistent. That is accurate reporting of a genuinely mixed value, not a
+      validation failure — the h5ad validator accepts such a file.
 
   library_id:
     title: Library ID
@@ -380,6 +400,9 @@ slots:
   sample_collection_method:
     title: Sample Collection Method
     description: The method the sample was physically obtained from the donor.
+    annotations:
+      annDataLocation: obs
+      tier: Tier 1
     range: SampleCollectionMethod
     required: true
     notes: "brush; scraping; biopsy; surgical resection; blood draw; body fluid; other"

--- a/shared/src/hca_validation/schema_utils/schema_utils.py
+++ b/shared/src/hca_validation/schema_utils/schema_utils.py
@@ -80,8 +80,8 @@ def coverage_classes(schemaview: SchemaView) -> list[str]:
     """DEFAULT LinkML class names eligible for metadata coverage reporting.
 
     Returns the canonical (non-bionetwork-specific) class for each entity type
-    when that class has at least one coverage-eligible slot. Cell currently has
-    no slots and so is excluded in v0.
+    when that class has at least one coverage-eligible slot. Cell is excluded
+    deliberately — see below.
 
     Bionetwork-specific variants (AdiposeDataset, GutSample, etc.) are intentionally
     excluded: the validator emits coverage at the generic entity grain (donor,
@@ -90,6 +90,25 @@ def coverage_classes(schemaview: SchemaView) -> list[str]:
     eligible = []
     for network_mapping in schema_classes.values():
         class_name = network_mapping["DEFAULT"]
+        # Cell gained slots in #538, which would otherwise make it eligible and
+        # emit entity_class == "cell" rows. The tracker validates every coverage
+        # row against a closed allowlist of ["dataset", "donor", "obs", "sample"],
+        # and because metadata_coverage shares a schema with tool_reports, an
+        # unrecognized grain fails the *entire* validation-results message rather
+        # than degrading coverage. Nothing consumes cell-grain coverage today, so
+        # suppressing it here avoids a cross-repo deploy ordering constraint.
+        #
+        # Note the asymmetry, which is deliberate rather than an oversight: only
+        # `entity_class` is allowlisted. The row's `field` is `string().required()`
+        # with no `oneOf`, and the tracker's completeness rollup intersects incoming
+        # fields against its own data dictionary, ignoring ones it does not know. So
+        # new *fields* are safe to emit without coordination, while a new *grain* is
+        # not — which is why #538 could add sample-grain rows for `is_primary_data`
+        # and `sample_collection_method` in the same change that suppresses Cell.
+        # Remove once clevercanary/hca-atlas-tracker#1499 ships, which widens the
+        # allowlist and makes entities["cell"] optional.
+        if class_name == "Cell":
+            continue
         if any(True for _ in iter_coverage_slots(schemaview, class_name)):
             eligible.append(class_name)
     return eligible

--- a/shared/src/hca_validation/schema_utils/schema_utils.py
+++ b/shared/src/hca_validation/schema_utils/schema_utils.py
@@ -103,8 +103,10 @@ def coverage_classes(schemaview: SchemaView) -> list[str]:
         # with no `oneOf`, and the tracker's completeness rollup intersects incoming
         # fields against its own data dictionary, ignoring ones it does not know. So
         # new *fields* are safe to emit without coordination, while a new *grain* is
-        # not — which is why #538 could add sample-grain rows for `is_primary_data`
-        # and `sample_collection_method` in the same change that suppresses Cell.
+        # not — which is why #538 could add a sample-grain row for
+        # `sample_collection_method` in the same change that suppresses Cell.
+        # (`is_primary_data` also gained the obs annotation but emits nothing: it
+        # remains a deprecated_slot, and deprecated slots are filtered from coverage.)
         # Remove once clevercanary/hca-atlas-tracker#1499 ships, which widens the
         # allowlist and makes entities["cell"] optional.
         if class_name == "Cell":

--- a/shared/tests/test_schema.py
+++ b/shared/tests/test_schema.py
@@ -117,11 +117,12 @@ def test_is_primary_data_stays_sheet_inert():
     Annotations are inert for validation, which is what lets the obs annotation coexist
     with the placeholder — see the slot's comments and #544.
     """
-    field = schema.Sample.model_fields["is_primary_data"]
-    assert field.annotation == (str | None), field.annotation
-    assert not field.is_required()
+    assert not schema.Sample.model_fields["is_primary_data"].is_required()
 
-    # The values a sheet might plausibly carry must all still pass.
+    # The behavioural check, and the one that matters: these are the values a sheet
+    # might plausibly carry, and all of them must still pass. This also subsumes an
+    # annotation-equality assertion — if the slot regained `range: boolean`, "na",
+    # "unknown" and "primary" would each raise here.
     for value in ("TRUE", "true", "na", "unknown", "primary", None):
         assert schema.Sample.model_validate({**_MINIMAL_SAMPLE, "is_primary_data": value}), (
             f"{value!r} should be accepted"

--- a/shared/tests/test_schema.py
+++ b/shared/tests/test_schema.py
@@ -59,6 +59,30 @@ _OBS_ANNOTATED_SLOTS = [
 ]
 
 
+# A Sample row that satisfies every required slot, so a test can vary one field and be
+# sure any failure came from that field. The models set `extra = "forbid"`, so this must
+# name only declared slots.
+_MINIMAL_SAMPLE = {
+    "sample_id": "S1",
+    "donor_id": "D1",
+    "dataset_id": "DS1",
+    "institute": "X",
+    "cell_enrichment": "na",
+    "library_id": "L1",
+    "library_preparation_batch": "b1",
+    "library_sequencing_run": "r1",
+    "sample_collection_method": "biopsy",
+    "sample_preservation_method": "fresh",
+    "sample_source": "surgical donor",
+    "sampled_site_condition": "healthy",
+    "suspension_type": "cell",
+    "tissue_type": "tissue",
+    "tissue_ontology_term_id": "UBERON:0000955",
+    "disease_ontology_term_id": "PATO:0000461",
+    "development_stage_ontology_term_id": "HsapDv:0000237",
+}
+
+
 @pytest.mark.parametrize(("class_name", "slot_name"), _OBS_ANNOTATED_SLOTS)
 def test_obs_slots_carry_anndata_location(schemaview, class_name, slot_name):
     """Regression guard for #538.
@@ -81,10 +105,25 @@ def test_cell_class_excluded_from_coverage(schemaview):
     assert "Cell" not in coverage_classes(schemaview)
 
 
-def test_is_primary_data_is_no_longer_a_deprecated_placeholder():
-    """#538 restored it to a real boolean slot. It stays optional until entry sheets
-    carry the column (#544) — LinkML's `required` is enforced against entry sheet rows,
-    so flipping it would fail every sheet lacking it."""
+def test_is_primary_data_stays_sheet_inert():
+    """#538 annotated `is_primary_data` but deliberately left it a deprecated_slot.
+
+    This is the load-bearing property: entry sheet validation runs
+    `Sample.model_validate(row_dict)` on data taken straight from sheet columns, so the
+    slot's `range` decides what curators may type. As an unconstrained string it accepts
+    anything, including the "na" convention this schema documents elsewhere
+    (`cell_enrichment`, `suspension_type`). Giving it `range: boolean` would start
+    rejecting those values, so sheets that validate today would begin failing.
+
+    Annotations are inert for validation, which is what lets the obs annotation coexist
+    with the placeholder — see the slot's comments and #544.
+    """
     field = schema.Sample.model_fields["is_primary_data"]
-    assert field.annotation == (bool | None), field.annotation
+    assert field.annotation == (str | None), field.annotation
     assert not field.is_required()
+
+    # The values a sheet might plausibly carry must all still pass.
+    for value in ("TRUE", "true", "na", "unknown", "primary", None):
+        assert schema.Sample.model_validate({**_MINIMAL_SAMPLE, "is_primary_data": value}), (
+            f"{value!r} should be accepted"
+        )

--- a/shared/tests/test_schema.py
+++ b/shared/tests/test_schema.py
@@ -28,8 +28,7 @@ def test_schemaview_classes(schemaview):
     """
     for classes in schema_classes.values():
         for class_name in classes.values():
-            print(class_name)
-            assert schemaview.get_class(class_name) is not None
+            assert schemaview.get_class(class_name) is not None, f"{class_name} missing from schemaview"
 
 
 def test_generated_classes():

--- a/shared/tests/test_schema.py
+++ b/shared/tests/test_schema.py
@@ -2,16 +2,30 @@
 Test script for schema functionality.
 """
 
+import pytest
+
 import hca_validation.schema.generated.core as schema
-from hca_validation.schema_utils.schema_utils import load_schemaview, schema_classes
+from hca_validation.schema_utils.schema_utils import (
+    coverage_classes,
+    get_slot_anndata_location,
+    load_schemaview,
+    schema_classes,
+)
 
 
-def test_schemaview_classes():
+@pytest.fixture(scope="module")
+def schemaview():
+    """Shared across the module because `class_induced_slots` is the expensive part —
+    linkml_runtime memoizes it per SchemaView instance, so a fresh instance per test
+    re-pays roughly 40ms per class. Mirrors the fixture in the dataset-validator's
+    coverage tests."""
+    return load_schemaview()
+
+
+def test_schemaview_classes(schemaview):
     """
     Test that all classes in the mapping exist in the schema when loaded as a schemaview.
     """
-    schemaview = load_schemaview()
-    print(schemaview)
     for classes in schema_classes.values():
         for class_name in classes.values():
             print(class_name)
@@ -25,3 +39,52 @@ def test_generated_classes():
     for classes in schema_classes.values():
         for class_name in classes.values():
             assert hasattr(schema, class_name)
+
+
+# Columns that live in obs and that consumers discover by walking the schema for an
+# `annDataLocation: obs` annotation. Before #538 these four were invisible to that walk:
+# the Cell pair had no home in the model at all, and the Sample pair carried no
+# annotation.
+#
+# The consumer that motivated this is `drop_obs_columns` (#531, landing in #539), whose
+# delete guard refuses any column the schema names — so while these four were invisible
+# it would happily delete columns the h5ad validator requires. Note that tool is not on
+# `main` yet, so grepping for it here will come up empty until #539 merges; the other
+# reader of this annotation today is `iter_coverage_slots` in schema_utils.
+_OBS_ANNOTATED_SLOTS = [
+    ("Cell", "author_cell_type"),
+    ("Cell", "cell_type_ontology_term_id"),
+    ("Sample", "is_primary_data"),
+    ("Sample", "sample_collection_method"),
+]
+
+
+@pytest.mark.parametrize(("class_name", "slot_name"), _OBS_ANNOTATED_SLOTS)
+def test_obs_slots_carry_anndata_location(schemaview, class_name, slot_name):
+    """Regression guard for #538.
+
+    Asserted through `get_slot_anndata_location` rather than by reading the YAML,
+    because that resolution is the thing consumers depend on — a slot can be declared
+    correctly and still fail to induce onto its class.
+    """
+    slots = {s.name: s for s in schemaview.class_induced_slots(class_name)}
+    assert slot_name in slots, f"{slot_name} does not induce onto {class_name}"
+    assert get_slot_anndata_location(slots[slot_name]) == "obs"
+
+
+def test_cell_class_excluded_from_coverage(schemaview):
+    """Cell has slots as of #538, so its exclusion from coverage is now a deliberate
+    choice rather than a side effect of the class being empty. See `coverage_classes`
+    in schema_utils for why it stays excluded and when to remove it.
+    """
+    assert schemaview.class_induced_slots("Cell"), "Cell should have slots after #538"
+    assert "Cell" not in coverage_classes(schemaview)
+
+
+def test_is_primary_data_is_no_longer_a_deprecated_placeholder():
+    """#538 restored it to a real boolean slot. It stays optional until entry sheets
+    carry the column (#544) — LinkML's `required` is enforced against entry sheet rows,
+    so flipping it would fail every sheet lacking it."""
+    field = schema.Sample.model_fields["is_primary_data"]
+    assert field.annotation == (bool | None), field.annotation
+    assert not field.is_required()


### PR DESCRIPTION
Closes #538

## What changed

Three obs columns the HCA schema genuinely defines were invisible to any code that discovers obs
fields by walking the generated Pydantic models for an `annDataLocation: obs` annotation.

- **`shared/src/hca_validation/schema/cell.yaml`** — `Cell` was a bare `pass`. It now carries
  `author_cell_type` and `cell_type_ontology_term_id`, both optional with `annDataLocation: obs`.
- **`shared/src/hca_validation/schema/sample.yaml`** — `is_primary_data` and
  `sample_collection_method` each gain `annDataLocation: obs`. **Nothing else about either slot
  changes** — `is_primary_data` stays the `deprecated_slot` it is on main (see Assumptions).
- **`shared/src/hca_validation/schema_utils/schema_utils.py`** — `coverage_classes()` now excludes
  `Cell` by name. It was excluded incidentally before, because the class had no slots.
- **Regenerated** `shared/src/hca_validation/schema/generated/core.py` and
  `data_dictionaries/core_data_dictionary.json` (whose previously-empty `cell` class is now populated).
- **Refreshed** the bundled model at `packages/hca-anndata-tools/src/hca_anndata_tools/schema/core.py`.
- **Tests** in `shared/tests/test_schema.py` and `services/dataset-validator/tests/test_metadata_coverage.py`.

## Why

`drop_obs_columns` (#531, PR #539) refuses to delete any column the HCA schema names, deriving that
set from these annotations. All three fell through the guard — verified against the real tool before
this change, all three deleted successfully.

`cell_type_ontology_term_id` is the worst case: **unrecoverable**, because `populate_labels` derives
`cell_type` *from* it, not the reverse. The other two have no `requirement_level` in the validator
schema, so their absence is a hard validation error.

A supplementary hardcoded column list in `hca-anndata-tools` was considered and rejected — the whole
premise of #531 was that hardcoded column lists rot. Fixing the schema repairs every present and
future consumer at once.

## Assumptions I made

**Field placement is not a guess — it matches the published contract.** `site-config/data-portal/dev/dataDictionary/tier-1.json`
in DataBiosphere/data-portal puts `is_primary_data` and `sample_collection_method` on **sample**, and
`author_cell_type` and `cell_type_ontology_term_id` on **cell**. This PR agrees on all four.

**`is_primary_data` stays a deprecated placeholder, and only gains the annotation.** This is the
central constraint of the PR: **entry sheet validation behaviour must not change.** LinkML slots drive
it via `validate_sheet.py:881` → `Sample.model_validate(row_dict)`, where `row_dict` comes straight
from sheet column headers — so a slot's `range` decides what curators may type. Verified against both
trees:

| sheet value | main | if made `range: boolean` |
|---|---|---|
| `TRUE` / `true` | accepted | accepted |
| `na` | accepted | **ERROR** |
| `unknown` | accepted | **ERROR** |
| free text | accepted | **ERROR** |

`na` is a documented convention in this very schema (`cell_enrichment`, `suspension_type`), so sheets
that validate today would have begun failing. Annotations are validation-inert, which is what lets the
obs annotation coexist with the placeholder — confirmed independently by `sample_collection_method`,
whose enum enforcement is unchanged by the same addition.

**Removing the slot from `Sample` was rejected as worse.** The generated models set
`extra = "forbid"`, so any sheet carrying an `is_primary_data` column would fail with
`extra_forbidden` — for every value, not just invalid ones.

**The Sample-vs-Cell grain question is deferred, not answered.** CELLxGENE defines this in obs as a
per-cell `bool`, and the published dictionary describes it as "the canonical instance of this cellular
observation" — per-observation semantics — while filing it under `sample`. A sample's cells can
legitimately disagree, so `Sample` is the wrong grain; the placeholder deliberately makes no semantic
claim. Moving it to `Cell` needs a `slot_usage` override, because LinkML slots are global by name.
Tracked in **#544**.

**The `Cell` coverage exclusion is a hardcoded class-name check, deliberately.** Review flagged that
every sibling exclusion in that file is declarative (deprecated slots, FK slots, bionetwork variants)
and proposed a class-level annotation instead. Declined: those exclusions are all *intrinsic*
properties of the thing excluded, whereas this one encodes another repo's current deploy state.
Encoding that in `cell.yaml` would push tracker coupling into the schema, backwards for #540's
direction of travel. A one-line `continue` naming clevercanary/hca-atlas-tracker#1499 is also easier
to delete than a mechanism is to unbuild.

**This adds one `field_coverage` row and that is safe.** Annotating `sample_collection_method` makes
it coverage-eligible. `is_primary_data` emits nothing, because deprecated slots are filtered from
coverage — so only one new sample-grain row. Checked against the tracker rather than assumed: `field` is
`string().required()` with **no** `oneOf`, and `getFieldCatalog` intersects incoming fields against the
tracker's own data dictionary, ignoring unknown ones. Only `entity_class` is allowlisted, which is
exactly why a new *grain* needs coordination and new *fields* do not. Denominators shift for anyone
computing percentages over the row set.

**Descriptions, examples and rationale come from the published dictionary**, not from me. Pulled
verbatim from `site-config/data-portal/dev/dataDictionary/tier-1.json` for `author_cell_type`,
`cell_type_ontology_term_id` and `sample_collection_method` — including the three forbidden CL terms
(`CL:0000255`, `CL:0000257`, `CL:0000548`) an earlier revision of this PR omitted. `is_primary_data`
keeps main's placeholder wording, since the published description denotes a real per-cell boolean
field rather than an inert placeholder.

**The delete guard now covers every validator-required obs column.** Measured: the validator declares
28 obs columns (23 required, 5 optional); the guard sees 40. Validator-required columns invisible to
the guard: **zero**. The only validator-known columns the guard cannot see are
`self_reported_ethnicity` and `self_reported_ethnicity_ontology_term_id`, which is deliberate — HCA
forbids them for privacy and `strip_forbidden_obs_columns` exists to remove them, so protecting them
would block the tool whose job is stripping them.

**The bundled model is now copied verbatim** (3-line provenance header + the generated file) instead of
having its import block hand-trimmed. The file is excluded from ruff (`ruff.toml:6`) and pyright sets
`reportUnusedImport: false`, so dead codegen imports cost nothing — while a trimmed header silently
breaks if the generator ever emits a construct needing `field_validator`. #536 tracks automating this.

**Test placement deviates from plan.** The guard-side regression tests belong in
`packages/hca-anndata-tools/tests/test_drop.py` and `test_schema_helpers.py`, which live on #539's
branch, not `main`. Recorded as owed at rebase in a comment on #539.

## How to verify

Definition of done from #538:

**1. `annDataLocation: obs` on `is_primary_data` and `sample_collection_method`** — and on the Cell pair:

```bash
cd shared && uv run python -c "
from hca_validation.schema_utils import load_schemaview, get_slot_anndata_location, coverage_classes
sv = load_schemaview()
for cls, want in (('Cell', ['author_cell_type','cell_type_ontology_term_id']),
                  ('Sample', ['is_primary_data','sample_collection_method'])):
    for s in sv.class_induced_slots(cls):
        if s.name in want:
            print(f'{cls}.{s.name:30} annDataLocation={get_slot_anndata_location(s)!r} required={s.required}')
print('coverage_classes:', coverage_classes(sv))
"
```

Expect `annDataLocation='obs'` on all four, and `coverage_classes: ['Dataset', 'Donor', 'Sample']` —
no `Cell`.

**2. The generated artifacts are in sync with the YAML:**

```bash
cd shared && make build
cd .. && git diff --exit-code shared/src/hca_validation/schema/generated/core.py data_dictionaries/core_data_dictionary.json && echo "in sync"
```

**3. The bundled copy matches the generated file:**

```bash
diff <(tail -n +4 packages/hca-anndata-tools/src/hca_anndata_tools/schema/core.py) \
     shared/src/hca_validation/schema/generated/core.py && echo "in sync"
```

**4. Coverage payload unchanged in shape (no `cell` grain), plus the two new sample rows:**

```bash
cd services/dataset-validator && uv run pytest tests/test_metadata_coverage.py -v -k "cell_entity or newly_annotated"
```

**5. `drop_obs_columns` refuses all three.** Requires #539's branch, so verify after it rebases onto
this. Build an h5ad carrying the three columns and attempt the drop; expect a refusal naming
`sample_collection_method` as schema-required and the other two as schema-described, and expect a
control drop of an unnamed column to still succeed. Pre-merge result from a scratch worktree combining
the two branches:

```
ALL THREE -> Refusing to drop: HCA schema-required obs columns cannot be dropped:
['sample_collection_method']; schema-described obs columns cannot be dropped:
['cell_type_ontology_term_id', 'is_primary_data'] — ... cannot be recovered once removed
```

**Full gate:**

```bash
cd shared && uv run pytest tests/ -m "not integration" -q            # 52 passed
cd ../services/dataset-validator && uv run pytest tests/ -q          # 79 passed
cd ../../packages/hca-anndata-tools && uv run pytest tests/ -q       # 280 passed
cd ../.. && uvx ruff@0.11.8 check . && uvx ruff@0.11.8 format --check . && make typecheck
```

## Ordering

#539 stays draft until this merges, then rebases onto it — at which point its guard is honest and the
owed regression tests land there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
