### PR TITLE
ci: bump gh-action-pypi-publish to v1.14.2 so 2.5 metadata publishes

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -52,8 +52,13 @@ jobs:
       - name: Check sibling dependency bounds
         run: uv run --no-project --with packaging python scripts/check_sibling_deps.py packages/hca-schema-validator/dist/*
 
+      # Do not pin below v1.14.2. This action bundles twine, and the
+      # metadata validation comes from the `packaging` that image ships.
+      # v1.14.0 carried packaging 25.0, which rejects Metadata-Version 2.5
+      # — what hatchling >=1.32.0 emits — and that failed the 0.15.0
+      # release (#588). packaging >=26.1 accepts it; v1.14.2 ships 26.2.
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: packages/hca-schema-validator/dist/
 
@@ -88,8 +93,13 @@ jobs:
       - name: Check sibling dependency bounds
         run: uv run --no-project --with packaging python scripts/check_sibling_deps.py packages/hca-anndata-tools/dist/*
 
+      # Do not pin below v1.14.2. This action bundles twine, and the
+      # metadata validation comes from the `packaging` that image ships.
+      # v1.14.0 carried packaging 25.0, which rejects Metadata-Version 2.5
+      # — what hatchling >=1.32.0 emits — and that failed the 0.15.0
+      # release (#588). packaging >=26.1 accepts it; v1.14.2 ships 26.2.
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: packages/hca-anndata-tools/dist/
 
@@ -130,7 +140,12 @@ jobs:
       - name: Check sibling dependency bounds
         run: uv run --no-project --with packaging python scripts/check_sibling_deps.py packages/hca-anndata-mcp/dist/*
 
+      # Do not pin below v1.14.2. This action bundles twine, and the
+      # metadata validation comes from the `packaging` that image ships.
+      # v1.14.0 carried packaging 25.0, which rejects Metadata-Version 2.5
+      # — what hatchling >=1.32.0 emits — and that failed the 0.15.0
+      # release (#588). packaging >=26.1 accepts it; v1.14.2 ships 26.2.
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: packages/hca-anndata-mcp/dist/

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -63,6 +63,11 @@ jobs:
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: packages/hca-schema-validator/dist/
+          # Makes a workflow_dispatch retry safe: dispatch runs all three
+          # publish jobs, so a retry after a partial success would otherwise
+          # fail on "File already exists" — and publish-hca-anndata-mcp gates
+          # on the other two succeeding, locking it out of dispatch entirely.
+          skip-existing: true
 
   publish-hca-anndata-tools:
     needs: release-please
@@ -106,6 +111,11 @@ jobs:
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: packages/hca-anndata-tools/dist/
+          # Makes a workflow_dispatch retry safe: dispatch runs all three
+          # publish jobs, so a retry after a partial success would otherwise
+          # fail on "File already exists" — and publish-hca-anndata-mcp gates
+          # on the other two succeeding, locking it out of dispatch entirely.
+          skip-existing: true
 
   publish-hca-anndata-mcp:
     needs: [release-please, publish-hca-anndata-tools, publish-hca-schema-validator]
@@ -155,3 +165,8 @@ jobs:
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: packages/hca-anndata-mcp/dist/
+          # Makes a workflow_dispatch retry safe: dispatch runs all three
+          # publish jobs, so a retry after a partial success would otherwise
+          # fail on "File already exists" — and publish-hca-anndata-mcp gates
+          # on the other two succeeding, locking it out of dispatch entirely.
+          skip-existing: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -52,11 +52,13 @@ jobs:
       - name: Check sibling dependency bounds
         run: uv run --no-project --with packaging python scripts/check_sibling_deps.py packages/hca-schema-validator/dist/*
 
-      # Do not pin below v1.14.2. This action bundles twine, and the
-      # metadata validation comes from the `packaging` that image ships.
-      # v1.14.0 carried packaging 25.0, which rejects Metadata-Version 2.5
-      # — what hatchling >=1.32.0 emits — and that failed the 0.15.0
-      # release (#588). packaging >=26.1 accepts it; v1.14.2 ships 26.2.
+      # Do not pin below v1.14.2. This action bundles twine, and accepting
+      # Metadata-Version 2.5 — what hatchling >=1.32.0 emits — needs both
+      # twine 7 and packaging >=26.1. Neither alone suffices: twine 6.1.0
+      # with packaging 26.2 rejects it, and so does twine 7.0.0 with
+      # packaging 25.0. v1.14.0 shipped twine 6.1.0 / packaging 25.0 and
+      # failed the 0.15.0 release (#588); v1.14.2 ships 7.0.0 / 26.2.
+      # Nothing auto-bumps this pin — Dependabot is tracked in #465.
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
@@ -93,11 +95,13 @@ jobs:
       - name: Check sibling dependency bounds
         run: uv run --no-project --with packaging python scripts/check_sibling_deps.py packages/hca-anndata-tools/dist/*
 
-      # Do not pin below v1.14.2. This action bundles twine, and the
-      # metadata validation comes from the `packaging` that image ships.
-      # v1.14.0 carried packaging 25.0, which rejects Metadata-Version 2.5
-      # — what hatchling >=1.32.0 emits — and that failed the 0.15.0
-      # release (#588). packaging >=26.1 accepts it; v1.14.2 ships 26.2.
+      # Do not pin below v1.14.2. This action bundles twine, and accepting
+      # Metadata-Version 2.5 — what hatchling >=1.32.0 emits — needs both
+      # twine 7 and packaging >=26.1. Neither alone suffices: twine 6.1.0
+      # with packaging 26.2 rejects it, and so does twine 7.0.0 with
+      # packaging 25.0. v1.14.0 shipped twine 6.1.0 / packaging 25.0 and
+      # failed the 0.15.0 release (#588); v1.14.2 ships 7.0.0 / 26.2.
+      # Nothing auto-bumps this pin — Dependabot is tracked in #465.
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
@@ -140,11 +144,13 @@ jobs:
       - name: Check sibling dependency bounds
         run: uv run --no-project --with packaging python scripts/check_sibling_deps.py packages/hca-anndata-mcp/dist/*
 
-      # Do not pin below v1.14.2. This action bundles twine, and the
-      # metadata validation comes from the `packaging` that image ships.
-      # v1.14.0 carried packaging 25.0, which rejects Metadata-Version 2.5
-      # — what hatchling >=1.32.0 emits — and that failed the 0.15.0
-      # release (#588). packaging >=26.1 accepts it; v1.14.2 ships 26.2.
+      # Do not pin below v1.14.2. This action bundles twine, and accepting
+      # Metadata-Version 2.5 — what hatchling >=1.32.0 emits — needs both
+      # twine 7 and packaging >=26.1. Neither alone suffices: twine 6.1.0
+      # with packaging 26.2 rejects it, and so does twine 7.0.0 with
+      # packaging 25.0. v1.14.0 shipped twine 6.1.0 / packaging 25.0 and
+      # failed the 0.15.0 release (#588); v1.14.2 ships 7.0.0 / 26.2.
+      # Nothing auto-bumps this pin — Dependabot is tracked in #465.
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:


### PR DESCRIPTION
Closes #588

## What changed

1. `pypa/gh-action-pypi-publish` bumped from `cef2210` (v1.14.0) to `dc37677b` (v1.14.2) at all three call sites in `.github/workflows/release-please.yml`, plus a comment at each recording why the floor exists.
2. `skip-existing: true` added to all three publish steps, so a `workflow_dispatch` retry cannot deadlock (see below).

## Why

The 0.15.0 release cut its tags and GitHub Releases but published **nothing to PyPI** — the repo is currently half-released. Both publish jobs failed at the upload step:

```
InvalidDistribution: Invalid distribution metadata:
'2.5' is not a valid metadata version
```

The *Check sibling dependency bounds* step passed on both, so this was never a code problem.

hatchling is declared unpinned (`requires = ["hatchling"]`), so `uv build` resolves it fresh from PyPI at build time. hatchling 1.32.0 shipped 2026-08-11 — after the last good release on 2026-07-31 — and bumped the metadata version it emits. The metadata is fine; our publish action is stale. Validation comes from the twine and `packaging` bundled in the action's image, and **both** matter — neither alone is sufficient:

```
twine 6.1.0 + packaging 26.2 => ERROR
twine 7.0.0 + packaging 25.0 => ERROR
twine 7.0.0 + packaging 26.2 => PASSED
```


| Action | twine | packaging | 2.5 wheel |
|---|---|---|---|
| v1.14.0 (pinned before) | 6.1.0 | **25.0** | rejects |
| v1.14.2 (pinned now) | 7.0.0 | **26.2** | accepts |

This is worth doing regardless of which build backend we end up on — a publish path carrying packaging 25.0 rejects any 2.5 wheel from any backend. The durable fix for the floating backend is #589.

## Why `skip-existing`

`workflow_dispatch` is the recovery path for a failed release — and the path this
branch exists to make usable. Without `skip-existing` (the action defaults to
`false`) that path has a trap in it.

The first dispatch after a *total* failure is safe: nothing reached PyPI. But a
dispatch after a **partial** success re-uploads already-published versions, PyPI
answers "File already exists", and the job fails. `publish-hca-anndata-mcp` gates
on both siblings being `success` or `skipped` (`release-please.yml:113-116`), so
that failure would lock mcp out of ever publishing via dispatch.

With `skip-existing`, a re-upload is a no-op rather than an error, so a retry
converges on "all three published" from any partial state.

## Assumptions I made

- **Bumping the action, not pinning hatchling back.** Both would unblock the release. Pinning hatchling to 1.31.0 would work today but leaves us permanently trailing and re-blocked whenever we do bump, while leaving a 2025-era `packaging` in the publish path. Bumping the action fixes the actual staleness and stays forward-compatible.
- **Not migrating to `uv_build` here**, even though it emits 2.4 and would also unblock this. Landing a build-backend migration as a release hotfix means the first real exercise of the new backend is an irreversible upload to PyPI. Tracked as #589 to land on its own and prove itself on a routine release.
- **Pinned to the commit SHA `dc37677b`, not `a892a5a`.** `gh api .../git/ref/tags/v1.14.2` returns `a892a5a`, which is the *annotated tag object* — Actions cannot resolve that. I corrected #588's body, which originally named the wrong one.
- **Comment repeated at all three call sites**, matching how the existing uv/Python pinning comment is repeated verbatim across the three parallel jobs.
- v1.14.2 is the newest release of the action (2026-07-29); I did not pin to a floating `release/v1`, keeping the SHA-pinning convention from #494.
- **Did not add a `hatchling` bound here.** The unbounded `requires = ["hatchling"]` is the root cause and appears in four files, including `shared/pyproject.toml:49`. Fixing it properly is #589, which deletes the need for a bound entirely — pinning here would be work we immediately undo. #589 now covers `shared/` and records the interim-bound option should it stall.

## How to verify

The definition of done on #588:

- [ ] **Action bumped at all three call sites** — `grep -n "pypi-publish" .github/workflows/release-please.yml` shows `dc37677b…  # v1.14.2` three times.
- [ ] **`skip-existing` set on all three** — `grep -n "skip-existing" .github/workflows/release-please.yml` shows three hits.
- [ ] **#587 step 1 landed first.** ⚠️ **This PR alone does not unblock the release.** `workflow_dispatch` runs all three publish jobs, and `publish-hca-anndata-mcp` never ran in the failed run — it still declares `hca-schema-validator>=0.14,<0.15` on main while the validator is now 0.15.0, so it will fail the sibling check. Widen that bound to `>=0.15,<0.16` before re-running.
- [ ] **Re-run the workflow** — `gh workflow run "Release Please"`. The publish jobs run unconditionally on `workflow_dispatch` (`release-please.yml:28`); `release-please` itself no-ops since the tags exist.
- [ ] **All three packages on PyPI** —
      `curl -s https://pypi.org/pypi/hca-schema-validator/json | jq -r .info.version` → `0.15.0`, and likewise `hca-anndata-tools` → `0.6.3`, `hca-anndata-mcp` → `0.7.3`.
- [ ] **Unblocks #587 step 2** (Batch lock pin bump), which cannot run until the packages are on PyPI.

Reproducing the diagnosis independently, if you want it:

```bash
# what each hatchling emits
uv build --wheel --build-constraints <(echo "hatchling==1.32.0") --out-dir /tmp/d-new
uv build --wheel --build-constraints <(echo "hatchling==1.31.0") --out-dir /tmp/d-old

# what each action image carries
docker run --rm --entrypoint python \
  ghcr.io/pypa/gh-action-pypi-publish:dc37677b2e1c63e2034f94d8a5b11f265b73ba33 \
  -c "import packaging,twine;print(twine.__version__,packaging.__version__)"
```

## Note

CI on this repo does not exercise the publish path, so this change cannot be proven green by a PR check — only by the re-run above. That is the same exposure the workflow has always had.

---

**Correction (review round):** an earlier revision of this description attributed the fix to `packaging` alone. That was based on a matrix that varied packaging while holding twine at 7.x. Re-tested: twine 7 is required too (`twine 6.1.0 + packaging 26.2` still rejects). The in-code comment now says both.

