### PR TITLE
feat(hca-schema-validator)!: verify X against layers['desouped_counts']

### DIFF
--- a/docs/dataset-validator-checks.md
+++ b/docs/dataset-validator-checks.md
@@ -64,6 +64,8 @@ Three matrices, and no more. Everything else in circulation — `normalized_coun
 | `layers['desouped_counts']` | when ambient RNA removal was applied | counts surviving removal, float32 |
 | `X` | yes | `log1p(normalize_total(desouped_counts if present else raw.X))` |
 
+The table is the contract, not the check list. `raw.X`'s dtype and integrality are enforced (by the vendored raw-layer validation); `desouped_counts`' are **not** — check 5 below establishes only that the layer is usable as a reference, and check 6 that it does not exceed `raw.X`. Validating the layer as counts in its own right is open work.
+
 `desouped_counts` is required rather than optional because it cannot be recovered: ambient RNA removal is parameterised and often stochastic, so discarding it leaves `X` an assertion no one can check. `normalize_total`'s target sum is *not* pinned — the checks compare per-cell profiles, in which the target cancels, so `scanpy`'s `target_sum=None` default is accepted.
 
 Checks run cheapest first and short-circuit, so one defect yields one message:

--- a/docs/dataset-validator-checks.md
+++ b/docs/dataset-validator-checks.md
@@ -58,7 +58,7 @@ All other rules come from the vendored base class (§5).
 
 Three matrices, and no more. Everything else in circulation — `normalized_counts`, `desouped_normalized_counts`, `logcounts` — is recomputable from these, so storing it buys no information and silently goes stale when the file is edited.
 
-| | required | holds |
+| matrix | required | holds |
 |---|---|---|
 | `raw.X` | yes | raw counts, float32, empty droplets removed only |
 | `layers['desouped_counts']` | when ambient RNA removal was applied | counts surviving removal, float32 |
@@ -72,7 +72,7 @@ Checks run cheapest first and short-circuit, so one defect yields one message:
 2. **`X` holds NaN or infinite values** — reported before the rest, which a non-finite entry makes unreliable rather than merely wrong.
 3. **`X` above the `log1p` ceiling** (~20; `exp(20)` is 4.8e8 counts in one cell) — raw counts in `X`, or a normalization that was never log-transformed.
 4. **`X` holds no positive values** — the matrix was emptied or dropped.
-5. **`layers['desouped_counts']` holds NaN, infinities, or no counts** — it cannot serve as the reference. Checked before it is trusted, because such a layer does not make checks 7–8 fail, it makes them silently not happen: every sampled row drops out of the comparison and the file reports clean. Nothing else would catch it — no vendored check reads layer *values*, only their encoding.
+5. **`layers['desouped_counts']` holds NaN, infinities, negatives, or no counts** — it cannot serve as the reference. Checked before it is trusted, because such a layer does not make checks 7–8 fail, it makes them silently not happen: every sampled row drops out of the comparison and the file reports clean. Nothing else would catch it — no vendored check reads layer *values*, only their encoding.
 6. **`layers['desouped_counts']` exceeds `raw.X`** — the layer is not a desouped version of `raw.X`, so it cannot be trusted as the reference.
 7. **`X` disagrees with its source.** With the layer present that is the whole finding. Against `raw.X`, the recovered counts name the cause — a pipeline can remove counts but never invent them:
 

--- a/docs/dataset-validator-checks.md
+++ b/docs/dataset-validator-checks.md
@@ -74,9 +74,10 @@ Checks run cheapest first and short-circuit, so one defect yields one message:
 2. **`X` holds NaN or infinite values** — reported before the rest, which a non-finite entry makes unreliable rather than merely wrong.
 3. **`X` above the `log1p` ceiling** (~20; `exp(20)` is 4.8e8 counts in one cell) — raw counts in `X`, or a normalization that was never log-transformed.
 4. **`X` holds no positive values** — the matrix was emptied or dropped.
-5. **`layers['desouped_counts']` holds NaN, infinities, negatives, or no counts** — it cannot serve as the reference. Checked before it is trusted, because such a layer does not make checks 7–8 fail, it makes them silently not happen: every sampled row drops out of the comparison and the file reports clean. Nothing else would catch it — no vendored check reads layer *values*, only their encoding.
+5. **`layers['desouped_counts']` holds NaN, infinities, negatives, or no counts** — it cannot serve as the reference. Checked before it is trusted, because such a layer does not make checks 8–9 fail, it makes them silently not happen: every sampled row drops out of the comparison and the file reports clean. Nothing else would catch it — no vendored check reads layer *values*, only their encoding.
 6. **`layers['desouped_counts']` exceeds `raw.X`** — the layer is not a desouped version of `raw.X`, so it cannot be trusted as the reference.
-7. **`X` disagrees with its source.** With the layer present that is the whole finding. Against `raw.X`, the recovered counts name the cause — a pipeline can remove counts but never invent them:
+7. **No sampled cell could be compared** — the checks below would not run, and passing on that is indistinguishable from passing on a clean file. The whole-matrix checks do not cover it: they ask about `X` and `raw.X` as a whole, so an `X` whose first cells are empty or negative while later ones are not clears all four and still leaves the sample with nothing to compare.
+8. **`X` disagrees with its source.** With the layer present that is the whole finding. Against `raw.X`, the recovered counts name the cause — a pipeline can remove counts but never invent them:
 
    | recovered counts | verdict |
    |---|---|
@@ -87,11 +88,11 @@ Checks run cheapest first and short-circuit, so one defect yields one message:
 
    The last row is a real population rather than a tolerance artifact; the corpus measurement that establishes that is recorded on `_implied_counts_verdict`.
 
-8. **`X` log-transformed but never total-normalized** — every cell's recovered total is its own depth, so no rescaling was applied.
+9. **`X` log-transformed but never total-normalized** — every cell's recovered total is its own depth, so no rescaling was applied.
 
 Silent when `raw.X` is absent: the vendored `_validate_raw` owns that case. Also silent when the layer's chunking does not match `X`'s — `read_backed` chunks CSC as `(n_obs, chunk_size)`, so sampling 200 rows off a CSC layer would read the layer whole; the vendored sparsity check has already errored on that encoding, so the file fails regardless.
 
-Sampling: checks 1–4 scan both matrices in full; 5–8 use the first 200 cells, since the identity is per-cell and independent across cells.
+Sampling: checks 1–4 scan both matrices in full; 5–9 use the first 200 cells, since the identity is per-cell and independent across cells.
 
 Assay coverage: these run on every file, and do **not** yet inherit the ATAC-seq / Methyl-seq / methylation-profiling / snmC-seq exemptions that `hca_schema_definition.yaml` declares for raw-layer validation. HCA does not currently accept those assays; see the open issue before it does.
 

--- a/docs/dataset-validator-checks.md
+++ b/docs/dataset-validator-checks.md
@@ -50,8 +50,48 @@ Runs the full vendored schema validator against the unmodified CELLxGENE schema 
 - **Raw-layer retry** — re-runs `_validate_raw()` if the base class skipped it but `assay_ontology_term_id` exists.
 - **GENCODE-aware feature-ID warnings** — warning text includes a GENCODE version label, plus a dataset-organism vs. feature-ID-organism mismatch warning (excluding exempt organisms).
 - **Warning reordering** — feature-ID warnings pushed to the end.
+- **Expression matrix contract** — see §4.1. Not inherited from CELLxGENE, which checks that `raw.X` is raw but never looks at `X`.
 
 All other rules come from the vendored base class (§5).
+
+### 4.1 Expression matrix contract (`check_x_normalization`)
+
+Three matrices, and no more. Everything else in circulation — `normalized_counts`, `desouped_normalized_counts`, `logcounts` — is recomputable from these, so storing it buys no information and silently goes stale when the file is edited.
+
+| | required | holds |
+|---|---|---|
+| `raw.X` | yes | raw counts, float32, empty droplets removed only |
+| `layers['desouped_counts']` | when ambient RNA removal was applied | counts surviving removal, float32 |
+| `X` | yes | `log1p(normalize_total(desouped_counts if present else raw.X))` |
+
+`desouped_counts` is required rather than optional because it cannot be recovered: ambient RNA removal is parameterised and often stochastic, so discarding it leaves `X` an assertion no one can check. `normalize_total`'s target sum is *not* pinned — the checks compare per-cell profiles, in which the target cancels, so `scanpy`'s `target_sum=None` default is accepted.
+
+Checks run cheapest first and short-circuit, so one defect yields one message:
+
+1. **`X` identical to `raw.X`** — normalization never ran. The two-matrix layout means `raw.X` present implies `X` is the normalized one; CELLxGENE has no state where both are present and equal, which is why its `_has_valid_raw` walks past such files without inspecting `X`.
+2. **`X` holds NaN or infinite values** — reported before the rest, which a non-finite entry makes unreliable rather than merely wrong.
+3. **`X` above the `log1p` ceiling** (~20; `exp(20)` is 4.8e8 counts in one cell) — raw counts in `X`, or a normalization that was never log-transformed.
+4. **`X` holds no positive values** — the matrix was emptied or dropped.
+5. **`layers['desouped_counts']` holds NaN, infinities, or no counts** — it cannot serve as the reference. Checked before it is trusted, because such a layer does not make checks 7–8 fail, it makes them silently not happen: every sampled row drops out of the comparison and the file reports clean. Nothing else would catch it — no vendored check reads layer *values*, only their encoding.
+6. **`layers['desouped_counts']` exceeds `raw.X`** — the layer is not a desouped version of `raw.X`, so it cannot be trusted as the reference.
+7. **`X` disagrees with its source.** With the layer present that is the whole finding. Against `raw.X`, the recovered counts name the cause — a pipeline can remove counts but never invent them:
+
+   | recovered counts | verdict |
+   |---|---|
+   | not whole numbers | `X` is not a normalization of any count matrix (a different transform, or altered afterwards) |
+   | whole, only above `raw.X` | `X` came from a different matrix |
+   | whole, only below `raw.X` | desouping ran and `layers['desouped_counts']` is missing |
+   | whole, both above and below | both at once — desouping ran, *and* `raw.X` cannot be its source |
+
+   The last row is a real population rather than a tolerance artifact; the corpus measurement that establishes that is recorded on `_implied_counts_verdict`.
+
+8. **`X` log-transformed but never total-normalized** — every cell's recovered total is its own depth, so no rescaling was applied.
+
+Silent when `raw.X` is absent: the vendored `_validate_raw` owns that case. Also silent when the layer's chunking does not match `X`'s — `read_backed` chunks CSC as `(n_obs, chunk_size)`, so sampling 200 rows off a CSC layer would read the layer whole; the vendored sparsity check has already errored on that encoding, so the file fails regardless.
+
+Sampling: checks 1–4 scan both matrices in full; 5–8 use the first 200 cells, since the identity is per-cell and independent across cells.
+
+Assay coverage: these run on every file, and do **not** yet inherit the ATAC-seq / Methyl-seq / methylation-profiling / snmC-seq exemptions that `hca_schema_definition.yaml` declares for raw-layer validation. HCA does not currently accept those assays; see the open issue before it does.
 
 ---
 

--- a/packages/hca-schema-validator/src/hca_schema_validator/validator.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/validator.py
@@ -774,6 +774,9 @@ def _implied_counts_verdict(x_rows, raw_rows):
         excess += int((differs & (implied > raw_support)).sum())
         deficit += int((differs & (implied < raw_support)).sum())
 
+    # The entry-count test guards the division as well as the verdict: it can
+    # only pass when `testable` is at least _MIN_NON_INTEGRAL_ENTRIES, since
+    # `integral` is counted over the same entries `testable` is.
     non_integral = testable - integral
     if non_integral >= _MIN_NON_INTEGRAL_ENTRIES and non_integral / testable > 1 - _INTEGRAL_FRACTION:
         return _VERDICT_NOT_COUNTS
@@ -829,6 +832,18 @@ def _unusable_layer_error(declared_rows):
             f"layers['{DESOUPED_COUNTS_LAYER}'] contains NaN or infinite values, which cannot be "
             f"counts. That layer must hold the counts left behind by ambient RNA removal, so every "
             f"entry in it must be a finite count."
+        )
+
+    if bool((values < 0).any()):
+        # Same failure shape as the two above, reached differently: a row whose
+        # negatives cancel its positives has a non-positive total, which
+        # `_profile_mismatch` skips. Enough such rows and the sample empties out.
+        # raw.X is spared this only because the vendored `_validate_raw_data`
+        # rejects its non-positive values as non-counts; nothing does that here.
+        return (
+            f"layers['{DESOUPED_COUNTS_LAYER}'] contains negative values, which cannot be counts. "
+            f"That layer must hold the counts left behind by ambient RNA removal, so every entry "
+            f"in it must be zero or a positive count."
         )
 
     if not bool((values > 0).any()):
@@ -1008,9 +1023,9 @@ def check_x_normalization(adata):
     3. ``X`` holds values too large to be ``log1p`` output → raw counts, or a
        normalization that was never log-transformed.
     4. ``X`` holds no positive values → the matrix was emptied or dropped.
-    5. ``layers['desouped_counts']`` holds NaN, infinities, or no counts at all →
-       it cannot serve as the source, and left unchecked it would switch the two
-       checks below off rather than fail them.
+    5. ``layers['desouped_counts']`` holds NaN, infinities, negatives, or no
+       counts at all → it cannot serve as the source, and left unchecked it would
+       switch the two checks below off rather than fail them.
     6. ``layers['desouped_counts']`` holds more counts than ``raw.X`` → the
        layer is not what it claims to be, so it cannot be trusted as the source.
     7. ``X`` is not a total-normalization of its source. When the source is

--- a/packages/hca-schema-validator/src/hca_schema_validator/validator.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/validator.py
@@ -396,6 +396,51 @@ _DEPTH_MATCH_FRACTION = 0.5
 # 1.0 — a correctly normalized file would be condemned by a sample of one.
 _DEPTH_MATCH_MIN_CELLS = 2
 
+# The layer holding the counts that remain after ambient RNA removal. When it is
+# present it — not raw.X — is the matrix X must be a normalization of, because
+# desouping is what stands between the two.
+DESOUPED_COUNTS_LAYER = "desouped_counts"
+
+# How far a recovered count may sit from a whole number, or from its raw
+# counterpart, and still be treated as equal. X is stored float32, so a count
+# recovered through log1p/expm1 carries a relative error of roughly 1e-6; the
+# absolute term dominates for the small counts that make up almost every entry,
+# and the relative term keeps deep genes from drifting into a false verdict.
+_IMPLIED_COUNT_ATOL = 0.05
+_IMPLIED_COUNT_RTOL = 1e-3
+
+# Recovered counts above this are not tested for integrality. The float32 round
+# trip costs more than half a count somewhere above ~1e5, at which point the
+# question stops being answerable rather than merely noisy; this sits an order of
+# magnitude below that. Almost every entry in a count matrix is far smaller, so
+# the test still sees the overwhelming majority of the sample.
+#
+# The integrality test uses _IMPLIED_COUNT_ATOL alone, not _counts_equal. A
+# relative term makes the test vacuous long before this ceiling: the furthest a
+# value can sit from the nearest whole number is 0.5, which 1e-3 * count passes
+# at a count of 450. Every entry above that would score integral unconditionally
+# while still counting toward the sample, diluting the non-integral fraction on
+# deep data until the verdict could not fire at all.
+_INTEGRAL_TEST_MAX_COUNT = 1e4
+
+# Fraction of testable entries that must recover to whole numbers before X is
+# accepted as a normalization of *some* count matrix.
+_INTEGRAL_FRACTION = 0.95
+
+# Non-integral entries needed before that fraction is acted on. The fraction
+# alone is unsafe on a small sample — on a 13-entry object a single noisy value
+# clears 5% on its own — while a genuinely non-count X puts most of its entries
+# on the wrong side. Requiring both keeps the verdict honest at either size.
+_MIN_NON_INTEGRAL_ENTRIES = 3
+
+# Why X and its source disagree. NOT_COUNTS says X is not a normalization of any
+# count matrix; EXCESS that it came from a different one; DESOUPED that it came
+# from this one with counts removed; MIXED that both are true at once.
+_VERDICT_NOT_COUNTS = "not_counts"
+_VERDICT_EXCESS = "excess"
+_VERDICT_DESOUPED = "desouped"
+_VERDICT_MIXED = "mixed"
+
 
 def _max_finite(values, floor=0.0):
     """Largest finite entry in ``values``, or ``floor`` when there is none.
@@ -543,13 +588,56 @@ def _scan_x_against_raw(x, raw_x):
     return bool(stats[0]), float(stats[1]), bool(stats[2])
 
 
-def _profile_mismatch(x_rows, raw_rows):
+def _comparable_row(x_row, source_row):
+    """``(expm1(X), source)`` over the genes X carries, or None if unusable.
+
+    The one place the comparison's gene set is decided. Both ``_profile_mismatch``
+    and ``_implied_counts`` need it, and they run back to back on the same rows —
+    the second explains why the first failed — so a divergence between them would
+    have the verdict reasoning over a different set of genes than the check that
+    raised the alarm, with nothing to catch it.
+
+    Restricted to the genes X actually carries. `feature_is_filtered` is a
+    schema-supported var flag whose defined meaning is "zero in X, present in
+    raw.X" — the vendored validator's own remediation message tells curators to
+    set it — so those genes are legitimately absent from X and must not read as a
+    mismatch. The arithmetic still works out exactly: normalize_total scaled the
+    row by target/sum(source), so over any subset of genes both the target and
+    the full total cancel from the profile, and dividing the recovered total by
+    the same subset's source total gives back the same rescale factor an
+    unfiltered row would report.
+
+    The cost is that genes present in the source but zeroed in X are ignored
+    rather than compared, which is what makes the check tolerant of an X that
+    dropped genes it should have kept.
+
+    Rows carrying a non-finite source value are refused outright. Such a value
+    would make the row's total NaN, NaN passes a ``<= 0`` test, the deviation
+    computed from it would be NaN, and ``max`` keeps NaN once it appears — after
+    which ``worst > _PROFILE_RTOL`` is False forever. One NaN anywhere in the
+    source matrix would otherwise silence the check for the entire file.
+    """
+    if not np.all(np.isfinite(source_row)):
+        return None
+
+    support = x_row != 0
+    if not support.any():
+        return None
+
+    return np.expm1(x_row[support]), source_row[support]
+
+
+def _profile_mismatch(x_rows, source_rows):
     """Largest relative deviation from the normalization identity, or None.
+
+    ``source_rows`` is the matrix X should be derived from — ``raw.X``, or
+    ``layers['desouped_counts']`` when ambient RNA removal was applied and the
+    counts it left were retained.
 
     ``normalize_total`` scales each cell by a constant and ``log1p`` is applied
     elementwise, so for every cell::
 
-        expm1(X[i]) / sum(expm1(X[i]))  ==  raw.X[i] / sum(raw.X[i])
+        expm1(X[i]) / sum(expm1(X[i]))  ==  source[i] / sum(source[i])
 
     The target sum cancels, which is what makes this checkable without knowing
     it. That matters because ``scanpy.pp.normalize_total`` defaults to
@@ -557,7 +645,7 @@ def _profile_mismatch(x_rows, raw_rows):
     to 1e4 — so a check written against an assumed constant would fire on every
     file that took the default.
 
-    Rows whose raw counts sum to zero are skipped rather than guarded against
+    Rows whose source counts sum to zero are skipped rather than guarded against
     division by zero; the vendored ``_has_valid_raw`` already errors on
     all-zero rows, so reporting them here would duplicate that.
 
@@ -571,87 +659,365 @@ def _profile_mismatch(x_rows, raw_rows):
     # Densified once for the whole sample rather than per row: these are at most
     # _PROFILE_SAMPLE_ROWS rows, already materialized by the caller.
     x_dense = _densify(x_rows).astype(np.float64)
-    raw_dense = _densify(raw_rows).astype(np.float64)
+    source_dense = _densify(source_rows).astype(np.float64)
 
     worst = None
     rescale_factors: list[float] = []
     for i in range(x_dense.shape[0]):
-        x_row = x_dense[i]
-        raw_row = raw_dense[i]
+        comparable = _comparable_row(x_dense[i], source_dense[i])
+        if comparable is None:
+            continue
+        expanded, source_support = comparable
 
-        # A non-finite raw value would make raw_total NaN, and NaN passes the
-        # `<= 0` test below. The row's deviation would then be NaN, and `max`
-        # keeps NaN once it appears — after which `worst > _PROFILE_RTOL` is
-        # False forever and the whole check goes quiet. One NaN anywhere in
-        # raw.X would disable it for the entire file.
-        if not np.all(np.isfinite(raw_row)):
+        source_total = source_support.sum()
+        if source_total <= 0:
             continue
 
-        # Restricted to the genes X actually carries. `feature_is_filtered` is a
-        # schema-supported var flag whose defined meaning is "zero in X, present
-        # in raw.X" — the vendored validator's own remediation message tells
-        # curators to set it — so those genes are legitimately absent from X and
-        # must not read as a mismatch. The arithmetic still works out exactly:
-        # normalize_total scaled the row by target/sum(raw), so over any subset
-        # of genes both the target and the full total cancel from the profile,
-        # and dividing the recovered total by the same subset's raw total gives
-        # back the same rescale factor an unfiltered row would report.
-        #
-        # The cost is that genes present in raw.X but zeroed in X are ignored
-        # rather than compared, which is what makes the check tolerant of an X
-        # that dropped genes it should have kept.
-        support = x_row != 0
-        if not support.any():
-            continue
-        raw_support = raw_row[support]
-        raw_total = raw_support.sum()
-        if raw_total <= 0:
-            continue
-
-        expanded = np.expm1(x_row[support])
         expanded_total = expanded.sum()
         if not np.isfinite(expanded_total) or expanded_total <= 0:
             continue
-        rescale_factors.append(float(expanded_total / raw_total))
+        rescale_factors.append(float(expanded_total / source_total))
 
-        raw_profile = raw_support / raw_total
-        deviation = np.abs(expanded / expanded_total - raw_profile)
+        source_profile = source_support / source_total
+        deviation = np.abs(expanded / expanded_total - source_profile)
         # Relative to the raw profile, so a large absolute deviation on a
         # near-zero entry doesn't dominate. Compared against the raw profile
         # rather than the X profile because raw is the reference here.
-        scale = np.maximum(raw_profile, np.finfo(np.float64).tiny)
+        scale = np.maximum(source_profile, np.finfo(np.float64).tiny)
         row_worst = float((deviation / scale).max())
         worst = row_worst if worst is None else max(worst, row_worst)
     return worst, rescale_factors
 
 
+def _counts_equal(left, right):
+    """Entrywise "these two recovered counts are the same", within tolerance."""
+    return np.isclose(left, right, rtol=_IMPLIED_COUNT_RTOL, atol=_IMPLIED_COUNT_ATOL)
+
+
+def _implied_counts(x_row, source_row):
+    """Counts recovered from one row of X, and the source counts beside them.
+
+    ``normalize_total`` multiplied the cell by one constant, so undoing ``log1p``
+    leaves every gene scaled by that same constant. Recovering it does not need
+    the target sum: the ratio ``expm1(X)/source`` is that constant at every gene
+    the two matrices agree on, so its **median** recovers it even when a minority
+    of genes disagree — which is exactly the case desouping produces, and is why
+    the median is load-bearing here rather than a robustness flourish.
+
+    Returns ``(implied, source)`` over the genes X carries, or ``None`` when the
+    row cannot be used. Both are count-scale vectors, directly comparable.
+    """
+    comparable = _comparable_row(x_row, source_row)
+    if comparable is None:
+        return None
+    expanded, source_support = comparable
+
+    scaled = source_support > 0
+    if not scaled.any():
+        return None
+    scale = float(np.median(expanded[scaled] / source_support[scaled]))
+    if not np.isfinite(scale) or scale <= 0:
+        return None
+
+    return expanded / scale, source_support
+
+
+def _implied_counts_verdict(x_rows, raw_rows):
+    """Why X disagrees with the counts it should have come from, or None.
+
+    Called only once the profile identity has already failed, so this decides
+    *what to say*, not *whether* to say it. Every verdict rests on one physical
+    invariant: a pipeline can remove counts but never invent them.
+
+    - **NOT_COUNTS** — the recovered values are not whole numbers, so X is not a
+      normalization of any count matrix.
+    - **EXCESS** — they are whole numbers, but exceed the raw counts somewhere.
+      Nothing adds counts, so X came from a different matrix.
+    - **DESOUPED** — whole numbers, never above the raw counts, below them
+      somewhere. Counts were removed between the two, which is what ambient RNA
+      removal does.
+    - **MIXED** — both directions at once, which is neither of the above and is
+      reported as neither. Measured across the prod corpus, this is a real
+      population rather than a tolerance artifact: all 31 genuinely-desouped
+      files score *exactly* zero entries above raw.X, while four eye objects
+      carry heavy removal (12-13% of entries) alongside a trace of genes that X
+      has and raw.X does not. Float error would appear in all of them or none.
+
+    Returns None when none of these fits — the sample recovers to whole numbers
+    that match the raw counts, yet the profile still disagreed. That leaves the
+    caller to report the disagreement without naming a cause, which is the
+    honest outcome rather than a fallback.
+    """
+    x_dense = _densify(x_rows).astype(np.float64)
+    raw_dense = _densify(raw_rows).astype(np.float64)
+
+    testable = 0
+    integral = 0
+    excess = 0
+    deficit = 0
+
+    for i in range(x_dense.shape[0]):
+        recovered = _implied_counts(x_dense[i], raw_dense[i])
+        if recovered is None:
+            continue
+        implied, raw_support = recovered
+
+        # Above the ceiling the float32 round trip is worth more than half a
+        # count, so integrality stops being decidable. Excluded from the test
+        # rather than allowed to answer it wrongly.
+        decidable = implied <= _INTEGRAL_TEST_MAX_COUNT
+        testable += int(decidable.sum())
+        candidates = implied[decidable]
+        integral += int((np.abs(candidates - np.rint(candidates)) <= _IMPLIED_COUNT_ATOL).sum())
+
+        differs = ~_counts_equal(implied, raw_support)
+        excess += int((differs & (implied > raw_support)).sum())
+        deficit += int((differs & (implied < raw_support)).sum())
+
+    non_integral = testable - integral
+    if non_integral >= _MIN_NON_INTEGRAL_ENTRIES and non_integral / testable > 1 - _INTEGRAL_FRACTION:
+        return _VERDICT_NOT_COUNTS
+    if excess and deficit:
+        return _VERDICT_MIXED
+    if excess:
+        return _VERDICT_EXCESS
+    if deficit:
+        return _VERDICT_DESOUPED
+    return None
+
+
+def _layer_chunks_align(layer, x):
+    """True when the layer can be row-sliced without reading matrices whole.
+
+    ``read_backed`` chunks a CSC matrix as ``(n_obs, chunk_size)`` against CSR's
+    ``(5000, n_vars)``, so slicing the first 200 rows off a CSC layer beside a
+    CSR X touches every chunk in the grid — the entire layer read to sample 200
+    rows, at a per-chunk peak of ``n_obs x 5000``.
+
+    Refused for the same reason ``_scan_x_against_raw`` refuses the mixed case:
+    the vendored ``_validate_sparsity`` inspects layers too and records an error
+    for any non-CSR encoding, so the file is already known invalid and a second
+    opinion is not worth the OOM.
+    """
+    if isinstance(layer, DaskArray) != isinstance(x, DaskArray):
+        return False
+    if isinstance(layer, DaskArray):
+        return layer.chunks == x.chunks
+    return True
+
+
+def _unusable_layer_error(declared_rows):
+    """The error from the declared layer being unfit as the source, or None.
+
+    Asked before the layer is trusted, because an unusable layer does not make
+    the comparison below fail — it makes it silently not happen. ``_comparable_row``
+    refuses any row carrying a non-finite source value, and a row with nothing
+    positive in it divides out as unusable, so a layer that is entirely NaN or
+    entirely zero across the sample drops every row: ``_profile_mismatch`` returns
+    no verdict and no rescale factors, checks 6 and 7 are both skipped, and the
+    file is reported clean. Attaching such a layer would otherwise switch the
+    whole contract off, which is the one outcome this check must never produce.
+
+    No vendored check reads layer *values* — ``_validate_sparsity`` only inspects
+    the encoding — so unlike ``raw.X``, whose non-finite entries ``_validate_raw_data``
+    already rejects as non-integer, nothing else would catch this.
+    """
+    values = _densify(declared_rows)
+
+    if not np.all(np.isfinite(values)):
+        return (
+            f"layers['{DESOUPED_COUNTS_LAYER}'] contains NaN or infinite values, which cannot be "
+            f"counts. That layer must hold the counts left behind by ambient RNA removal, so every "
+            f"entry in it must be a finite count."
+        )
+
+    if not bool((values > 0).any()):
+        return (
+            f"layers['{DESOUPED_COUNTS_LAYER}'] holds no counts. That layer must hold the counts "
+            f"left behind by ambient RNA removal, and X must be a normalization of them. Populate "
+            f"it with those counts, or remove it if ambient RNA removal was not applied."
+        )
+
+    return None
+
+
+def _exceeds_counts(candidate_rows, ceiling_rows):
+    """True when ``candidate_rows`` holds more counts than ``ceiling_rows`` anywhere.
+
+    The same invariant ``_implied_counts_verdict`` applies to recovered counts,
+    but asked of two matrices as stored — no log1p/expm1 round trip stands
+    between them, so a single entry over the ceiling is decisive here in a way it
+    is not there.
+
+    The cheap comparison runs first and the tolerance only on the entries that
+    survive it. That ordering is what keeps this the cheap check its position in
+    ``check_x_normalization`` claims: applying ``_counts_equal`` to the whole
+    sample builds four full-width float64 temporaries, ~260 MB at 200 x 36,788,
+    to answer a question that is False everywhere on a valid file. Restricted to
+    the exceeding entries — of which a valid file has none — it allocates
+    nothing.
+    """
+    candidate = _densify(candidate_rows)
+    ceiling = _densify(ceiling_rows)
+
+    # False wherever either side is NaN, so those entries drop out here rather
+    # than needing a mask of their own. An infinity does compare greater, and is
+    # excluded below.
+    over = candidate > ceiling
+    if not over.any():
+        return False
+
+    above = candidate[over].astype(np.float64)
+    limit = ceiling[over].astype(np.float64)
+    return bool((np.isfinite(above) & np.isfinite(limit) & ~_counts_equal(above, limit)).any())
+
+
+def _source_mismatch_error(verdict, worst, n_rows):
+    """The message for an X that disagrees with raw.X, chosen by verdict.
+
+    The generic form is the fallback rather than the norm: it says only that the
+    two disagree, which is all that can be claimed when the sample was too small
+    to classify.
+    """
+    if verdict == _VERDICT_NOT_COUNTS:
+        return (
+            "X is not a normalization of any count matrix: undoing log1p and the per-cell scaling "
+            "recovers values that are not whole numbers. Either X was produced by a different "
+            "transform — scran, SCTransform, TPM, log2(CPM+1) — or it was altered after "
+            "normalization, which is what rounding or truncating to an integer dtype does."
+        )
+
+    if verdict == _VERDICT_EXCESS:
+        return (
+            "X was normalized from a different matrix than raw.X: undoing the normalization "
+            "recovers more counts than raw.X holds. No processing step adds counts — filtering, QC "
+            "and ambient RNA removal can only take them away — so X cannot have been derived from "
+            "raw.X. raw.X must hold the counts that X was normalized from."
+        )
+
+    if verdict == _VERDICT_MIXED:
+        return (
+            f"X disagrees with raw.X in both directions: counts were removed across most of the "
+            f"genes that differ, which is the signature of ambient RNA removal, but X also holds "
+            f"counts that raw.X does not. Nothing adds counts, so raw.X cannot be the matrix X was "
+            f"normalized from even though desouping evidently ran. Retain the counts X was derived "
+            f"from as layers['{DESOUPED_COUNTS_LAYER}'], and confirm raw.X holds the counts those "
+            f"were removed from."
+        )
+
+    if verdict == _VERDICT_DESOUPED:
+        return (
+            f"X appears to be normalized from desouped counts, but layers['{DESOUPED_COUNTS_LAYER}'] "
+            f"is missing. Undoing the normalization recovers fewer counts than raw.X and never "
+            f"more, which is the signature of ambient RNA removal. Desouped counts cannot be "
+            f"recomputed from raw.X, so they must be retained as layers['{DESOUPED_COUNTS_LAYER}'] "
+            f"— float32 counts, same shape as raw.X. Without them X can be neither verified nor "
+            f"re-derived."
+        )
+
+    return (
+        f"X is not a normalization of raw.X: the per-cell expression profile of X disagrees with "
+        f"raw.X by a relative error of {worst:.3g} (tolerance {_PROFILE_RTOL:g}), sampled over "
+        f"{n_rows} cells. X should be log1p(normalize_total(raw.X)), or "
+        f"log1p(normalize_total(layers['{DESOUPED_COUNTS_LAYER}'])) when ambient RNA removal was "
+        f"applied and those counts were retained."
+    )
+
+
+def _whole_matrix_error(identical, max_value, has_non_finite):
+    """The error from the checks that read both matrices in full, or None.
+
+    These four are answered by a single pass over X and raw.X, before any
+    row is sampled, and each short-circuits the rest: once X is known to hold
+    raw counts or a NaN, the sampled comparisons below would only restate
+    that in vaguer terms.
+    """
+    if identical:
+        # The spec used to say that an author-provided dataset with no
+        # normalized matrix has `adata.X` = the raw matrix — which, since raw.X
+        # is required regardless, made X == raw.X a documented state. CELLxGENE
+        # has no such state: raw goes in raw.X when a normalized matrix exists,
+        # otherwise in X with raw.X absent, so location alone says which is
+        # which. That third state is precisely why `_has_valid_raw` walks past
+        # these files — it validates raw.X, finds valid counts, and nothing ever
+        # looks at X. The sentence is gone (#562), so this is an error.
+        return (
+            "X is identical to raw.X, so normalization has not been applied. X must hold "
+            "normalized values — log1p(normalize_total(raw.X)) — and raw.X the raw counts."
+        )
+
+    if has_non_finite:
+        # Reported before the checks below because a NaN or inf makes them
+        # unreliable rather than merely wrong: `_profile_mismatch` skips any row
+        # whose expanded total is non-finite, so a partially-NaN X would be
+        # judged on its remaining rows and reported clean — success claimed over
+        # a matrix that was never fully evaluated. The maximum ignores
+        # non-finite entries for the same reason.
+        return (
+            "X contains NaN or infinite values, which cannot be normalized expression. Every entry in X must be finite."
+        )
+
+    if max_value > _MAX_PLAUSIBLE_LOG1P_VALUE:
+        return (
+            f"X contains values up to {max_value:.4g}, which is too large to be log1p output "
+            f"(log1p of 10,000 counts is about 9.2). X may hold raw counts, or a normalization "
+            f"that was never log-transformed."
+        )
+
+    if max_value <= 0:
+        # Every stored value is zero (or negative). raw.X is non-empty, since a
+        # matching all-zero raw.X would have been caught as identical above and
+        # the vendored _has_valid_raw errors on all-zero rows regardless. The
+        # profile check cannot see this — every row divides out as unusable and
+        # returns no verdict — so without this an emptied X validates clean,
+        # which is the class of defect this whole check exists to catch.
+        return (
+            "X contains no positive values, so it cannot hold normalized expression. "
+            "Confirm X was not emptied or dropped during processing."
+        )
+
+    return None
+
+
 def check_x_normalization(adata):
-    """Check that X holds a normalization of raw.X, and return (warnings, errors).
+    """Check that X holds a normalization of its source counts, and return (warnings, errors).
 
     HCA requires raw counts in ``raw.X`` and normalized values in ``X``. The
-    vendored validator checks that ``raw.X`` *is* raw, and that the two
-    matrices agree on shape and indices — but never that ``X`` differs from
-    ``raw.X``, nor that it is derived from it. All seven breast-v1 source
-    datasets ship ``X`` byte-identical to ``raw.X`` and validate clean today
-    (see #524).
+    vendored validator checks that ``raw.X`` *is* raw, and that the two matrices
+    agree on shape and indices — but never that ``X`` differs from ``raw.X``,
+    nor that it is derived from it. All seven breast-v1 source datasets ship
+    ``X`` byte-identical to ``raw.X`` and validated clean before #524.
 
-    Six checks, cheapest first, each short-circuiting: once one fires the
-    later ones would only restate the same defect in vaguer terms.
+    The matrix X must be derived from is not always ``raw.X``. When ambient RNA
+    removal was applied, the counts that survive it are what X was normalized
+    from, and they cannot be recomputed from ``raw.X`` — the removal is
+    parameterised and often stochastic. So the contract is three matrices
+    (#562)::
 
-    1. ``X`` identical to ``raw.X`` → **warning only**, pending a spec change
-       that removes the sentence making this a documented state (#562).
+        raw.X                      raw counts
+        layers['desouped_counts']  counts after ambient RNA removal, when it ran
+        X                          log1p(normalize_total( desouped_counts
+                                                          if present else raw.X ))
+
+    Checks run cheapest first and short-circuit: once one fires the later ones
+    would only restate the same defect in vaguer terms.
+
+    1. ``X`` identical to ``raw.X`` → normalization never ran.
     2. ``X`` holds NaN or infinite values → not expression data at all, and it
        makes every check below unreliable rather than merely wrong.
     3. ``X`` holds values too large to be ``log1p`` output → raw counts, or a
        normalization that was never log-transformed.
     4. ``X`` holds no positive values → the matrix was emptied or dropped.
-    5. ``X`` is not a total-normalization of ``raw.X`` → **warning only**. When
-       ambient RNA removal was applied, X is normalized from the desouped
-       counts rather than from ``raw.X``, so the disagreement is specified
-       behaviour rather than a defect. Becomes an error once ``desouped_counts``
-       is a required layer and X can be compared against its real source
-       (#562).
-    6. ``X`` was log-transformed but never total-normalized.
+    5. ``layers['desouped_counts']`` holds NaN, infinities, or no counts at all →
+       it cannot serve as the source, and left unchecked it would switch the two
+       checks below off rather than fail them.
+    6. ``layers['desouped_counts']`` holds more counts than ``raw.X`` → the
+       layer is not what it claims to be, so it cannot be trusted as the source.
+    7. ``X`` is not a total-normalization of its source. When the source is
+       ``desouped_counts`` that is the whole finding; when it is ``raw.X``,
+       ``_implied_counts_verdict`` names the cause — including the case where
+       desouping evidently ran but its counts were not retained.
+    8. ``X`` was log-transformed but never total-normalized.
 
     Silent when ``raw.X`` is absent: the vendored ``_validate_raw`` already owns
     that case and reports it, and a second message would not add anything.
@@ -673,88 +1039,66 @@ def check_x_normalization(adata):
         # Not comparable without materializing a backed matrix; see
         # _scan_x_against_raw. The file has other errors by construction.
         return [], []
-    identical, max_value, has_non_finite = verdict
 
-    warnings: list[str] = []
-    errors: list[str] = []
-
-    if identical:
-        # A warning for now, pending a spec change. The h5ad structure spec
-        # currently says that for an author-provided dataset with no normalized
-        # matrix, `adata.X` = the raw matrix — which, since `raw.X` is also
-        # required, makes X == raw.X a documented state. CELLxGENE has no such
-        # state: raw goes in `raw.X` when a normalized matrix exists, otherwise
-        # in X with `raw.X` absent, so location alone says which is which. That
-        # third state is precisely why `_has_valid_raw` walks past these files —
-        # it validates `raw.X`, finds valid counts, and nothing looks at X.
-        #
-        # The spec sentence is expected to be removed, at which point this
-        # becomes an error again. Warning until then so the 7 breast source
-        # datasets in this state are flagged rather than blocked. See #562.
-        warnings.append(
-            "X is identical to raw.X, so normalization has not been applied. X should hold "
-            "normalized values and raw.X the raw counts; run normalize_raw to derive X."
-        )
-        return warnings, errors
-
-    if has_non_finite:
-        # Reported before the checks below because a NaN or inf makes them
-        # unreliable rather than merely wrong: `_profile_mismatch` skips any row
-        # whose expanded total is non-finite, so a partially-NaN X would be
-        # judged on its remaining rows and reported clean — success claimed over
-        # a matrix that was never fully evaluated. The maximum ignores
-        # non-finite entries for the same reason.
-        errors.append(
-            "X contains NaN or infinite values, which cannot be normalized expression. Every entry in X must be finite."
-        )
-        return warnings, errors
-
-    if max_value > _MAX_PLAUSIBLE_LOG1P_VALUE:
-        errors.append(
-            f"X contains values up to {max_value:.4g}, which is too large to be log1p output "
-            f"(log1p of 10,000 counts is about 9.2). X may hold raw counts, or a normalization "
-            f"that was never log-transformed."
-        )
-        return warnings, errors
-
-    if max_value <= 0:
-        # Every stored value is zero (or negative). raw.X is non-empty, since a
-        # matching all-zero raw.X would have been caught as identical above and
-        # the vendored _has_valid_raw errors on all-zero rows regardless. The
-        # profile check cannot see this — every row divides out as unusable and
-        # returns no verdict — so without this an emptied X validates clean,
-        # which is the class of defect this whole check exists to catch.
-        errors.append(
-            "X contains no positive values, so it cannot hold normalized expression. "
-            "Confirm X was not emptied or dropped during processing."
-        )
-        return warnings, errors
+    scan_error = _whole_matrix_error(*verdict)
+    if scan_error is not None:
+        return [], [scan_error]
 
     n_rows = min(_PROFILE_SAMPLE_ROWS, x.shape[0])
-    worst, rescale_factors = _profile_mismatch(_materialize(x[:n_rows]), _materialize(raw_x[:n_rows]))
+    x_rows = _materialize(x[:n_rows])
+    raw_rows = _materialize(raw_x[:n_rows])
+
+    # When ambient RNA removal ran, the counts it left behind — not raw.X — are
+    # what X was normalized from, so they are what X must be checked against.
+    # Resolved once, into the matrix and the name it goes by, because every
+    # decision below turns on it: which matrix to compare against, whether a
+    # cause can be inferred, and what to call the source when reporting.
+    #
+    # anndata aligns layers to X's shape on construction, so no shape guard is
+    # needed here; a layer of the wrong shape cannot be loaded in the first place.
+    declared = adata.layers.get(DESOUPED_COUNTS_LAYER)
+
+    if declared is not None and not _layer_chunks_align(declared, x):
+        # Sampling the layer would cost the whole layer; see _layer_chunks_align.
+        # The file has other errors by construction.
+        return [], []
+
+    declared_rows = None if declared is None else _materialize(declared[:n_rows])
+    source_rows = raw_rows if declared_rows is None else declared_rows
+    source_name = "raw.X" if declared_rows is None else f"layers['{DESOUPED_COUNTS_LAYER}']"
+
+    if declared_rows is not None:
+        unusable = _unusable_layer_error(declared_rows)
+        if unusable is not None:
+            return [], [unusable]
+
+    if declared_rows is not None and _exceeds_counts(declared_rows, raw_rows):
+        # Checked before the layer is trusted as the source. If it holds more
+        # counts than raw.X it is not a desouped version of raw.X at all, and
+        # comparing X against it would report on a relationship between two
+        # matrices that are not the ones the contract describes.
+        return [], [
+            f"layers['{DESOUPED_COUNTS_LAYER}'] holds more counts than raw.X. Ambient RNA removal "
+            f"only removes counts, so the desouped matrix must be everywhere less than or equal to "
+            f"raw.X. Check that raw.X holds the pre-desouping counts, and that the layer was not "
+            f"populated from a different matrix."
+        ]
+
+    worst, rescale_factors = _profile_mismatch(x_rows, source_rows)
 
     if worst is not None and worst > _PROFILE_RTOL:
-        # A warning, not an error, and deliberately so. The h5ad structure spec
-        # says that when ambient RNA removal (desouping) was applied, X is a
-        # normalization of the *desouped* counts, not of raw.X — so this
-        # disagreement is the specified outcome for those files, not a defect.
-        # 18 of the 71 prod files carrying a raw.X are in that state (17 eye
-        # integrated-objects and one msk source dataset, the latter still
-        # carrying its `soupX` layer). Erroring would block all of them.
-        #
-        # Distinguishing desouping from a genuine mismatch is possible — counts
-        # can only be removed, never invented, so an implied count *exceeding*
-        # raw.X is unambiguous — but it needs `desouped_counts` to be a required
-        # layer before X can be checked against the matrix it really came from.
-        # See #562; this becomes an error once that lands.
-        warnings.append(
-            f"X does not appear to be a normalization of raw.X: the per-cell expression profile "
-            f"of X disagrees with raw.X by a relative error of {worst:.3g} (tolerance "
-            f"{_PROFILE_RTOL:g}), sampled over {n_rows} cells. This is expected when ambient RNA "
-            f"removal was applied, since X is then normalized from the desouped counts rather "
-            f"than from raw.X; otherwise X should be log1p(normalize_total(raw.X))."
-        )
-        return warnings, errors
+        if declared_rows is not None:
+            # The layer is present and X does not match it. There is no further
+            # cause to name: the file states which matrix X came from, and X did
+            # not come from it.
+            return [], [
+                f"X is not a normalization of {source_name}. When that layer is present it is the "
+                f"matrix X must be derived from, so X should be "
+                f"log1p(normalize_total({source_name})). Re-derive X from the desouped counts, or "
+                f"correct the layer if it does not hold the counts X was built from."
+            ]
+
+        return [], [_source_mismatch_error(_implied_counts_verdict(x_rows, raw_rows), worst, n_rows)]
 
     # The profile identity alone does not prove `normalize_total` ran: it holds
     # exactly for a plain `log1p(raw.X)` too, because expm1 inverts log1p and the
@@ -772,14 +1116,14 @@ def check_x_normalization(adata):
     # separates them.
     unscaled = sum(1 for factor in rescale_factors if abs(factor - 1.0) < _DEPTH_MATCH_RTOL)
     if len(rescale_factors) >= _DEPTH_MATCH_MIN_CELLS and unscaled / len(rescale_factors) > _DEPTH_MATCH_FRACTION:
-        errors.append(
+        return [], [
             f"X was log-transformed but never total-normalized: for {unscaled} of "
             f"{len(rescale_factors)} sampled cells the total recovered from X is that cell's own "
-            f"raw count depth, so no rescaling was applied. normalize_total makes every cell "
-            f"sum to a common target. X should be log1p(normalize_total(raw.X))."
-        )
+            f"count depth in {source_name}, so no rescaling was applied. normalize_total makes "
+            f"every cell sum to a common target. X should be log1p(normalize_total({source_name}))."
+        ]
 
-    return warnings, errors
+    return [], []
 
 
 def check_cosmetic_labels(adata, schema_def=None):

--- a/packages/hca-schema-validator/src/hca_schema_validator/validator.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/validator.py
@@ -956,9 +956,14 @@ def _whole_matrix_error(identical, max_value, has_non_finite):
         # which. That third state is precisely why `_has_valid_raw` walks past
         # these files — it validates raw.X, finds valid counts, and nothing ever
         # looks at X. The sentence is gone (#562), so this is an error.
+        # Named no source, deliberately. This check runs in the whole-matrix
+        # pass, before layers are read, so it cannot know whether the file
+        # carries desouped counts — and naming raw.X would point a curator who
+        # does carry them at the wrong matrix.
         return (
-            "X is identical to raw.X, so normalization has not been applied. X must hold "
-            "normalized values — log1p(normalize_total(raw.X)) — and raw.X the raw counts."
+            "X is identical to raw.X, so normalization has not been applied. X must hold the "
+            "normalized values and raw.X the raw counts. Normalize X from raw.X, or from "
+            f"layers['{DESOUPED_COUNTS_LAYER}'] if ambient RNA removal was applied."
         )
 
     if has_non_finite:

--- a/packages/hca-schema-validator/src/hca_schema_validator/validator.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/validator.py
@@ -402,10 +402,21 @@ _DEPTH_MATCH_MIN_CELLS = 2
 DESOUPED_COUNTS_LAYER = "desouped_counts"
 
 # How far a recovered count may sit from a whole number, or from its raw
-# counterpart, and still be treated as equal. X is stored float32, so a count
-# recovered through log1p/expm1 carries a relative error of roughly 1e-6; the
-# absolute term dominates for the small counts that make up almost every entry,
-# and the relative term keeps deep genes from drifting into a false verdict.
+# counterpart, and still be treated as equal. The absolute term dominates for the
+# small counts that make up almost every entry; the relative term keeps deep
+# genes from drifting into a false verdict.
+#
+# The relative term is set three orders above what the round trip alone costs. X
+# is stored float32, so recovering a count through log1p/expm1 carries a relative
+# error of roughly 1e-6 — but the recovery also divides by a scale estimated as a
+# median over the row, which carries the spread of whatever that row disagrees
+# about, and that is the larger of the two errors on exactly the rows this has to
+# judge.
+#
+# The margin is affordable because the populations it separates sit nowhere near
+# it. Measured across the 140-file local prod corpus: genuinely desouped files
+# score 0.0000% of entries above raw.X and 0.00% non-integral, while files whose
+# X is not a normalization of any count matrix score 19.5-40.2% non-integral.
 _IMPLIED_COUNT_ATOL = 0.05
 _IMPLIED_COUNT_RTOL = 1e-3
 

--- a/packages/hca-schema-validator/src/hca_schema_validator/validator.py
+++ b/packages/hca-schema-validator/src/hca_schema_validator/validator.py
@@ -828,7 +828,7 @@ def _unusable_layer_error(declared_rows):
     refuses any row carrying a non-finite source value, and a row with nothing
     positive in it divides out as unusable, so a layer that is entirely NaN or
     entirely zero across the sample drops every row: ``_profile_mismatch`` returns
-    no verdict and no rescale factors, checks 6 and 7 are both skipped, and the
+    no verdict and no rescale factors, checks 8 and 9 are both skipped, and the
     file is reported clean. Attaching such a layer would otherwise switch the
     whole contract off, which is the one outcome this check must never produce.
 
@@ -1041,14 +1041,16 @@ def check_x_normalization(adata):
     4. ``X`` holds no positive values → the matrix was emptied or dropped.
     5. ``layers['desouped_counts']`` holds NaN, infinities, negatives, or no
        counts at all → it cannot serve as the source, and left unchecked it would
-       switch the two checks below off rather than fail them.
+       switch the comparisons below off rather than fail them.
     6. ``layers['desouped_counts']`` holds more counts than ``raw.X`` → the
        layer is not what it claims to be, so it cannot be trusted as the source.
-    7. ``X`` is not a total-normalization of its source. When the source is
+    7. No sampled cell could be compared at all → the checks below would not run,
+       and passing on that is indistinguishable from passing on a clean file.
+    8. ``X`` is not a total-normalization of its source. When the source is
        ``desouped_counts`` that is the whole finding; when it is ``raw.X``,
        ``_implied_counts_verdict`` names the cause — including the case where
        desouping evidently ran but its counts were not retained.
-    8. ``X`` was log-transformed but never total-normalized.
+    9. ``X`` was log-transformed but never total-normalized.
 
     Silent when ``raw.X`` is absent: the vendored ``_validate_raw`` already owns
     that case and reports it, and a second message would not add anything.
@@ -1117,7 +1119,21 @@ def check_x_normalization(adata):
 
     worst, rescale_factors = _profile_mismatch(x_rows, source_rows)
 
-    if worst is not None and worst > _PROFILE_RTOL:
+    if worst is None:
+        # Not one sampled cell could be compared. Reported rather than passed
+        # over, because "the check found nothing wrong" and "the check never ran"
+        # are the same return value otherwise — the failure the layer guard above
+        # exists to prevent, reached by a different route. The whole-matrix checks
+        # do not cover it: they ask about X and raw.X as a whole, so an X whose
+        # first cells are empty or negative while later ones are not clears all
+        # four and still leaves the sample with nothing to compare.
+        return [], [
+            f"X could not be checked against {source_name}: none of the first {n_rows} cells hold "
+            f"values that can be compared. X must hold normalized expression for every cell. "
+            f"Confirm X was not partly emptied or overwritten."
+        ]
+
+    if worst > _PROFILE_RTOL:
         if declared_rows is not None:
             # The layer is present and X does not match it. There is no further
             # cause to name: the file states which matrix X came from, and X did

--- a/packages/hca-schema-validator/tests/fixtures/hca_fixtures.py
+++ b/packages/hca-schema-validator/tests/fixtures/hca_fixtures.py
@@ -832,7 +832,7 @@ def normalize_counts(counts, target_sum=1e4):
     return sparse.csr_matrix(numpy.log1p(dense / row_sums * target_sum).astype(numpy.float32))
 
 
-def make_adata(x, raw_x, obs=None, uns=None, obsm=None, var=None):
+def make_adata(x, raw_x, obs=None, uns=None, obsm=None, var=None, layers=None):
     """Build an AnnData whose raw.X is `raw_x` and X is `x`.
 
     Wraps the raw-wiring incantation, including the non-obvious
@@ -840,6 +840,9 @@ def make_adata(x, raw_x, obs=None, uns=None, obsm=None, var=None):
     fixtures below still inline their own copies; converting them is a separate
     change, so treat this as the form new callers should use rather than as the
     single source of truth it is not yet.
+
+    `layers` is applied after `raw` is wired, so the layers belong to the object
+    under test and are not copied into `raw` along with everything else.
     """
     built = anndata.AnnData(
         X=raw_x.copy(),
@@ -851,6 +854,8 @@ def make_adata(x, raw_x, obs=None, uns=None, obsm=None, var=None):
     built.raw = built.copy()
     built.X = x
     built.raw.var.drop("feature_is_filtered", axis=1, inplace=True)
+    for name, matrix in (layers or {}).items():
+        built.layers[name] = matrix
     return built
 
 

--- a/packages/hca-schema-validator/tests/test_validator.py
+++ b/packages/hca-schema-validator/tests/test_validator.py
@@ -1500,6 +1500,7 @@ def test_desouped_counts_layer_holding_more_than_raw_x_errors():
         (np.nan, "NaN or infinite"),
         (np.inf, "NaN or infinite"),
         (0.0, "holds no counts"),
+        (-3.0, "contains negative values"),
     ],
 )
 def test_unusable_desouped_counts_layer_cannot_switch_the_contract_off(poison, fragment):
@@ -1507,8 +1508,9 @@ def test_unusable_desouped_counts_layer_cannot_switch_the_contract_off(poison, f
 
     The layer is trusted as the reference on presence, and every downstream row
     comparison drops out on it: `_comparable_row` refuses a row with a non-finite
-    source value, and a row with nothing positive divides out as unusable. So
-    without this guard a layer that is entirely NaN, infinite, or zero makes
+    source value, and a row whose total is not positive — nothing in it, or
+    negatives cancelling its positives — divides out as unusable. So without this
+    guard a layer that is entirely NaN, infinite, zero, or negative makes
     `_profile_mismatch` return no verdict and no rescale factors, both remaining
     checks are skipped, and an X that is a normalization of *nothing* validates
     clean. Nothing else in the stack would catch it: the vendored sparsity check

--- a/packages/hca-schema-validator/tests/test_validator.py
+++ b/packages/hca-schema-validator/tests/test_validator.py
@@ -1528,6 +1528,32 @@ def test_unusable_desouped_counts_layer_cannot_switch_the_contract_off(poison, f
     _assert_only_x_error(is_valid, validator, fragment)
 
 
+def test_a_sample_with_nothing_to_compare_is_an_error_not_a_pass():
+    """ "The check never ran" must not look like "the check found nothing wrong".
+
+    The whole-matrix checks ask about X and raw.X as a whole, so they clear an X
+    whose *sampled* cells are all unusable while later cells are fine. Here the
+    layer clears its own guard — finite, non-negative, and carrying counts in row
+    0 — but row 0 of X has no support and row 1 of the layer has no counts, so
+    every sampled row drops out and the comparison has nothing left to judge.
+    Without this check the file validates clean on a sample that proved nothing.
+    """
+    counts = _raw_counts()
+    dense = counts.toarray()
+
+    layer = dense.copy()
+    layer[1, :] = 0  # row 1 contributes no counts to compare against
+
+    x = _normalize_counts(dense).toarray()
+    x[0, :] = 0  # row 0 of X carries nothing to compare
+
+    is_valid, validator = _validate_from_fixture(
+        _make_adata(x.astype(np.float32), counts, layers={DESOUPED_COUNTS_LAYER: layer.astype(np.float32)})
+    )
+
+    _assert_only_x_error(is_valid, validator, "could not be checked against")
+
+
 def test_integrality_is_decidable_up_to_the_documented_ceiling():
     """The ceiling is the ceiling — no relative term retires the test early.
 

--- a/packages/hca-schema-validator/tests/test_validator.py
+++ b/packages/hca-schema-validator/tests/test_validator.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pytest
 
 from hca_schema_validator import HCA_DERIVED_OBS_LABELS, HCAValidator
+from hca_schema_validator.validator import DESOUPED_COUNTS_LAYER
 
 # Test fixtures directory
 FIXTURES_DIR = Path(__file__).parent / "fixtures" / "h5ads"
@@ -1119,46 +1120,86 @@ def _normalize_counts(counts, target_sum=1e4):
     return normalize_counts(counts, target_sum)
 
 
-def _make_adata(x, raw_x):
+def _make_adata(x, raw_x, layers=None):
     from .fixtures.hca_fixtures import make_adata
 
-    return make_adata(x, raw_x)
+    return make_adata(x, raw_x, layers=layers)
 
 
 def _x_normalization_errors(validator):
-    """Validator errors raised by the X/raw.X checks.
+    """Validator errors raised by the X/source-matrix checks.
 
-    Matched on the message *subject* — all three lead with "X" — rather than on
-    interior wording, so rewording a message cannot silently turn an `== []`
-    assertion into a vacuous pass. Keying on "raw.X" would not work: the
-    magnitude check never mentions raw.X, since it is a statement about X alone.
+    Matched on the message *subject* — every message leads with either "X" or
+    the layer it is about — rather than on interior wording, so rewording a
+    message cannot silently turn an `== []` assertion into a vacuous pass.
+    Keying on "raw.X" would not work: the magnitude check never mentions raw.X,
+    since it is a statement about X alone.
 
     The vendored errors that discuss both matrices lead with their own subjects
     ("Number of genes in X ...", "Cells in X and raw.X ..."), so they do not
     collide.
     """
-    return [e for e in validator.errors if e.removeprefix("ERROR: ").startswith("X ")]
+    subjects = ("X ", f"layers['{DESOUPED_COUNTS_LAYER}'] ")
+    return [e for e in validator.errors if e.removeprefix("ERROR: ").startswith(subjects)]
 
 
-def test_x_identical_to_raw_x_warns():
+def _assert_only_x_error(is_valid, validator, fragment):
+    """The X checks produced exactly one error, and it is the expected one.
+
+    The `len(errors) == 1` half is the part that proves short-circuiting works —
+    each check returns rather than accumulating — so it is asserted through one
+    helper rather than restated at every call site, where a new test could copy
+    the substring check alone and quietly drop the guarantee.
+    """
+    assert is_valid is False
+    errors = _x_normalization_errors(validator)
+    assert len(errors) == 1, errors
+    assert fragment in errors[0]
+
+
+def _log2_cpm(counts):
+    """log2(CPM+1) — a real normalization this contract does not accept.
+
+    The log base was never 'e', so undoing log1p recovers values off the integer
+    grid. Shared by the two tests that pin the NOT_COUNTS verdict, so they cannot
+    disagree about what the rejected transform is.
+    """
+    dense = np.asarray(counts, dtype=np.float64)
+    row_sums = dense.sum(axis=1, keepdims=True)
+    row_sums[row_sums == 0] = 1.0
+    return np.log2(dense / row_sums * 1e4 + 1.0).astype(np.float32)
+
+
+def _desouped(counts, gene, value):
+    """The fixture's counts with one gene in the second cell set to `value`.
+
+    Below the raw count it stands in for ambient RNA removal; above it, for a
+    layer that cannot be a desouped version of raw.X at all. Only the second
+    cell is touched because the first carries a zero in the fixture, and a gene
+    absent from X is outside every comparison here.
+    """
+    from scipy import sparse
+
+    altered = counts.toarray().astype(np.float32)
+    altered[1, gene] = value
+    return sparse.csr_matrix(altered)
+
+
+def test_x_identical_to_raw_x_errors():
     """The breast-v1 case: normalization never ran, so X *is* the count matrix.
 
     Reported on its own rather than left to the profile check, which would also
     fire but describe the symptom instead of the cause.
 
-    A warning rather than an error for now: the h5ad structure spec says an
-    author-provided dataset with no normalized matrix has `adata.X` = the raw
-    matrix, and `raw.X` is required regardless, so X == raw.X is currently a
-    documented state. CELLxGENE has no such state. Becomes an error when that
-    sentence is removed (#562).
+    An error since #562 removed the spec sentence that made X == raw.X a
+    documented state ("if no normalized matrix is provided, adata.X = the raw
+    matrix", with raw.X required regardless). CELLxGENE has no such state, which
+    is why its `_has_valid_raw` walks straight past these files.
     """
     counts = _raw_counts()
     is_valid, validator = _validate_from_fixture(_make_adata(counts.copy(), counts))
 
-    assert _x_normalization_errors(validator) == []
-    hits = [w for w in validator.warnings if "identical to raw.X" in w]
-    assert len(hits) == 1, validator.warnings
-    assert is_valid is True
+    _assert_only_x_error(is_valid, validator, "identical to raw.X")
 
 
 def test_x_holding_raw_counts_errors_before_expm1_overflows():
@@ -1174,31 +1215,53 @@ def test_x_holding_raw_counts_errors_before_expm1_overflows():
     inflated = (counts.toarray() * 100.0).astype("float32")
     is_valid, validator = _validate_from_fixture(_make_adata(sparse.csr_matrix(inflated), counts))
 
-    assert is_valid is False
-    errors = _x_normalization_errors(validator)
-    assert len(errors) == 1, errors
-    assert "too large to be log1p output" in errors[0]
+    _assert_only_x_error(is_valid, validator, "too large to be log1p output")
 
 
-def test_x_normalized_from_a_different_matrix_warns():
+def test_x_normalized_from_a_matrix_holding_more_counts_errors():
     """X is plausibly normalized — fractional, correctly scaled, right shape —
-    but derived from the wrong counts.
+    and its implied counts are whole numbers, but one of them exceeds raw.X.
 
-    A warning rather than an error: the h5ad structure spec says X is normalized
-    from the *desouped* counts when ambient RNA removal was applied, so this
-    disagreement is the specified outcome for such files. 18 of the 71 prod
-    files carrying a raw.X are in that state. It becomes an error once
-    `desouped_counts` is required and X can be checked against its real source
-    (#562).
+    That single entry settles it without any appeal to tolerances: filtering, QC
+    and ambient RNA removal all take counts away, and nothing puts them back, so
+    a matrix holding *more* than raw.X cannot have been derived from it.
     """
     counts = _raw_counts()
-    other = counts.toarray() + 1.0  # same shape, different counts
-    is_valid, validator = _validate_from_fixture(_make_adata(_normalize_counts(other), counts))
+    inflated = _desouped(counts, gene=3, value=9)  # raw holds 4 there
+    is_valid, validator = _validate_from_fixture(_make_adata(_normalize_counts(inflated.toarray()), counts))
 
-    assert _x_normalization_errors(validator) == []
-    hits = [w for w in validator.warnings if "does not appear to be a normalization of raw.X" in w]
-    assert len(hits) == 1, validator.warnings
-    assert is_valid is True
+    _assert_only_x_error(is_valid, validator, "normalized from a different matrix than raw.X")
+
+
+def test_x_normalized_from_desouped_counts_without_the_layer_errors():
+    """The eye case: ambient RNA removal ran and its output was discarded.
+
+    The implied counts are whole numbers that sit at or below raw.X and never
+    above it — counts were removed between the two. Those removed counts cannot
+    be recomputed, so the file is unverifiable until the layer is retained.
+    """
+    counts = _raw_counts()
+    desouped = _desouped(counts, gene=3, value=3)  # raw holds 4 there
+    is_valid, validator = _validate_from_fixture(_make_adata(_normalize_counts(desouped.toarray()), counts))
+
+    _assert_only_x_error(is_valid, validator, f"layers['{DESOUPED_COUNTS_LAYER}'] is missing")
+
+
+def test_x_from_a_non_count_transform_errors():
+    """log2(CPM+1) — a real normalization, of a real count matrix, that this
+    contract does not accept.
+
+    Undoing log1p and the per-cell scaling recovers values that are not whole
+    numbers, because the log base was never 'e'. Distinguished from the two
+    verdicts above precisely so the message does not accuse the file of coming
+    from the wrong matrix when the transform is what differs.
+    """
+    from scipy import sparse
+
+    counts = _raw_counts()
+    is_valid, validator = _validate_from_fixture(_make_adata(sparse.csr_matrix(_log2_cpm(counts.toarray())), counts))
+
+    _assert_only_x_error(is_valid, validator, "not a normalization of any count matrix")
 
 
 def test_x_normalization_accepts_any_target_sum():
@@ -1275,10 +1338,7 @@ def test_x_with_no_positive_values_errors():
     zeros = sparse.csr_matrix(np.zeros(counts.shape, dtype=np.float32))
     is_valid, validator = _validate_from_fixture(_make_adata(zeros, counts))
 
-    assert is_valid is False
-    errors = _x_normalization_errors(validator)
-    assert len(errors) == 1, errors
-    assert "no positive values" in errors[0]
+    _assert_only_x_error(is_valid, validator, "no positive values")
 
 
 def test_x_log_transformed_without_normalize_total_errors():
@@ -1295,10 +1355,7 @@ def test_x_log_transformed_without_normalize_total_errors():
     log_only = sparse.csr_matrix(np.log1p(counts.toarray()).astype(np.float32))
     is_valid, validator = _validate_from_fixture(_make_adata(log_only, counts))
 
-    assert is_valid is False
-    errors = _x_normalization_errors(validator)
-    assert len(errors) == 1, errors
-    assert "never total-normalized" in errors[0]
+    _assert_only_x_error(is_valid, validator, "never total-normalized")
 
 
 def test_x_with_non_finite_values_errors():
@@ -1317,10 +1374,7 @@ def test_x_with_non_finite_values_errors():
     partial[0, 0] = np.nan  # a single bad entry in an otherwise valid matrix
     is_valid, validator = _validate_from_fixture(_make_adata(sparse.csr_matrix(partial), counts))
 
-    assert is_valid is False
-    errors = _x_normalization_errors(validator)
-    assert len(errors) == 1, errors
-    assert "NaN or infinite" in errors[0]
+    _assert_only_x_error(is_valid, validator, "NaN or infinite")
 
 
 def test_x_normalization_allows_genes_zeroed_in_x():
@@ -1363,7 +1417,202 @@ def test_non_finite_raw_x_does_not_disable_the_profile_check():
 
     _, validator = _validate_from_fixture(_make_adata(wrong_source, sparse.csr_matrix(poisoned)))
 
-    # Reported as a warning since #562 — what matters here is that the NaN row
-    # no longer suppresses the verdict for the rows that do disagree.
-    hits = [w for w in validator.warnings if "does not appear to be a normalization of raw.X" in w]
-    assert len(hits) == 1, validator.warnings
+    # Which of the mismatch messages fires is not the point here — that the NaN
+    # row no longer suppresses the verdict for the rows that do disagree is.
+    assert len(_x_normalization_errors(validator)) == 1, validator.errors
+
+
+# --- #562: X is verified against the matrix it was actually normalized from ---
+#
+# When ambient RNA removal ran, raw.X is not that matrix. The counts it left
+# behind are, they cannot be recomputed from raw.X, and so they have to be kept.
+
+
+def test_x_normalized_from_the_desouped_counts_layer_passes():
+    """The state #562 exists to make possible.
+
+    X disagrees with raw.X — counts were removed — but agrees exactly with the
+    layer holding what survived, so the file is complete and verifiable. Without
+    the layer this same X is the error two tests above.
+    """
+    counts = _raw_counts()
+    desouped = _desouped(counts, gene=3, value=3)
+
+    is_valid, validator = _validate_from_fixture(
+        _make_adata(
+            _normalize_counts(desouped.toarray()),
+            counts,
+            layers={DESOUPED_COUNTS_LAYER: desouped},
+        )
+    )
+
+    assert _x_normalization_errors(validator) == [], validator.errors
+    assert is_valid is True
+
+
+def test_x_not_normalized_from_the_desouped_counts_layer_errors():
+    """The layer is present and X did not come from it.
+
+    No cause is named here, unlike the raw.X path: the file states which matrix
+    X was derived from, so there is nothing left to infer when X disagrees with
+    it. X here is a normalization of raw.X, which the layer says is the wrong
+    source.
+    """
+    counts = _raw_counts()
+    desouped = _desouped(counts, gene=3, value=3)
+
+    is_valid, validator = _validate_from_fixture(
+        _make_adata(
+            _normalize_counts(counts.toarray()),
+            counts,
+            layers={DESOUPED_COUNTS_LAYER: desouped},
+        )
+    )
+
+    _assert_only_x_error(is_valid, validator, f"not a normalization of layers['{DESOUPED_COUNTS_LAYER}']")
+
+
+def test_desouped_counts_layer_holding_more_than_raw_x_errors():
+    """The layer is checked before it is trusted as the reference.
+
+    A desouped matrix holding more counts than raw.X is not a desouped version
+    of raw.X, so judging X against it would report on a relationship between two
+    matrices the contract does not describe. Reported instead of the mismatch
+    that X would otherwise be blamed for.
+    """
+    counts = _raw_counts()
+    inflated = _desouped(counts, gene=3, value=9)
+
+    is_valid, validator = _validate_from_fixture(
+        _make_adata(
+            _normalize_counts(inflated.toarray()),
+            counts,
+            layers={DESOUPED_COUNTS_LAYER: inflated},
+        )
+    )
+
+    _assert_only_x_error(is_valid, validator, "holds more counts than raw.X")
+
+
+@pytest.mark.parametrize(
+    "poison, fragment",
+    [
+        (np.nan, "NaN or infinite"),
+        (np.inf, "NaN or infinite"),
+        (0.0, "holds no counts"),
+    ],
+)
+def test_unusable_desouped_counts_layer_cannot_switch_the_contract_off(poison, fragment):
+    """A degenerate layer must fail the checks, not disable them.
+
+    The layer is trusted as the reference on presence, and every downstream row
+    comparison drops out on it: `_comparable_row` refuses a row with a non-finite
+    source value, and a row with nothing positive divides out as unusable. So
+    without this guard a layer that is entirely NaN, infinite, or zero makes
+    `_profile_mismatch` return no verdict and no rescale factors, both remaining
+    checks are skipped, and an X that is a normalization of *nothing* validates
+    clean. Nothing else in the stack would catch it: the vendored sparsity check
+    reads layer encodings, never layer values.
+
+    X here is deliberately unrelated to raw.X, so a passing result would mean the
+    contract was switched off rather than satisfied.
+    """
+    counts = _raw_counts()
+    unrelated = np.full(counts.shape, 0.5, dtype=np.float32)
+    layer = np.full(counts.shape, poison, dtype=np.float32)
+
+    is_valid, validator = _validate_from_fixture(_make_adata(unrelated, counts, layers={DESOUPED_COUNTS_LAYER: layer}))
+
+    _assert_only_x_error(is_valid, validator, fragment)
+
+
+def test_integrality_is_decidable_up_to_the_documented_ceiling():
+    """The ceiling is the ceiling — no relative term retires the test early.
+
+    Scoring integrality with `_counts_equal` would carry its 1e-3 relative term,
+    and the furthest a value can sit from a whole number is 0.5, so every count
+    above 450 would score integral unconditionally while still counting toward
+    the sample. Deep data would dilute the non-integral fraction below the
+    threshold and NOT_COUNTS could not fire at all — well under the 1e4 ceiling
+    that is supposed to govern.
+    """
+    from hca_schema_validator.validator import _VERDICT_NOT_COUNTS, _implied_counts_verdict
+
+    rng = np.random.default_rng(1)
+    raw = rng.integers(600, 5000, size=(40, 60)).astype(np.float64)
+
+    # Whole-number counts offset by a constant fraction: integral nowhere, and
+    # every entry sits between 450 and _INTEGRAL_TEST_MAX_COUNT.
+    fractional = raw + 0.37
+    assert _implied_counts_verdict(_normalize_counts(fractional).toarray(), raw) == _VERDICT_NOT_COUNTS
+
+    # The control at the same depth: genuine counts still recover as integral.
+    assert _implied_counts_verdict(_normalize_counts(raw).toarray(), raw) is None
+
+
+def test_implied_counts_verdict_separates_the_failure_modes():
+    """Unit-level, on a matrix large enough to be classified.
+
+    The fixture h5ad is 2x7, which is thirteen usable entries — enough to reach
+    every branch, but not enough to show that the classification holds up at a
+    realistic width. These are the same shapes at 40x60.
+    """
+    from hca_schema_validator.validator import (
+        _VERDICT_DESOUPED,
+        _VERDICT_EXCESS,
+        _VERDICT_MIXED,
+        _VERDICT_NOT_COUNTS,
+        _implied_counts_verdict,
+    )
+
+    rng = np.random.default_rng(0)
+    raw = rng.integers(1, 200, size=(40, 60)).astype(np.float64)
+
+    def normalized(source):
+        """Dense, because _implied_counts_verdict densifies its input anyway."""
+        return _normalize_counts(source).toarray()
+
+    desouped = raw.copy()
+    desouped[:, 7] -= 1  # one gene loses a count in every cell
+    assert _implied_counts_verdict(normalized(desouped), raw) == _VERDICT_DESOUPED
+
+    inflated = raw.copy()
+    inflated[:, 7] += 5
+    assert _implied_counts_verdict(normalized(inflated), raw) == _VERDICT_EXCESS
+
+    # Counts removed from most genes that differ, and a few appearing from
+    # nowhere — the shape of the four real objects `_implied_counts_verdict`
+    # documents. The removal is what a curator would act on, but raw.X still
+    # cannot be the source, so neither verdict alone would be honest.
+    both = raw.copy()
+    both[:, 7:20] -= 1
+    both[:, 3] += 2
+    assert _implied_counts_verdict(normalized(both), raw) == _VERDICT_MIXED
+
+    assert _implied_counts_verdict(_log2_cpm(raw), raw) == _VERDICT_NOT_COUNTS
+
+    # The control: a correct normalization recovers raw exactly, so nothing is
+    # claimed. `check_x_normalization` never asks in this case — the profile
+    # check has already passed — but a classifier that condemned it would make
+    # every verdict above suspect.
+    assert _implied_counts_verdict(normalized(raw), raw) is None
+
+
+def test_x_disagreeing_with_raw_x_in_both_directions_errors():
+    """Counts removed *and* counts invented, through the validator.
+
+    Reported as its own finding rather than collapsed into either neighbour:
+    naming only the removal would tell a curator to retain the desouped counts
+    while leaving raw.X unquestioned, and naming only the excess would bury the
+    signal they can actually act on.
+    """
+    counts = _raw_counts().toarray().astype(np.float32)
+    source = counts.copy()
+    source[1, 3] -= 1  # a count removed
+    source[1, 5] += 2  # a count that raw.X does not have
+
+    is_valid, validator = _validate_from_fixture(
+        _make_adata(_normalize_counts(source), _raw_counts()),
+    )
+
+    _assert_only_x_error(is_valid, validator, "in both directions")


### PR DESCRIPTION
Closes #562

## What changed

`check_x_normalization` now verifies `adata.X` against the matrix it was actually normalized from, and #524's two warning-level checks are errors.

The contract is three matrices:

| matrix | required | holds |
|---|---|---|
| `raw.X` | yes | raw counts |
| `layers['desouped_counts']` | when ambient RNA removal was applied | counts surviving removal |
| `X` | yes | `log1p(normalize_total(desouped_counts if present else raw.X))` |

Eight checks, cheapest first, short-circuiting so one defect yields one message:

1. `X` identical to `raw.X`
2. `X` holds NaN or infinities
3. `X` above the `log1p` ceiling
4. `X` holds no positive values
5. `layers['desouped_counts']` holds NaN, infinities, or no counts
6. `layers['desouped_counts']` exceeds `raw.X`
7. `X` is not a normalization of its source — and when the source is `raw.X`, the recovered counts name the cause
8. `X` was log-transformed but never total-normalized

Check 7's classification rests on one invariant: a pipeline can remove counts but never invent them. Recovered counts only *below* `raw.X` mean desouping ran and the layer is missing; only *above* mean `X` came from a different matrix; both directions mean each at once; non-integral means `X` is not a normalization of any count matrix.

Docs: new §4.1 in `docs/dataset-validator-checks.md`.

## Why

The h5ad structure spec says that when desouping was performed, `X` points at the desouped normalized counts — so `X` is deliberately *not* a normalization of `raw.X`. Nothing enforced that, and #524's `raw.X`-only comparison would have flagged every correctly-desouped file. Retaining the desouped counts is what makes desouping recoverable: the removal is parameterised and often stochastic, so once those counts are discarded `X` is an assertion no one can check.

## Assumptions I made

- **Strict for everything.** Source datasets and integrated objects get identical treatment. This is a deliberate call, and it costs: 24 of 71 prod files with a `raw.X` go from valid to invalid. The alternative — exempting integrated objects — would have left the population the check exists to catch unexamined.
- **The layer contract lives in code, not in LinkML or `hca_schema_definition.yaml`.** Revisit later; see #569 for the schema-declared alternative.
- **`normalize_total`'s target sum is not pinned.** The checks compare per-cell profiles, in which the target cancels, so scanpy's `target_sum=None` default is accepted. This matters — pinning `1e4` would reject correctly normalized files.
- **Assay exemptions are not inherited.** These run on every file and do not yet honour the ATAC-seq / methylation exemptions `hca_schema_definition.yaml` declares for raw-layer validation. HCA does not accept those assays today; see #566.
- **The eye files are out of scope.** 14 CAP exports are clean; the integrated objects that discarded their desouped counts need recovery work with the eye team, tracked separately.
- **Calibration is from real data, not synthetics.** All thresholds were set against 140 local prod files, not chosen a priori.
- **The 200-row sample is per-check.** Checks 1–4 scan both matrices in full; 5–8 sample, since the identity is per-cell and independent across cells.

## How to verify

The issue's definition of done, mapped to steps. Two items are deliberately not met by this PR — see the end.

**Implement the trichotomy in `check_x_normalization`, replacing the `raw.X`-only comparison** (shipped as a four-way classification — MIXED was found to be a real population, not a tolerance artifact):

```bash
cd packages/hca-schema-validator
uv run pytest tests/test_validator.py -q -k "x_norm or desouped or implied or unusable or integrality"
```

Expect all to pass. `test_implied_counts_verdict_separates_the_failure_modes` exercises each verdict at 40x60; `test_x_normalized_from_the_desouped_counts_layer_passes` and `test_x_not_normalized_from_the_desouped_counts_layer_errors` are the layer contract.

**Check the classification against real files.** On a machine with the prod tree at `~/hca-tracker-upload/prod`, run the validator over a desouped file and a clean one:

- `musculoskeletal/Cohen_25-*.h5ad` — carries a `soupX` layer, so desouping demonstrably ran. Expect the error naming `layers['desouped_counts']` as missing.
- any `gut/*curated*.h5ad` — produced by our own `normalize_raw`. Expect no `X`/`raw.X` error.
- any `breast/source-datasets/*.h5ad` — `X` is identical to `raw.X`. Expect the "identical to raw.X" error.

**Confirm the full gate:**

```bash
cd packages/hca-schema-validator && uv run ruff check . && uv run ruff format --check . && uv run pytest tests/ -q
make typecheck   # from the repo root
```

Expect 143 passed, ruff clean, 0 pyright errors across all four passes.

**Read the docs change** — `docs/dataset-validator-checks.md` §4.1 — and confirm the eight checks and the verdict table match what you see in the errors above.

Definition-of-done items **not** met here, by design:

- [ ] `desouped_counts` in the LinkML schema — deliberately kept in code for now
- [ ] Retire `desouped_normalized_counts` from the spec, pin the layer names, state the `feature_is_filtered` edge — these are Google-doc edits, filed with exact replacement text as #564
- [ ] Decide what to do about eye — separate, with the eye team

## Review rounds

`/simplify`, `/security-review`, and `/code-review` all ran on this branch. Five findings, four fixed here:

- A NaN, infinite, or all-zero `desouped_counts` layer dropped every sampled row and made the last two checks silently not run, so an `X` that was a normalization of nothing validated clean. Now check 5. Reproduced before and after.
- A CSC layer would have been read whole to sample 200 rows. Now skipped, matching what `_scan_x_against_raw` already does for `X`/`raw.X`.
- The integrality test carried a 1e-3 relative term, which made it vacuous above a count of 450 rather than at its stated 1e4 ceiling. Now absolute-tolerance only; re-verdicting the 47 non-clean corpus files moved nothing.
- The docs and docstring check lists were renumbered to match.

Deferred as #570: the median-based scale recovery misdiagnoses desouping that touched a majority of genes, or fractional counts from `roundToInt = FALSE`. It selects which error message a failing file gets — the file fails either way — and all 31 genuinely-desouped corpus files classify correctly today.

## Related

- #524 — the `X`/`raw.X` check this promotes to errors
- #564 — spec text; #566 — assay exemptions; #567 — the layer is not itself validated as counts; #569 — declared `ambient_count_correction` as the antecedent; #570 — deferred classifier finding

🤖 Generated with [Claude Code](https://claude.com/claude-code)