### PR TITLE
build(hca-schema-validator-service): lock validator 0.15.0 for the Batch image

### DIFF
--- a/services/hca-schema-validator/pyproject.toml
+++ b/services/hca-schema-validator/pyproject.toml
@@ -3,7 +3,7 @@ name = "hca-schema-validator-service"
 version = "0.1.0"
 requires-python = "~=3.11"
 dependencies = [
-    "hca-schema-validator>=0.14.0,<0.15.0",
+    "hca-schema-validator>=0.15.0,<0.16.0",
 ]
 
 [dependency-groups]

--- a/services/hca-schema-validator/uv.lock
+++ b/services/hca-schema-validator/uv.lock
@@ -359,7 +359,7 @@ wheels = [
 
 [[package]]
 name = "hca-schema-validator"
-version = "0.14.2"
+version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anndata" },
@@ -380,9 +380,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/10/f3e1ed5bef03437445a0e27cd2c12df586276e9db517ec7bb18dfabbe915/hca_schema_validator-0.14.2.tar.gz", hash = "sha256:d6371e47aa66c6ee5e4f19b227422ec6d3b54bd9441d2625bdfe0df68b48a3da", size = 6388752, upload-time = "2026-07-31T04:52:02.784Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/a9/849a6df54995f94e7e4ff250709a02887ee4c3d589f42d38f4ee91729256/hca_schema_validator-0.15.0.tar.gz", hash = "sha256:8705802bb3db41468f9565a89a74f492fe3e410f443f04970726464945ce99a6", size = 6410610, upload-time = "2026-08-19T05:54:49.562Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/d8/1fa5b17a3f882ce985e240afd61010a34be13e807d74c365e20c3ca414b8/hca_schema_validator-0.14.2-py3-none-any.whl", hash = "sha256:d6bdd0543b28c41e7eb79e0d6b0018057b56ff40e29e8629514f3cf33182d948", size = 6222245, upload-time = "2026-07-31T04:52:00.859Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/e2/89108e6ec0584cf44667f1fd06c1988cb90b23dbdf65e9b2d47c78dada80/hca_schema_validator-0.15.0-py3-none-any.whl", hash = "sha256:b9310e1211e3e800d67efc13c64ca9b5dfbb02489cd8197b4765df0b8229e0dd", size = 6237105, upload-time = "2026-08-19T05:54:47.706Z" },
 ]
 
 [[package]]
@@ -400,7 +400,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "hca-schema-validator", specifier = ">=0.14.0,<0.15.0" }]
+requires-dist = [{ name = "hca-schema-validator", specifier = ">=0.15.0,<0.16.0" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Refs #587 — completes step 2's lock change. Deliberately **not** `Closes`: the issue's final item is rebuilding the Batch image, which happens outside this PR. Closing here would mark #587 done while Batch was still running 0.14.2.

Step 1 landed separately in #591.

## What changed

Two files, committed together because the constraint and the lock must not disagree:

```diff
 # services/hca-schema-validator/pyproject.toml
-    "hca-schema-validator>=0.14.0,<0.15.0",
+    "hca-schema-validator>=0.15.0,<0.16.0",
```

```
# services/hca-schema-validator/uv.lock
Updated hca-schema-validator v0.14.2 -> v0.15.0
```

The lock diff is confined to that one package — version, sdist/wheel URLs and hashes, and the recorded `requires-dist`.

## Why

The Batch image installs from `uv.lock` via `uv export --frozen` (`deployment/dataset-validator/Dockerfile:33-35`), so **the lock decides which validator ships, not the constraint**. The service pinned `>=0.14.0,<0.15.0` with the lock holding 0.14.2, so Batch kept running the old validator after 0.15.0 published.

0.15.0 crosses the constraint, so this is CLAUDE.md's constraint-crossing path: bump the pin, then plain `uv lock`. Deliberately **not** `uv lock --upgrade-package hca-schema-validator` — that is the tool for a patch *inside* an existing constraint, and here it would have left the lock untouched while the build still succeeded. Silent staleness is the exact failure mode the documented path exists to avoid.

This brings #586's populator refusal and the two breaking checks from #560 and #571 into the Batch service.

## Assumptions I made

- **`Refs`, not `Closes`.** See above — honest tracking over an auto-closed issue.
- **Typed `build:`.** Changes the service's dependency closure, not runtime behaviour. This is a non-published service (`[tool.uv] package = false`), so release-please has nothing to cut for it.
- **No service code changes needed.** The wrapper imports only `HCAValidator` and `HCACellAnnotationValidator`; #560 and #571 are behavioural (new errors reported), not signature changes.
- **Left the `--no-hashes` gap alone.** The lock records `sha256` for every artifact, but the image exports with `--no-hashes` and installs unverified. Pre-existing, the Dockerfile is untouched here, and folding a supply-chain change into a version bump would be wrong. Filed as **#594** with viability testing.
- **Did not rebuild the image.** Out of scope by agreement; the rebuild is yours.

## How to verify

### Definition of done for #587 step 2

- [x] Pin bumped to `>=0.15.0,<0.16.0`
- [x] Plain `uv lock` run, not `--upgrade-package`
- [x] **Lock verified to have actually moved** — CLAUDE.md calls for this because the failure is silent:
      ```bash
      grep -A1 'name = "hca-schema-validator"' services/hca-schema-validator/uv.lock
      #   name = "hca-schema-validator"
      #   version = "0.15.0"
      ```
- [x] Both files committed together
- [ ] **Image rebuilt from a clean tree** — `make batch-publish-container ENV=dev`, then `ENV=prod` from `main`. Yours; this PR is inert until then.

### The check that actually matters

Run the Dockerfile's own command with its exact flags — this is the real build-time gate, not a proxy:

```bash
cd services/hca-schema-validator
uv export --frozen --no-hashes --no-dev --no-emit-project -o /tmp/req.txt
grep '^hca-schema-validator' /tmp/req.txt      # -> hca-schema-validator==0.15.0
```

`--frozen` fails if the lock and `pyproject.toml` disagree, so a clean run proves they are consistent.

### Local gate

| | |
|---|---|
| `uv run pytest tests/` (service) | 11 passed |
| `make typecheck` | 0 errors, all 4 pyright passes |
| `ruff@0.11.8 check` / `format --check` | clean, 130 files |

### What the gate does *not* prove

The service tests mock `HCAValidator` (`tests/test_hca_schema_validator.py:77`), so they pass regardless of the locked version. A green suite says nothing about 0.15.0. What carries the weight instead:

- `uv export --frozen` above, and
- a smoke check that the wrapper's imports resolve against the newly locked wheel and the #571 surface is present:

```bash
cd services/hca-schema-validator && uv run python -c "
import hca_schema_validator as m
from hca_schema_validator import HCAValidator, HCACellAnnotationValidator
from hca_schema_validator.validator import check_x_normalization, DESOUPED_COUNTS_LAYER
print(m.__version__, check_x_normalization.__name__, DESOUPED_COUNTS_LAYER)"
# -> 0.15.0 check_x_normalization desouped_counts
```
