### PR TITLE
feat(hca-anndata-tools): add backfill_obs_from_source to recover metadata lost in integration

### DIFF
--- a/packages/hca-anndata-mcp/src/hca_anndata_mcp/server.py
+++ b/packages/hca-anndata-mcp/src/hca_anndata_mcp/server.py
@@ -2,6 +2,7 @@
 
 from fastmcp import FastMCP
 
+from hca_anndata_mcp.tools.backfill import backfill_obs_from_source
 from hca_anndata_mcp.tools.drop import drop_obs_columns
 from hca_anndata_mcp.tools.label import label_h5ad
 from hca_anndata_mcp.tools.plot import plot_embedding_mcp
@@ -60,6 +61,14 @@ mcp = FastMCP(
         "IDs not carrying the expected prefix, and on any rename that would produce "
         "duplicate IDs, and note it renames only this file: a renamed file no longer "
         "joins against unrenamed copies elsewhere (e.g. copy_cap_annotations sources), "
+        "backfill_obs_from_source to copy obs values from a source h5ad into a target joined "
+        "on cell ID, filling only cells whose target value is missing (NaN, empty, or a "
+        "placeholder like 'unknown') — the remedy for metadata lost in integration; it never "
+        "overwrites a set value (disagreements are counted and reported as conflicts, not "
+        "written), silently skips source cells absent from the target (integration filters "
+        "cells), reports per-column filled counts and how full each column is afterward, and "
+        "writes nothing when there is nothing to fill; run it once per source dataset, and "
+        "run any rename_cell_ids repair first — it joins by cell identity and trusts the join, "
         "validate_marker_genes to check CAP marker genes against var, "
         "copy_cap_annotations to copy CAP annotations from a source into an HCA target file, "
         "replace_placeholder_values to replace banned placeholder values with NaN in obs columns, "
@@ -100,6 +109,7 @@ mcp.tool()(convert_cellxgene_to_hca)
 mcp.tool()(strip_forbidden_obs_columns)
 mcp.tool()(drop_obs_columns)
 mcp.tool()(rename_cell_ids)
+mcp.tool()(backfill_obs_from_source)
 mcp.tool()(validate_marker_genes)
 mcp.tool()(copy_cap_annotations)
 mcp.tool()(replace_placeholder_values)

--- a/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/backfill.py
+++ b/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/backfill.py
@@ -1,0 +1,12 @@
+"""MCP wrapper for hca_anndata_tools.backfill_obs_from_source.
+
+Thin re-export to keep parity with the other MCP tools (each gets its
+own wrapper file). The underlying function in hca-anndata-tools already
+returns a dict-shaped result; this module exists so future wrapper-only
+behavior (e.g. path normalization, MCP-side logging) lands here without
+touching the tools layer.
+"""
+
+from hca_anndata_tools import backfill_obs_from_source
+
+__all__ = ["backfill_obs_from_source"]

--- a/packages/hca-anndata-mcp/tests/test_backfill.py
+++ b/packages/hca-anndata-mcp/tests/test_backfill.py
@@ -1,0 +1,33 @@
+"""Unit tests for the backfill_obs_from_source MCP wrapper."""
+
+import anndata as ad
+import numpy as np
+import pandas as pd
+
+from hca_anndata_mcp.tools.backfill import backfill_obs_from_source
+
+
+def _write_h5ad(path, ids, lib_values):
+    obs = pd.DataFrame({"library_id": pd.Categorical(lib_values)}, index=pd.Index(ids, name="cellID"))
+    ad.AnnData(X=np.zeros((len(ids), 2), dtype=np.float32), obs=obs).write_h5ad(path)
+    return str(path)
+
+
+def test_backfill_missing_file():
+    result = backfill_obs_from_source("/nonexistent/t.h5ad", "/nonexistent/s.h5ad", columns=["library_id"])
+    assert "error" in result
+    assert "not found" in result["error"]
+
+
+def test_backfill_through_wrapper(tmp_path):
+    """Happy path through the wrapper: pins the wiring only — result keys and
+    one cheap observable. Backfill semantics are the tools layer's tests."""
+    target = _write_h5ad(tmp_path / "target.h5ad", ["c1", "c2"], ["unknown", "L2"])
+    source = _write_h5ad(tmp_path / "source.h5ad", ["c1", "c2"], ["L1", "L2"])
+
+    result = backfill_obs_from_source(target, source, columns=["library_id"])
+
+    assert "error" not in result
+    assert result["total_filled"] == 1
+    assert result["per_column"]["library_id"]["pct_full_after"] == 100.0
+    assert list(ad.read_h5ad(result["output_path"]).obs["library_id"]) == ["L1", "L2"]

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/__init__.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/__init__.py
@@ -3,6 +3,7 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from .backfill import backfill_obs_from_source
     from .cap import get_cap_annotations
     from .compress import compress_h5ad
     from .convert import convert_cellxgene_to_hca
@@ -64,6 +65,7 @@ _LAZY_IMPORTS = {
     "strip_forbidden_obs_columns": ".strip",
     "drop_obs_columns": ".drop",
     "rename_cell_ids": ".rename",
+    "backfill_obs_from_source": ".backfill",
     "check_x_normalization": ".inspect",
     "check_schema_type": ".inspect",
 }

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
@@ -19,8 +19,9 @@ if TYPE_CHECKING:
     import numpy as np
 
 # The HCA placeholder vocabulary (case-insensitive): obs values that mean
-# "no data". Shared by replace_placeholder_values (which blanks them) and
-# backfill_obs_from_source (which treats them as fillable).
+# "no data". replace_placeholder_values blanks exact (lowercased) matches of
+# these; backfill_obs_from_source additionally treats empty/whitespace values
+# as missing, via is_missing_value below.
 DEFAULT_PLACEHOLDERS = [
     "unknown",
     "na",
@@ -33,6 +34,13 @@ DEFAULT_PLACEHOLDERS = [
     "null",
     "undefined",
 ]
+
+
+def is_missing_value(value: str, placeholders: set[str]) -> bool:
+    """True if a string value means "no data": empty/whitespace or a
+    placeholder (compare against a pre-lowercased set)."""
+    s = value.strip()
+    return not s or s.lower() in placeholders
 
 
 @contextmanager
@@ -250,18 +258,30 @@ def transplant_obs_columns(
     return deleted
 
 
-def check_duplicate_ids(index: list[str], label: str) -> str | None:
-    """Return an error message if index has duplicates, else None."""
-    if len(set(index)) == len(index):
+def check_duplicate_ids(index, label: str) -> str | None:
+    """Return an error message if index has duplicates, else None.
+
+    Accepts anything pd.Index accepts (list, ndarray, or an existing Index,
+    which passes through without a copy); the check runs in pandas' C
+    hashtable rather than a per-element Python loop.
+    """
+    idx = pd.Index(index)
+    if not idx.has_duplicates:
         return None
-    seen, dupes = set(), []
-    for x in index:
-        if x in seen and x not in dupes:
-            dupes.append(x)
-            if len(dupes) >= 5:
-                break
-        seen.add(x)
+    dupes = idx[idx.duplicated()].unique()[:5].tolist()
     return f"{label} have duplicate IDs (first 5): {dupes}"
+
+
+def read_string_dataset(group: h5py.Group, name: str) -> np.ndarray:
+    """Read a string dataset as an object array of str.
+
+    asstr() decodes in C (vlen and fixed-width alike); dtype=object matters —
+    a fixed-width unicode dtype would silently clip longer values assigned
+    into the array later (see rename_cell_ids).
+    """
+    import numpy as np
+
+    return np.asarray(group[name].asstr()[:], dtype=object)
 
 
 def replace_string_dataset(parent: h5py.Group, name: str, data: np.ndarray) -> None:
@@ -275,7 +295,10 @@ def replace_string_dataset(parent: h5py.Group, name: str, data: np.ndarray) -> N
         "chunks": ds.chunks,
         "shuffle": ds.shuffle,
         "fletcher32": ds.fletcher32,
-        "maxshape": ds.maxshape,
+        # A contiguous dataset reports maxshape == shape; passing any
+        # non-None maxshape to create_dataset forces chunked layout, so
+        # only carry it when the dataset is actually resizable.
+        "maxshape": ds.maxshape if ds.maxshape != ds.shape else None,
     }
     del parent[name]
     new_ds = parent.create_dataset(name, data=data, dtype=h5py.string_dtype(encoding="utf-8"), **storage)
@@ -293,6 +316,13 @@ def compact_categories(categories: list[str], codes: np.ndarray) -> tuple[list[s
     import numpy as np
 
     valid = codes >= 0
+    # Range-check before bincount: one corrupt out-of-range code would
+    # otherwise size the bincount allocation to max(code)+1 entries.
+    if valid.any() and int(codes[valid].max()) >= len(categories):
+        raise ValueError(
+            f"categorical codes reference category {int(codes[valid].max())} "
+            f"but only {len(categories)} categories exist — the column is corrupt"
+        )
     used = np.flatnonzero(np.bincount(codes[valid], minlength=len(categories)))
     kept = [categories[i] for i in used]
     lookup = np.full(len(categories), -1, dtype=np.int64)

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
@@ -18,6 +18,22 @@ import pandas as pd
 if TYPE_CHECKING:
     import numpy as np
 
+# The HCA placeholder vocabulary (case-insensitive): obs values that mean
+# "no data". Shared by replace_placeholder_values (which blanks them) and
+# backfill_obs_from_source (which treats them as fillable).
+DEFAULT_PLACEHOLDERS = [
+    "unknown",
+    "na",
+    "n/a",
+    "none",
+    "not available",
+    "not applicable",
+    "tbd",
+    "todo",
+    "null",
+    "undefined",
+]
+
 
 @contextmanager
 def open_h5ad(path: str, backed: Literal["r", "r+"] | None = "r"):
@@ -267,12 +283,43 @@ def replace_string_dataset(parent: h5py.Group, name: str, data: np.ndarray) -> N
         new_ds.attrs[key] = attr_value
 
 
+def compact_categories(categories: list[str], codes: np.ndarray) -> tuple[list[str], np.ndarray]:
+    """Drop categories no code references and remap the codes accordingly.
+
+    Codes below 0 (NaN) stay -1. Returns the kept categories and the remapped
+    codes as int64 — :func:`replace_categorical_column` sizes the on-disk
+    dtype itself.
+    """
+    import numpy as np
+
+    valid = codes >= 0
+    used = np.flatnonzero(np.bincount(codes[valid], minlength=len(categories)))
+    kept = [categories[i] for i in used]
+    lookup = np.full(len(categories), -1, dtype=np.int64)
+    lookup[used] = np.arange(len(used))
+    new_codes = np.full(codes.shape, -1, dtype=np.int64)
+    new_codes[valid] = lookup[codes[valid]]
+    return kept, new_codes
+
+
+def _codes_dtype(n_categories: int, original: np.dtype) -> np.dtype:
+    """Smallest signed dtype holding the category count, never narrower than
+    the original codes dtype (extending categories can overflow int8)."""
+    import numpy as np
+
+    for dt in (np.int8, np.int16, np.int32, np.int64):
+        if np.iinfo(dt).max >= n_categories - 1 and np.dtype(dt).itemsize >= original.itemsize:
+            return np.dtype(dt)
+    return np.dtype(np.int64)
+
+
 def replace_categorical_column(parent: h5py.Group, col: str, categories: list[str], codes: np.ndarray) -> None:
     """Delete and recreate a categorical column group, preserving its encoding
     attrs and the codes dataset's storage settings (compression, chunks).
 
-    The codes array is written with the dtype it arrives in — the caller
-    decides whether the original dtype still fits the new category count.
+    The codes are written at the smallest dtype that holds the new category
+    count without narrowing the original — a caller that extended the
+    categories does not have to know about int8 overflow.
     """
     import numpy as np
 
@@ -283,6 +330,7 @@ def replace_categorical_column(parent: h5py.Group, col: str, categories: list[st
     codes_compression = item["codes"].compression
     codes_compression_opts = item["codes"].compression_opts
     codes_chunks = item["codes"].chunks
+    codes = codes.astype(_codes_dtype(len(categories), item["codes"].dtype))
 
     del parent[col]
     grp = parent.create_group(col)

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
@@ -234,6 +234,76 @@ def transplant_obs_columns(
     return deleted
 
 
+def check_duplicate_ids(index: list[str], label: str) -> str | None:
+    """Return an error message if index has duplicates, else None."""
+    if len(set(index)) == len(index):
+        return None
+    seen, dupes = set(), []
+    for x in index:
+        if x in seen and x not in dupes:
+            dupes.append(x)
+            if len(dupes) >= 5:
+                break
+        seen.add(x)
+    return f"{label} have duplicate IDs (first 5): {dupes}"
+
+
+def replace_string_dataset(parent: h5py.Group, name: str, data: np.ndarray) -> None:
+    """Delete and recreate a string dataset, preserving its attrs and storage
+    properties (compression, chunks, shuffle, fletcher32, maxshape)."""
+    ds = parent[name]
+    attrs = dict(ds.attrs)
+    storage = {
+        "compression": ds.compression,
+        "compression_opts": ds.compression_opts,
+        "chunks": ds.chunks,
+        "shuffle": ds.shuffle,
+        "fletcher32": ds.fletcher32,
+        "maxshape": ds.maxshape,
+    }
+    del parent[name]
+    new_ds = parent.create_dataset(name, data=data, dtype=h5py.string_dtype(encoding="utf-8"), **storage)
+    for key, attr_value in attrs.items():
+        new_ds.attrs[key] = attr_value
+
+
+def replace_categorical_column(parent: h5py.Group, col: str, categories: list[str], codes: np.ndarray) -> None:
+    """Delete and recreate a categorical column group, preserving its encoding
+    attrs and the codes dataset's storage settings (compression, chunks).
+
+    The codes array is written with the dtype it arrives in — the caller
+    decides whether the original dtype still fits the new category count.
+    """
+    import numpy as np
+
+    item = parent[col]
+    encoding_type = item.attrs["encoding-type"]
+    encoding_version = item.attrs["encoding-version"]
+    ordered = bool(item.attrs["ordered"])
+    codes_compression = item["codes"].compression
+    codes_compression_opts = item["codes"].compression_opts
+    codes_chunks = item["codes"].chunks
+
+    del parent[col]
+    grp = parent.create_group(col)
+    grp.attrs["encoding-type"] = encoding_type
+    grp.attrs["encoding-version"] = encoding_version
+    grp.attrs["ordered"] = ordered
+    cat_data = np.array(categories, dtype=object) if categories else np.array([], dtype=h5py.string_dtype())
+    cat_ds = grp.create_dataset("categories", data=cat_data)
+    cat_ds.attrs["encoding-type"] = "string-array"
+    cat_ds.attrs["encoding-version"] = "0.2.0"
+    codes_ds = grp.create_dataset(
+        "codes",
+        data=codes,
+        compression=codes_compression,
+        compression_opts=codes_compression_opts,
+        chunks=codes_chunks,
+    )
+    codes_ds.attrs["encoding-type"] = "array"
+    codes_ds.attrs["encoding-version"] = "0.2.0"
+
+
 def verify_categorical_integrity(
     f: h5py.File,
     columns: list[str],

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/backfill.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/backfill.py
@@ -18,7 +18,6 @@ repeated runs chain without accumulating file copies.
 from __future__ import annotations
 
 import contextlib
-import shutil
 from pathlib import Path
 
 import h5py
@@ -26,8 +25,9 @@ import numpy as np
 import pandas as pd
 
 from ._io import (
+    DEFAULT_PLACEHOLDERS,
     _decode_bytes,
-    check_duplicate_ids,
+    compact_categories,
     read_categorical_data,
     read_edit_log_h5py,
     replace_categorical_column,
@@ -36,9 +36,9 @@ from ._io import (
     write_edit_log_h5py,
 )
 from .cap import LEGACY_LAYOUT_DESCRIPTION, is_legacy_cap_layout
-from .edit import _DEFAULT_PLACEHOLDERS
 from .write import (
     _compute_sha256,
+    _copy_with_sha256,
     build_edit_log,
     cleanup_previous_version,
     generate_output_path,
@@ -46,8 +46,8 @@ from .write import (
     resolve_latest,
 )
 
-# Cap on the conflict examples quoted per column, so a large disagreement
-# stays readable in the result and the edit log.
+# Cap on the conflict examples quoted per column, and on the duplicate IDs
+# quoted in error messages, so a large disagreement stays readable.
 _N_EXAMPLES = 5
 
 
@@ -85,6 +85,10 @@ def _read_column(obs: h5py.Group, col: str, placeholders: set[str], side: str) -
     empty, or placeholder). Categorical columns also carry ``cats``/``codes``.
     Any other layout (numeric, boolean, nullable-dtype groups) has no missing
     vocabulary this tool understands, so it is refused rather than guessed at.
+
+    The missing predicate runs once per distinct value, never per row — the
+    categorical branch works on the categories, the string branch factorizes
+    first (a metadata column on a 2M-cell file has few distinct values).
     """
     item = obs[col]
     if isinstance(item, h5py.Group) and "categories" in item:
@@ -93,12 +97,9 @@ def _read_column(obs: h5py.Group, col: str, placeholders: set[str], side: str) -
         cat_missing = np.array([_is_missing_str(c, placeholders) for c in cats], dtype=bool)
         valid = codes >= 0
         values = np.full(len(codes), None, dtype=object)
+        values[valid] = cat_values[codes[valid]]
         missing = ~valid
-        if len(cats):
-            values[valid] = cat_values[codes[valid]]
-            hit = np.zeros(len(codes), dtype=bool)
-            hit[valid] = cat_missing[codes[valid]]
-            missing = missing | hit
+        missing[valid] = cat_missing[codes[valid]]
         return {"kind": "categorical", "cats": list(cats), "codes": codes, "values": values, "missing": missing}, None
     if isinstance(item, h5py.Group):
         return None, (
@@ -110,24 +111,30 @@ def _read_column(obs: h5py.Group, col: str, placeholders: set[str], side: str) -
             f"{side} column '{col}' is not categorical or string — only those obs column types can be backfilled"
         )
     values = np.asarray(item.asstr()[:], dtype=object)  # pyright: ignore[reportAttributeAccessIssue]
-    missing = np.fromiter((_is_missing_str(v, placeholders) for v in values), dtype=bool, count=len(values))
+    codes, uniques = pd.factorize(values)
+    uniq_missing = np.array([_is_missing_str(u, placeholders) for u in uniques], dtype=bool)
+    valid = codes >= 0
+    missing = ~valid
+    missing[valid] = uniq_missing[codes[valid]]
     return {"kind": "string", "values": values, "missing": missing}, None
 
 
 def _read_obs_for_backfill(
-    path: str, columns: list[str], placeholders: set[str], side: str
+    path: str, columns: list[str], placeholders: set[str], side: str, is_target: bool = False
 ) -> tuple[dict | None, dict | None]:
     """Read the obs index and the requested columns from one file.
 
-    Returns (data, error_result); exactly one is set. ``data`` holds ``ids``
-    (list of cell IDs), ``columns`` (column name → the dict from
-    :func:`_read_column`), and for the target side ``raw_log``.
+    Returns (data, error_result); exactly one is set. ``data`` holds ``index``
+    (a pandas Index of cell IDs) and ``columns`` (column name → the dict from
+    :func:`_read_column`). ``is_target`` marks the mutation candidate: it adds
+    the legacy-CAP-layout refusal and the edit-log read (``raw_log``); ``side``
+    is display text for messages only.
     """
     with h5py.File(path, "r") as f:
         obs = f.get("obs")
         if not isinstance(obs, h5py.Group):
             return None, {"error": f"{side} file has no obs group: {path}"}
-        if side == "Target":
+        if is_target:
             uns = f.get("uns")
             if isinstance(uns, h5py.Group) and is_legacy_cap_layout(uns):
                 # Parity with drop.py / rename.py (#552): mutating tools
@@ -146,31 +153,24 @@ def _read_obs_for_backfill(
                 }
             if col not in obs_keys:
                 return None, {"error": f"{side} file has no obs column '{col}'"}
-        ids = [_decode_bytes(v) for v in obs[index_name][:]]  # pyright: ignore[reportIndexIssue]
-        dupe_err = check_duplicate_ids(ids, f"{side} cells")
-        if dupe_err:
-            return None, {"error": dupe_err}
+        # asstr() decodes in C; dtype=object avoids a fixed-width unicode
+        # dtype (see rename.py). The pandas Index is built once and reused
+        # for the duplicate check and the join.
+        ids = np.asarray(obs[index_name].asstr()[:], dtype=object)  # pyright: ignore[reportAttributeAccessIssue, reportIndexIssue]
+        index = pd.Index(ids)
+        if index.has_duplicates:
+            dupes = index[index.duplicated()].unique()[:_N_EXAMPLES].tolist()
+            return None, {"error": f"{side} cells have duplicate IDs (first {_N_EXAMPLES}): {dupes}"}
         col_data = {}
         for col in columns:
             data, err = _read_column(obs, col, placeholders, side)
             if err:
                 return None, {"error": err}
             col_data[col] = data
-        result = {"ids": ids, "columns": col_data}
-        if side == "Target":
+        result = {"index": index, "columns": col_data}
+        if is_target:
             result["raw_log"] = read_edit_log_h5py(f)
         return result, None
-
-
-def _codes_dtype(n_categories: int, original: np.dtype) -> np.dtype:
-    """Smallest signed dtype holding the new category count, never narrower
-    than the original codes dtype (extending categories can overflow int8)."""
-    if np.iinfo(original).max >= max(n_categories - 1, 0):
-        return original
-    for dt in (np.int8, np.int16, np.int32):
-        if np.iinfo(dt).max >= n_categories - 1 and np.dtype(dt).itemsize >= original.itemsize:
-            return np.dtype(dt)
-    return np.dtype(np.int64)
 
 
 def _fill_categorical(obs: h5py.Group, col: str, data: dict, fill_rows: np.ndarray, fill_values: np.ndarray) -> None:
@@ -183,22 +183,12 @@ def _fill_categorical(obs: h5py.Group, col: str, data: dict, fill_rows: np.ndarr
     cats: list[str] = data["cats"]
     codes: np.ndarray = data["codes"]
     new_cats = cats + sorted(set(fill_values) - set(cats))
-    cat_pos = {c: i for i, c in enumerate(new_cats)}
     # Work in int64: the new category positions can overflow the original
-    # codes dtype before the unused-category remap shrinks the range.
+    # codes dtype before the unused-category compaction shrinks the range.
     work = codes.astype(np.int64)
-    work[fill_rows] = [cat_pos[v] for v in fill_values]
-
-    used = sorted(set(work[work >= 0]))
-    final_cats = [new_cats[i] for i in used]
-    lookup = np.full(len(new_cats), -1, dtype=np.int64)
-    for new_idx, old_idx in enumerate(used):
-        lookup[old_idx] = new_idx
-    valid = work >= 0
-    final_codes = np.full_like(work, -1)
-    final_codes[valid] = lookup[work[valid]]
-
-    replace_categorical_column(obs, col, final_cats, final_codes.astype(_codes_dtype(len(final_cats), codes.dtype)))
+    work[fill_rows] = pd.Index(new_cats).get_indexer(fill_values)
+    final_cats, final_codes = compact_categories(new_cats, work)
+    replace_categorical_column(obs, col, final_cats, final_codes)
 
 
 def _verify_backfill(f: h5py.File, per_column: dict, fills: dict, placeholders: set[str]) -> str | None:
@@ -211,12 +201,10 @@ def _verify_backfill(f: h5py.File, per_column: dict, fills: dict, placeholders: 
     obs = f["obs"]
     for col, (fill_rows, fill_values) in fills.items():
         data, err = _read_column(obs, col, placeholders, "Output")  # pyright: ignore[reportArgumentType]
-        if err:
+        if err is not None:
             return err
-        if data is None:
-            return f"Verification failed: could not re-read column '{col}'"
-        written = data["values"][fill_rows]
-        if not (written == fill_values).all():
+        assert data is not None
+        if not (data["values"][fill_rows] == fill_values).all():
             return f"Verification failed: column '{col}' does not hold the filled values"
         actual_missing = int(data["missing"].sum())
         expected_missing = per_column[col]["missing_after"]
@@ -287,23 +275,25 @@ def backfill_obs_from_source(target_path: str, source_path: str, columns: list[s
         if Path(target_path).resolve() == Path(source_path).resolve():
             return {"error": "Source and target are the same file"}
 
-        placeholders = {v.lower() for v in _DEFAULT_PLACEHOLDERS}
+        placeholders = {v.lower() for v in DEFAULT_PLACEHOLDERS}
 
-        target, err = _read_obs_for_backfill(target_path, columns, placeholders, "Target")
-        if err or target is None:
-            return err or {"error": "Failed to read target"}
+        target, err = _read_obs_for_backfill(target_path, columns, placeholders, "Target", is_target=True)
+        if err is not None:
+            return err
+        assert target is not None
         source, err = _read_obs_for_backfill(source_path, columns, placeholders, "Source")
-        if err or source is None:
-            return err or {"error": "Failed to read source"}
+        if err is not None:
+            return err
+        assert source is not None
 
-        target_ids: list[str] = target["ids"]
-        n_target = len(target_ids)
-        n_source = len(source["ids"])
+        target_index: pd.Index = target["index"]
+        n_target = len(target_index)
+        n_source = len(source["index"])
 
         # --- Join on cell ID ---
-        indexer = pd.Index(source["ids"]).get_indexer(pd.Index(target_ids))
-        matched = indexer >= 0
-        n_matched = int(matched.sum())
+        indexer = source["index"].get_indexer(target_index)
+        matched_rows = np.flatnonzero(indexer >= 0)
+        n_matched = len(matched_rows)
         if n_matched == 0:
             return {
                 "error": (
@@ -311,55 +301,51 @@ def backfill_obs_from_source(target_path: str, source_path: str, columns: list[s
                     f"target has {n_target}, 0 shared) — is this the right source file?"
                 )
             }
-        matched_rows = np.flatnonzero(matched)
         source_rows = indexer[matched_rows]
 
         # --- Per-column stats and fill plan (nothing written yet) ---
         per_column: dict[str, dict] = {}
         fills: dict[str, tuple[np.ndarray, np.ndarray]] = {}
-        expected_valid_counts: dict[str, int] = {}
-        total_filled = 0
         for col in columns:
             tgt = target["columns"][col]
             src = source["columns"][col]
-
-            src_missing_at = np.ones(n_target, dtype=bool)
-            src_values_at = np.full(n_target, None, dtype=object)
-            src_missing_at[matched_rows] = src["missing"][source_rows]
-            src_values_at[matched_rows] = src["values"][source_rows]
-
             tgt_missing: np.ndarray = tgt["missing"]
-            fill_mask = matched & tgt_missing & ~src_missing_at
-            already_set_mask = matched & ~tgt_missing
-            conflict_rows = np.flatnonzero(already_set_mask & ~src_missing_at)
-            conflict_rows = conflict_rows[tgt["values"][conflict_rows] != src_values_at[conflict_rows]]
 
-            fill_rows = np.flatnonzero(fill_mask)
+            # Work in matched-row space: an integrated target dwarfs any one
+            # source, so target-length scatter arrays would mostly hold air.
+            tgt_missing_m = tgt_missing[matched_rows]
+            src_missing_m = src["missing"][source_rows]
+            src_values_m = src["values"][source_rows]
+
+            fill_m = tgt_missing_m & ~src_missing_m
+            fill_rows = matched_rows[fill_m]
+            fill_values = src_values_m[fill_m]
+
+            conflict_m = np.flatnonzero(~tgt_missing_m & ~src_missing_m)
+            conflict_m = conflict_m[tgt["values"][matched_rows[conflict_m]] != src_values_m[conflict_m]]
+
             filled = len(fill_rows)
             missing_before = int(tgt_missing.sum())
+            matched_missing = int(tgt_missing_m.sum())
             missing_after = missing_before - filled
             per_column[col] = {
                 "filled": filled,
-                "already_set": int(already_set_mask.sum()),
-                "conflicts": len(conflict_rows),
+                "already_set": n_matched - matched_missing,
+                "conflicts": len(conflict_m),
                 "conflict_examples": [
-                    [target_ids[i], tgt["values"][i], src_values_at[i]] for i in conflict_rows[:_N_EXAMPLES]
+                    [target_index[matched_rows[i]], tgt["values"][matched_rows[i]], src_values_m[i]]
+                    for i in conflict_m[:_N_EXAMPLES]
                 ],
-                "source_missing": int((matched & tgt_missing & src_missing_at).sum()),
-                "unmatched": int((~matched & tgt_missing).sum()),
+                "source_missing": int((tgt_missing_m & src_missing_m).sum()),
+                "unmatched": missing_before - matched_missing,
                 "missing_before": missing_before,
                 "missing_after": missing_after,
-                "pct_full_after": round(100.0 * (n_target - missing_after) / n_target, 1) if n_target else 0.0,
+                "pct_full_after": round(100.0 * (n_target - missing_after) / n_target, 1),
             }
             if filled:
-                total_filled += filled
-                fills[col] = (fill_rows, src_values_at[fill_rows])
-                if tgt["kind"] == "categorical":
-                    # Fills onto placeholder-coded rows don't change the
-                    # valid-code count; fills onto NaN (code -1) rows do.
-                    codes: np.ndarray = tgt["codes"]
-                    expected_valid_counts[col] = int((codes >= 0).sum()) + int((codes[fill_rows] < 0).sum())
+                fills[col] = (fill_rows, fill_values)
 
+        total_filled = sum(stats["filled"] for stats in per_column.values())
         overlap = {
             "n_source_cells": n_source,
             "n_target_cells": n_target,
@@ -375,8 +361,18 @@ def backfill_obs_from_source(target_path: str, source_path: str, columns: list[s
                 "per_column": per_column,
             }
 
-        # --- Edit log, then copy-and-patch ---
+        # --- Copy (hashing the target in the same read), then patch ---
         source_basename = Path(source_path).name
+        source_sha256 = _compute_sha256(source_path)
+
+        output_path = generate_output_path(target_path)
+        if output_path == target_path:
+            # generate_output_path timestamps to the second (see rename.py):
+            # a second edit within the same second would name the output after
+            # its own source. Refuse before touching anything.
+            return {"error": "An edit snapshot for this second already exists — retry in a moment."}
+        target_sha256 = _copy_with_sha256(target_path, output_path)
+
         entry = make_edit_entry(
             operation="backfill_obs_from_source",
             description=(
@@ -385,24 +381,17 @@ def backfill_obs_from_source(target_path: str, source_path: str, columns: list[s
             ),
             details={
                 "backfill_source_file": source_basename,
-                "backfill_source_sha256": _compute_sha256(source_path),
+                "backfill_source_sha256": source_sha256,
                 "columns": columns,
                 **overlap,
                 "total_filled": total_filled,
                 "per_column": per_column,
             },
         )
-        log_result = build_edit_log(target["raw_log"], [entry], target_path, _compute_sha256(target_path))
+        log_result = build_edit_log(target["raw_log"], [entry], target_path, target_sha256)
         if "error" in log_result:
+            Path(output_path).unlink()
             return log_result
-
-        output_path = generate_output_path(target_path)
-        if output_path == target_path:
-            # generate_output_path timestamps to the second (see rename.py):
-            # a second edit within the same second would name the output after
-            # its own source. Refuse before touching anything.
-            return {"error": "An edit snapshot for this second already exists — retry in a moment."}
-        shutil.copy2(target_path, output_path)
 
         with h5py.File(output_path, "a") as f_out:
             obs_out = f_out["obs"]
@@ -416,7 +405,7 @@ def backfill_obs_from_source(target_path: str, source_path: str, columns: list[s
                     replace_string_dataset(obs_out, col, new_values)  # pyright: ignore[reportArgumentType]
             write_edit_log_h5py(f_out, log_result["json"])
 
-            verify_err = verify_categorical_integrity(f_out, list(fills), expected_valid_counts)
+            verify_err = verify_categorical_integrity(f_out, list(fills))
             verify_err = verify_err or _verify_backfill(f_out, per_column, fills, placeholders)
             if verify_err:
                 raise RuntimeError(verify_err)

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/backfill.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/backfill.py
@@ -1,0 +1,438 @@
+"""Backfill missing obs values in a target h5ad from a source h5ad, joined on cell ID.
+
+Built for metadata lost in integration (#534): cells in an integrated object
+carry placeholders ("unknown", NaN) for columns whose true values survive in
+the source dataset the cells came from. The join key is the obs index, and the
+never-overwrite rule is the core contract — a value is written only where the
+target holds nothing (NaN, empty, or a recognized placeholder). A real target
+value that disagrees with the source is left alone and reported as a conflict.
+
+Partial overlap is the normal case, not an oddity: an integrated object
+filters cells and draws from several sources, so source cells absent from the
+target are skipped silently and target cells absent from the source simply
+stay as they are. Run once per source; each run resolves the newest edit
+snapshot of the target and replaces the previous snapshot on success, so
+repeated runs chain without accumulating file copies.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import shutil
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pandas as pd
+
+from ._io import (
+    _decode_bytes,
+    check_duplicate_ids,
+    read_categorical_data,
+    read_edit_log_h5py,
+    replace_categorical_column,
+    replace_string_dataset,
+    verify_categorical_integrity,
+    write_edit_log_h5py,
+)
+from .cap import LEGACY_LAYOUT_DESCRIPTION, is_legacy_cap_layout
+from .edit import _DEFAULT_PLACEHOLDERS
+from .write import (
+    _compute_sha256,
+    build_edit_log,
+    cleanup_previous_version,
+    generate_output_path,
+    make_edit_entry,
+    resolve_latest,
+)
+
+# Cap on the conflict examples quoted per column, so a large disagreement
+# stays readable in the result and the edit log.
+_N_EXAMPLES = 5
+
+
+def _check_arguments(columns) -> list[str]:
+    """Collect every problem with the call's arguments.
+
+    Shape-checks before any file is opened. This is an MCP-exposed tool, so
+    the arguments arrive as decoded JSON and may hold numbers or nulls;
+    everything downstream assumes strings.
+    """
+    if not isinstance(columns, list) or not columns:
+        return ["columns must be a non-empty list of obs column names"]
+    problems: list[str] = []
+    for col in columns:
+        # h5py resolves a name containing '/' as an HDF5 link path, not a
+        # dict key (see drop.py for the full trap) — reject before any lookup.
+        if not isinstance(col, str) or "/" in col or not col.strip():
+            problems.append(f"not a valid obs column name (must be a non-blank string without '/'): {col!r}")
+    if len(set(columns)) != len(columns):
+        problems.append("columns contains duplicates")
+    return problems
+
+
+def _is_missing_str(value: str, placeholders: set[str]) -> bool:
+    """True if a string value means "no data": empty/whitespace or a placeholder."""
+    s = value.strip()
+    return not s or s.lower() in placeholders
+
+
+def _read_column(obs: h5py.Group, col: str, placeholders: set[str], side: str) -> tuple[dict | None, str | None]:
+    """Read one obs column into a uniform shape: (column dict, error).
+
+    The dict holds ``kind`` ('categorical' or 'string'), per-row ``values``
+    (object array of strings, None where NaN), and a ``missing`` mask (NaN,
+    empty, or placeholder). Categorical columns also carry ``cats``/``codes``.
+    Any other layout (numeric, boolean, nullable-dtype groups) has no missing
+    vocabulary this tool understands, so it is refused rather than guessed at.
+    """
+    item = obs[col]
+    if isinstance(item, h5py.Group) and "categories" in item:
+        cats, codes = read_categorical_data(item)  # pyright: ignore[reportArgumentType]
+        cat_values = np.array(list(cats), dtype=object)
+        cat_missing = np.array([_is_missing_str(c, placeholders) for c in cats], dtype=bool)
+        valid = codes >= 0
+        values = np.full(len(codes), None, dtype=object)
+        missing = ~valid
+        if len(cats):
+            values[valid] = cat_values[codes[valid]]
+            hit = np.zeros(len(codes), dtype=bool)
+            hit[valid] = cat_missing[codes[valid]]
+            missing = missing | hit
+        return {"kind": "categorical", "cats": list(cats), "codes": codes, "values": values, "missing": missing}, None
+    if isinstance(item, h5py.Group):
+        return None, (
+            f"{side} column '{col}' uses a nullable-dtype layout, which is not supported — "
+            "only categorical and string obs columns can be backfilled"
+        )
+    if h5py.check_string_dtype(item.dtype) is None:  # pyright: ignore[reportAttributeAccessIssue]
+        return None, (
+            f"{side} column '{col}' is not categorical or string — only those obs column types can be backfilled"
+        )
+    values = np.asarray(item.asstr()[:], dtype=object)  # pyright: ignore[reportAttributeAccessIssue]
+    missing = np.fromiter((_is_missing_str(v, placeholders) for v in values), dtype=bool, count=len(values))
+    return {"kind": "string", "values": values, "missing": missing}, None
+
+
+def _read_obs_for_backfill(
+    path: str, columns: list[str], placeholders: set[str], side: str
+) -> tuple[dict | None, dict | None]:
+    """Read the obs index and the requested columns from one file.
+
+    Returns (data, error_result); exactly one is set. ``data`` holds ``ids``
+    (list of cell IDs), ``columns`` (column name → the dict from
+    :func:`_read_column`), and for the target side ``raw_log``.
+    """
+    with h5py.File(path, "r") as f:
+        obs = f.get("obs")
+        if not isinstance(obs, h5py.Group):
+            return None, {"error": f"{side} file has no obs group: {path}"}
+        if side == "Target":
+            uns = f.get("uns")
+            if isinstance(uns, h5py.Group) and is_legacy_cap_layout(uns):
+                # Parity with drop.py / rename.py (#552): mutating tools
+                # refuse the deprecated top-level CAP layout.
+                return None, {
+                    "error": (
+                        f"Refusing to backfill: the target uses {LEGACY_LAYOUT_DESCRIPTION}, which is not supported"
+                    )
+                }
+        index_name = _decode_bytes(obs.attrs.get("_index", "_index"))
+        obs_keys = set(obs.keys())
+        for col in columns:
+            if col == index_name:
+                return None, {
+                    "error": f"'{index_name}' is the {side.lower()} obs index (the join key), not a backfillable column"
+                }
+            if col not in obs_keys:
+                return None, {"error": f"{side} file has no obs column '{col}'"}
+        ids = [_decode_bytes(v) for v in obs[index_name][:]]  # pyright: ignore[reportIndexIssue]
+        dupe_err = check_duplicate_ids(ids, f"{side} cells")
+        if dupe_err:
+            return None, {"error": dupe_err}
+        col_data = {}
+        for col in columns:
+            data, err = _read_column(obs, col, placeholders, side)
+            if err:
+                return None, {"error": err}
+            col_data[col] = data
+        result = {"ids": ids, "columns": col_data}
+        if side == "Target":
+            result["raw_log"] = read_edit_log_h5py(f)
+        return result, None
+
+
+def _codes_dtype(n_categories: int, original: np.dtype) -> np.dtype:
+    """Smallest signed dtype holding the new category count, never narrower
+    than the original codes dtype (extending categories can overflow int8)."""
+    if np.iinfo(original).max >= max(n_categories - 1, 0):
+        return original
+    for dt in (np.int8, np.int16, np.int32):
+        if np.iinfo(dt).max >= n_categories - 1 and np.dtype(dt).itemsize >= original.itemsize:
+            return np.dtype(dt)
+    return np.dtype(np.int64)
+
+
+def _fill_categorical(obs: h5py.Group, col: str, data: dict, fill_rows: np.ndarray, fill_values: np.ndarray) -> None:
+    """Rewrite a categorical column with the fills applied.
+
+    Extends the categories with any new fill values, then drops categories
+    the fills left unused (the placeholder being replaced, typically) —
+    matching replace_placeholder_values' cleanup behavior.
+    """
+    cats: list[str] = data["cats"]
+    codes: np.ndarray = data["codes"]
+    new_cats = cats + sorted(set(fill_values) - set(cats))
+    cat_pos = {c: i for i, c in enumerate(new_cats)}
+    # Work in int64: the new category positions can overflow the original
+    # codes dtype before the unused-category remap shrinks the range.
+    work = codes.astype(np.int64)
+    work[fill_rows] = [cat_pos[v] for v in fill_values]
+
+    used = sorted(set(work[work >= 0]))
+    final_cats = [new_cats[i] for i in used]
+    lookup = np.full(len(new_cats), -1, dtype=np.int64)
+    for new_idx, old_idx in enumerate(used):
+        lookup[old_idx] = new_idx
+    valid = work >= 0
+    final_codes = np.full_like(work, -1)
+    final_codes[valid] = lookup[work[valid]]
+
+    replace_categorical_column(obs, col, final_cats, final_codes.astype(_codes_dtype(len(final_cats), codes.dtype)))
+
+
+def _verify_backfill(f: h5py.File, per_column: dict, fills: dict, placeholders: set[str]) -> str | None:
+    """Re-read every filled column from the output and check the result.
+
+    Two independent checks per column: the filled rows hold exactly the
+    values the source supplied, and the missing count landed on the predicted
+    ``missing_after``. Returns an error message, or None if all pass.
+    """
+    obs = f["obs"]
+    for col, (fill_rows, fill_values) in fills.items():
+        data, err = _read_column(obs, col, placeholders, "Output")  # pyright: ignore[reportArgumentType]
+        if err:
+            return err
+        if data is None:
+            return f"Verification failed: could not re-read column '{col}'"
+        written = data["values"][fill_rows]
+        if not (written == fill_values).all():
+            return f"Verification failed: column '{col}' does not hold the filled values"
+        actual_missing = int(data["missing"].sum())
+        expected_missing = per_column[col]["missing_after"]
+        if actual_missing != expected_missing:
+            return (
+                f"Verification failed: column '{col}' has {actual_missing} missing values, expected {expected_missing}"
+            )
+    return None
+
+
+def backfill_obs_from_source(target_path: str, source_path: str, columns: list[str]) -> dict:
+    """Copy obs values from a source h5ad into a target, filling only gaps.
+
+    Joins source cells to target cells on the obs index and, for each
+    requested column, writes the source value into every matched target cell
+    whose current value is missing — NaN, empty, or a recognized placeholder
+    such as "unknown" (the same list replace_placeholder_values uses). Values
+    already set in the target are never touched: where a set value disagrees
+    with the source it is counted as a conflict and reported with examples,
+    not overwritten and not an error. Source cells with no matching target
+    cell are skipped silently — the target may have filtered them out.
+
+    Uses h5py copy-and-patch (the replace_placeholder_values technique): the
+    expression matrix is never loaded, and only the filled obs columns are
+    rewritten, preserving their compression settings. Categorical columns get
+    their categories extended for new values and cleaned of categories the
+    fill left unused. If no column has anything to fill, nothing is written
+    and an error is returned carrying the full per-column stats.
+
+    Writes a new timestamped snapshot of the target with an edit-log entry,
+    like every other mutating tool, and deletes the previous snapshot (never
+    the original). The source file is read-only and never modified. Both
+    paths auto-resolve to their latest timestamped edit snapshot, so per-source
+    runs against the same target chain naturally.
+
+    If the target's cell IDs need repair (e.g. a rename_cell_ids fix), do that
+    **before** backfilling — this tool propagates values by cell identity and
+    trusts the join.
+
+    Args:
+        target_path: Path to the .h5ad file to fill.
+        source_path: Path to the .h5ad file holding the values.
+        columns: Obs column names to backfill. Each must exist in both files
+            as a categorical or string column.
+
+    Returns:
+        Dict with ``output_path``, ``source``, ``n_source_cells``,
+        ``n_target_cells``, ``n_matched``, ``total_filled``, and
+        ``per_column`` — for each column: ``filled``, ``already_set``,
+        ``conflicts`` + ``conflict_examples`` (up to five
+        ``[cell_id, target_value, source_value]``), ``source_missing``
+        (target missing but source missing too), ``unmatched`` (target
+        missing with no source cell to consult), ``missing_before`` /
+        ``missing_after`` over all target cells, and ``pct_full_after`` —
+        or ``{"error": ...}``.
+    """
+    output_path = None
+    try:
+        problems = _check_arguments(columns)
+        if problems:
+            return {"error": "Refusing to backfill: " + "; ".join(problems)}
+
+        target_path = resolve_latest(target_path)
+        source_path = resolve_latest(source_path)
+        for side, path in (("Target", target_path), ("Source", source_path)):
+            if not Path(path).is_file():
+                return {"error": f"{side} file not found: {path}"}
+        if Path(target_path).resolve() == Path(source_path).resolve():
+            return {"error": "Source and target are the same file"}
+
+        placeholders = {v.lower() for v in _DEFAULT_PLACEHOLDERS}
+
+        target, err = _read_obs_for_backfill(target_path, columns, placeholders, "Target")
+        if err or target is None:
+            return err or {"error": "Failed to read target"}
+        source, err = _read_obs_for_backfill(source_path, columns, placeholders, "Source")
+        if err or source is None:
+            return err or {"error": "Failed to read source"}
+
+        target_ids: list[str] = target["ids"]
+        n_target = len(target_ids)
+        n_source = len(source["ids"])
+
+        # --- Join on cell ID ---
+        indexer = pd.Index(source["ids"]).get_indexer(pd.Index(target_ids))
+        matched = indexer >= 0
+        n_matched = int(matched.sum())
+        if n_matched == 0:
+            return {
+                "error": (
+                    f"No source cells match the target on cell ID (source has {n_source}, "
+                    f"target has {n_target}, 0 shared) — is this the right source file?"
+                )
+            }
+        matched_rows = np.flatnonzero(matched)
+        source_rows = indexer[matched_rows]
+
+        # --- Per-column stats and fill plan (nothing written yet) ---
+        per_column: dict[str, dict] = {}
+        fills: dict[str, tuple[np.ndarray, np.ndarray]] = {}
+        expected_valid_counts: dict[str, int] = {}
+        total_filled = 0
+        for col in columns:
+            tgt = target["columns"][col]
+            src = source["columns"][col]
+
+            src_missing_at = np.ones(n_target, dtype=bool)
+            src_values_at = np.full(n_target, None, dtype=object)
+            src_missing_at[matched_rows] = src["missing"][source_rows]
+            src_values_at[matched_rows] = src["values"][source_rows]
+
+            tgt_missing: np.ndarray = tgt["missing"]
+            fill_mask = matched & tgt_missing & ~src_missing_at
+            already_set_mask = matched & ~tgt_missing
+            conflict_rows = np.flatnonzero(already_set_mask & ~src_missing_at)
+            conflict_rows = conflict_rows[tgt["values"][conflict_rows] != src_values_at[conflict_rows]]
+
+            fill_rows = np.flatnonzero(fill_mask)
+            filled = len(fill_rows)
+            missing_before = int(tgt_missing.sum())
+            missing_after = missing_before - filled
+            per_column[col] = {
+                "filled": filled,
+                "already_set": int(already_set_mask.sum()),
+                "conflicts": len(conflict_rows),
+                "conflict_examples": [
+                    [target_ids[i], tgt["values"][i], src_values_at[i]] for i in conflict_rows[:_N_EXAMPLES]
+                ],
+                "source_missing": int((matched & tgt_missing & src_missing_at).sum()),
+                "unmatched": int((~matched & tgt_missing).sum()),
+                "missing_before": missing_before,
+                "missing_after": missing_after,
+                "pct_full_after": round(100.0 * (n_target - missing_after) / n_target, 1) if n_target else 0.0,
+            }
+            if filled:
+                total_filled += filled
+                fills[col] = (fill_rows, src_values_at[fill_rows])
+                if tgt["kind"] == "categorical":
+                    # Fills onto placeholder-coded rows don't change the
+                    # valid-code count; fills onto NaN (code -1) rows do.
+                    codes: np.ndarray = tgt["codes"]
+                    expected_valid_counts[col] = int((codes >= 0).sum()) + int((codes[fill_rows] < 0).sum())
+
+        overlap = {
+            "n_source_cells": n_source,
+            "n_target_cells": n_target,
+            "n_matched": n_matched,
+        }
+        if total_filled == 0:
+            return {
+                "error": (
+                    "Nothing to backfill: no matched cell has a missing target value "
+                    "the source can fill — no file was written"
+                ),
+                **overlap,
+                "per_column": per_column,
+            }
+
+        # --- Edit log, then copy-and-patch ---
+        source_basename = Path(source_path).name
+        entry = make_edit_entry(
+            operation="backfill_obs_from_source",
+            description=(
+                f"Backfilled {total_filled} missing obs values in "
+                f"{len(fills)} of {len(columns)} columns from {source_basename}"
+            ),
+            details={
+                "backfill_source_file": source_basename,
+                "backfill_source_sha256": _compute_sha256(source_path),
+                "columns": columns,
+                **overlap,
+                "total_filled": total_filled,
+                "per_column": per_column,
+            },
+        )
+        log_result = build_edit_log(target["raw_log"], [entry], target_path, _compute_sha256(target_path))
+        if "error" in log_result:
+            return log_result
+
+        output_path = generate_output_path(target_path)
+        if output_path == target_path:
+            # generate_output_path timestamps to the second (see rename.py):
+            # a second edit within the same second would name the output after
+            # its own source. Refuse before touching anything.
+            return {"error": "An edit snapshot for this second already exists — retry in a moment."}
+        shutil.copy2(target_path, output_path)
+
+        with h5py.File(output_path, "a") as f_out:
+            obs_out = f_out["obs"]
+            for col, (fill_rows, fill_values) in fills.items():
+                tgt = target["columns"][col]
+                if tgt["kind"] == "categorical":
+                    _fill_categorical(obs_out, col, tgt, fill_rows, fill_values)  # pyright: ignore[reportArgumentType]
+                else:
+                    new_values = tgt["values"].copy()
+                    new_values[fill_rows] = fill_values
+                    replace_string_dataset(obs_out, col, new_values)  # pyright: ignore[reportArgumentType]
+            write_edit_log_h5py(f_out, log_result["json"])
+
+            verify_err = verify_categorical_integrity(f_out, list(fills), expected_valid_counts)
+            verify_err = verify_err or _verify_backfill(f_out, per_column, fills, placeholders)
+            if verify_err:
+                raise RuntimeError(verify_err)
+
+        cleanup_previous_version(target_path, output_path)
+
+        return {
+            "output_path": output_path,
+            "source": source_basename,
+            **overlap,
+            "total_filled": total_filled,
+            "per_column": per_column,
+        }
+
+    except Exception as e:
+        if output_path and Path(output_path).is_file():
+            with contextlib.suppress(OSError):
+                Path(output_path).unlink()
+        return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/backfill.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/backfill.py
@@ -27,9 +27,11 @@ import pandas as pd
 from ._io import (
     DEFAULT_PLACEHOLDERS,
     _decode_bytes,
-    compact_categories,
+    check_duplicate_ids,
+    is_missing_value,
     read_categorical_data,
     read_edit_log_h5py,
+    read_string_dataset,
     replace_categorical_column,
     replace_string_dataset,
     verify_categorical_integrity,
@@ -71,12 +73,6 @@ def _check_arguments(columns) -> list[str]:
     return problems
 
 
-def _is_missing_str(value: str, placeholders: set[str]) -> bool:
-    """True if a string value means "no data": empty/whitespace or a placeholder."""
-    s = value.strip()
-    return not s or s.lower() in placeholders
-
-
 def _read_column(obs: h5py.Group, col: str, placeholders: set[str], side: str) -> tuple[dict | None, str | None]:
     """Read one obs column into a uniform shape: (column dict, error).
 
@@ -94,13 +90,20 @@ def _read_column(obs: h5py.Group, col: str, placeholders: set[str], side: str) -
     if isinstance(item, h5py.Group) and "categories" in item:
         cats, codes = read_categorical_data(item)  # pyright: ignore[reportArgumentType]
         cat_values = np.array(list(cats), dtype=object)
-        cat_missing = np.array([_is_missing_str(c, placeholders) for c in cats], dtype=bool)
+        cat_missing = np.array([is_missing_value(c, placeholders) for c in cats], dtype=bool)
         valid = codes >= 0
         values = np.full(len(codes), None, dtype=object)
         values[valid] = cat_values[codes[valid]]
         missing = ~valid
         missing[valid] = cat_missing[codes[valid]]
-        return {"kind": "categorical", "cats": list(cats), "codes": codes, "values": values, "missing": missing}, None
+        return {
+            "kind": "categorical",
+            "cats": list(cats),
+            "codes": codes,
+            "ordered": bool(item.attrs["ordered"]),
+            "values": values,
+            "missing": missing,
+        }, None
     if isinstance(item, h5py.Group):
         return None, (
             f"{side} column '{col}' uses a nullable-dtype layout, which is not supported — "
@@ -110,9 +113,9 @@ def _read_column(obs: h5py.Group, col: str, placeholders: set[str], side: str) -
         return None, (
             f"{side} column '{col}' is not categorical or string — only those obs column types can be backfilled"
         )
-    values = np.asarray(item.asstr()[:], dtype=object)  # pyright: ignore[reportAttributeAccessIssue]
+    values = read_string_dataset(obs, col)
     codes, uniques = pd.factorize(values)
-    uniq_missing = np.array([_is_missing_str(u, placeholders) for u in uniques], dtype=bool)
+    uniq_missing = np.array([is_missing_value(u, placeholders) for u in uniques], dtype=bool)
     valid = codes >= 0
     missing = ~valid
     missing[valid] = uniq_missing[codes[valid]]
@@ -153,14 +156,12 @@ def _read_obs_for_backfill(
                 }
             if col not in obs_keys:
                 return None, {"error": f"{side} file has no obs column '{col}'"}
-        # asstr() decodes in C; dtype=object avoids a fixed-width unicode
-        # dtype (see rename.py). The pandas Index is built once and reused
-        # for the duplicate check and the join.
-        ids = np.asarray(obs[index_name].asstr()[:], dtype=object)  # pyright: ignore[reportAttributeAccessIssue, reportIndexIssue]
-        index = pd.Index(ids)
-        if index.has_duplicates:
-            dupes = index[index.duplicated()].unique()[:_N_EXAMPLES].tolist()
-            return None, {"error": f"{side} cells have duplicate IDs (first {_N_EXAMPLES}): {dupes}"}
+        # The pandas Index is built once and reused for the duplicate check
+        # and the join.
+        index = pd.Index(read_string_dataset(obs, index_name))
+        dupe_err = check_duplicate_ids(index, f"{side} cells")
+        if dupe_err:
+            return None, {"error": dupe_err}
         col_data = {}
         for col in columns:
             data, err = _read_column(obs, col, placeholders, side)
@@ -176,18 +177,31 @@ def _read_obs_for_backfill(
 def _fill_categorical(obs: h5py.Group, col: str, data: dict, fill_rows: np.ndarray, fill_values: np.ndarray) -> None:
     """Rewrite a categorical column with the fills applied.
 
-    Extends the categories with any new fill values, then drops categories
-    the fills left unused (the placeholder being replaced, typically) —
-    matching replace_placeholder_values' cleanup behavior.
+    Extends the categories with any new fill values, then drops exactly the
+    categories the fills left unused (the placeholder being replaced,
+    typically). A category that was already unused before the fill is kept —
+    the declared vocabulary is set data this tool must not touch.
     """
     cats: list[str] = data["cats"]
     codes: np.ndarray = data["codes"]
     new_cats = cats + sorted(set(fill_values) - set(cats))
     # Work in int64: the new category positions can overflow the original
-    # codes dtype before the unused-category compaction shrinks the range.
+    # codes dtype before the unused-category drop shrinks the range.
     work = codes.astype(np.int64)
     work[fill_rows] = pd.Index(new_cats).get_indexer(fill_values)
-    final_cats, final_codes = compact_categories(new_cats, work)
+
+    used_before = np.zeros(len(new_cats), dtype=bool)
+    used_before[codes[codes >= 0]] = True
+    used_after = np.zeros(len(new_cats), dtype=bool)
+    used_after[work[work >= 0]] = True
+    keep = np.flatnonzero(used_after | ~used_before)
+
+    final_cats = [new_cats[i] for i in keep]
+    lookup = np.full(len(new_cats), -1, dtype=np.int64)
+    lookup[keep] = np.arange(len(keep))
+    valid = work >= 0
+    final_codes = np.full(work.shape, -1, dtype=np.int64)
+    final_codes[valid] = lookup[work[valid]]
     replace_categorical_column(obs, col, final_cats, final_codes)
 
 
@@ -325,6 +339,17 @@ def backfill_obs_from_source(target_path: str, source_path: str, columns: list[s
             conflict_m = conflict_m[tgt["values"][matched_rows[conflict_m]] != src_values_m[conflict_m]]
 
             filled = len(fill_rows)
+            if filled and tgt["kind"] == "categorical" and tgt["ordered"]:
+                new_categories = sorted(set(fill_values) - set(tgt["cats"]))
+                if new_categories:
+                    return {
+                        "error": (
+                            f"Column '{col}' is an ordered categorical and the fill would introduce "
+                            f"new categories {new_categories[:_N_EXAMPLES]} — appending to an ordered "
+                            f"vocabulary silently corrupts its ordering. Make the column unordered or "
+                            f"re-derive the ordering upstream first."
+                        )
+                    }
             missing_before = int(tgt_missing.sum())
             matched_missing = int(tgt_missing_m.sum())
             missing_after = missing_before - filled
@@ -362,15 +387,15 @@ def backfill_obs_from_source(target_path: str, source_path: str, columns: list[s
             }
 
         # --- Copy (hashing the target in the same read), then patch ---
-        source_basename = Path(source_path).name
-        source_sha256 = _compute_sha256(source_path)
-
         output_path = generate_output_path(target_path)
         if output_path == target_path:
             # generate_output_path timestamps to the second (see rename.py):
             # a second edit within the same second would name the output after
-            # its own source. Refuse before touching anything.
+            # its own source. Refuse before touching anything — and before the
+            # source hash below, which reads the whole source file.
             return {"error": "An edit snapshot for this second already exists — retry in a moment."}
+        source_basename = Path(source_path).name
+        source_sha256 = _compute_sha256(source_path)
         target_sha256 = _copy_with_sha256(target_path, output_path)
 
         entry = make_edit_entry(

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/backfill.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/backfill.py
@@ -88,6 +88,14 @@ def _read_column(obs: h5py.Group, col: str, placeholders: set[str], side: str) -
     """
     item = obs[col]
     if isinstance(item, h5py.Group) and "categories" in item:
+        # A numeric/boolean pandas Categorical is stored the same way; its
+        # values have no missing vocabulary here either, so refuse it with
+        # the clear error rather than tripping over .strip() on a non-string.
+        if h5py.check_string_dtype(item["categories"].dtype) is None:  # pyright: ignore[reportAttributeAccessIssue]
+            return None, (
+                f"{side} column '{col}' is a categorical of non-string values — "
+                "only string-valued categorical and string obs columns can be backfilled"
+            )
         cats, codes = read_categorical_data(item)  # pyright: ignore[reportArgumentType]
         cat_values = np.array(list(cats), dtype=object)
         cat_missing = np.array([is_missing_value(c, placeholders) for c in cats], dtype=bool)

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/backfill.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/backfill.py
@@ -91,7 +91,9 @@ def _read_column(obs: h5py.Group, col: str, placeholders: set[str], side: str) -
         # A numeric/boolean pandas Categorical is stored the same way; its
         # values have no missing vocabulary here either, so refuse it with
         # the clear error rather than tripping over .strip() on a non-string.
-        if h5py.check_string_dtype(item["categories"].dtype) is None:  # pyright: ignore[reportAttributeAccessIssue]
+        # An EMPTY categories array (an all-NaN column) is fine — anndata
+        # writes it with a non-string dtype, but there is nothing to compare.
+        if len(item["categories"]) and h5py.check_string_dtype(item["categories"].dtype) is None:  # pyright: ignore[reportAttributeAccessIssue, reportArgumentType]
             return None, (
                 f"{side} column '{col}' is a categorical of non-string values — "
                 "only string-valued categorical and string obs columns can be backfilled"

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -16,6 +16,7 @@ import pandas as pd
 
 from ._io import (
     _decode_bytes,
+    check_duplicate_ids,
     ensure_provenance_group,
     open_h5ad,
     read_categorical_data,
@@ -82,20 +83,6 @@ def _compute_axis_overlap(cap_ids: set[str], hca_ids: set[str]) -> dict:
             "pct": round(100.0 * n_missing_from_cap / n_hca, 1) if n_hca else 0.0,
         },
     }
-
-
-def _check_duplicate_ids(index: list[str], label: str) -> str | None:
-    """Return an error message if index has duplicates, else None."""
-    if len(set(index)) == len(index):
-        return None
-    seen, dupes = set(), []
-    for x in index:
-        if x in seen and x not in dupes:
-            dupes.append(x)
-            if len(dupes) >= 5:
-                break
-        seen.add(x)
-    return f"{label} have duplicate IDs (first 5): {dupes}"
 
 
 def _get_annotation_sets(cap_block: Mapping[str, Any]) -> list[str]:
@@ -218,7 +205,7 @@ def copy_cap_annotations(
             return {"error": "No CAP obs columns found to copy"}
 
         source_index = set(source_index_list)
-        dupe_err = _check_duplicate_ids(source_index_list, "CAP cells") or _check_duplicate_ids(
+        dupe_err = check_duplicate_ids(source_index_list, "CAP cells") or check_duplicate_ids(
             source_var_list, "CAP genes"
         )
         if dupe_err:
@@ -243,7 +230,7 @@ def copy_cap_annotations(
             raw_log = read_edit_log_h5py(f)
 
         target_index_set = set(target_index)
-        dupe_err = _check_duplicate_ids(target_index, "HCA cells") or _check_duplicate_ids(target_var_list, "HCA genes")
+        dupe_err = check_duplicate_ids(target_index, "HCA cells") or check_duplicate_ids(target_var_list, "HCA genes")
         if dupe_err:
             return {"error": dupe_err}
         target_var_set = set(target_var_list)

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
@@ -18,6 +18,7 @@ from ._io import (
     open_h5ad,
     read_categorical_data,
     read_edit_log_h5py,
+    replace_categorical_column,
     verify_categorical_integrity,
     write_edit_log_h5py,
 )
@@ -352,14 +353,6 @@ def replace_placeholder_values(
                 item = f["obs"][col]
                 cats, codes = read_categorical_data(item)  # pyright: ignore[reportArgumentType]
 
-                # Preserve original settings
-                encoding_type = item.attrs["encoding-type"]
-                encoding_version = item.attrs["encoding-version"]
-                ordered = bool(item.attrs["ordered"])
-                codes_compression = item["codes"].compression
-                codes_compression_opts = item["codes"].compression_opts
-                codes_chunks = item["codes"].chunks
-
                 # Set blocked codes to -1 (NaN)
                 blocked = {i for i in range(len(cats)) if cats[i].lower() in bl}
                 for i in blocked:
@@ -376,25 +369,7 @@ def replace_placeholder_values(
                 new_codes = np.full_like(codes, -1)
                 new_codes[mask] = lookup[codes[mask]]
 
-                # Rewrite the column preserving compression settings
-                del f["obs"][col]
-                grp = f["obs"].create_group(col)
-                grp.attrs["encoding-type"] = encoding_type
-                grp.attrs["encoding-version"] = encoding_version
-                grp.attrs["ordered"] = ordered
-                cat_data = np.array(new_cats, dtype=object) if new_cats else np.array([], dtype=h5py.string_dtype())
-                cat_ds = grp.create_dataset("categories", data=cat_data)
-                cat_ds.attrs["encoding-type"] = "string-array"
-                cat_ds.attrs["encoding-version"] = "0.2.0"
-                codes_ds = grp.create_dataset(
-                    "codes",
-                    data=new_codes.astype(codes.dtype),
-                    compression=codes_compression,
-                    compression_opts=codes_compression_opts,
-                    chunks=codes_chunks,
-                )
-                codes_ds.attrs["encoding-type"] = "array"
-                codes_ds.attrs["encoding-version"] = "0.2.0"
+                replace_categorical_column(f["obs"], col, new_cats, new_codes.astype(codes.dtype))  # pyright: ignore[reportArgumentType]
 
             write_edit_log_h5py(f, log_result["json"])
 

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
@@ -10,11 +10,12 @@ import typing
 from pathlib import Path
 
 import h5py
-import numpy as np
 from pydantic import TypeAdapter, ValidationError
 
 from ._io import (
+    DEFAULT_PLACEHOLDERS,
     _decode_bytes,
+    compact_categories,
     open_h5ad,
     read_categorical_data,
     read_edit_log_h5py,
@@ -33,20 +34,6 @@ from .write import (
     resolve_latest,
     write_h5ad,
 )
-
-# Default HCA placeholder values (case-insensitive)
-_DEFAULT_PLACEHOLDERS = [
-    "unknown",
-    "na",
-    "n/a",
-    "none",
-    "not available",
-    "not applicable",
-    "tbd",
-    "todo",
-    "null",
-    "undefined",
-]
 
 
 def _type_display(annotation) -> str:
@@ -295,7 +282,7 @@ def replace_placeholder_values(
         if not columns:
             return {"error": "columns must not be empty"}
 
-        bl = {v.lower() for v in (placeholders or _DEFAULT_PLACEHOLDERS)}
+        bl = {v.lower() for v in (placeholders or DEFAULT_PLACEHOLDERS)}
 
         # Scan for placeholder values and read edit log in one pass
         columns_fixed = {}
@@ -358,18 +345,8 @@ def replace_placeholder_values(
                 for i in blocked:
                     codes[codes == i] = -1
 
-                # Remove unused categories and remap codes
-                used = sorted(set(codes[codes >= 0]))
-                new_cats = [cats[i] for i in used]
-                # Vectorized remap via lookup table
-                lookup = np.full(len(cats), -1, dtype=codes.dtype)
-                for new_idx, old_idx in enumerate(used):
-                    lookup[old_idx] = new_idx
-                mask = codes >= 0
-                new_codes = np.full_like(codes, -1)
-                new_codes[mask] = lookup[codes[mask]]
-
-                replace_categorical_column(f["obs"], col, new_cats, new_codes.astype(codes.dtype))  # pyright: ignore[reportArgumentType]
+                new_cats, new_codes = compact_categories(list(cats), codes)
+                replace_categorical_column(f["obs"], col, new_cats, new_codes)  # pyright: ignore[reportArgumentType]
 
             write_edit_log_h5py(f, log_result["json"])
 

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
@@ -333,6 +333,12 @@ def replace_placeholder_values(
 
         # Copy and patch
         output_path = generate_output_path(path)
+        if output_path == path:
+            # generate_output_path timestamps to the second (see rename.py):
+            # a second edit within the same second names the output after its
+            # own source, and the failure path would then unlink that source
+            # snapshot. Refuse before touching anything.
+            return {"error": "An edit snapshot for this second already exists — retry in a moment."}
         shutil.copy2(path, output_path)
 
         with h5py.File(output_path, "a") as f:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/rename.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/rename.py
@@ -26,6 +26,7 @@ from ._io import (
     _decode_bytes,
     read_categorical_data,
     read_edit_log_h5py,
+    replace_string_dataset,
     write_edit_log_h5py,
 )
 from .cap import LEGACY_LAYOUT_DESCRIPTION, is_legacy_cap_layout
@@ -112,25 +113,6 @@ def _compute_new_ids(
     new_ids[selected] = [prefix_to + cell_id[len(prefix_from) :] for cell_id in ids[selected]]
     examples = [[str(ids[i]), str(new_ids[i])] for i in selected[:_N_EXAMPLES]]
     return new_ids, examples
-
-
-def _replace_string_dataset(parent: h5py.Group, name: str, data: np.ndarray) -> None:
-    """Delete and recreate a string dataset, preserving its attrs and storage
-    properties (compression, chunks, shuffle, fletcher32, maxshape)."""
-    ds = parent[name]
-    attrs = dict(ds.attrs)  # pyright: ignore[reportAttributeAccessIssue]
-    storage = {
-        "compression": ds.compression,  # pyright: ignore[reportAttributeAccessIssue]
-        "compression_opts": ds.compression_opts,  # pyright: ignore[reportAttributeAccessIssue]
-        "chunks": ds.chunks,  # pyright: ignore[reportAttributeAccessIssue]
-        "shuffle": ds.shuffle,  # pyright: ignore[reportAttributeAccessIssue]
-        "fletcher32": ds.fletcher32,  # pyright: ignore[reportAttributeAccessIssue]
-        "maxshape": ds.maxshape,  # pyright: ignore[reportAttributeAccessIssue]
-    }
-    del parent[name]
-    new_ds = parent.create_dataset(name, data=data, dtype=h5py.string_dtype(encoding="utf-8"), **storage)
-    for key, attr_value in attrs.items():
-        new_ds.attrs[key] = attr_value
 
 
 def rename_cell_ids(path: str, column: str, value: str, prefix_from: str, prefix_to: str) -> dict:
@@ -345,9 +327,9 @@ def rename_cell_ids(path: str, column: str, value: str, prefix_from: str, prefix
 
         log_error = None
         with h5py.File(output_path, "a") as f_out:
-            _replace_string_dataset(f_out["obs"], index_name, new_ids)  # pyright: ignore[reportArgumentType]
+            replace_string_dataset(f_out["obs"], index_name, new_ids)  # pyright: ignore[reportArgumentType]
             for obsm_key, sub_name in obsm_df_indexes:
-                _replace_string_dataset(f_out["obsm"][obsm_key], sub_name, new_ids)  # pyright: ignore[reportArgumentType, reportIndexIssue]
+                replace_string_dataset(f_out["obsm"][obsm_key], sub_name, new_ids)  # pyright: ignore[reportArgumentType, reportIndexIssue]
 
             entry = make_edit_entry(
                 operation="rename_cell_ids",

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/rename.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/rename.py
@@ -26,6 +26,7 @@ from ._io import (
     _decode_bytes,
     read_categorical_data,
     read_edit_log_h5py,
+    read_string_dataset,
     replace_string_dataset,
     write_edit_log_h5py,
 )
@@ -229,11 +230,10 @@ def rename_cell_ids(path: str, column: str, value: str, prefix_from: str, prefix
                 # Gated before the index read: a mistyped selector should not
                 # pay for decoding 2M IDs it will never use.
                 return {"error": f"Refusing to rename: no rows match obs['{column}'] == {value!r}"}
-            # dtype=object pins what asstr() already returns (verified for
-            # both vlen and fixed-width string datasets): a fixed-width
-            # unicode dtype here would silently clip the longer renamed IDs
-            # on assignment in _compute_new_ids.
-            ids = np.asarray(obs[index_name].asstr()[:], dtype=object)  # pyright: ignore[reportAttributeAccessIssue, reportIndexIssue]
+            # dtype=object (inside read_string_dataset) pins what asstr()
+            # already returns: a fixed-width unicode dtype here would silently
+            # clip the longer renamed IDs on assignment in _compute_new_ids.
+            ids = read_string_dataset(obs, index_name)
 
             # A DataFrame in obsm carries its own duplicate copy of the cell
             # IDs (anndata writes the frame's index alongside the parent's),
@@ -251,7 +251,7 @@ def rename_cell_ids(path: str, column: str, value: str, prefix_from: str, prefix
                     ):
                         continue
                     sub_name = _decode_bytes(member.attrs.get("_index", "_index"))
-                    sub_ids = np.asarray(member[sub_name].asstr()[:], dtype=object)  # pyright: ignore[reportAttributeAccessIssue, reportIndexIssue]
+                    sub_ids = read_string_dataset(member, sub_name)
                     if sub_ids.shape != ids.shape or not (sub_ids == ids).all():
                         return {
                             "error": (

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
@@ -7,6 +7,7 @@ import glob
 import hashlib
 import json
 import re
+import shutil
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
@@ -29,6 +30,21 @@ def _compute_sha256(path: str) -> str:
     with Path(path).open("rb") as f:
         for chunk in iter(lambda: f.read(_HASH_CHUNK_SIZE), b""):
             h.update(chunk)
+    return h.hexdigest()
+
+
+def _copy_with_sha256(source_path: str, dest_path: str) -> str:
+    """Copy source to dest and return the source's SHA-256 hex digest.
+
+    One streaming pass instead of a hash read followed by a copy read —
+    on a multi-GB h5ad that halves the read I/O of a copy-and-patch tool.
+    """
+    h = hashlib.sha256()
+    with Path(source_path).open("rb") as src, Path(dest_path).open("wb") as dst:
+        for chunk in iter(lambda: src.read(_HASH_CHUNK_SIZE), b""):
+            h.update(chunk)
+            dst.write(chunk)
+    shutil.copystat(source_path, dest_path)
     return h.hexdigest()
 
 

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
@@ -38,7 +38,13 @@ def _copy_with_sha256(source_path: str, dest_path: str) -> str:
 
     One streaming pass instead of a hash read followed by a copy read —
     on a multi-GB h5ad that halves the read I/O of a copy-and-patch tool.
+
+    Refuses same-path calls: opening dest with 'wb' would truncate the
+    source to zero bytes before reading it, so this must fail the way
+    shutil.copy2 does rather than trust every caller's same-second guard.
     """
+    if Path(source_path).resolve() == Path(dest_path).resolve():
+        raise shutil.SameFileError(f"{source_path!r} and {dest_path!r} are the same file")
     h = hashlib.sha256()
     with Path(source_path).open("rb") as src, Path(dest_path).open("wb") as dst:
         for chunk in iter(lambda: src.read(_HASH_CHUNK_SIZE), b""):

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
@@ -39,11 +39,14 @@ def _copy_with_sha256(source_path: str, dest_path: str) -> str:
     One streaming pass instead of a hash read followed by a copy read —
     on a multi-GB h5ad that halves the read I/O of a copy-and-patch tool.
 
-    Refuses same-path calls: opening dest with 'wb' would truncate the
+    Refuses same-file calls: opening dest with 'wb' would truncate the
     source to zero bytes before reading it, so this must fail the way
     shutil.copy2 does rather than trust every caller's same-second guard.
+    samefile() compares filesystem identity (inode), catching hard links
+    that a resolved-path comparison would miss; it raises on a missing
+    path, so it only runs when dest already exists.
     """
-    if Path(source_path).resolve() == Path(dest_path).resolve():
+    if Path(dest_path).exists() and Path(source_path).samefile(dest_path):
         raise shutil.SameFileError(f"{source_path!r} and {dest_path!r} are the same file")
     h = hashlib.sha256()
     with Path(source_path).open("rb") as src, Path(dest_path).open("wb") as dst:

--- a/packages/hca-anndata-tools/tests/test_backfill.py
+++ b/packages/hca-anndata-tools/tests/test_backfill.py
@@ -7,7 +7,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from hca_anndata_tools.backfill import _codes_dtype, backfill_obs_from_source
+from hca_anndata_tools._io import _codes_dtype
+from hca_anndata_tools.backfill import backfill_obs_from_source
 
 # The canonical scenario, one row per case the tool must handle:
 #
@@ -26,18 +27,16 @@ SOURCE_IDS = ["c1", "c2", "c3", "c4", "c7", "x1"]
 SOURCE_LIB = ["L1", "L2", "unknown", "L2", "na", "L5"]
 
 
-def _make_h5ad(path, ids, columns, categorical=True, index_name="cellID", uns=None):
-    """Write a minimal h5ad with the given obs columns.
+def _make_h5ad(path, ids, columns, categorical=True, uns=None):
+    """Write a minimal h5ad with the given obs columns (index named cellID).
 
     Categorical columns represent NaN as None; string columns cannot hold
     NaN, so string variants substitute "" (which the tool treats as missing).
     """
-    obs = pd.DataFrame(index=pd.Index(ids, name=index_name))
+    obs = pd.DataFrame(index=pd.Index(ids, name="cellID"))
     for name, values in columns.items():
-        if categorical and not all(isinstance(v, int | float) for v in values):
+        if categorical:
             obs[name] = pd.Categorical(values)
-        elif categorical:
-            obs[name] = np.asarray(values, dtype=np.float32)
         else:
             obs[name] = ["" if v is None else v for v in values]
     adata = ad.AnnData(X=np.zeros((len(ids), 2), dtype=np.float32), obs=obs)
@@ -203,8 +202,15 @@ def test_backfill_column_missing_from_target(target_source):
 
 
 def test_backfill_numeric_column_refused(tmp_path):
-    target = _make_h5ad(tmp_path / "target.h5ad", ["c1", "c2"], {"n_counts": [1.0, 2.0]})
-    source = _make_h5ad(tmp_path / "source.h5ad", ["c1", "c2"], {"n_counts": [1.0, 2.0]})
+    def make_numeric(path):
+        obs = pd.DataFrame(
+            {"n_counts": np.array([1.0, 2.0], dtype=np.float32)}, index=pd.Index(["c1", "c2"], name="cellID")
+        )
+        ad.AnnData(X=np.zeros((2, 2), dtype=np.float32), obs=obs).write_h5ad(path)
+        return str(path)
+
+    target = make_numeric(tmp_path / "target.h5ad")
+    source = make_numeric(tmp_path / "source.h5ad")
 
     result = backfill_obs_from_source(target, source, columns=["n_counts"])
 

--- a/packages/hca-anndata-tools/tests/test_backfill.py
+++ b/packages/hca-anndata-tools/tests/test_backfill.py
@@ -332,6 +332,51 @@ def test_backfill_extends_categories_without_disturbing_existing(tmp_path):
     assert set(out.obs["library_id"].cat.categories) == {"L_existing", "L_new_1", "L_new_2"}
 
 
+def test_backfill_keeps_preexisting_unused_categories(tmp_path):
+    """The declared category vocabulary is set data: only categories the fill
+    itself left unused (the replaced placeholder) are dropped."""
+    obs = pd.DataFrame(
+        {"library_id": pd.Categorical(["unknown", None], categories=["unknown", "L_unused"])},
+        index=pd.Index(["c1", "c2"], name="cellID"),
+    )
+    ad.AnnData(X=np.zeros((2, 2), dtype=np.float32), obs=obs).write_h5ad(tmp_path / "target.h5ad")
+    source = _make_h5ad(tmp_path / "source.h5ad", ["c1", "c2"], {"library_id": ["L1", "L2"]})
+
+    result = backfill_obs_from_source(str(tmp_path / "target.h5ad"), source, columns=["library_id"])
+
+    assert "error" not in result
+    out = ad.read_h5ad(result["output_path"])
+    assert list(out.obs["library_id"]) == ["L1", "L2"]
+    # "unknown" became unused through the fill — dropped; "L_unused" was
+    # already unused before the fill — kept.
+    assert set(out.obs["library_id"].cat.categories) == {"L_unused", "L1", "L2"}
+
+
+def test_backfill_refuses_new_categories_on_ordered_categorical(tmp_path):
+    """Appending to an ordered vocabulary would corrupt its ordering; a fill
+    that stays inside the existing vocabulary is fine."""
+    obs = pd.DataFrame(
+        {"stage": pd.Categorical([None, "E10", "E12"], categories=["E10", "E12"], ordered=True)},
+        index=pd.Index(["c1", "c2", "c3"], name="cellID"),
+    )
+    ad.AnnData(X=np.zeros((3, 2), dtype=np.float32), obs=obs).write_h5ad(tmp_path / "target.h5ad")
+    target = str(tmp_path / "target.h5ad")
+
+    new_cat_source = _make_h5ad(tmp_path / "source-new.h5ad", ["c1"], {"stage": ["E09"]})
+    result = backfill_obs_from_source(target, new_cat_source, columns=["stage"])
+    assert "error" in result
+    assert "ordered categorical" in result["error"]
+    assert not list(tmp_path.glob("*-edit-*.h5ad"))
+
+    in_vocab_source = _make_h5ad(tmp_path / "source-ok.h5ad", ["c1"], {"stage": ["E10"]})
+    result = backfill_obs_from_source(target, in_vocab_source, columns=["stage"])
+    assert "error" not in result
+    out = ad.read_h5ad(result["output_path"])
+    assert out.obs["stage"]["c1"] == "E10"
+    assert out.obs["stage"].cat.ordered
+    assert list(out.obs["stage"].cat.categories) == ["E10", "E12"]
+
+
 def test_codes_dtype_upcasts_when_categories_outgrow_int8():
     assert _codes_dtype(100, np.dtype(np.int8)) == np.dtype(np.int8)
     assert _codes_dtype(200, np.dtype(np.int8)) == np.dtype(np.int16)

--- a/packages/hca-anndata-tools/tests/test_backfill.py
+++ b/packages/hca-anndata-tools/tests/test_backfill.py
@@ -218,6 +218,24 @@ def test_backfill_numeric_column_refused(tmp_path):
     assert "not categorical or string" in result["error"]
 
 
+def test_backfill_non_string_categorical_refused(tmp_path):
+    """A numeric pandas Categorical is stored as a categories-group too; it
+    must get the clear unsupported-column refusal, not a .strip() crash."""
+
+    def make_numeric_categorical(path):
+        obs = pd.DataFrame({"n_reads": pd.Categorical([1, 2])}, index=pd.Index(["c1", "c2"], name="cellID"))
+        ad.AnnData(X=np.zeros((2, 2), dtype=np.float32), obs=obs).write_h5ad(path)
+        return str(path)
+
+    target = make_numeric_categorical(tmp_path / "target.h5ad")
+    source = make_numeric_categorical(tmp_path / "source.h5ad")
+
+    result = backfill_obs_from_source(target, source, columns=["n_reads"])
+
+    assert "error" in result
+    assert "categorical of non-string values" in result["error"]
+
+
 def test_backfill_index_is_not_a_column(target_source):
     target, source = target_source
     result = backfill_obs_from_source(target, source, columns=["cellID"])

--- a/packages/hca-anndata-tools/tests/test_backfill.py
+++ b/packages/hca-anndata-tools/tests/test_backfill.py
@@ -1,0 +1,333 @@
+"""Tests for backfill_obs_from_source."""
+
+import json
+
+import anndata as ad
+import numpy as np
+import pandas as pd
+import pytest
+
+from hca_anndata_tools.backfill import _codes_dtype, backfill_obs_from_source
+
+# The canonical scenario, one row per case the tool must handle:
+#
+#   cell  target lib   source lib   expectation
+#   c1    NaN          L1           filled (from NaN)
+#   c2    "unknown"    L2           filled (from placeholder)
+#   c3    L9           "unknown"    already_set (source missing — no conflict)
+#   c4    L1           L2           already_set + conflict (reported, not written)
+#   c5    NaN          (absent)     unmatched
+#   c6    ""           (absent)     unmatched (empty string counts as missing)
+#   c7    NaN          "na"         source_missing (both sides empty)
+#   x1    (absent)     L5           source cell skipped silently
+TARGET_IDS = ["c1", "c2", "c3", "c4", "c5", "c6", "c7"]
+TARGET_LIB = [None, "unknown", "L9", "L1", None, "", None]
+SOURCE_IDS = ["c1", "c2", "c3", "c4", "c7", "x1"]
+SOURCE_LIB = ["L1", "L2", "unknown", "L2", "na", "L5"]
+
+
+def _make_h5ad(path, ids, columns, categorical=True, index_name="cellID", uns=None):
+    """Write a minimal h5ad with the given obs columns.
+
+    Categorical columns represent NaN as None; string columns cannot hold
+    NaN, so string variants substitute "" (which the tool treats as missing).
+    """
+    obs = pd.DataFrame(index=pd.Index(ids, name=index_name))
+    for name, values in columns.items():
+        if categorical and not all(isinstance(v, int | float) for v in values):
+            obs[name] = pd.Categorical(values)
+        elif categorical:
+            obs[name] = np.asarray(values, dtype=np.float32)
+        else:
+            obs[name] = ["" if v is None else v for v in values]
+    adata = ad.AnnData(X=np.zeros((len(ids), 2), dtype=np.float32), obs=obs)
+    if uns:
+        adata.uns.update(uns)
+    adata.write_h5ad(path)
+    return str(path)
+
+
+@pytest.fixture
+def target_source(tmp_path):
+    target = _make_h5ad(tmp_path / "target.h5ad", TARGET_IDS, {"library_id": TARGET_LIB})
+    source = _make_h5ad(tmp_path / "source.h5ad", SOURCE_IDS, {"library_id": SOURCE_LIB})
+    return target, source
+
+
+def test_backfill_categorical(target_source):
+    target, source = target_source
+    result = backfill_obs_from_source(target, source, columns=["library_id"])
+
+    assert "error" not in result
+    assert result["n_source_cells"] == 6
+    assert result["n_target_cells"] == 7
+    assert result["n_matched"] == 5
+    assert result["total_filled"] == 2
+
+    stats = result["per_column"]["library_id"]
+    assert stats["filled"] == 2
+    assert stats["already_set"] == 2
+    assert stats["conflicts"] == 1
+    assert stats["conflict_examples"] == [["c4", "L1", "L2"]]
+    assert stats["source_missing"] == 1
+    assert stats["unmatched"] == 2
+    assert stats["missing_before"] == 5
+    assert stats["missing_after"] == 3
+    assert stats["pct_full_after"] == round(100 * 4 / 7, 1)
+
+    out = ad.read_h5ad(result["output_path"])
+    lib = out.obs["library_id"]
+    assert lib["c1"] == "L1"  # filled from NaN
+    assert lib["c2"] == "L2"  # filled over placeholder
+    assert lib["c3"] == "L9"  # source missing — left alone
+    assert lib["c4"] == "L1"  # conflict — left alone, not overwritten
+    assert pd.isna(lib["c5"])  # unmatched — still NaN
+    assert lib["c6"] == ""  # unmatched — untouched
+    assert pd.isna(lib["c7"])  # source had only a placeholder
+    # c2 was the only "unknown"; the fill left the category unused
+    assert "unknown" not in lib.cat.categories
+    assert set(lib.cat.categories) == {"L1", "L2", "L9", ""}
+
+
+def test_backfill_records_edit_log(target_source):
+    target, source = target_source
+    result = backfill_obs_from_source(target, source, columns=["library_id"])
+
+    out = ad.read_h5ad(result["output_path"])
+    entries = json.loads(out.uns["provenance"]["edit_history"])
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["operation"] == "backfill_obs_from_source"
+    assert entry["details"]["backfill_source_file"] == "source.h5ad"
+    assert entry["details"]["per_column"]["library_id"]["filled"] == 2
+    assert entry["source_file"] == "target.h5ad"
+
+
+def test_backfill_string_columns(tmp_path):
+    target = _make_h5ad(tmp_path / "target.h5ad", TARGET_IDS, {"library_id": TARGET_LIB}, categorical=False)
+    source = _make_h5ad(tmp_path / "source.h5ad", SOURCE_IDS, {"library_id": SOURCE_LIB}, categorical=False)
+
+    result = backfill_obs_from_source(target, source, columns=["library_id"])
+
+    assert "error" not in result
+    stats = result["per_column"]["library_id"]
+    assert stats["filled"] == 2
+    assert stats["conflicts"] == 1
+    assert stats["missing_after"] == 3
+
+    out = ad.read_h5ad(result["output_path"])
+    lib = out.obs["library_id"]
+    assert lib["c1"] == "L1"
+    assert lib["c2"] == "L2"
+    assert lib["c4"] == "L1"
+    assert lib["c7"] == ""  # source had only a placeholder — untouched
+
+
+def test_backfill_multiple_columns_reported_separately(tmp_path):
+    # run_id has nothing to fill (all set); library_id fills — per-column
+    # stats must keep the two apart (the issue's library_preparation_batch case).
+    target = _make_h5ad(
+        tmp_path / "target.h5ad",
+        TARGET_IDS,
+        {"library_id": TARGET_LIB, "run_id": ["R1", "R2", "R3", "R4", "R5", "R6", "R7"]},
+    )
+    source = _make_h5ad(
+        tmp_path / "source.h5ad",
+        SOURCE_IDS,
+        {"library_id": SOURCE_LIB, "run_id": ["R1", "R2", "R3", "R4", "R5", "R9"]},
+    )
+
+    result = backfill_obs_from_source(target, source, columns=["library_id", "run_id"])
+
+    assert "error" not in result
+    assert result["per_column"]["library_id"]["filled"] == 2
+    assert result["per_column"]["run_id"]["filled"] == 0
+    assert result["per_column"]["run_id"]["already_set"] == 5
+    assert result["per_column"]["run_id"]["pct_full_after"] == 100.0
+    assert result["total_filled"] == 2
+
+
+def test_backfill_nothing_to_fill_writes_nothing(tmp_path):
+    target = _make_h5ad(tmp_path / "target.h5ad", ["c1", "c2"], {"library_id": ["L1", "L2"]})
+    source = _make_h5ad(tmp_path / "source.h5ad", ["c1", "c2"], {"library_id": ["L1", "L9"]})
+
+    result = backfill_obs_from_source(target, source, columns=["library_id"])
+
+    assert "error" in result
+    assert "Nothing to backfill" in result["error"]
+    # The stats still surface what was found — including the conflict
+    assert result["per_column"]["library_id"]["already_set"] == 2
+    assert result["per_column"]["library_id"]["conflicts"] == 1
+    assert not list(tmp_path.glob("*-edit-*.h5ad"))
+
+
+def test_backfill_zero_overlap_is_error(tmp_path):
+    target = _make_h5ad(tmp_path / "target.h5ad", ["c1", "c2"], {"library_id": [None, None]})
+    source = _make_h5ad(tmp_path / "source.h5ad", ["z1", "z2"], {"library_id": ["L1", "L2"]})
+
+    result = backfill_obs_from_source(target, source, columns=["library_id"])
+
+    assert "error" in result
+    assert "0 shared" in result["error"]
+    assert not list(tmp_path.glob("*-edit-*.h5ad"))
+
+
+def test_backfill_partial_overlap_is_not_an_error(tmp_path):
+    # Source cells absent from the target are skipped silently — the target
+    # may simply have filtered them out.
+    target = _make_h5ad(tmp_path / "target.h5ad", ["c1"], {"library_id": [None]})
+    source = _make_h5ad(tmp_path / "source.h5ad", ["c1", "z1", "z2", "z3"], {"library_id": ["L1"] * 4})
+
+    result = backfill_obs_from_source(target, source, columns=["library_id"])
+
+    assert "error" not in result
+    assert result["n_matched"] == 1
+    assert result["per_column"]["library_id"]["filled"] == 1
+
+
+def test_backfill_column_missing_from_source(target_source, tmp_path):
+    target, _ = target_source
+    source = _make_h5ad(tmp_path / "other-source.h5ad", SOURCE_IDS, {"other_col": SOURCE_LIB})
+
+    result = backfill_obs_from_source(target, source, columns=["library_id"])
+
+    assert "error" in result
+    assert "Source file has no obs column 'library_id'" in result["error"]
+
+
+def test_backfill_column_missing_from_target(target_source):
+    target, source = target_source
+    result = backfill_obs_from_source(target, source, columns=["nope"])
+    assert "error" in result
+    assert "Target file has no obs column 'nope'" in result["error"]
+
+
+def test_backfill_numeric_column_refused(tmp_path):
+    target = _make_h5ad(tmp_path / "target.h5ad", ["c1", "c2"], {"n_counts": [1.0, 2.0]})
+    source = _make_h5ad(tmp_path / "source.h5ad", ["c1", "c2"], {"n_counts": [1.0, 2.0]})
+
+    result = backfill_obs_from_source(target, source, columns=["n_counts"])
+
+    assert "error" in result
+    assert "not categorical or string" in result["error"]
+
+
+def test_backfill_index_is_not_a_column(target_source):
+    target, source = target_source
+    result = backfill_obs_from_source(target, source, columns=["cellID"])
+    assert "error" in result
+    assert "join key" in result["error"]
+
+
+def test_backfill_duplicate_source_ids_refused(target_source, tmp_path):
+    target, _ = target_source
+    with pytest.warns(UserWarning, match="Observation names are not unique"):
+        source = _make_h5ad(tmp_path / "dupes.h5ad", ["c1", "c1", "c2"], {"library_id": ["L1", "L2", "L3"]})
+
+    result = backfill_obs_from_source(target, source, columns=["library_id"])
+
+    assert "error" in result
+    assert "Source cells have duplicate IDs" in result["error"]
+
+
+def test_backfill_argument_validation(target_source):
+    target, source = target_source
+    for bad_columns, expected in [
+        ([], "non-empty list"),
+        (["library_id", "library_id"], "duplicates"),
+        (["obs/library_id"], "without '/'"),
+        ([42], "not a valid obs column name"),
+    ]:
+        result = backfill_obs_from_source(target, source, columns=bad_columns)
+        assert "error" in result
+        assert expected in result["error"]
+
+
+def test_backfill_same_file_refused(target_source):
+    target, _ = target_source
+    result = backfill_obs_from_source(target, target, columns=["library_id"])
+    assert "error" in result
+    assert "same file" in result["error"]
+
+
+def test_backfill_missing_files(target_source):
+    target, source = target_source
+    assert "Target file not found" in backfill_obs_from_source("/nonexistent/t.h5ad", source, ["library_id"])["error"]
+    assert "Source file not found" in backfill_obs_from_source(target, "/nonexistent/s.h5ad", ["library_id"])["error"]
+
+
+def test_backfill_legacy_cap_target_refused(target_source, tmp_path):
+    _, source = target_source
+    target = _make_h5ad(
+        tmp_path / "legacy.h5ad",
+        TARGET_IDS,
+        {"library_id": TARGET_LIB},
+        uns={"cellannotation_metadata": {"some_set": {}}},
+    )
+
+    result = backfill_obs_from_source(target, source, columns=["library_id"])
+
+    assert "error" in result
+    assert "deprecated top-level CAP layout" in result["error"]
+
+
+def test_backfill_runs_chain(tmp_path, monkeypatch):
+    """Per-source runs chain: each resolves the newest snapshot and replaces
+    the previous one, never touching the original."""
+    # Distinct timestamps per run — two real runs can land in the same second,
+    # which the same-second guard refuses.
+    ticks = iter(["2026-08-19-00-00-01", "2026-08-19-00-00-02"])
+    monkeypatch.setattr("hca_anndata_tools.write.generate_timestamp", lambda: next(ticks))
+    target = _make_h5ad(tmp_path / "target.h5ad", ["c1", "c2"], {"library_id": [None, None]})
+    source_a = _make_h5ad(tmp_path / "source-a.h5ad", ["c1"], {"library_id": ["L1"]})
+    source_b = _make_h5ad(tmp_path / "source-b.h5ad", ["c2"], {"library_id": ["L2"]})
+
+    first = backfill_obs_from_source(target, source_a, columns=["library_id"])
+    assert "error" not in first
+    # Passing the ORIGINAL path again: resolve_latest must pick up the snapshot
+    second = backfill_obs_from_source(target, source_b, columns=["library_id"])
+    assert "error" not in second
+
+    assert (tmp_path / "target.h5ad").is_file()  # original never deleted
+    snapshots = list(tmp_path.glob("target-edit-*.h5ad"))
+    assert [str(p) for p in snapshots] == [second["output_path"]]  # previous snapshot cleaned up
+
+    out = ad.read_h5ad(second["output_path"])
+    assert list(out.obs["library_id"]) == ["L1", "L2"]
+    entries = json.loads(out.uns["provenance"]["edit_history"])
+    assert [e["operation"] for e in entries] == ["backfill_obs_from_source"] * 2
+    assert second["per_column"]["library_id"]["pct_full_after"] == 100.0
+
+
+def test_backfill_same_second_snapshot_refused(target_source, monkeypatch):
+    """A second edit within the same second would name the output after its
+    own source; the guard refuses before touching anything."""
+    monkeypatch.setattr("hca_anndata_tools.backfill.generate_output_path", lambda p: p)
+    target, source = target_source
+
+    result = backfill_obs_from_source(target, source, columns=["library_id"])
+
+    assert "error" in result
+    assert "already exists" in result["error"]
+    assert ad.read_h5ad(target).n_obs == 7  # target untouched
+
+
+def test_backfill_extends_categories_without_disturbing_existing(tmp_path):
+    """New fill values extend the categories; existing values keep their
+    meaning (read-back equality is the check, not code equality)."""
+    target = _make_h5ad(tmp_path / "target.h5ad", ["c1", "c2", "c3"], {"library_id": ["unknown", "L_existing", None]})
+    source = _make_h5ad(tmp_path / "source.h5ad", ["c1", "c3"], {"library_id": ["L_new_1", "L_new_2"]})
+
+    result = backfill_obs_from_source(target, source, columns=["library_id"])
+
+    assert "error" not in result
+    out = ad.read_h5ad(result["output_path"])
+    assert list(out.obs["library_id"]) == ["L_new_1", "L_existing", "L_new_2"]
+    assert set(out.obs["library_id"].cat.categories) == {"L_existing", "L_new_1", "L_new_2"}
+
+
+def test_codes_dtype_upcasts_when_categories_outgrow_int8():
+    assert _codes_dtype(100, np.dtype(np.int8)) == np.dtype(np.int8)
+    assert _codes_dtype(200, np.dtype(np.int8)) == np.dtype(np.int16)
+    assert _codes_dtype(200, np.dtype(np.int32)) == np.dtype(np.int32)
+    assert _codes_dtype(2**20, np.dtype(np.int16)) == np.dtype(np.int32)

--- a/packages/hca-anndata-tools/tests/test_edit.py
+++ b/packages/hca-anndata-tools/tests/test_edit.py
@@ -339,6 +339,20 @@ def test_replace_placeholder_all_values_replaced(tmp_path):
     assert len(written.obs["test_col"].cat.categories) == 0
 
 
+def test_replace_placeholder_same_second_snapshot_refused(tmp_path, monkeypatch):
+    """A second edit within the same second would name the output after its
+    own source and the failure path would unlink that source snapshot; the
+    guard refuses before touching anything (mirrors rename/backfill)."""
+    monkeypatch.setattr("hca_anndata_tools.edit.generate_output_path", lambda p: p)
+    path = _make_placeholder_h5ad(tmp_path, ["valid", "unknown"])
+
+    result = replace_placeholder_values(str(path), ["test_col"])
+
+    assert "error" in result
+    assert "already exists" in result["error"]
+    assert path.is_file()  # the source snapshot was not unlinked
+
+
 def test_replace_placeholder_edit_log(tmp_path):
     path = _make_placeholder_h5ad(tmp_path, ["valid", "unknown"])
     result = replace_placeholder_values(str(path), ["test_col"])

--- a/packages/hca-anndata-tools/tests/test_write.py
+++ b/packages/hca-anndata-tools/tests/test_write.py
@@ -3,12 +3,15 @@
 import hashlib
 import json
 import re
+import shutil
 from pathlib import Path
 
 import anndata as ad
+import pytest
 
 from hca_anndata_tools.write import (
     EDIT_LOG_KEY,
+    _copy_with_sha256,
     generate_output_path,
     resolve_latest,
     strip_timestamp,
@@ -391,3 +394,29 @@ def test_has_edit_log_operation_accepts_list_shape(sample_h5ad_for_write):
 
     assert has_edit_log_operation(adata, "import_cellxgene") is True
     assert has_edit_log_operation(adata, "normalize_raw") is False
+
+
+# --- _copy_with_sha256 ---
+
+
+def test_copy_with_sha256_copies_and_hashes_in_one_pass(tmp_path):
+    src = tmp_path / "src.bin"
+    src.write_bytes(b"hello h5ad")
+    dst = tmp_path / "dst.bin"
+
+    digest = _copy_with_sha256(str(src), str(dst))
+
+    assert dst.read_bytes() == b"hello h5ad"
+    assert digest == hashlib.sha256(b"hello h5ad").hexdigest()
+
+
+def test_copy_with_sha256_refuses_same_path(tmp_path):
+    """Opening dest with 'wb' would truncate the source before reading it —
+    a same-path call must fail like shutil.copy2, not zero out the file."""
+    src = tmp_path / "src.bin"
+    src.write_bytes(b"do not truncate")
+
+    with pytest.raises(shutil.SameFileError):
+        _copy_with_sha256(str(src), str(src))
+
+    assert src.read_bytes() == b"do not truncate"

--- a/packages/hca-anndata-tools/tests/test_write.py
+++ b/packages/hca-anndata-tools/tests/test_write.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import json
+import os
 import re
 import shutil
 from pathlib import Path
@@ -418,5 +419,19 @@ def test_copy_with_sha256_refuses_same_path(tmp_path):
 
     with pytest.raises(shutil.SameFileError):
         _copy_with_sha256(str(src), str(src))
+
+    assert src.read_bytes() == b"do not truncate"
+
+
+def test_copy_with_sha256_refuses_hard_link(tmp_path):
+    """Two hard links share an inode but not a resolved path — the guard
+    must compare filesystem identity, not path strings."""
+    src = tmp_path / "src.bin"
+    src.write_bytes(b"do not truncate")
+    link = tmp_path / "link.bin"
+    os.link(src, link)
+
+    with pytest.raises(shutil.SameFileError):
+        _copy_with_sha256(str(src), str(link))
 
     assert src.read_bytes() == b"do not truncate"


### PR DESCRIPTION
Closes #534

## What changed

- New `backfill_obs_from_source(target_path, source_path, columns)` in `hca-anndata-tools`: joins source cells to target cells on the obs index and copies values into target cells whose current value is missing (NaN, empty, or a placeholder such as `unknown`). Exposed as an MCP tool in `hca-anndata-mcp`.
- Never overwrites a set value: target/source disagreements are counted per column as `conflicts` with up to five `[cell_id, target, source]` examples — reported, not written, not an error.
- Reports per column: `filled`, `already_set`, `conflicts`, `source_missing` (both sides empty — a genuine upstream gap), `unmatched` (no source cell to consult), `missing_before`/`missing_after`/`pct_full_after` over all target cells; plus file-level `n_source_cells`/`n_target_cells`/`n_matched`.
- Runs once per source; chains through the timestamped-snapshot convention (resolve latest → write new snapshot + edit-log entry → delete previous snapshot, never the original). "Nothing to fill" writes nothing (no pointless multi-GB copy) and still returns the stats.
- Categorical care: categories extend for new values (codes dtype upcast when int8 would overflow); only categories the fill itself orphaned are dropped; fills that would append new categories to an **ordered** categorical are refused.
- Shared-machinery extractions into `_io.py`/`write.py` (duplicate-ID check, string/categorical column rewrites, category compaction, missing-value predicate, single-read hash+copy), adopted by `edit.py`, `rename.py`, and `copy_cap.py` where their behavior was identical. Review-round hardening included: same-second snapshot guard added to `replace_placeholder_values`, same-path refusal in `_copy_with_sha256`, contiguous-layout preservation in `replace_string_dataset`, code-range check before `bincount`.

## Why

126,227 nee2023 cells in the breast-v1 integrated object carry real `library_id`/`library_sequencing_run` values in their source dataset but `unknown`/NaN in the integrated object — recoverable by a cell-level join, but no tool existed for it (`copy_cap_annotations` is the same shape but hardwired to CAP annotation sets).

## Assumptions I made

- **Partial overlap is normal, not an error** (decided with the issue author during planning): source cells absent from the target are skipped silently — integration filters cells and draws from seven sources. Only a zero-overlap join errors. The issue's original overlap-threshold and unmatched-ID-example safeguards were dropped by that decision; the per-column stats carry the signal instead.
- **Conflicts report, they don't abort** (option chosen by the issue author): the issue's original "error rather than guess" became "leave alone, count, and show examples" — we never make anything worse, and the diff stays visible.
- Missing = NaN, empty/whitespace-only, or the `DEFAULT_PLACEHOLDERS` vocabulary (case-insensitive, stripped). This is deliberately broader than `replace_placeholder_values`' exact matching; the divergence is documented and #600 tracks whether to align them.
- Only categorical and string obs columns are supported; numeric/boolean/nullable-dtype columns are refused (no missing vocabulary this tool understands).
- Both paths auto-resolve to their latest `-edit-` snapshot; the source file is never modified. Run any `rename_cell_ids` repair **before** backfilling — the tool joins by cell identity and trusts the join (#533 ordering note).
- Follow-up #600 covers the write-machinery hardening that reaches beyond this diff (same-second guard for the remaining tools, `_copy_with_sha256` adoption, missing-value semantics decision).

## How to verify

The issue's requirements, each mapped to a check (all runnable without real data via the test suite: `cd packages/hca-anndata-tools && uv run pytest tests/test_backfill.py -v`):

1. **"Never overwrite an existing value ... report already_set ... conflicts"** → `test_backfill_categorical` (c3/c4 rows: set values untouched, conflict counted with example `[c4, L1, L2]`).
2. **"Report per column, not per file"** (the `library_preparation_batch` counterexample) → `test_backfill_multiple_columns_reported_separately`: one column fills, the other reports `filled: 0` / `pct_full_after: 100.0`.
3. **"Report join coverage before mutating"** → every result carries `n_source_cells`/`n_target_cells`/`n_matched`; `test_backfill_zero_overlap_is_error` shows the wrong-file refusal, `test_backfill_partial_overlap_is_not_an_error` the silent-skip contract.
4. **"Handle the many-sources case"** → `test_backfill_runs_chain`: two single-source runs chain through snapshots; original file survives, one snapshot remains, edit log holds both entries.
5. **"Categorical dtype needs care"** → `test_backfill_extends_categories_without_disturbing_existing`, `test_backfill_keeps_preexisting_unused_categories`, `test_backfill_refuses_new_categories_on_ordered_categorical`, `test_codes_dtype_upcasts_when_categories_outgrow_int8`.

**On real data** (the acceptance demo): with the breast-v1 integrated object and the nee2023 source (paths in the HCA tracker upload dirs), run the MCP tool `backfill_obs_from_source` with `columns=["library_id", "library_sequencing_run"]` and expect `filled` ≈ 126,227 per the issue's measurement, `conflicts` = 0, and a `pct_full_after` that rises accordingly; then `view_edit_log` on the output to see the recorded per-column stats. Rerunning the same backfill should return the "Nothing to backfill" no-write result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)