### PR TITLE
feat(hca-anndata-tools): add rename_cell_ids to remedy collapsed cell IDs

### DIFF
--- a/packages/hca-anndata-mcp/src/hca_anndata_mcp/server.py
+++ b/packages/hca-anndata-mcp/src/hca_anndata_mcp/server.py
@@ -6,6 +6,7 @@ from hca_anndata_mcp.tools.drop import drop_obs_columns
 from hca_anndata_mcp.tools.label import label_h5ad
 from hca_anndata_mcp.tools.plot import plot_embedding_mcp
 from hca_anndata_mcp.tools.populate import populate_labels
+from hca_anndata_mcp.tools.rename import rename_cell_ids
 from hca_anndata_mcp.tools.strip import strip_forbidden_obs_columns
 from hca_anndata_mcp.tools.validate import validate_cell_annotation, validate_schema
 from hca_anndata_tools import (
@@ -51,6 +52,14 @@ mcp = FastMCP(
         "under a non-canonical name (cell_type_label, ...); it refuses any "
         "column the HCA schema names and drops all or nothing, and refuses "
         "outright any file using the deprecated top-level CAP layout, "
+        "rename_cell_ids to rename the cell IDs (obs index) of rows selected by an obs "
+        "column value, substituting one ID prefix for another — the remedy for a sample "
+        "whose IDs lost a distinguishing segment in a pipeline; HCA-layout files only "
+        "(refuses CellxGENE-layout files such as CAP exports — renaming an export forks a "
+        "record its source system would overwrite), errors on zero matches, on selected "
+        "IDs not carrying the expected prefix, and on any rename that would produce "
+        "duplicate IDs, and note it renames only this file: a renamed file no longer "
+        "joins against unrenamed copies elsewhere (e.g. copy_cap_annotations sources), "
         "validate_marker_genes to check CAP marker genes against var, "
         "copy_cap_annotations to copy CAP annotations from a source into an HCA target file, "
         "replace_placeholder_values to replace banned placeholder values with NaN in obs columns, "
@@ -90,6 +99,7 @@ mcp.tool()(set_uns)
 mcp.tool()(convert_cellxgene_to_hca)
 mcp.tool()(strip_forbidden_obs_columns)
 mcp.tool()(drop_obs_columns)
+mcp.tool()(rename_cell_ids)
 mcp.tool()(validate_marker_genes)
 mcp.tool()(copy_cap_annotations)
 mcp.tool()(replace_placeholder_values)

--- a/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/rename.py
+++ b/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/rename.py
@@ -1,0 +1,12 @@
+"""MCP wrapper for hca_anndata_tools.rename_cell_ids.
+
+Thin re-export to keep parity with the other MCP tools (each gets its
+own wrapper file). The underlying function in hca-anndata-tools already
+returns a dict-shaped result; this module exists so future wrapper-only
+behavior (e.g. path normalization, MCP-side logging) lands here without
+touching the tools layer.
+"""
+
+from hca_anndata_tools import rename_cell_ids
+
+__all__ = ["rename_cell_ids"]

--- a/packages/hca-anndata-mcp/tests/test_rename.py
+++ b/packages/hca-anndata-mcp/tests/test_rename.py
@@ -1,52 +1,39 @@
 """Unit tests for the rename_cell_ids MCP wrapper."""
 
 import anndata as ad
-import numpy as np
-import pandas as pd
 
 from hca_anndata_mcp.tools.rename import rename_cell_ids
 
 
-def _write_hca_file(path):
-    ids = ["MH_mix_AAA", "MH_mix_TTT", "MH_mix_CCC"]
-    obs = pd.DataFrame(
-        {"sample_id": pd.Categorical(["B1_0023", "N_0123", "B1_0023"])},
-        index=pd.Index(ids, name="cellID"),
-    )
-    adata = ad.AnnData(X=np.zeros((3, 2), dtype=np.float32), obs=obs)
-    adata.write_h5ad(path)
-    return path
-
-
 def test_rename_missing_file():
-    result = rename_cell_ids("/nonexistent/file.h5ad", where={"a": "b"}, prefix_from="x_", prefix_to="y_")
+    result = rename_cell_ids("/nonexistent/file.h5ad", column="a", value="b", prefix_from="x_", prefix_to="y_")
     assert "error" in result
     assert "File not found" in result["error"]
 
 
 def test_rename_through_wrapper(tmp_path):
     """Happy path through the wrapper: selected rows renamed, counts reported."""
-    path = _write_hca_file(tmp_path / "test.h5ad")
+    from hca_anndata_tools.testing import HCA_TEST_ROWS, create_hca_h5ad
 
-    result = rename_cell_ids(str(path), where={"sample_id": "B1_0023"}, prefix_from="MH_mix_", prefix_to="MH_mix_BR1_")
+    path = create_hca_h5ad(tmp_path / "test.h5ad")
+
+    result = rename_cell_ids(
+        str(path), column="sample_id", value="B1_0023", prefix_from="MH_mix_", prefix_to="MH_mix_BR1_"
+    )
 
     assert "error" not in result
-    assert result["n_renamed"] == 2
-    assert list(ad.read_h5ad(result["output_path"]).obs_names) == [
-        "MH_mix_BR1_AAA",
-        "MH_mix_TTT",
-        "MH_mix_BR1_CCC",
+    assert result["n_renamed"] == sum(1 for _, sample in HCA_TEST_ROWS if sample == "B1_0023")
+    expected = [
+        "MH_mix_BR1_" + cell_id[len("MH_mix_") :] if sample == "B1_0023" else cell_id
+        for cell_id, sample in HCA_TEST_ROWS
     ]
+    assert list(ad.read_h5ad(result["output_path"]).obs_names) == expected
 
 
-def test_rename_refuses_cellxgene_through_wrapper(tmp_path):
+def test_rename_refuses_cellxgene_through_wrapper(sample_h5ad):
     """The HCA-layout gate lives in the tools layer; this pins that the
-    wrapper does not bypass it."""
-    from hca_anndata_tools.testing import create_sample_h5ad
-
-    path = create_sample_h5ad(tmp_path / "cxg.h5ad")  # sets uns['schema_version']
-
-    result = rename_cell_ids(str(path), where={"tissue": "brain"}, prefix_from="cell_", prefix_to="c_")
+    wrapper does not bypass it. Read-only, so the session fixture is safe."""
+    result = rename_cell_ids(str(sample_h5ad), column="tissue", value="brain", prefix_from="cell_", prefix_to="c_")
 
     assert "error" in result
     assert "CellxGENE" in result["error"]

--- a/packages/hca-anndata-mcp/tests/test_rename.py
+++ b/packages/hca-anndata-mcp/tests/test_rename.py
@@ -12,8 +12,9 @@ def test_rename_missing_file():
 
 
 def test_rename_through_wrapper(tmp_path):
-    """Happy path through the wrapper: selected rows renamed, counts reported."""
-    from hca_anndata_tools.testing import HCA_TEST_ROWS, create_hca_h5ad
+    """Happy path through the wrapper: pins the wiring only — result keys and
+    one cheap observable. Rename semantics are the tools layer's tests."""
+    from hca_anndata_tools.testing import create_hca_h5ad
 
     path = create_hca_h5ad(tmp_path / "test.h5ad")
 
@@ -22,12 +23,9 @@ def test_rename_through_wrapper(tmp_path):
     )
 
     assert "error" not in result
-    assert result["n_renamed"] == sum(1 for _, sample in HCA_TEST_ROWS if sample == "B1_0023")
-    expected = [
-        "MH_mix_BR1_" + cell_id[len("MH_mix_") :] if sample == "B1_0023" else cell_id
-        for cell_id, sample in HCA_TEST_ROWS
-    ]
-    assert list(ad.read_h5ad(result["output_path"]).obs_names) == expected
+    assert result["n_renamed"] == result["n_selected"] > 0
+    assert result["examples"][0] == ["MH_mix_AAA", "MH_mix_BR1_AAA"]
+    assert "MH_mix_BR1_AAA" in ad.read_h5ad(result["output_path"]).obs_names
 
 
 def test_rename_refuses_cellxgene_through_wrapper(sample_h5ad):

--- a/packages/hca-anndata-mcp/tests/test_rename.py
+++ b/packages/hca-anndata-mcp/tests/test_rename.py
@@ -1,0 +1,52 @@
+"""Unit tests for the rename_cell_ids MCP wrapper."""
+
+import anndata as ad
+import numpy as np
+import pandas as pd
+
+from hca_anndata_mcp.tools.rename import rename_cell_ids
+
+
+def _write_hca_file(path):
+    ids = ["MH_mix_AAA", "MH_mix_TTT", "MH_mix_CCC"]
+    obs = pd.DataFrame(
+        {"sample_id": pd.Categorical(["B1_0023", "N_0123", "B1_0023"])},
+        index=pd.Index(ids, name="cellID"),
+    )
+    adata = ad.AnnData(X=np.zeros((3, 2), dtype=np.float32), obs=obs)
+    adata.write_h5ad(path)
+    return path
+
+
+def test_rename_missing_file():
+    result = rename_cell_ids("/nonexistent/file.h5ad", where={"a": "b"}, prefix_from="x_", prefix_to="y_")
+    assert "error" in result
+    assert "File not found" in result["error"]
+
+
+def test_rename_through_wrapper(tmp_path):
+    """Happy path through the wrapper: selected rows renamed, counts reported."""
+    path = _write_hca_file(tmp_path / "test.h5ad")
+
+    result = rename_cell_ids(str(path), where={"sample_id": "B1_0023"}, prefix_from="MH_mix_", prefix_to="MH_mix_BR1_")
+
+    assert "error" not in result
+    assert result["n_renamed"] == 2
+    assert list(ad.read_h5ad(result["output_path"]).obs_names) == [
+        "MH_mix_BR1_AAA",
+        "MH_mix_TTT",
+        "MH_mix_BR1_CCC",
+    ]
+
+
+def test_rename_refuses_cellxgene_through_wrapper(tmp_path):
+    """The HCA-layout gate lives in the tools layer; this pins that the
+    wrapper does not bypass it."""
+    from hca_anndata_tools.testing import create_sample_h5ad
+
+    path = create_sample_h5ad(tmp_path / "cxg.h5ad")  # sets uns['schema_version']
+
+    result = rename_cell_ids(str(path), where={"tissue": "brain"}, prefix_from="cell_", prefix_to="c_")
+
+    assert "error" in result
+    assert "CellxGENE" in result["error"]

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/__init__.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/__init__.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from .marker_genes import validate_marker_genes
     from .normalize import normalize_raw
     from .plot import plot_embedding
+    from .rename import rename_cell_ids
     from .stats import get_descriptive_stats
     from .storage import get_storage_info
     from .strip import strip_forbidden_obs_columns
@@ -62,6 +63,7 @@ _LAZY_IMPORTS = {
     "normalize_raw": ".normalize",
     "strip_forbidden_obs_columns": ".strip",
     "drop_obs_columns": ".drop",
+    "rename_cell_ids": ".rename",
     "check_x_normalization": ".inspect",
     "check_schema_type": ".inspect",
 }

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/rename.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/rename.py
@@ -1,0 +1,306 @@
+"""Rename cell IDs (the obs index) for rows selected by an obs column value.
+
+Built for one defect class: a sample's cell IDs lost a distinguishing
+segment somewhere in a pipeline, and the fix is to select that sample's rows
+and put the segment back (#533). The operation is deliberately narrow — a
+prefix substitution, not a mapping or a pattern rewrite — because the safety
+comes from two independent witnesses that must agree before anything is
+written: the obs selector names the rows, and the prefix check confirms every
+one of them carries the ID form the caller expects. A more general rewrite
+would collapse that to a single witness. Widening (a ``mapping=`` or
+``suffix_from=`` mode) waits for a real case that needs it; the gates here are
+form-independent and would carry over.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import shutil
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+from ._io import (
+    _decode_bytes,
+    read_categorical_data,
+    read_edit_log_h5py,
+    write_edit_log_h5py,
+)
+from .inspect import _read_schema_version
+from .write import (
+    build_edit_log,
+    cleanup_previous_version,
+    generate_output_path,
+    make_edit_entry,
+    resolve_latest,
+)
+
+# Before/after pairs returned for eyeball confirmation, and the cap on IDs
+# quoted inside error messages so a 2M-row failure stays readable.
+_N_EXAMPLES = 5
+
+
+def _check_arguments(where, prefix_from, prefix_to) -> list[str]:
+    """Collect every problem with the call's arguments.
+
+    Shape-checks everything before any file is opened. This is an MCP-exposed
+    tool, so the arguments arrive as decoded JSON and may hold numbers, nulls,
+    or the wrong containers; everything downstream assumes strings.
+    """
+    problems: list[str] = []
+
+    if not isinstance(where, dict) or len(where) != 1:
+        problems.append("where must be a dict with exactly one {column: value} pair")
+    else:
+        column, value = next(iter(where.items()))
+        if not isinstance(column, str) or not isinstance(value, str):
+            problems.append(f"where must map a column name to a string value; got {{{column!r}: {value!r}}}")
+        # h5py resolves a name containing '/' as an HDF5 link path, not a dict
+        # key (see drop.py for the full trap) — reject before any lookup.
+        elif "/" in column or not column.strip():
+            problems.append(f"not a valid obs column name (cannot contain '/' or be blank): {column!r}")
+
+    if not isinstance(prefix_from, str) or not prefix_from:
+        problems.append("prefix_from must be a non-empty string")
+    if not isinstance(prefix_to, str):
+        problems.append("prefix_to must be a string")
+    elif prefix_from == prefix_to:
+        problems.append("prefix_from and prefix_to are identical — nothing would change")
+
+    return problems
+
+
+def _selection_mask(obs: h5py.Group, column: str, value: str) -> np.ndarray:
+    """Boolean mask of the rows whose ``column`` equals ``value``.
+
+    Categorical columns are matched through their codes without materializing
+    a per-row string array; anything else is read and decoded in full.
+    """
+    item = obs[column]
+    if isinstance(item, h5py.Group) and "categories" in item:
+        categories, codes = read_categorical_data(item)
+        if value not in categories:
+            return np.zeros(codes.shape, dtype=bool)
+        return codes == categories.get_loc(value)
+    values = np.array([_decode_bytes(v) for v in item[:]], dtype=object)
+    return values == value
+
+
+def _compute_new_ids(
+    ids: list[str], mask: np.ndarray, prefix_from: str, prefix_to: str
+) -> tuple[list[str], list[list[str]]]:
+    """Apply the prefix substitution to the selected rows.
+
+    Pure function, separable from the gates on purpose (see the module
+    docstring): a future operation mode supplies a different version of this
+    step and inherits every gate unchanged.
+
+    Returns the full new ID list and the before/after example pairs.
+    """
+    new_ids = list(ids)
+    examples: list[list[str]] = []
+    for i in np.flatnonzero(mask):
+        old = ids[i]
+        new_ids[i] = prefix_to + old[len(prefix_from) :]
+        if len(examples) < _N_EXAMPLES:
+            examples.append([old, new_ids[i]])
+    return new_ids, examples
+
+
+def rename_cell_ids(path: str, where: dict, prefix_from: str, prefix_to: str) -> dict:
+    """Rename the cell IDs of rows selected by an obs column value.
+
+    Selects the rows whose obs ``column`` equals ``value`` (the single pair in
+    ``where``) and rewrites their obs-index entries from
+    ``prefix_from + <rest>`` to ``prefix_to + <rest>``. All-or-nothing: every
+    gate runs before anything is written, and any failure leaves the file
+    untouched with all problems reported together.
+
+    The gates, in the order a caller hits them:
+
+    * **HCA-layout files only.** A file declaring a CellxGENE
+      ``uns['schema_version']`` is refused outright. The motivating case is
+      the CAP export of an atlas: CAP — not the exported file — is the system
+      of record for its annotations, so renaming the export forks a file CAP
+      would overwrite on its next export (#533, #596).
+    * **The selector must match.** Zero matching rows is an error, not a
+      no-op — the caller named specific rows, so finding none is a mistake
+      worth failing on.
+    * **Selector and substitution must agree.** Every selected row's ID must
+      start with ``prefix_from``; a partial match means the two witnesses
+      disagree about which rows are being renamed.
+    * **Uniqueness is a hard gate.** The *entire* resulting index is checked
+      before writing, and a collision is reported with the colliding IDs — a
+      rename that introduces duplicate cell IDs is the exact defect this tool
+      exists to fix.
+
+    Only the index dataset is rewritten — no rows move. Everything row-shaped
+    (obs columns, ``X``, ``raw.X``, ``obsm``/``obsp``) aligns to cells by
+    position, not by ID, so it all rides along untouched; the IDs exist in
+    exactly one place in the file. ``raw`` needs nothing: it has no ``obs`` of
+    its own. The index dataset's name is read from ``obs.attrs['_index']``
+    rather than assumed — HCA-layout files are not uniform here (``cellID``
+    on the breast integrated object).
+
+    Writes a new timestamped snapshot with an edit-log entry, like every
+    other mutating tool. That means copying the whole file to change a few
+    thousand strings — deliberate: the snapshot convention is what keeps a
+    curation history auditable, and an in-place rewrite of an HDF5
+    variable-length string dataset is unproven here.
+
+    Args:
+        path: Path to an .h5ad file. Auto-resolves to the latest timestamped
+            edit snapshot before operating.
+        where: Exactly one ``{column: value}`` pair naming the obs column and
+            the value that selects the rows to rename. The obs index itself
+            is not a column and is refused as a selector.
+        prefix_from: The prefix every selected ID must currently start with.
+        prefix_to: Its replacement.
+
+    Returns:
+        Dict with ``output_path``, ``n_selected``, ``n_renamed`` (always equal
+        to ``n_selected`` for this operation, reported separately so a future
+        mode where they can differ keeps the same shape), and ``examples``
+        (up to five ``[before, after]`` pairs), or ``{"error": ...}``.
+    """
+    output_path = None
+    try:
+        problems = _check_arguments(where, prefix_from, prefix_to)
+        if problems:
+            return {"error": "Refusing to rename: " + "; ".join(problems)}
+        column, value = next(iter(where.items()))
+
+        path = resolve_latest(path)
+        if not Path(path).is_file():
+            return {"error": f"File not found: {path}"}
+
+        with h5py.File(path, "r") as f_in:
+            obs = f_in.get("obs")
+            if obs is None:
+                return {"error": "File has no obs group"}
+            if not isinstance(obs, h5py.Group):
+                return {"error": "obs is not a group — the file predates the modern h5ad layout"}
+
+            version = _read_schema_version(f_in)
+            if version:
+                return {
+                    "error": (
+                        f"Refusing to rename: the file declares CellxGENE schema {version}. "
+                        f"This tool is scoped to HCA-layout files — renaming an exported file "
+                        f"(e.g. a CAP export) forks a record its source system would overwrite; "
+                        f"see issues #533 and #596."
+                    )
+                }
+
+            index_name = _decode_bytes(obs.attrs.get("_index", "_index"))
+            if column == index_name:
+                return {
+                    "error": (
+                        f"Refusing to rename: '{index_name}' is the obs index, not a column — select by an obs column"
+                    )
+                }
+            # Membership against direct children, not `column in obs`, which
+            # would resolve link paths (the '/' trap checked above).
+            if column not in set(obs.keys()):
+                return {"error": f"Refusing to rename: obs column not present: '{column}'"}
+
+            ids = [_decode_bytes(v) for v in obs[index_name][:]]  # pyright: ignore[reportIndexIssue]
+            mask = _selection_mask(obs, column, value)
+
+        n_selected = int(mask.sum())
+        if n_selected == 0:
+            return {"error": f"Refusing to rename: no rows match obs['{column}'] == {value!r}"}
+
+        bad_prefix = [ids[i] for i in np.flatnonzero(mask) if not ids[i].startswith(prefix_from)]
+        if bad_prefix:
+            shown = bad_prefix[:_N_EXAMPLES]
+            return {
+                "error": (
+                    f"Refusing to rename: {len(bad_prefix)} of {n_selected} selected rows do not start "
+                    f"with {prefix_from!r} (e.g. {shown}) — the selector and the prefix disagree about "
+                    f"which rows are being renamed"
+                )
+            }
+
+        new_ids, examples = _compute_new_ids(ids, mask, prefix_from, prefix_to)
+
+        if len(set(new_ids)) != len(new_ids):
+            seen: set[str] = set()
+            collisions: list[str] = []
+            for cell_id in new_ids:
+                if cell_id in seen:
+                    collisions.append(cell_id)
+                else:
+                    seen.add(cell_id)
+            shown = sorted(set(collisions))[:_N_EXAMPLES]
+            return {
+                "error": (
+                    f"Refusing to rename: the result would contain {len(collisions)} duplicate cell "
+                    f"IDs (e.g. {shown}) — a rename that introduces collisions is the defect this "
+                    f"tool exists to fix, not something it will write"
+                )
+            }
+
+        output_path = generate_output_path(path)
+        shutil.copy2(path, output_path)
+
+        log_error = None
+        with h5py.File(output_path, "a") as f_out:
+            index_ds = f_out["obs"][index_name]  # pyright: ignore[reportIndexIssue]
+            attrs = dict(index_ds.attrs)  # pyright: ignore[reportAttributeAccessIssue]
+            compression = index_ds.compression  # pyright: ignore[reportAttributeAccessIssue]
+            compression_opts = index_ds.compression_opts  # pyright: ignore[reportAttributeAccessIssue]
+            chunks = index_ds.chunks  # pyright: ignore[reportAttributeAccessIssue]
+            del f_out["obs"][index_name]  # pyright: ignore[reportIndexIssue]
+            new_ds = f_out["obs"].create_dataset(  # pyright: ignore[reportAttributeAccessIssue]
+                index_name,
+                data=np.array(new_ids, dtype=object),
+                dtype=h5py.string_dtype(encoding="utf-8"),
+                compression=compression,
+                compression_opts=compression_opts,
+                chunks=chunks,
+            )
+            for key, attr_value in attrs.items():
+                new_ds.attrs[key] = attr_value
+
+            entry = make_edit_entry(
+                operation="rename_cell_ids",
+                description=(
+                    f"Renamed {n_selected} cell IDs from prefix {prefix_from!r} to {prefix_to!r} "
+                    f"for rows where obs['{column}'] == {value!r}"
+                ),
+                details={
+                    "where": {column: value},
+                    "prefix_from": prefix_from,
+                    "prefix_to": prefix_to,
+                    "n_selected": n_selected,
+                    "n_renamed": n_selected,
+                    "examples": examples,
+                },
+            )
+            existing_log = read_edit_log_h5py(f_out)
+            log_result = build_edit_log(existing_log, [entry], path)
+            if "error" in log_result:
+                log_error = log_result
+            else:
+                write_edit_log_h5py(f_out, log_result["json"])
+
+        if log_error is not None:
+            Path(output_path).unlink()
+            return log_error
+
+        cleanup_previous_version(path, output_path)
+
+        return {
+            "output_path": output_path,
+            "n_selected": n_selected,
+            "n_renamed": n_selected,
+            "examples": examples,
+        }
+
+    except Exception as e:
+        if output_path and Path(output_path).is_file():
+            with contextlib.suppress(OSError):
+                Path(output_path).unlink()
+        return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/rename.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/rename.py
@@ -295,25 +295,28 @@ def rename_cell_ids(path: str, column: str, value: str, prefix_from: str, prefix
                 )
             }
 
+        # The pre-existing check runs unconditionally, before the rename is
+        # even computed: a file whose IDs already collide is refused outright,
+        # including when this rename would happen to make the index unique —
+        # resolving a collision by renaming one side of it is a curation
+        # decision a human must take, not a side effect this tool may write.
+        # The two refusals also carry different remedies: repair the file
+        # versus change the arguments.
+        pre_existing = pd.Index(ids).duplicated()
+        if pre_existing.any():
+            already = sorted(set(ids[pre_existing]))
+            return {
+                "error": (
+                    f"Refusing to rename: the file already contains {len(already)} duplicate cell "
+                    f"IDs before any rename (e.g. {already[:_N_EXAMPLES]}) — repair the file's "
+                    f"pre-existing collisions first"
+                )
+            }
+
         new_ids, examples = _compute_new_ids(ids, selected, prefix_from, prefix_to)
 
         duplicated = pd.Index(new_ids).duplicated()
         if duplicated.any():
-            # Name the right culprit: duplicates the file already had are not
-            # the rename's doing, and the remedy (repair the file) differs
-            # from the remedy for a bad prefix choice (change the arguments).
-            # Either way the gate stays hard — writing into a file whose IDs
-            # already collide would paper over a defect this tool exists to fix.
-            pre_existing = pd.Index(ids).duplicated()
-            if pre_existing.any():
-                already = sorted(set(ids[pre_existing]))
-                return {
-                    "error": (
-                        f"Refusing to rename: the file already contains {len(already)} duplicate cell "
-                        f"IDs before any rename (e.g. {already[:_N_EXAMPLES]}) — repair the file's "
-                        f"pre-existing collisions first"
-                    )
-                }
             colliding = sorted(set(new_ids[duplicated]))
             return {
                 "error": (

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/rename.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/rename.py
@@ -75,21 +75,42 @@ def _selection_mask(obs: h5py.Group, column: str, value: str) -> np.ndarray:
 
     Categorical columns are matched through their codes without materializing
     a per-row string array; plain string datasets are decoded by h5py in C via
-    ``asstr()``. A non-string, non-categorical column can never equal a string
-    value, so it selects nothing rather than erroring mid-read.
+    ``asstr()``; nullable string columns (values+mask groups) match on their
+    values with nulls masked out. A non-string, non-categorical column can
+    never equal a string value, so it selects nothing rather than erroring
+    mid-read.
     """
     item = obs[column]
     if isinstance(item, h5py.Group) and "categories" in item:
+        cats = item["categories"]
+        if isinstance(cats, h5py.Group):
+            # A pandas StringDtype column lands on disk (anndata >= 0.11) as
+            # a categorical whose category labels are themselves a nullable
+            # values+mask group — read_categorical_data assumes a dataset and
+            # would crash on it. A masked label can never equal the value.
+            labels = np.asarray(cats["values"].asstr()[:])  # pyright: ignore[reportAttributeAccessIssue, reportIndexIssue]
+            label_matches = labels == value
+            if "mask" in cats:
+                label_matches &= ~np.asarray(cats["mask"][:]).astype(bool)  # pyright: ignore[reportIndexIssue]
+            eligible = np.flatnonzero(label_matches)
+            return np.isin(np.asarray(item["codes"][:]), eligible)  # pyright: ignore[reportIndexIssue]
         categories, codes = read_categorical_data(item)
         if value not in categories:
             return np.zeros(codes.shape, dtype=bool)
         return codes == categories.get_loc(value)
     if isinstance(item, h5py.Group):
         # Nullable-dtype columns (pandas boolean / Int64 / string) are stored
-        # as values+mask groups with no categories; they have no `.dtype`, so
-        # without this branch the string check below would crash instead of
-        # honoring the select-nothing contract above.
+        # as values+mask groups with no categories, and have no `.dtype`. A
+        # nullable *string* column can genuinely match, so compare its values
+        # with nulls masked out; the non-string nullables fall through to the
+        # select-nothing contract above.
         values = item.get("values")
+        if isinstance(values, h5py.Dataset) and h5py.check_string_dtype(values.dtype) is not None:
+            matches = np.asarray(values.asstr()[:] == value)
+            null_mask = item.get("mask")
+            if isinstance(null_mask, h5py.Dataset):
+                matches &= ~null_mask[:].astype(bool)
+            return matches
         shape = values.shape if isinstance(values, h5py.Dataset) else (0,)
         return np.zeros(shape, dtype=bool)
     if h5py.check_string_dtype(item.dtype) is None:  # pyright: ignore[reportAttributeAccessIssue]

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/rename.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/rename.py
@@ -247,7 +247,11 @@ def rename_cell_ids(path: str, column: str, value: str, prefix_from: str, prefix
                 # Gated before the index read: a mistyped selector should not
                 # pay for decoding 2M IDs it will never use.
                 return {"error": f"Refusing to rename: no rows match obs['{column}'] == {value!r}"}
-            ids = np.asarray(obs[index_name].asstr()[:])  # pyright: ignore[reportAttributeAccessIssue, reportIndexIssue]
+            # dtype=object pins what asstr() already returns (verified for
+            # both vlen and fixed-width string datasets): a fixed-width
+            # unicode dtype here would silently clip the longer renamed IDs
+            # on assignment in _compute_new_ids.
+            ids = np.asarray(obs[index_name].asstr()[:], dtype=object)  # pyright: ignore[reportAttributeAccessIssue, reportIndexIssue]
 
             # A DataFrame in obsm carries its own duplicate copy of the cell
             # IDs (anndata writes the frame's index alongside the parent's),
@@ -265,7 +269,7 @@ def rename_cell_ids(path: str, column: str, value: str, prefix_from: str, prefix
                     ):
                         continue
                     sub_name = _decode_bytes(member.attrs.get("_index", "_index"))
-                    sub_ids = np.asarray(member[sub_name].asstr()[:])  # pyright: ignore[reportAttributeAccessIssue, reportIndexIssue]
+                    sub_ids = np.asarray(member[sub_name].asstr()[:], dtype=object)  # pyright: ignore[reportAttributeAccessIssue, reportIndexIssue]
                     if sub_ids.shape != ids.shape or not (sub_ids == ids).all():
                         return {
                             "error": (

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/rename.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/rename.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import h5py
 import numpy as np
+import pandas as pd
 
 from ._io import (
     _decode_bytes,
@@ -29,6 +30,7 @@ from ._io import (
 )
 from .inspect import _read_schema_version
 from .write import (
+    _compute_sha256,
     build_edit_log,
     cleanup_previous_version,
     generate_output_path,
@@ -41,25 +43,21 @@ from .write import (
 _N_EXAMPLES = 5
 
 
-def _check_arguments(where, prefix_from, prefix_to) -> list[str]:
+def _check_arguments(column, value, prefix_from, prefix_to) -> list[str]:
     """Collect every problem with the call's arguments.
 
     Shape-checks everything before any file is opened. This is an MCP-exposed
-    tool, so the arguments arrive as decoded JSON and may hold numbers, nulls,
-    or the wrong containers; everything downstream assumes strings.
+    tool, so the arguments arrive as decoded JSON and may hold numbers or
+    nulls; everything downstream assumes strings.
     """
     problems: list[str] = []
 
-    if not isinstance(where, dict) or len(where) != 1:
-        problems.append("where must be a dict with exactly one {column: value} pair")
-    else:
-        column, value = next(iter(where.items()))
-        if not isinstance(column, str) or not isinstance(value, str):
-            problems.append(f"where must map a column name to a string value; got {{{column!r}: {value!r}}}")
-        # h5py resolves a name containing '/' as an HDF5 link path, not a dict
-        # key (see drop.py for the full trap) — reject before any lookup.
-        elif "/" in column or not column.strip():
-            problems.append(f"not a valid obs column name (cannot contain '/' or be blank): {column!r}")
+    if not isinstance(column, str) or not isinstance(value, str):
+        problems.append(f"column and value must be strings; got {column!r} and {value!r}")
+    # h5py resolves a name containing '/' as an HDF5 link path, not a dict
+    # key (see drop.py for the full trap) — reject before any lookup.
+    elif "/" in column or not column.strip():
+        problems.append(f"not a valid obs column name (cannot contain '/' or be blank): {column!r}")
 
     if not isinstance(prefix_from, str) or not prefix_from:
         problems.append("prefix_from must be a non-empty string")
@@ -75,7 +73,9 @@ def _selection_mask(obs: h5py.Group, column: str, value: str) -> np.ndarray:
     """Boolean mask of the rows whose ``column`` equals ``value``.
 
     Categorical columns are matched through their codes without materializing
-    a per-row string array; anything else is read and decoded in full.
+    a per-row string array; plain string datasets are decoded by h5py in C via
+    ``asstr()``. A non-string, non-categorical column can never equal a string
+    value, so it selects nothing rather than erroring mid-read.
     """
     item = obs[column]
     if isinstance(item, h5py.Group) and "categories" in item:
@@ -83,39 +83,35 @@ def _selection_mask(obs: h5py.Group, column: str, value: str) -> np.ndarray:
         if value not in categories:
             return np.zeros(codes.shape, dtype=bool)
         return codes == categories.get_loc(value)
-    values = np.array([_decode_bytes(v) for v in item[:]], dtype=object)
-    return values == value
+    if h5py.check_string_dtype(item.dtype) is None:  # pyright: ignore[reportAttributeAccessIssue]
+        return np.zeros(item.shape, dtype=bool)  # pyright: ignore[reportAttributeAccessIssue]
+    return np.asarray(item.asstr()[:] == value)  # pyright: ignore[reportAttributeAccessIssue]
 
 
 def _compute_new_ids(
-    ids: list[str], mask: np.ndarray, prefix_from: str, prefix_to: str
-) -> tuple[list[str], list[list[str]]]:
+    ids: np.ndarray, selected: np.ndarray, prefix_from: str, prefix_to: str
+) -> tuple[np.ndarray, list[list[str]]]:
     """Apply the prefix substitution to the selected rows.
 
     Pure function, separable from the gates on purpose (see the module
     docstring): a future operation mode supplies a different version of this
     step and inherits every gate unchanged.
 
-    Returns the full new ID list and the before/after example pairs.
+    Returns the full new ID array and the before/after example pairs.
     """
-    new_ids = list(ids)
-    examples: list[list[str]] = []
-    for i in np.flatnonzero(mask):
-        old = ids[i]
-        new_ids[i] = prefix_to + old[len(prefix_from) :]
-        if len(examples) < _N_EXAMPLES:
-            examples.append([old, new_ids[i]])
+    new_ids = ids.copy()
+    new_ids[selected] = [prefix_to + cell_id[len(prefix_from) :] for cell_id in ids[selected]]
+    examples = [[str(ids[i]), str(new_ids[i])] for i in selected[:_N_EXAMPLES]]
     return new_ids, examples
 
 
-def rename_cell_ids(path: str, where: dict, prefix_from: str, prefix_to: str) -> dict:
+def rename_cell_ids(path: str, column: str, value: str, prefix_from: str, prefix_to: str) -> dict:
     """Rename the cell IDs of rows selected by an obs column value.
 
-    Selects the rows whose obs ``column`` equals ``value`` (the single pair in
-    ``where``) and rewrites their obs-index entries from
-    ``prefix_from + <rest>`` to ``prefix_to + <rest>``. All-or-nothing: every
-    gate runs before anything is written, and any failure leaves the file
-    untouched with all problems reported together.
+    Selects the rows whose obs ``column`` equals ``value`` and rewrites their
+    obs-index entries from ``prefix_from + <rest>`` to ``prefix_to + <rest>``.
+    All-or-nothing: every gate runs before anything is written, and any
+    failure leaves the file untouched with all problems reported together.
 
     The gates, in the order a caller hits them:
 
@@ -152,24 +148,23 @@ def rename_cell_ids(path: str, where: dict, prefix_from: str, prefix_to: str) ->
     Args:
         path: Path to an .h5ad file. Auto-resolves to the latest timestamped
             edit snapshot before operating.
-        where: Exactly one ``{column: value}`` pair naming the obs column and
-            the value that selects the rows to rename. The obs index itself
-            is not a column and is refused as a selector.
+        column: The obs column whose value selects the rows to rename. The
+            obs index itself is not a column and is refused as a selector.
+        value: The value that selects the rows.
         prefix_from: The prefix every selected ID must currently start with.
         prefix_to: Its replacement.
 
     Returns:
         Dict with ``output_path``, ``n_selected``, ``n_renamed`` (always equal
-        to ``n_selected`` for this operation, reported separately so a future
-        mode where they can differ keeps the same shape), and ``examples``
-        (up to five ``[before, after]`` pairs), or ``{"error": ...}``.
+        to ``n_selected`` for this operation; the issue asks for both so a
+        broader-than-intended selector stays visible), and ``examples`` (up to
+        five ``[before, after]`` pairs), or ``{"error": ...}``.
     """
     output_path = None
     try:
-        problems = _check_arguments(where, prefix_from, prefix_to)
+        problems = _check_arguments(column, value, prefix_from, prefix_to)
         if problems:
             return {"error": "Refusing to rename: " + "; ".join(problems)}
-        column, value = next(iter(where.items()))
 
         path = resolve_latest(path)
         if not Path(path).is_file():
@@ -205,45 +200,52 @@ def rename_cell_ids(path: str, where: dict, prefix_from: str, prefix_to: str) ->
             if column not in set(obs.keys()):
                 return {"error": f"Refusing to rename: obs column not present: '{column}'"}
 
-            ids = [_decode_bytes(v) for v in obs[index_name][:]]  # pyright: ignore[reportIndexIssue]
             mask = _selection_mask(obs, column, value)
+            n_selected = int(mask.sum())
+            if n_selected == 0:
+                # Gated before the index read: a mistyped selector should not
+                # pay for decoding 2M IDs it will never use.
+                return {"error": f"Refusing to rename: no rows match obs['{column}'] == {value!r}"}
+            ids = np.asarray(obs[index_name].asstr()[:])  # pyright: ignore[reportAttributeAccessIssue, reportIndexIssue]
 
-        n_selected = int(mask.sum())
-        if n_selected == 0:
-            return {"error": f"Refusing to rename: no rows match obs['{column}'] == {value!r}"}
-
-        bad_prefix = [ids[i] for i in np.flatnonzero(mask) if not ids[i].startswith(prefix_from)]
-        if bad_prefix:
-            shown = bad_prefix[:_N_EXAMPLES]
+        selected = np.flatnonzero(mask)
+        # Count and sample the disagreements rather than materializing them
+        # all — on a wrong-prefix call the offenders can be the whole sample.
+        bad_count = 0
+        bad_examples: list[str] = []
+        for cell_id in ids[selected]:
+            if not cell_id.startswith(prefix_from):
+                bad_count += 1
+                if len(bad_examples) < _N_EXAMPLES:
+                    bad_examples.append(cell_id)
+        if bad_count:
             return {
                 "error": (
-                    f"Refusing to rename: {len(bad_prefix)} of {n_selected} selected rows do not start "
-                    f"with {prefix_from!r} (e.g. {shown}) — the selector and the prefix disagree about "
-                    f"which rows are being renamed"
+                    f"Refusing to rename: {bad_count} of {n_selected} selected rows do not start "
+                    f"with {prefix_from!r} (e.g. {bad_examples}) — the selector and the prefix "
+                    f"disagree about which rows are being renamed"
                 )
             }
 
-        new_ids, examples = _compute_new_ids(ids, mask, prefix_from, prefix_to)
+        new_ids, examples = _compute_new_ids(ids, selected, prefix_from, prefix_to)
 
-        if len(set(new_ids)) != len(new_ids):
-            seen: set[str] = set()
-            collisions: list[str] = []
-            for cell_id in new_ids:
-                if cell_id in seen:
-                    collisions.append(cell_id)
-                else:
-                    seen.add(cell_id)
-            shown = sorted(set(collisions))[:_N_EXAMPLES]
+        duplicated = pd.Index(new_ids).duplicated()
+        if duplicated.any():
+            colliding = sorted(set(new_ids[duplicated]))
             return {
                 "error": (
-                    f"Refusing to rename: the result would contain {len(collisions)} duplicate cell "
-                    f"IDs (e.g. {shown}) — a rename that introduces collisions is the defect this "
-                    f"tool exists to fix, not something it will write"
+                    f"Refusing to rename: the result would contain {len(colliding)} duplicate cell "
+                    f"IDs (e.g. {colliding[:_N_EXAMPLES]}) — a rename that introduces collisions is "
+                    f"the defect this tool exists to fix, not something it will write"
                 )
             }
 
         output_path = generate_output_path(path)
         shutil.copy2(path, output_path)
+
+        # Hash the source before opening the output: build_edit_log would
+        # otherwise re-read the whole file while the output handle is open.
+        source_sha256 = _compute_sha256(path)
 
         log_error = None
         with h5py.File(output_path, "a") as f_out:
@@ -255,7 +257,7 @@ def rename_cell_ids(path: str, where: dict, prefix_from: str, prefix_to: str) ->
             del f_out["obs"][index_name]  # pyright: ignore[reportIndexIssue]
             new_ds = f_out["obs"].create_dataset(  # pyright: ignore[reportAttributeAccessIssue]
                 index_name,
-                data=np.array(new_ids, dtype=object),
+                data=new_ids,
                 dtype=h5py.string_dtype(encoding="utf-8"),
                 compression=compression,
                 compression_opts=compression_opts,
@@ -271,7 +273,8 @@ def rename_cell_ids(path: str, where: dict, prefix_from: str, prefix_to: str) ->
                     f"for rows where obs['{column}'] == {value!r}"
                 ),
                 details={
-                    "where": {column: value},
+                    "column": column,
+                    "value": value,
                     "prefix_from": prefix_from,
                     "prefix_to": prefix_to,
                     "n_selected": n_selected,
@@ -280,12 +283,16 @@ def rename_cell_ids(path: str, where: dict, prefix_from: str, prefix_to: str) ->
                 },
             )
             existing_log = read_edit_log_h5py(f_out)
-            log_result = build_edit_log(existing_log, [entry], path)
+            log_result = build_edit_log(existing_log, [entry], path, source_sha256)
             if "error" in log_result:
                 log_error = log_result
             else:
                 write_edit_log_h5py(f_out, log_result["json"])
 
+        # Deferred until the with-block has closed the output handle,
+        # matching drop.py: unlinking an open HDF5 file works on POSIX but
+        # raises on Windows, and the context __exit__ flush would hit a
+        # removed inode either way.
         if log_error is not None:
             Path(output_path).unlink()
             return log_error

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/rename.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/rename.py
@@ -28,6 +28,7 @@ from ._io import (
     read_edit_log_h5py,
     write_edit_log_h5py,
 )
+from .cap import LEGACY_LAYOUT_DESCRIPTION, is_legacy_cap_layout
 from .inspect import _read_schema_version
 from .write import (
     _compute_sha256,
@@ -83,6 +84,14 @@ def _selection_mask(obs: h5py.Group, column: str, value: str) -> np.ndarray:
         if value not in categories:
             return np.zeros(codes.shape, dtype=bool)
         return codes == categories.get_loc(value)
+    if isinstance(item, h5py.Group):
+        # Nullable-dtype columns (pandas boolean / Int64 / string) are stored
+        # as values+mask groups with no categories; they have no `.dtype`, so
+        # without this branch the string check below would crash instead of
+        # honoring the select-nothing contract above.
+        values = item.get("values")
+        shape = values.shape if isinstance(values, h5py.Dataset) else (0,)
+        return np.zeros(shape, dtype=bool)
     if h5py.check_string_dtype(item.dtype) is None:  # pyright: ignore[reportAttributeAccessIssue]
         return np.zeros(item.shape, dtype=bool)  # pyright: ignore[reportAttributeAccessIssue]
     return np.asarray(item.asstr()[:] == value)  # pyright: ignore[reportAttributeAccessIssue]
@@ -103,6 +112,25 @@ def _compute_new_ids(
     new_ids[selected] = [prefix_to + cell_id[len(prefix_from) :] for cell_id in ids[selected]]
     examples = [[str(ids[i]), str(new_ids[i])] for i in selected[:_N_EXAMPLES]]
     return new_ids, examples
+
+
+def _replace_string_dataset(parent: h5py.Group, name: str, data: np.ndarray) -> None:
+    """Delete and recreate a string dataset, preserving its attrs and storage
+    properties (compression, chunks, shuffle, fletcher32, maxshape)."""
+    ds = parent[name]
+    attrs = dict(ds.attrs)  # pyright: ignore[reportAttributeAccessIssue]
+    storage = {
+        "compression": ds.compression,  # pyright: ignore[reportAttributeAccessIssue]
+        "compression_opts": ds.compression_opts,  # pyright: ignore[reportAttributeAccessIssue]
+        "chunks": ds.chunks,  # pyright: ignore[reportAttributeAccessIssue]
+        "shuffle": ds.shuffle,  # pyright: ignore[reportAttributeAccessIssue]
+        "fletcher32": ds.fletcher32,  # pyright: ignore[reportAttributeAccessIssue]
+        "maxshape": ds.maxshape,  # pyright: ignore[reportAttributeAccessIssue]
+    }
+    del parent[name]
+    new_ds = parent.create_dataset(name, data=data, dtype=h5py.string_dtype(encoding="utf-8"), **storage)
+    for key, attr_value in attrs.items():
+        new_ds.attrs[key] = attr_value
 
 
 def rename_cell_ids(path: str, column: str, value: str, prefix_from: str, prefix_to: str) -> dict:
@@ -131,11 +159,14 @@ def rename_cell_ids(path: str, column: str, value: str, prefix_from: str, prefix
       rename that introduces duplicate cell IDs is the exact defect this tool
       exists to fix.
 
-    Only the index dataset is rewritten — no rows move. Everything row-shaped
-    (obs columns, ``X``, ``raw.X``, ``obsm``/``obsp``) aligns to cells by
-    position, not by ID, so it all rides along untouched; the IDs exist in
-    exactly one place in the file. ``raw`` needs nothing: it has no ``obs`` of
-    its own. The index dataset's name is read from ``obs.attrs['_index']``
+    No rows move — everything row-shaped (obs columns, ``X``, ``raw.X``,
+    ``obsm``/``obsp``) aligns to cells by position, not by ID, so it all rides
+    along untouched, and ``raw`` needs nothing: it has no ``obs`` of its own.
+    The IDs live in the obs index plus one duplicate copy inside each
+    DataFrame stored in ``obsm`` (anndata writes the frame's own index and
+    refuses to read a file where the copies disagree), so those are rewritten
+    in the same pass — and a file whose copies *already* disagree is refused
+    as broken. The index dataset's name is read from ``obs.attrs['_index']``
     rather than assumed — HCA-layout files are not uniform here (``cellID``
     on the breast integrated object).
 
@@ -188,6 +219,16 @@ def rename_cell_ids(path: str, column: str, value: str, prefix_from: str, prefix
                     )
                 }
 
+            uns = f_in.get("uns")
+            if isinstance(uns, h5py.Group) and is_legacy_cap_layout(uns):
+                # Parity with drop.py / copy_cap.py (#552): the legacy layout
+                # marks a CAP export even when uns['schema_version'] is absent,
+                # and renaming a CAP export is exactly what the gate above
+                # exists to prevent.
+                return {
+                    "error": f"Refusing to rename: the file uses {LEGACY_LAYOUT_DESCRIPTION}, which is not supported"
+                }
+
             index_name = _decode_bytes(obs.attrs.get("_index", "_index"))
             if column == index_name:
                 return {
@@ -207,6 +248,33 @@ def rename_cell_ids(path: str, column: str, value: str, prefix_from: str, prefix
                 # pay for decoding 2M IDs it will never use.
                 return {"error": f"Refusing to rename: no rows match obs['{column}'] == {value!r}"}
             ids = np.asarray(obs[index_name].asstr()[:])  # pyright: ignore[reportAttributeAccessIssue, reportIndexIssue]
+
+            # A DataFrame in obsm carries its own duplicate copy of the cell
+            # IDs (anndata writes the frame's index alongside the parent's),
+            # and anndata refuses to read a file where the two disagree. So
+            # every such copy must be renamed in the same pass — and if one
+            # already disagrees, the file is broken in a way a rename would
+            # only paper over.
+            obsm_df_indexes: list[tuple[str, str]] = []  # (obsm key, index dataset name)
+            obsm = f_in.get("obsm")
+            if isinstance(obsm, h5py.Group):
+                for obsm_key, member in obsm.items():
+                    if not (
+                        isinstance(member, h5py.Group)
+                        and _decode_bytes(member.attrs.get("encoding-type", "")) == "dataframe"
+                    ):
+                        continue
+                    sub_name = _decode_bytes(member.attrs.get("_index", "_index"))
+                    sub_ids = np.asarray(member[sub_name].asstr()[:])  # pyright: ignore[reportAttributeAccessIssue, reportIndexIssue]
+                    if sub_ids.shape != ids.shape or not (sub_ids == ids).all():
+                        return {
+                            "error": (
+                                f"Refusing to rename: obsm[{obsm_key!r}] is a DataFrame whose index "
+                                f"does not match the obs index — the file is internally inconsistent "
+                                f"and must be repaired before any rename"
+                            )
+                        }
+                    obsm_df_indexes.append((obsm_key, sub_name))
 
         selected = np.flatnonzero(mask)
         # Count and sample the disagreements rather than materializing them
@@ -231,6 +299,21 @@ def rename_cell_ids(path: str, column: str, value: str, prefix_from: str, prefix
 
         duplicated = pd.Index(new_ids).duplicated()
         if duplicated.any():
+            # Name the right culprit: duplicates the file already had are not
+            # the rename's doing, and the remedy (repair the file) differs
+            # from the remedy for a bad prefix choice (change the arguments).
+            # Either way the gate stays hard — writing into a file whose IDs
+            # already collide would paper over a defect this tool exists to fix.
+            pre_existing = pd.Index(ids).duplicated()
+            if pre_existing.any():
+                already = sorted(set(ids[pre_existing]))
+                return {
+                    "error": (
+                        f"Refusing to rename: the file already contains {len(already)} duplicate cell "
+                        f"IDs before any rename (e.g. {already[:_N_EXAMPLES]}) — repair the file's "
+                        f"pre-existing collisions first"
+                    )
+                }
             colliding = sorted(set(new_ids[duplicated]))
             return {
                 "error": (
@@ -241,6 +324,12 @@ def rename_cell_ids(path: str, column: str, value: str, prefix_from: str, prefix
             }
 
         output_path = generate_output_path(path)
+        if output_path == path:
+            # generate_output_path timestamps to the second, so a second edit
+            # within the same second names the output after its own source;
+            # copying would raise SameFileError and the failure path would
+            # then unlink the source snapshot. Refuse before touching anything.
+            return {"error": "An edit snapshot for this second already exists — retry in a moment."}
         shutil.copy2(path, output_path)
 
         # Hash the source before opening the output: build_edit_log would
@@ -249,22 +338,9 @@ def rename_cell_ids(path: str, column: str, value: str, prefix_from: str, prefix
 
         log_error = None
         with h5py.File(output_path, "a") as f_out:
-            index_ds = f_out["obs"][index_name]  # pyright: ignore[reportIndexIssue]
-            attrs = dict(index_ds.attrs)  # pyright: ignore[reportAttributeAccessIssue]
-            compression = index_ds.compression  # pyright: ignore[reportAttributeAccessIssue]
-            compression_opts = index_ds.compression_opts  # pyright: ignore[reportAttributeAccessIssue]
-            chunks = index_ds.chunks  # pyright: ignore[reportAttributeAccessIssue]
-            del f_out["obs"][index_name]  # pyright: ignore[reportIndexIssue]
-            new_ds = f_out["obs"].create_dataset(  # pyright: ignore[reportAttributeAccessIssue]
-                index_name,
-                data=new_ids,
-                dtype=h5py.string_dtype(encoding="utf-8"),
-                compression=compression,
-                compression_opts=compression_opts,
-                chunks=chunks,
-            )
-            for key, attr_value in attrs.items():
-                new_ds.attrs[key] = attr_value
+            _replace_string_dataset(f_out["obs"], index_name, new_ids)  # pyright: ignore[reportArgumentType]
+            for obsm_key, sub_name in obsm_df_indexes:
+                _replace_string_dataset(f_out["obsm"][obsm_key], sub_name, new_ids)  # pyright: ignore[reportArgumentType, reportIndexIssue]
 
             entry = make_edit_entry(
                 operation="rename_cell_ids",
@@ -280,6 +356,7 @@ def rename_cell_ids(path: str, column: str, value: str, prefix_from: str, prefix
                     "n_selected": n_selected,
                     "n_renamed": n_selected,
                     "examples": examples,
+                    "obsm_dataframes_updated": [obsm_key for obsm_key, _ in obsm_df_indexes],
                 },
             )
             existing_log = read_edit_log_h5py(f_out)

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/rename.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/rename.py
@@ -75,42 +75,21 @@ def _selection_mask(obs: h5py.Group, column: str, value: str) -> np.ndarray:
 
     Categorical columns are matched through their codes without materializing
     a per-row string array; plain string datasets are decoded by h5py in C via
-    ``asstr()``; nullable string columns (values+mask groups) match on their
-    values with nulls masked out. A non-string, non-categorical column can
-    never equal a string value, so it selects nothing rather than erroring
-    mid-read.
+    ``asstr()``. A non-string, non-categorical column can never equal a string
+    value, so it selects nothing rather than erroring mid-read.
     """
     item = obs[column]
     if isinstance(item, h5py.Group) and "categories" in item:
-        cats = item["categories"]
-        if isinstance(cats, h5py.Group):
-            # A pandas StringDtype column lands on disk (anndata >= 0.11) as
-            # a categorical whose category labels are themselves a nullable
-            # values+mask group — read_categorical_data assumes a dataset and
-            # would crash on it. A masked label can never equal the value.
-            labels = np.asarray(cats["values"].asstr()[:])  # pyright: ignore[reportAttributeAccessIssue, reportIndexIssue]
-            label_matches = labels == value
-            if "mask" in cats:
-                label_matches &= ~np.asarray(cats["mask"][:]).astype(bool)  # pyright: ignore[reportIndexIssue]
-            eligible = np.flatnonzero(label_matches)
-            return np.isin(np.asarray(item["codes"][:]), eligible)  # pyright: ignore[reportIndexIssue]
         categories, codes = read_categorical_data(item)
         if value not in categories:
             return np.zeros(codes.shape, dtype=bool)
         return codes == categories.get_loc(value)
     if isinstance(item, h5py.Group):
         # Nullable-dtype columns (pandas boolean / Int64 / string) are stored
-        # as values+mask groups with no categories, and have no `.dtype`. A
-        # nullable *string* column can genuinely match, so compare its values
-        # with nulls masked out; the non-string nullables fall through to the
-        # select-nothing contract above.
+        # as values+mask groups with no categories; they have no `.dtype`, so
+        # without this branch the string check below would crash instead of
+        # honoring the select-nothing contract above.
         values = item.get("values")
-        if isinstance(values, h5py.Dataset) and h5py.check_string_dtype(values.dtype) is not None:
-            matches = np.asarray(values.asstr()[:] == value)
-            null_mask = item.get("mask")
-            if isinstance(null_mask, h5py.Dataset):
-                matches &= ~null_mask[:].astype(bool)
-            return matches
         shape = values.shape if isinstance(values, h5py.Dataset) else (0,)
         return np.zeros(shape, dtype=bool)
     if h5py.check_string_dtype(item.dtype) is None:  # pyright: ignore[reportAttributeAccessIssue]

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/testing.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/testing.py
@@ -167,6 +167,7 @@ def create_hca_h5ad(
     index_name: str | None = "cellID",
     extra_rows: list[tuple[str, str]] | None = None,
     categorical_sample: bool = True,
+    obsm_dataframe: bool = False,
 ) -> Path:
     """Create a small HCA-layout h5ad file (no ``uns['schema_version']``).
 
@@ -183,6 +184,9 @@ def create_hca_h5ad(
             test plant a pre-existing ID that a rename would collide with.
         categorical_sample: Write ``sample_id`` as categorical (True) or as a
             plain string column (False).
+        obsm_dataframe: Also store a per-cell-scores DataFrame in obsm (a
+            common scanpy output) — anndata then writes a duplicate copy of
+            the cell IDs as the frame's own index.
 
     Returns:
         The path to the written file.
@@ -200,6 +204,10 @@ def create_hca_h5ad(
     var = pd.DataFrame(index=pd.Index([f"ENSG{i:011d}" for i in range(5)]))
     adata = ad.AnnData(X=rng.standard_normal((n_obs, 5)).astype(np.float32), obs=obs, var=var)
     adata.obsm["X_umap"] = rng.standard_normal((n_obs, 2)).astype(np.float32)
+    if obsm_dataframe:
+        adata.obsm["per_cell_scores"] = pd.DataFrame(
+            {"score": rng.standard_normal(n_obs).astype(np.float32)}, index=adata.obs_names
+        )
     adata.uns["title"] = "Test HCA file"
     adata.write_h5ad(path)
     return path

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/testing.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/testing.py
@@ -144,3 +144,62 @@ def create_cellxgene_h5ad(path: Path) -> Path:
 
     adata.write_h5ad(path)
     return path
+
+
+# The two-family ID shape from the breast-v1 pal2021 collapse (#533): three
+# "B1_0023" cells wearing the "N_0123" family's prefix, interleaved so a
+# correct row selection must go by column value, not by position, plus two
+# N cells under an unrelated prefix so a selector/prefix disagreement is
+# observable.
+HCA_TEST_ROWS = [
+    ("MH_mix_AAA", "B1_0023"),
+    ("MH_mix_TTT", "N_0123"),
+    ("MH_mix_CCC", "B1_0023"),
+    ("MH_mix_ACG", "N_0123"),
+    ("MH_mix_GGG", "B1_0023"),
+    ("N1105_epi_AAA", "N_0123"),
+    ("N1105_epi_CCC", "N_0123"),
+]
+
+
+def create_hca_h5ad(
+    path: Path,
+    index_name: str | None = "cellID",
+    extra_rows: list[tuple[str, str]] | None = None,
+    categorical_sample: bool = True,
+) -> Path:
+    """Create a small HCA-layout h5ad file (no ``uns['schema_version']``).
+
+    The other factories here both declare a CellxGENE ``schema_version``, so
+    tools gated to HCA-layout files refuse them; this is the HCA counterpart.
+    Rows are ``HCA_TEST_ROWS`` — cell IDs and their ``sample_id`` values —
+    with the index named ``cellID`` by default, matching the breast-v1
+    integrated object rather than anndata's ``_index`` default.
+
+    Args:
+        path: Where to write the .h5ad file.
+        index_name: Name for the obs index (None for anndata's default).
+        extra_rows: Extra ``(cell_id, sample_id)`` rows to append — lets a
+            test plant a pre-existing ID that a rename would collide with.
+        categorical_sample: Write ``sample_id`` as categorical (True) or as a
+            plain string column (False).
+
+    Returns:
+        The path to the written file.
+    """
+    rows = HCA_TEST_ROWS + (extra_rows or [])
+    ids = [cell_id for cell_id, _ in rows]
+    samples = [sample for _, sample in rows]
+
+    n_obs = len(rows)
+    rng = np.random.default_rng(7)
+    obs = pd.DataFrame(
+        {"sample_id": pd.Categorical(samples) if categorical_sample else samples},
+        index=pd.Index(ids, name=index_name),
+    )
+    var = pd.DataFrame(index=pd.Index([f"ENSG{i:011d}" for i in range(5)]))
+    adata = ad.AnnData(X=rng.standard_normal((n_obs, 5)).astype(np.float32), obs=obs, var=var)
+    adata.obsm["X_umap"] = rng.standard_normal((n_obs, 2)).astype(np.float32)
+    adata.uns["title"] = "Test HCA file"
+    adata.write_h5ad(path)
+    return path

--- a/packages/hca-anndata-tools/tests/test_rename.py
+++ b/packages/hca-anndata-tools/tests/test_rename.py
@@ -1,0 +1,212 @@
+"""Tests for rename_cell_ids.
+
+The fixture mirrors the defect the tool was built for (#533): two ID
+families that share a prefix because one family lost its distinguishing
+segment, with the surviving distinction held only in an obs column. The
+index is deliberately named ``cellID`` — the breast integrated object's
+name — so the default-``_index`` assumption can't creep back in; one test
+covers the default name.
+"""
+
+from pathlib import Path
+
+import anndata as ad
+import h5py
+import numpy as np
+import pandas as pd
+import pytest
+
+from hca_anndata_tools import rename_cell_ids
+from hca_anndata_tools.testing import create_sample_h5ad
+
+# The collapsed family: B1 cells wearing the N family's prefix. Interleaved
+# with the N cells so a correct rename must select by column value, not by
+# position.
+COLLAPSED_IDS = ["MH_mix_AAA", "MH_mix_CCC", "MH_mix_GGG"]
+N_IDS = ["MH_mix_TTT", "MH_mix_ACG", "N1105_epi_AAA", "N1105_epi_CCC"]
+
+
+def make_hca_h5ad(
+    path: Path,
+    index_name: str | None = "cellID",
+    extra_n_id: str | None = None,
+    categorical_sample: bool = True,
+) -> Path:
+    """Write a small HCA-layout file with the two-family ID shape.
+
+    ``extra_n_id`` appends one more unselected cell, letting a test plant a
+    pre-existing ID that a rename would collide with.
+    """
+    ids = []
+    samples = []
+    for i, cell_id in enumerate(COLLAPSED_IDS):
+        ids.append(cell_id)
+        samples.append("B1_0023")
+        ids.append(N_IDS[i])
+        samples.append("N_0123")
+    ids.append(N_IDS[3])
+    samples.append("N_0123")
+    if extra_n_id is not None:
+        ids.append(extra_n_id)
+        samples.append("N_0123")
+
+    n_obs = len(ids)
+    rng = np.random.default_rng(7)
+    obs = pd.DataFrame(
+        {
+            "sample_id": pd.Categorical(samples) if categorical_sample else samples,
+            "n_counts": rng.integers(100, 500, n_obs).astype(np.float32),
+        },
+        index=pd.Index(ids, name=index_name),
+    )
+    var = pd.DataFrame(index=pd.Index([f"ENSG{i:011d}" for i in range(5)]))
+    adata = ad.AnnData(X=rng.standard_normal((n_obs, 5)).astype(np.float32), obs=obs, var=var)
+    adata.obsm["X_umap"] = rng.standard_normal((n_obs, 2)).astype(np.float32)
+    adata.uns["title"] = "Test HCA file"  # no schema_version: HCA layout
+    adata.write_h5ad(path)
+    return path
+
+
+@pytest.fixture
+def hca_path(tmp_path) -> Path:
+    return make_hca_h5ad(tmp_path / "test.h5ad")
+
+
+def test_rename_happy_path(hca_path):
+    before = ad.read_h5ad(hca_path)
+
+    result = rename_cell_ids(
+        str(hca_path),
+        where={"sample_id": "B1_0023"},
+        prefix_from="MH_mix_",
+        prefix_to="MH_mix_BR1_",
+    )
+
+    assert "error" not in result
+    assert result["n_selected"] == len(COLLAPSED_IDS)
+    assert result["n_renamed"] == result["n_selected"]
+    assert result["examples"][0] == ["MH_mix_AAA", "MH_mix_BR1_AAA"]
+
+    after = ad.read_h5ad(result["output_path"])
+    # Selected rows renamed, everything else untouched, order preserved.
+    expected = [
+        "MH_mix_BR1_" + cell_id[len("MH_mix_") :] if sample == "B1_0023" else cell_id
+        for cell_id, sample in zip(before.obs_names, before.obs["sample_id"], strict=True)
+    ]
+    assert list(after.obs_names) == expected
+    # No rows moved: per-row data still aligns by position.
+    assert list(after.obs["sample_id"]) == list(before.obs["sample_id"])
+    np.testing.assert_array_equal(after.X, before.X)
+    np.testing.assert_array_equal(after.obsm["X_umap"], before.obsm["X_umap"])
+    # The original file was not modified.
+    assert list(ad.read_h5ad(hca_path).obs_names) == list(before.obs_names)
+
+
+def test_rename_preserves_index_attr_name(hca_path):
+    result = rename_cell_ids(
+        str(hca_path), where={"sample_id": "B1_0023"}, prefix_from="MH_mix_", prefix_to="MH_mix_BR1_"
+    )
+    with h5py.File(result["output_path"], "r") as f:
+        assert f["obs"].attrs["_index"] == "cellID"
+        assert "cellID" in f["obs"]
+
+
+def test_rename_writes_edit_log(hca_path):
+    result = rename_cell_ids(
+        str(hca_path), where={"sample_id": "B1_0023"}, prefix_from="MH_mix_", prefix_to="MH_mix_BR1_"
+    )
+    after = ad.read_h5ad(result["output_path"])
+    import json
+
+    log = json.loads(after.uns["provenance"]["edit_history"])
+    (entry,) = [e for e in log if e["operation"] == "rename_cell_ids"]
+    assert entry["details"]["where"] == {"sample_id": "B1_0023"}
+    assert entry["details"]["n_renamed"] == len(COLLAPSED_IDS)
+
+
+def test_rename_default_index_name(tmp_path):
+    """A file whose obs index uses anndata's default ``_index`` name works too."""
+    path = make_hca_h5ad(tmp_path / "test.h5ad", index_name=None)
+    result = rename_cell_ids(str(path), where={"sample_id": "B1_0023"}, prefix_from="MH_mix_", prefix_to="X_")
+    assert "error" not in result
+    assert result["n_renamed"] == len(COLLAPSED_IDS)
+
+
+def test_rename_non_categorical_selector(tmp_path):
+    """The selector column read must handle plain string datasets, not just
+    categoricals."""
+    path = make_hca_h5ad(tmp_path / "test.h5ad", categorical_sample=False)
+    result = rename_cell_ids(str(path), where={"sample_id": "B1_0023"}, prefix_from="MH_mix_", prefix_to="MH_mix_BR1_")
+    assert "error" not in result
+    assert result["n_selected"] == len(COLLAPSED_IDS)
+
+
+def test_rename_refuses_zero_matches(hca_path):
+    result = rename_cell_ids(str(hca_path), where={"sample_id": "nope"}, prefix_from="MH_mix_", prefix_to="X_")
+    assert "no rows match" in result["error"]
+
+
+def test_rename_refuses_missing_column(hca_path):
+    result = rename_cell_ids(str(hca_path), where={"donor": "B1_0023"}, prefix_from="MH_mix_", prefix_to="X_")
+    assert "not present" in result["error"]
+
+
+def test_rename_refuses_index_as_selector(hca_path):
+    result = rename_cell_ids(str(hca_path), where={"cellID": "MH_mix_AAA"}, prefix_from="MH_mix_", prefix_to="X_")
+    assert "obs index" in result["error"]
+
+
+def test_rename_refuses_prefix_disagreement(hca_path):
+    """Selected rows that don't carry prefix_from mean the two witnesses —
+    selector and substitution — disagree; nothing may be written."""
+    result = rename_cell_ids(str(hca_path), where={"sample_id": "N_0123"}, prefix_from="MH_mix_", prefix_to="X_")
+    assert "do not start with" in result["error"]
+    assert "2 of 4" in result["error"]  # the two N1105_epi_* cells
+
+
+def test_rename_refuses_collision(tmp_path):
+    """A rename that would produce a duplicate ID is refused and the file left
+    untouched — introducing collisions is the defect the tool exists to fix."""
+    path = make_hca_h5ad(tmp_path / "test.h5ad", extra_n_id="MH_mix_BR1_AAA")
+    before = list(ad.read_h5ad(path).obs_names)
+
+    result = rename_cell_ids(str(path), where={"sample_id": "B1_0023"}, prefix_from="MH_mix_", prefix_to="MH_mix_BR1_")
+
+    assert "duplicate cell IDs" in result["error"]
+    assert "MH_mix_BR1_AAA" in result["error"]
+    assert list(ad.read_h5ad(path).obs_names) == before
+
+
+def test_rename_refuses_cellxgene_layout(tmp_path):
+    """CellxGENE-layout files (e.g. CAP exports) are refused outright: the
+    export's source system is the record of truth, and a local rename forks it."""
+    path = create_sample_h5ad(tmp_path / "cxg.h5ad")  # sets uns['schema_version']
+    result = rename_cell_ids(str(path), where={"tissue": "brain"}, prefix_from="cell_", prefix_to="c_")
+    assert "CellxGENE" in result["error"]
+
+
+def test_rename_missing_file():
+    result = rename_cell_ids("/nonexistent/file.h5ad", where={"a": "b"}, prefix_from="x_", prefix_to="y_")
+    assert "File not found" in result["error"]
+
+
+@pytest.mark.parametrize(
+    ("where", "prefix_from", "prefix_to", "expected"),
+    [
+        ("B1_0023", "MH_mix_", "X_", "exactly one"),  # not a dict
+        ({}, "MH_mix_", "X_", "exactly one"),
+        ({"a": "b", "c": "d"}, "MH_mix_", "X_", "exactly one"),
+        ({"sample_id": 7}, "MH_mix_", "X_", "string value"),
+        ({"obs/sample_id": "B1_0023"}, "MH_mix_", "X_", "cannot contain '/'"),
+        ({"sample_id": "B1_0023"}, "", "X_", "non-empty"),
+        ({"sample_id": "B1_0023"}, "MH_mix_", "MH_mix_", "identical"),
+        ({"sample_id": "B1_0023"}, "MH_mix_", 3, "must be a string"),
+    ],
+)
+def test_rename_refuses_malformed_arguments(hca_path, where, prefix_from, prefix_to, expected):
+    """Argument shape is checked before any file is opened, and every problem
+    is reported — MCP callers arrive as decoded JSON with no type checking."""
+    result = rename_cell_ids(str(hca_path), where=where, prefix_from=prefix_from, prefix_to=prefix_to)
+    assert expected in result["error"]
+    # Nothing was written: no timestamped sibling appeared.
+    assert list(hca_path.parent.glob("*.h5ad")) == [hca_path]

--- a/packages/hca-anndata-tools/tests/test_rename.py
+++ b/packages/hca-anndata-tools/tests/test_rename.py
@@ -104,54 +104,6 @@ def test_rename_non_categorical_selector(tmp_path):
     assert result["n_selected"] == len(B1_IDS)
 
 
-def test_rename_nullable_string_categorical_selector(tmp_path):
-    """A pandas StringDtype column lands on disk as a categorical whose
-    category labels are a nullable values+mask group — it must still select,
-    with null labels never matching."""
-    import pandas as pd
-
-    path = create_hca_h5ad(tmp_path / "test.h5ad")
-    adata = ad.read_h5ad(path)
-    samples = list(adata.obs["sample_id"].astype(str))
-    samples[-1] = pd.NA  # a null row, to prove the mask is honored
-    adata.obs["sample_verbatim"] = pd.array(samples, dtype="string")
-    old_setting = ad.settings.allow_write_nullable_strings
-    ad.settings.allow_write_nullable_strings = True
-    try:
-        adata.write_h5ad(path)
-    finally:
-        ad.settings.allow_write_nullable_strings = old_setting
-
-    result = rename_cell_ids(
-        str(path), column="sample_verbatim", value="B1_0023", prefix_from="MH_mix_", prefix_to="MH_mix_BR1_"
-    )
-
-    assert "error" not in result
-    assert result["n_renamed"] == len(B1_IDS)
-
-
-def test_rename_nullable_string_array_selector(tmp_path):
-    """A bare nullable-string-array column (values+mask group, no categories —
-    the direct write_elem form) selects on its values with nulls masked out."""
-    path = create_hca_h5ad(tmp_path / "test.h5ad")
-    with h5py.File(path, "a") as f:
-        rows = [sample for _, sample in HCA_TEST_ROWS]
-        group = f["obs"].create_group("sample_verbatim")
-        group.attrs["encoding-type"] = "nullable-string-array"
-        group.attrs["encoding-version"] = "0.1.0"
-        group.create_dataset("values", data=np.array(rows, dtype=object), dtype=h5py.string_dtype())
-        mask = np.zeros(len(rows), dtype=bool)
-        mask[-1] = True  # null out one N row; must not affect the B1 selection
-        group.create_dataset("mask", data=mask)
-
-    result = rename_cell_ids(
-        str(path), column="sample_verbatim", value="B1_0023", prefix_from="MH_mix_", prefix_to="MH_mix_BR1_"
-    )
-
-    assert "error" not in result
-    assert result["n_renamed"] == len(B1_IDS)
-
-
 def test_rename_refuses_zero_matches(hca_path):
     result = rename_cell_ids(str(hca_path), column="sample_id", value="nope", prefix_from="MH_mix_", prefix_to="X_")
     assert "no rows match" in result["error"]

--- a/packages/hca-anndata-tools/tests/test_rename.py
+++ b/packages/hca-anndata-tools/tests/test_rename.py
@@ -152,6 +152,106 @@ def test_rename_refuses_cellxgene_layout(sample_h5ad):
     assert "CellxGENE" in result["error"]
 
 
+def test_rename_updates_obsm_dataframe_index(tmp_path):
+    """A DataFrame in obsm carries a duplicate copy of the cell IDs; renaming
+    only the obs index would leave a file anndata refuses to read."""
+    path = create_hca_h5ad(tmp_path / "test.h5ad", obsm_dataframe=True)
+
+    result = rename_cell_ids(
+        str(path), column="sample_id", value="B1_0023", prefix_from="MH_mix_", prefix_to="MH_mix_BR1_"
+    )
+
+    assert "error" not in result
+    after = ad.read_h5ad(result["output_path"])  # raises if the copies diverged
+    assert list(after.obsm["per_cell_scores"].index) == list(after.obs_names)
+    assert "MH_mix_BR1_AAA" in after.obsm["per_cell_scores"].index
+
+
+def test_rename_refuses_mismatched_obsm_dataframe_index(tmp_path):
+    """An obsm DataFrame index that already disagrees with the obs index marks
+    a broken file — refuse rather than paper over it."""
+    path = create_hca_h5ad(tmp_path / "test.h5ad", obsm_dataframe=True)
+    with h5py.File(path, "a") as f:
+        sub = f["obsm"]["per_cell_scores"]
+        index_name = sub.attrs["_index"]
+        broken = sub[index_name].asstr()[:]
+        broken[0] = "someone_else_entirely"
+        del sub[index_name]
+        f["obsm"]["per_cell_scores"].create_dataset(index_name, data=broken.astype(object))
+
+    result = rename_cell_ids(
+        str(path), column="sample_id", value="B1_0023", prefix_from="MH_mix_", prefix_to="MH_mix_BR1_"
+    )
+
+    assert "internally inconsistent" in result["error"]
+    assert_no_snapshot_written(path)
+
+
+def test_rename_same_second_snapshot_refused(tmp_path, monkeypatch):
+    """generate_output_path timestamps to the second; when a second edit would
+    name the output after its own source, refuse — the failure path used to
+    unlink the source snapshot (SameFileError -> except -> unlink)."""
+    path = create_hca_h5ad(tmp_path / "test.h5ad")
+    first = rename_cell_ids(
+        str(path), column="sample_id", value="B1_0023", prefix_from="MH_mix_", prefix_to="MH_mix_BR1_"
+    )
+    snapshot = Path(first["output_path"])
+
+    monkeypatch.setattr("hca_anndata_tools.rename.generate_output_path", lambda p: p)
+    result = rename_cell_ids(
+        str(snapshot), column="sample_id", value="B1_0023", prefix_from="MH_mix_BR1_", prefix_to="Z_"
+    )
+
+    assert "already exists" in result["error"]
+    assert snapshot.is_file()  # the source snapshot survived
+
+
+def test_rename_refuses_pre_existing_duplicates(tmp_path):
+    """Duplicates the file already had are named as such — the remedy (repair
+    the file) differs from the remedy for a collision the rename would cause."""
+    with pytest.warns(UserWarning, match="Observation names are not unique"):
+        path = create_hca_h5ad(tmp_path / "test.h5ad", extra_rows=[("N1105_epi_AAA", "N_0123")])
+
+    result = rename_cell_ids(
+        str(path), column="sample_id", value="B1_0023", prefix_from="MH_mix_", prefix_to="MH_mix_BR1_"
+    )
+
+    assert "before any rename" in result["error"]
+    assert "N1105_epi_AAA" in result["error"]
+    assert_no_snapshot_written(path)
+
+
+def test_rename_refuses_legacy_cap_layout(tmp_path):
+    """The deprecated top-level CAP layout marks a CAP export even when
+    uns['schema_version'] is absent — parity with drop.py / copy_cap.py (#552)."""
+    path = create_hca_h5ad(tmp_path / "legacy.h5ad")
+    adata = ad.read_h5ad(path)
+    adata.uns["cellannotation_schema_version"] = "1.0.0"
+    adata.write_h5ad(path)
+
+    result = rename_cell_ids(
+        str(path), column="sample_id", value="B1_0023", prefix_from="MH_mix_", prefix_to="MH_mix_BR1_"
+    )
+
+    assert "deprecated top-level CAP layout" in result["error"]
+    assert_no_snapshot_written(path)
+
+
+def test_rename_nullable_dtype_selector_selects_nothing(tmp_path):
+    """A pandas nullable-dtype column (values+mask group, no categories) can
+    never equal a string value; it must refuse cleanly, not crash on .dtype."""
+    import pandas as pd
+
+    path = create_hca_h5ad(tmp_path / "nullable.h5ad")
+    adata = ad.read_h5ad(path)
+    adata.obs["qc_flag"] = pd.array([True, False] * (adata.n_obs // 2) + [True] * (adata.n_obs % 2), dtype="boolean")
+    adata.write_h5ad(path)
+
+    result = rename_cell_ids(str(path), column="qc_flag", value="True", prefix_from="MH_mix_", prefix_to="X_")
+
+    assert "no rows match" in result["error"]
+
+
 def test_rename_missing_file():
     result = rename_cell_ids("/nonexistent/file.h5ad", column="a", value="b", prefix_from="x_", prefix_to="y_")
     assert "File not found" in result["error"]

--- a/packages/hca-anndata-tools/tests/test_rename.py
+++ b/packages/hca-anndata-tools/tests/test_rename.py
@@ -221,6 +221,23 @@ def test_rename_refuses_pre_existing_duplicates(tmp_path):
     assert_no_snapshot_written(path)
 
 
+def test_rename_refuses_pre_existing_duplicates_the_rename_would_resolve(tmp_path):
+    """The pre-existing gate fires even when the rename would make the index
+    unique — resolving a collision by renaming one side of it is a curation
+    decision, not a side effect this tool may write."""
+    with pytest.warns(UserWarning, match="Observation names are not unique"):
+        # Duplicate of a selected B1 ID: renaming the B1 copy would de-collide.
+        path = create_hca_h5ad(tmp_path / "test.h5ad", extra_rows=[("MH_mix_AAA", "N_0123")])
+
+    result = rename_cell_ids(
+        str(path), column="sample_id", value="B1_0023", prefix_from="MH_mix_", prefix_to="MH_mix_BR1_"
+    )
+
+    assert "before any rename" in result["error"]
+    assert "MH_mix_AAA" in result["error"]
+    assert_no_snapshot_written(path)
+
+
 def test_rename_refuses_legacy_cap_layout(tmp_path):
     """The deprecated top-level CAP layout marks a CAP export even when
     uns['schema_version'] is absent — parity with drop.py / copy_cap.py (#552)."""

--- a/packages/hca-anndata-tools/tests/test_rename.py
+++ b/packages/hca-anndata-tools/tests/test_rename.py
@@ -104,6 +104,54 @@ def test_rename_non_categorical_selector(tmp_path):
     assert result["n_selected"] == len(B1_IDS)
 
 
+def test_rename_nullable_string_categorical_selector(tmp_path):
+    """A pandas StringDtype column lands on disk as a categorical whose
+    category labels are a nullable values+mask group — it must still select,
+    with null labels never matching."""
+    import pandas as pd
+
+    path = create_hca_h5ad(tmp_path / "test.h5ad")
+    adata = ad.read_h5ad(path)
+    samples = list(adata.obs["sample_id"].astype(str))
+    samples[-1] = pd.NA  # a null row, to prove the mask is honored
+    adata.obs["sample_verbatim"] = pd.array(samples, dtype="string")
+    old_setting = ad.settings.allow_write_nullable_strings
+    ad.settings.allow_write_nullable_strings = True
+    try:
+        adata.write_h5ad(path)
+    finally:
+        ad.settings.allow_write_nullable_strings = old_setting
+
+    result = rename_cell_ids(
+        str(path), column="sample_verbatim", value="B1_0023", prefix_from="MH_mix_", prefix_to="MH_mix_BR1_"
+    )
+
+    assert "error" not in result
+    assert result["n_renamed"] == len(B1_IDS)
+
+
+def test_rename_nullable_string_array_selector(tmp_path):
+    """A bare nullable-string-array column (values+mask group, no categories —
+    the direct write_elem form) selects on its values with nulls masked out."""
+    path = create_hca_h5ad(tmp_path / "test.h5ad")
+    with h5py.File(path, "a") as f:
+        rows = [sample for _, sample in HCA_TEST_ROWS]
+        group = f["obs"].create_group("sample_verbatim")
+        group.attrs["encoding-type"] = "nullable-string-array"
+        group.attrs["encoding-version"] = "0.1.0"
+        group.create_dataset("values", data=np.array(rows, dtype=object), dtype=h5py.string_dtype())
+        mask = np.zeros(len(rows), dtype=bool)
+        mask[-1] = True  # null out one N row; must not affect the B1 selection
+        group.create_dataset("mask", data=mask)
+
+    result = rename_cell_ids(
+        str(path), column="sample_verbatim", value="B1_0023", prefix_from="MH_mix_", prefix_to="MH_mix_BR1_"
+    )
+
+    assert "error" not in result
+    assert result["n_renamed"] == len(B1_IDS)
+
+
 def test_rename_refuses_zero_matches(hca_path):
     result = rename_cell_ids(str(hca_path), column="sample_id", value="nope", prefix_from="MH_mix_", prefix_to="X_")
     assert "no rows match" in result["error"]

--- a/packages/hca-anndata-tools/tests/test_rename.py
+++ b/packages/hca-anndata-tools/tests/test_rename.py
@@ -1,75 +1,35 @@
 """Tests for rename_cell_ids.
 
-The fixture mirrors the defect the tool was built for (#533): two ID
-families that share a prefix because one family lost its distinguishing
-segment, with the surviving distinction held only in an obs column. The
-index is deliberately named ``cellID`` — the breast integrated object's
-name — so the default-``_index`` assumption can't creep back in; one test
-covers the default name.
+The fixture (``create_hca_h5ad`` / ``HCA_TEST_ROWS`` in ``testing.py``)
+mirrors the defect the tool was built for (#533): two ID families that share
+a prefix because one family lost its distinguishing segment, with the
+surviving distinction held only in an obs column. The index is deliberately
+named ``cellID`` — the breast integrated object's name — so the
+default-``_index`` assumption can't creep back in; one test covers the
+default name.
 """
 
+import json
 from pathlib import Path
 
 import anndata as ad
 import h5py
 import numpy as np
-import pandas as pd
 import pytest
 
 from hca_anndata_tools import rename_cell_ids
-from hca_anndata_tools.testing import create_sample_h5ad
+from hca_anndata_tools.testing import HCA_TEST_ROWS, create_hca_h5ad
 
-# The collapsed family: B1 cells wearing the N family's prefix. Interleaved
-# with the N cells so a correct rename must select by column value, not by
-# position.
-COLLAPSED_IDS = ["MH_mix_AAA", "MH_mix_CCC", "MH_mix_GGG"]
-N_IDS = ["MH_mix_TTT", "MH_mix_ACG", "N1105_epi_AAA", "N1105_epi_CCC"]
-
-
-def make_hca_h5ad(
-    path: Path,
-    index_name: str | None = "cellID",
-    extra_n_id: str | None = None,
-    categorical_sample: bool = True,
-) -> Path:
-    """Write a small HCA-layout file with the two-family ID shape.
-
-    ``extra_n_id`` appends one more unselected cell, letting a test plant a
-    pre-existing ID that a rename would collide with.
-    """
-    ids = []
-    samples = []
-    for i, cell_id in enumerate(COLLAPSED_IDS):
-        ids.append(cell_id)
-        samples.append("B1_0023")
-        ids.append(N_IDS[i])
-        samples.append("N_0123")
-    ids.append(N_IDS[3])
-    samples.append("N_0123")
-    if extra_n_id is not None:
-        ids.append(extra_n_id)
-        samples.append("N_0123")
-
-    n_obs = len(ids)
-    rng = np.random.default_rng(7)
-    obs = pd.DataFrame(
-        {
-            "sample_id": pd.Categorical(samples) if categorical_sample else samples,
-            "n_counts": rng.integers(100, 500, n_obs).astype(np.float32),
-        },
-        index=pd.Index(ids, name=index_name),
-    )
-    var = pd.DataFrame(index=pd.Index([f"ENSG{i:011d}" for i in range(5)]))
-    adata = ad.AnnData(X=rng.standard_normal((n_obs, 5)).astype(np.float32), obs=obs, var=var)
-    adata.obsm["X_umap"] = rng.standard_normal((n_obs, 2)).astype(np.float32)
-    adata.uns["title"] = "Test HCA file"  # no schema_version: HCA layout
-    adata.write_h5ad(path)
-    return path
+B1_IDS = [cell_id for cell_id, sample in HCA_TEST_ROWS if sample == "B1_0023"]
 
 
 @pytest.fixture
 def hca_path(tmp_path) -> Path:
-    return make_hca_h5ad(tmp_path / "test.h5ad")
+    return create_hca_h5ad(tmp_path / "test.h5ad")
+
+
+def assert_no_snapshot_written(path: Path) -> None:
+    assert not list(path.parent.glob("*-edit-*.h5ad"))
 
 
 def test_rename_happy_path(hca_path):
@@ -77,13 +37,14 @@ def test_rename_happy_path(hca_path):
 
     result = rename_cell_ids(
         str(hca_path),
-        where={"sample_id": "B1_0023"},
+        column="sample_id",
+        value="B1_0023",
         prefix_from="MH_mix_",
         prefix_to="MH_mix_BR1_",
     )
 
     assert "error" not in result
-    assert result["n_selected"] == len(COLLAPSED_IDS)
+    assert result["n_selected"] == len(B1_IDS)
     assert result["n_renamed"] == result["n_selected"]
     assert result["examples"][0] == ["MH_mix_AAA", "MH_mix_BR1_AAA"]
 
@@ -91,7 +52,7 @@ def test_rename_happy_path(hca_path):
     # Selected rows renamed, everything else untouched, order preserved.
     expected = [
         "MH_mix_BR1_" + cell_id[len("MH_mix_") :] if sample == "B1_0023" else cell_id
-        for cell_id, sample in zip(before.obs_names, before.obs["sample_id"], strict=True)
+        for cell_id, sample in HCA_TEST_ROWS
     ]
     assert list(after.obs_names) == expected
     # No rows moved: per-row data still aligns by position.
@@ -104,7 +65,7 @@ def test_rename_happy_path(hca_path):
 
 def test_rename_preserves_index_attr_name(hca_path):
     result = rename_cell_ids(
-        str(hca_path), where={"sample_id": "B1_0023"}, prefix_from="MH_mix_", prefix_to="MH_mix_BR1_"
+        str(hca_path), column="sample_id", value="B1_0023", prefix_from="MH_mix_", prefix_to="MH_mix_BR1_"
     )
     with h5py.File(result["output_path"], "r") as f:
         assert f["obs"].attrs["_index"] == "cellID"
@@ -113,100 +74,104 @@ def test_rename_preserves_index_attr_name(hca_path):
 
 def test_rename_writes_edit_log(hca_path):
     result = rename_cell_ids(
-        str(hca_path), where={"sample_id": "B1_0023"}, prefix_from="MH_mix_", prefix_to="MH_mix_BR1_"
+        str(hca_path), column="sample_id", value="B1_0023", prefix_from="MH_mix_", prefix_to="MH_mix_BR1_"
     )
     after = ad.read_h5ad(result["output_path"])
-    import json
 
     log = json.loads(after.uns["provenance"]["edit_history"])
     (entry,) = [e for e in log if e["operation"] == "rename_cell_ids"]
-    assert entry["details"]["where"] == {"sample_id": "B1_0023"}
-    assert entry["details"]["n_renamed"] == len(COLLAPSED_IDS)
+    assert entry["details"]["column"] == "sample_id"
+    assert entry["details"]["value"] == "B1_0023"
+    assert entry["details"]["n_renamed"] == len(B1_IDS)
 
 
 def test_rename_default_index_name(tmp_path):
     """A file whose obs index uses anndata's default ``_index`` name works too."""
-    path = make_hca_h5ad(tmp_path / "test.h5ad", index_name=None)
-    result = rename_cell_ids(str(path), where={"sample_id": "B1_0023"}, prefix_from="MH_mix_", prefix_to="X_")
+    path = create_hca_h5ad(tmp_path / "test.h5ad", index_name=None)
+    result = rename_cell_ids(str(path), column="sample_id", value="B1_0023", prefix_from="MH_mix_", prefix_to="X_")
     assert "error" not in result
-    assert result["n_renamed"] == len(COLLAPSED_IDS)
+    assert result["n_renamed"] == len(B1_IDS)
 
 
 def test_rename_non_categorical_selector(tmp_path):
     """The selector column read must handle plain string datasets, not just
     categoricals."""
-    path = make_hca_h5ad(tmp_path / "test.h5ad", categorical_sample=False)
-    result = rename_cell_ids(str(path), where={"sample_id": "B1_0023"}, prefix_from="MH_mix_", prefix_to="MH_mix_BR1_")
+    path = create_hca_h5ad(tmp_path / "test.h5ad", categorical_sample=False)
+    result = rename_cell_ids(
+        str(path), column="sample_id", value="B1_0023", prefix_from="MH_mix_", prefix_to="MH_mix_BR1_"
+    )
     assert "error" not in result
-    assert result["n_selected"] == len(COLLAPSED_IDS)
+    assert result["n_selected"] == len(B1_IDS)
 
 
 def test_rename_refuses_zero_matches(hca_path):
-    result = rename_cell_ids(str(hca_path), where={"sample_id": "nope"}, prefix_from="MH_mix_", prefix_to="X_")
+    result = rename_cell_ids(str(hca_path), column="sample_id", value="nope", prefix_from="MH_mix_", prefix_to="X_")
     assert "no rows match" in result["error"]
 
 
 def test_rename_refuses_missing_column(hca_path):
-    result = rename_cell_ids(str(hca_path), where={"donor": "B1_0023"}, prefix_from="MH_mix_", prefix_to="X_")
+    result = rename_cell_ids(str(hca_path), column="donor", value="B1_0023", prefix_from="MH_mix_", prefix_to="X_")
     assert "not present" in result["error"]
 
 
 def test_rename_refuses_index_as_selector(hca_path):
-    result = rename_cell_ids(str(hca_path), where={"cellID": "MH_mix_AAA"}, prefix_from="MH_mix_", prefix_to="X_")
+    result = rename_cell_ids(str(hca_path), column="cellID", value="MH_mix_AAA", prefix_from="MH_mix_", prefix_to="X_")
     assert "obs index" in result["error"]
 
 
 def test_rename_refuses_prefix_disagreement(hca_path):
     """Selected rows that don't carry prefix_from mean the two witnesses —
     selector and substitution — disagree; nothing may be written."""
-    result = rename_cell_ids(str(hca_path), where={"sample_id": "N_0123"}, prefix_from="MH_mix_", prefix_to="X_")
+    result = rename_cell_ids(str(hca_path), column="sample_id", value="N_0123", prefix_from="MH_mix_", prefix_to="X_")
     assert "do not start with" in result["error"]
     assert "2 of 4" in result["error"]  # the two N1105_epi_* cells
+    assert_no_snapshot_written(hca_path)
 
 
 def test_rename_refuses_collision(tmp_path):
     """A rename that would produce a duplicate ID is refused and the file left
     untouched — introducing collisions is the defect the tool exists to fix."""
-    path = make_hca_h5ad(tmp_path / "test.h5ad", extra_n_id="MH_mix_BR1_AAA")
+    path = create_hca_h5ad(tmp_path / "test.h5ad", extra_rows=[("MH_mix_BR1_AAA", "N_0123")])
     before = list(ad.read_h5ad(path).obs_names)
 
-    result = rename_cell_ids(str(path), where={"sample_id": "B1_0023"}, prefix_from="MH_mix_", prefix_to="MH_mix_BR1_")
+    result = rename_cell_ids(
+        str(path), column="sample_id", value="B1_0023", prefix_from="MH_mix_", prefix_to="MH_mix_BR1_"
+    )
 
     assert "duplicate cell IDs" in result["error"]
     assert "MH_mix_BR1_AAA" in result["error"]
     assert list(ad.read_h5ad(path).obs_names) == before
+    assert_no_snapshot_written(path)
 
 
-def test_rename_refuses_cellxgene_layout(tmp_path):
+def test_rename_refuses_cellxgene_layout(sample_h5ad):
     """CellxGENE-layout files (e.g. CAP exports) are refused outright: the
-    export's source system is the record of truth, and a local rename forks it."""
-    path = create_sample_h5ad(tmp_path / "cxg.h5ad")  # sets uns['schema_version']
-    result = rename_cell_ids(str(path), where={"tissue": "brain"}, prefix_from="cell_", prefix_to="c_")
+    export's source system is the record of truth, and a local rename forks
+    it. Read-only, so the session-scoped fixture is safe to share."""
+    result = rename_cell_ids(str(sample_h5ad), column="tissue", value="brain", prefix_from="cell_", prefix_to="c_")
     assert "CellxGENE" in result["error"]
 
 
 def test_rename_missing_file():
-    result = rename_cell_ids("/nonexistent/file.h5ad", where={"a": "b"}, prefix_from="x_", prefix_to="y_")
+    result = rename_cell_ids("/nonexistent/file.h5ad", column="a", value="b", prefix_from="x_", prefix_to="y_")
     assert "File not found" in result["error"]
 
 
 @pytest.mark.parametrize(
-    ("where", "prefix_from", "prefix_to", "expected"),
+    ("column", "value", "prefix_from", "prefix_to", "expected"),
     [
-        ("B1_0023", "MH_mix_", "X_", "exactly one"),  # not a dict
-        ({}, "MH_mix_", "X_", "exactly one"),
-        ({"a": "b", "c": "d"}, "MH_mix_", "X_", "exactly one"),
-        ({"sample_id": 7}, "MH_mix_", "X_", "string value"),
-        ({"obs/sample_id": "B1_0023"}, "MH_mix_", "X_", "cannot contain '/'"),
-        ({"sample_id": "B1_0023"}, "", "X_", "non-empty"),
-        ({"sample_id": "B1_0023"}, "MH_mix_", "MH_mix_", "identical"),
-        ({"sample_id": "B1_0023"}, "MH_mix_", 3, "must be a string"),
+        (7, "B1_0023", "MH_mix_", "X_", "must be strings"),
+        ("sample_id", None, "MH_mix_", "X_", "must be strings"),
+        ("obs/sample_id", "B1_0023", "MH_mix_", "X_", "cannot contain '/'"),
+        ("  ", "B1_0023", "MH_mix_", "X_", "be blank"),
+        ("sample_id", "B1_0023", "", "X_", "non-empty"),
+        ("sample_id", "B1_0023", "MH_mix_", "MH_mix_", "identical"),
+        ("sample_id", "B1_0023", "MH_mix_", 3, "must be a string"),
     ],
 )
-def test_rename_refuses_malformed_arguments(hca_path, where, prefix_from, prefix_to, expected):
+def test_rename_refuses_malformed_arguments(hca_path, column, value, prefix_from, prefix_to, expected):
     """Argument shape is checked before any file is opened, and every problem
     is reported — MCP callers arrive as decoded JSON with no type checking."""
-    result = rename_cell_ids(str(hca_path), where=where, prefix_from=prefix_from, prefix_to=prefix_to)
+    result = rename_cell_ids(str(hca_path), column=column, value=value, prefix_from=prefix_from, prefix_to=prefix_to)
     assert expected in result["error"]
-    # Nothing was written: no timestamped sibling appeared.
-    assert list(hca_path.parent.glob("*.h5ad")) == [hca_path]
+    assert_no_snapshot_written(hca_path)


### PR DESCRIPTION
Closes #533

## What changed

New tool `rename_cell_ids(path, column, value, prefix_from, prefix_to)` in `hca-anndata-tools`, exposed through `hca-anndata-mcp`: selects rows by an obs column value and substitutes one ID prefix for another in the obs index — the remedy for the breast-v1 pal2021 collapse, where 5,019 cells lost their `BR1_` segment.

All-or-nothing gates, everything checked before anything is written:
- **HCA-layout only** — refuses CellxGENE `schema_version` files *and* the deprecated top-level CAP layout (a CAP export must round-trip through CAP, #596).
- **Zero selector matches** is an error, not a no-op.
- **Selector/prefix agreement** — every selected ID must start with `prefix_from`.
- **Uniqueness hard gate** on the entire resulting index, with pre-existing duplicates named as such (repair the file) vs. rename-introduced collisions (change the arguments).
- **obsm DataFrame indexes** — anndata stores a duplicate copy of the cell IDs inside each obsm DataFrame; they are verified against the obs index (mismatch refuses the file as broken) and rewritten in the same pass.

Writes the standard timestamped snapshot + edit-log entry; refuses a second edit in the same wall-clock second rather than letting the failure path unlink the source snapshot. Index name read from `obs.attrs['_index']` (the breast file names it `cellID`). Also adds `create_hca_h5ad`/`HCA_TEST_ROWS` to `testing.py` — the first HCA-layout test factory (both existing ones declare a CellxGENE `schema_version`).

## Why

Phase 2 of epic #535: the integrated object needs 5,019 cell IDs renamed (`MH0023_mix_` → `MH0023_mix_BR1_` where `sample_id == "Pal_B1_0023"`), and no tool could rewrite an obs index. Per the design note on #533, the tool stays prefix-specific — the safety comes from two independent witnesses (selector + prefix check) that a general mapping/regex form would collapse to one — with the compute-new-IDs step kept separable so a future mode inherits every gate.

## Assumptions I made

- **Named `rename_cell_ids`, not the issue's `rename_obs_index`** — MCP tools speak the domain, and the obs index *is* the cell IDs. The `where={column: value}` dict from the issue's sketch was flattened to plain `column`/`value` parameters (no sibling takes a dict selector; semantics identical).
- **Snapshot-copy write mode** (Dave's call): a full ~21 GB copy per run on the real file, keeping the audit convention every other mutating tool follows, over an unproven in-place HDF5 vlen-string patch.
- **Tool only** (Dave's call): the breast integrated object is *not* renamed in this PR — running the rename is a deliberate curation act, sequenced against the CAP round-trip (#596), because a renamed file no longer joins against the stale CAP export (`copy_cap_annotations` would NaN-blank those 5,019 cells).
- **The uniqueness gate stays hard on pre-existing duplicates** (Dave's call): a file whose IDs already collide gets refused with a repair message; the multi-family-collapse repair scenario is deferred until a real case needs it.
- `n_renamed` always equals `n_selected` for the prefix operation; both are reported because the issue asks for broader-selector visibility.
- Review follow-ups filed rather than scope-crept here: #597 (extract shared h5py-patch helpers; also covers the strip.py layout-predicate divergence), #598 (same-second snapshot destruction in drop/strip — rename's own instance is fixed in this PR).

## How to verify

Issue #533's definition of done, mapped to steps:

**1. The tool exists with the specced gates (uniqueness, prefix agreement, zero matches, n_selected reporting, examples preview, index-rename-only, `_index`-attr-aware, HCA-only):**
```bash
cd packages/hca-anndata-tools && uv run pytest tests/test_rename.py -v
cd ../hca-anndata-mcp && uv run pytest tests/test_rename.py -v
```
27 tests cover the happy path (including positional-data invariants and the `cellID` index name), every refusal, and malformed MCP-style arguments.

**2. It renames exactly 5,019 IDs with zero collisions on the real file** — dry-verifiable without writing 21 GB: the gates replicate the measurements already confirmed on `all-breast-cells-r1-wip-4-edit-2026-07-09-02-42-58.h5ad` (5,019 `sample_id == "Pal_B1_0023"` rows, all prefixed `MH0023_mix_`, 0 post-rename collisions, obsm is ndarrays only). To execute for real (deliberate curation act, see Assumptions):
```python
from hca_anndata_tools import rename_cell_ids
rename_cell_ids("<breast file>", column="sample_id", value="Pal_B1_0023",
                prefix_from="MH0023_mix_", prefix_to="MH0023_mix_BR1_")
# expect n_selected == n_renamed == 5019, examples showing MH0023_mix_ → MH0023_mix_BR1_
```

**3. It refuses the CAP export:** call it on `Integrated Human Breast Cell Atlas v1.0 - all cells.h5ad` — expect the CellxGENE-layout refusal citing #533/#596.

**4. Nothing regressed:** `make typecheck` (0 errors ×4) and both package suites (367 + 47) pass; the tools suite is warning-free under `-W error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)