### PR TITLE
build(hca-schema-validator): move the service lock to validator 0.14.2

### DIFF
--- a/services/hca-schema-validator/uv.lock
+++ b/services/hca-schema-validator/uv.lock
@@ -359,7 +359,7 @@ wheels = [
 
 [[package]]
 name = "hca-schema-validator"
-version = "0.14.1"
+version = "0.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anndata" },
@@ -380,9 +380,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/58/f3/07316ad17e5edd35effa419346df1d0c828dda6d4b40f53d4b284c4c8ba0/hca_schema_validator-0.14.1.tar.gz", hash = "sha256:64f2fa29de0402312940ee6b47dd78ff774bb34b4b466031ed246647d02dd77e", size = 6521907, upload-time = "2026-07-14T02:57:44.793Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/10/f3e1ed5bef03437445a0e27cd2c12df586276e9db517ec7bb18dfabbe915/hca_schema_validator-0.14.2.tar.gz", hash = "sha256:d6371e47aa66c6ee5e4f19b227422ec6d3b54bd9441d2625bdfe0df68b48a3da", size = 6388752, upload-time = "2026-07-31T04:52:02.784Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/a7/7d410c672042cfc1689d191994187cfb98d4f0ab88c823f4e2a2e50b6bc0/hca_schema_validator-0.14.1-py3-none-any.whl", hash = "sha256:9f28ddf3503260684ac074490ada8d5c8e1d5fe647b66750478c9b6be5e47627", size = 6222369, upload-time = "2026-07-14T02:57:42.732Z" },
+    { url = "https://files.pythonhosted.org/packages/33/d8/1fa5b17a3f882ce985e240afd61010a34be13e807d74c365e20c3ca414b8/hca_schema_validator-0.14.2-py3-none-any.whl", hash = "sha256:d6bdd0543b28c41e7eb79e0d6b0018057b56ff40e29e8629514f3cf33182d948", size = 6222245, upload-time = "2026-07-31T04:52:00.859Z" },
 ]
 
 [[package]]
@@ -442,7 +442,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [


### PR DESCRIPTION
Step 2 of #551. Refs #551 (does not close it — the deploy steps remain).

## What changed

`services/hca-schema-validator/uv.lock` only: `hca-schema-validator` 0.14.1 → 0.14.2.

No `pyproject.toml` change. 0.14.2 falls inside the existing `>=0.14.0,<0.15.0` pin, so this is the "patch release inside the constraint" case from CLAUDE.md.

## Why

The Docker image installs from `uv export` against this lock, so **the lock decides which validator version ships** — not the constraint in `pyproject.toml`. With #491 merged and 0.14.2 on PyPI, the lock was one behind.

Bumped with `uv lock --upgrade-package hca-schema-validator`. A bare `uv lock` re-resolves conservatively and keeps 0.14.1, and that failure is **silent**: the build succeeds and the image just keeps shipping the old validator. Doing it now means the next deploy isn't the one that has to discover the trap.

0.14.2 contains ruff sweeps and a build change — no functional difference from 0.14.1. This is about keeping the deployed pin level with the latest published version, not about shipping a fix.

## Assumptions I made

- **The `zipp` marker hunk is inert.** The lock also picked up an explicit `marker = "python_full_version < '3.12'"` on `importlib-metadata`'s `zipp` dependency, which I did not ask for. I verified rather than assumed: exporting with the exact flags the Dockerfile runs, before and after, differs **only** in the `hca-schema-validator` line. The old lock was already emitting that marker at export time — uv is now recording explicitly what it already computed. The image is `python:3.11-slim-bookworm`, where the marker holds regardless.
- **No image is built by this PR.** It only moves the lock. The Batch image still ships 0.14.1 until `make batch-publish-container` runs, which is a later step of #551.

## How to verify

**1. The lock actually moved** (the check CLAUDE.md asks for):

```bash
grep -A1 'name = "hca-schema-validator"' services/hca-schema-validator/uv.lock
```

Expect `version = "0.14.2"`.

**2. Nothing else changes in what ships.** Export the requirements the Dockerfile installs, on this branch and on main, and diff:

```bash
cd services/hca-schema-validator
uv export --frozen --no-hashes --no-dev --no-emit-project -o /tmp/req_new.txt
git stash && uv export --frozen --no-hashes --no-dev --no-emit-project -o /tmp/req_old.txt && git stash pop
diff /tmp/req_old.txt /tmp/req_new.txt
```

Expect exactly one substantive line, `hca-schema-validator==0.14.1` → `0.14.2` (plus the `-o` filename in the header comment).

**3. Gate:**

```bash
cd services/hca-schema-validator && uv run pytest tests/ -q    # 11 pass
cd ../.. && make typecheck                                      # 0 errors, 4 passes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)