### PR TITLE
build(hca-anndata-mcp): widen the hca-schema-validator bound to >=0.15,<0.16

### DIFF
--- a/packages/hca-anndata-mcp/pyproject.toml
+++ b/packages/hca-anndata-mcp/pyproject.toml
@@ -16,7 +16,7 @@ requires-python = ">=3.10,<4.0"
 dependencies = [
     "fastmcp>=2,<3",
     "hca-anndata-tools>=0.6,<0.7",
-    "hca-schema-validator>=0.14,<0.15",
+    "hca-schema-validator>=0.15,<0.16",
 ]
 
 [project.urls]


### PR DESCRIPTION
Addresses step 1 of #587. (Does not close it — step 2, the Batch service lock bump, cannot run until the packages are actually on PyPI.)

## What changed

One line in `packages/hca-anndata-mcp/pyproject.toml`:

```diff
-    "hca-schema-validator>=0.14,<0.15",
+    "hca-schema-validator>=0.15,<0.16",
```

## Why

`hca-schema-validator` was minor-bumped to 0.15.0 by the release that cut the current tags, while this package still declared `>=0.14,<0.15`. Per CLAUDE.md, minor-bumping a package means updating the bound in every sibling that depends on it — release-please has no Python plugin that rewrites dependents' constraints, so it does not do this for us.

Nothing shows this locally: `[tool.uv.sources]` resolves the sibling from the checkout, so `uv sync`, pytest and pyright all pass regardless of what the bound says. It only surfaces in the publish job, where `scripts/check_sibling_deps.py` reads the built metadata directly.

This is the last thing standing between #590 and a working release re-run. `publish-hca-anndata-mcp` never ran in the failed release (it was skipped after the earlier jobs failed), so the bad bound was never exercised — it would have failed on the *re-run* instead.

## Assumptions I made

- **Typed `build:`, not `fix:`.** This changes published packaging metadata rather than runtime behaviour. Typing it `fix:` would cut a 0.7.4 release PR while 0.7.3 is tagged-but-unpublished, which is pure churn — and the widened bound ships in the 0.7.3 wheel either way, since the publish job builds from `main` HEAD rather than from the tag. Follows the existing `build(packages):` precedent from #479.
- **`hca-anndata-tools>=0.6,<0.7` left alone** — that package went to 0.6.3, which the bound already admits.
- **Did not touch a lock file.** Library locks under `packages/` are gitignored (#483), so there is nothing to commit alongside.
- **Step 2 of #587 deliberately not included.** The Batch service pin bump needs the packages to exist on PyPI first, so it cannot be verified from this branch.

## How to verify

I ran the exact gate that fails in CI, in both directions — building the wheel and sdist and running the checker against them:

```bash
cd packages/hca-anndata-mcp && uv build --out-dir /tmp/mcp-dist
uv run --no-project --python 3.11 --with packaging \
  python scripts/check_sibling_deps.py /tmp/mcp-dist/*
```

With the new bound:

```
ok   hca_anndata_mcp-0.7.3-py3-none-any.whl
ok   hca_anndata_mcp-0.7.3.tar.gz
```

Negative control — same build with the old bound restored:

```
FAIL hca_anndata_mcp-0.7.3-py3-none-any.whl
       'hca-schema-validator<0.15,>=0.14' excludes hca-schema-validator 0.15.0,
       the version in this repo — the wheel would require a version it was not
       built against
FAIL hca_anndata_mcp-0.7.3.tar.gz
```

Local gate, all clean:

- `uv run pytest tests/ -q` in `packages/hca-anndata-mcp` → **44 passed**
- `make typecheck` → 0 errors across all four pyright passes
- `uvx ruff@0.11.8 check .` → All checks passed; `format --check` → 130 files already formatted

### Definition of done for step 1 of #587

- [ ] Bound widened to `>=0.15,<0.16`
- [ ] `check_sibling_deps.py` passes against the built wheel **and** sdist
- [ ] After merge, `gh workflow run "Release Please"` publishes all three: `hca-schema-validator` 0.15.0, `hca-anndata-tools` 0.6.3, `hca-anndata-mcp` 0.7.3
- [ ] Unblocks #587 step 2 (Batch lock pin bump)

## Sequencing note

Run the dispatch **before** merging any new release PR that release-please may open. The publish jobs build from `main` HEAD, so a version bump landing in between would change which version gets published against the already-cut tags.
