### PR TITLE
fix(hca-anndata-tools): stop same-second snapshot collisions from destroying the previous snapshot

### DIFF
--- a/packages/hca-anndata-tools/src/hca_anndata_tools/backfill.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/backfill.py
@@ -39,6 +39,7 @@ from ._io import (
 )
 from .cap import LEGACY_LAYOUT_DESCRIPTION, is_legacy_cap_layout
 from .write import (
+    SAME_SECOND_SNAPSHOT_ERROR,
     _compute_sha256,
     _copy_with_sha256,
     build_edit_log,
@@ -403,7 +404,7 @@ def backfill_obs_from_source(target_path: str, source_path: str, columns: list[s
             # a second edit within the same second would name the output after
             # its own source. Refuse before touching anything — and before the
             # source hash below, which reads the whole source file.
-            return {"error": "An edit snapshot for this second already exists — retry in a moment."}
+            return {"error": SAME_SECOND_SNAPSHOT_ERROR}
         source_basename = Path(source_path).name
         source_sha256 = _compute_sha256(source_path)
         target_sha256 = _copy_with_sha256(target_path, output_path)

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -40,6 +40,7 @@ from .marker_genes import validate_marker_genes
 from .strip_cap import _LEGACY_TOP_LEVEL_PROVENANCE, strip_cap_annotations
 from .write import (
     EDIT_LOG_KEY,
+    SAME_SECOND_SNAPSHOT_ERROR,
     _compute_sha256,
     build_edit_log,
     cleanup_previous_version,
@@ -416,7 +417,7 @@ def copy_cap_annotations(
             time.sleep(1)
             output_path = generate_output_path(target_path)
         if is_target_alias(output_path):
-            return {"error": "An edit snapshot for this second already exists — retry in a moment."}
+            return {"error": SAME_SECOND_SNAPSHOT_ERROR}
 
         with tempfile.TemporaryDirectory() as tmpdir:
             temp_path = str(Path(tmpdir) / "cap_temp.h5ad")

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/drop.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/drop.py
@@ -292,8 +292,24 @@ def drop_obs_columns(path: str, columns: list[str] | tuple[str, ...]) -> dict:
             output_path = generate_output_path(path)
         if output_path == path:
             return {"error": "An edit snapshot for this second already exists — retry in a moment."}
-        shutil.copy2(path, output_path)
+        # Set *before* the copy, not after: shutil.copyfile opens the
+        # destination for writing and does not remove it if the copy then
+        # fails partway (ENOSPC on a multi-GB h5ad is the realistic case), so
+        # a partial file at output_path is ours to clean up. Leaving it behind
+        # would be worse than the original bug — it carries the newest -edit-
+        # timestamp, so resolve_latest would hand that truncated file to every
+        # later call on the dataset.
         snapshot_created = True
+        try:
+            shutil.copy2(path, output_path)
+        except shutil.SameFileError:
+            # The one failure that writes nothing: copy2 compares inodes before
+            # opening the destination. It is also the one case where unlinking
+            # output_path would delete the source, so return here rather than
+            # falling through to the handler. Catches what the equality check
+            # above cannot — aliases of the source ('./'-prefixed paths, hard
+            # links) whose string form differs (#598).
+            return {"error": "An edit snapshot for this second already exists — retry in a moment."}
 
         # Defer the malformed-log cleanup until after the with-block closes the
         # output file, matching strip_forbidden_obs_columns: unlinking an open

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/drop.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/drop.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import contextlib
 import shutil
+import time
 from pathlib import Path
 
 import h5py
@@ -227,6 +228,11 @@ def drop_obs_columns(path: str, columns: list[str] | tuple[str, ...]) -> dict:
         was rejected or the write failed.
     """
     output_path = None
+    # Whether *we* created the file at output_path. The name is bound before
+    # the copy, so the failure path below must not delete a file it may never
+    # have written — that is what turned shutil.copy2's safe SameFileError
+    # into deletion of the source snapshot (#598).
+    snapshot_created = False
     try:
         # Shape-check the argument before anything reads it. This is an
         # MCP-exposed tool, so `columns` arrives as decoded JSON and may hold
@@ -277,12 +283,17 @@ def drop_obs_columns(path: str, columns: list[str] | tuple[str, ...]) -> dict:
 
         output_path = generate_output_path(path)
         if output_path == path:
-            # generate_output_path timestamps to the second, so a second edit
-            # within the same second names the output after its own source;
-            # copying would raise SameFileError and the failure path would
-            # then unlink the source snapshot. Refuse before touching anything.
+            # generate_output_path timestamps to the second (see rename.py):
+            # a second edit within the same second names the output after its
+            # own source. Wait out the boundary rather than failing the run,
+            # as copy_cap does — this tool is fast enough that back-to-back
+            # curation steps land in one second routinely.
+            time.sleep(1)
+            output_path = generate_output_path(path)
+        if output_path == path:
             return {"error": "An edit snapshot for this second already exists — retry in a moment."}
         shutil.copy2(path, output_path)
+        snapshot_created = True
 
         # Defer the malformed-log cleanup until after the with-block closes the
         # output file, matching strip_forbidden_obs_columns: unlinking an open
@@ -328,7 +339,7 @@ def drop_obs_columns(path: str, columns: list[str] | tuple[str, ...]) -> dict:
         }
 
     except Exception as e:
-        if output_path and Path(output_path).is_file():
+        if snapshot_created and output_path and Path(output_path).is_file():
             with contextlib.suppress(OSError):
                 Path(output_path).unlink()
         return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/drop.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/drop.py
@@ -308,13 +308,13 @@ def drop_obs_columns(path: str, columns: list[str] | tuple[str, ...]) -> dict:
                 Path(output_path).unlink()
                 return log_error
 
-            cleanup_previous_version(path, output_path)
+        cleanup_previous_version(path, output_path)
 
-            return {
-                "output_path": output_path,
-                "obs_columns_dropped": requested,
-                "uns_keys_dropped": owned_uns_keys,
-            }
+        return {
+            "output_path": output_path,
+            "obs_columns_dropped": requested,
+            "uns_keys_dropped": owned_uns_keys,
+        }
 
     except Exception as e:
         return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/drop.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/drop.py
@@ -276,6 +276,12 @@ def drop_obs_columns(path: str, columns: list[str] | tuple[str, ...]) -> dict:
             return {"error": "Refusing to drop: " + "; ".join(problems)}
 
         output_path = generate_output_path(path)
+        if output_path == path:
+            # generate_output_path timestamps to the second, so a second edit
+            # within the same second names the output after its own source;
+            # copying would raise SameFileError and the failure path would
+            # then unlink the source snapshot. Refuse before touching anything.
+            return {"error": "An edit snapshot for this second already exists — retry in a moment."}
         shutil.copy2(path, output_path)
 
         # Defer the malformed-log cleanup until after the with-block closes the

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/drop.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/drop.py
@@ -17,9 +17,6 @@ per dataset.
 
 from __future__ import annotations
 
-import contextlib
-import shutil
-import time
 from pathlib import Path
 
 import h5py
@@ -35,9 +32,9 @@ from .schema.helpers import obs_column_tiers
 from .write import (
     build_edit_log,
     cleanup_previous_version,
-    generate_output_path,
     make_edit_entry,
     resolve_latest,
+    snapshot_copy,
 )
 
 
@@ -227,12 +224,6 @@ def drop_obs_columns(path: str, columns: list[str] | tuple[str, ...]) -> dict:
         ``uns_keys_dropped`` on success, or ``{"error": ...}`` if the request
         was rejected or the write failed.
     """
-    output_path = None
-    # Whether *we* created the file at output_path. The name is bound before
-    # the copy, so the failure path below must not delete a file it may never
-    # have written — that is what turned shutil.copy2's safe SameFileError
-    # into deletion of the source snapshot (#598).
-    snapshot_created = False
     try:
         # Shape-check the argument before anything reads it. This is an
         # MCP-exposed tool, so `columns` arrives as decoded JSON and may hold
@@ -281,81 +272,49 @@ def drop_obs_columns(path: str, columns: list[str] | tuple[str, ...]) -> dict:
         if problems:
             return {"error": "Refusing to drop: " + "; ".join(problems)}
 
-        output_path = generate_output_path(path)
-        if output_path == path:
-            # generate_output_path timestamps to the second (see rename.py):
-            # a second edit within the same second names the output after its
-            # own source. Wait out the boundary rather than failing the run,
-            # as copy_cap does — this tool is fast enough that back-to-back
-            # curation steps land in one second routinely.
-            time.sleep(1)
-            output_path = generate_output_path(path)
-        if output_path == path:
-            return {"error": "An edit snapshot for this second already exists — retry in a moment."}
-        # Set *before* the copy, not after: shutil.copyfile opens the
-        # destination for writing and does not remove it if the copy then
-        # fails partway (ENOSPC on a multi-GB h5ad is the realistic case), so
-        # a partial file at output_path is ours to clean up. Leaving it behind
-        # would be worse than the original bug — it carries the newest -edit-
-        # timestamp, so resolve_latest would hand that truncated file to every
-        # later call on the dataset.
-        snapshot_created = True
-        try:
-            shutil.copy2(path, output_path)
-        except shutil.SameFileError:
-            # The one failure that writes nothing: copy2 compares inodes before
-            # opening the destination. It is also the one case where unlinking
-            # output_path would delete the source, so return here rather than
-            # falling through to the handler. Catches what the equality check
-            # above cannot — aliases of the source ('./'-prefixed paths, hard
-            # links) whose string form differs (#598).
-            return {"error": "An edit snapshot for this second already exists — retry in a moment."}
+        with snapshot_copy(path) as output_path:
+            # Defer the malformed-log cleanup until after the with-block closes the
+            # output file, matching strip_forbidden_obs_columns: unlinking an open
+            # HDF5 handle works on POSIX but raises on Windows, and the context
+            # __exit__ flush would hit a removed inode either way.
+            log_error = None
+            with h5py.File(output_path, "a") as f_out:
+                for col in requested:
+                    del f_out["obs"][col]
+                update_column_order(f_out, [], set(requested))
+                for key in owned_uns_keys:
+                    del f_out["uns"][key]
 
-        # Defer the malformed-log cleanup until after the with-block closes the
-        # output file, matching strip_forbidden_obs_columns: unlinking an open
-        # HDF5 handle works on POSIX but raises on Windows, and the context
-        # __exit__ flush would hit a removed inode either way.
-        log_error = None
-        with h5py.File(output_path, "a") as f_out:
-            for col in requested:
-                del f_out["obs"][col]
-            update_column_order(f_out, [], set(requested))
-            for key in owned_uns_keys:
-                del f_out["uns"][key]
+                described = f"Dropped obs columns: {requested}"
+                if owned_uns_keys:
+                    described += f" (and the palettes they own: {owned_uns_keys})"
+                entry = make_edit_entry(
+                    operation="drop_obs_columns",
+                    description=described,
+                    details={
+                        "obs_columns_dropped": requested,
+                        "uns_keys_dropped": owned_uns_keys,
+                    },
+                )
 
-            described = f"Dropped obs columns: {requested}"
-            if owned_uns_keys:
-                described += f" (and the palettes they own: {owned_uns_keys})"
-            entry = make_edit_entry(
-                operation="drop_obs_columns",
-                description=described,
-                details={
-                    "obs_columns_dropped": requested,
-                    "uns_keys_dropped": owned_uns_keys,
-                },
-            )
+                existing_log = read_edit_log_h5py(f_out)
+                log_result = build_edit_log(existing_log, [entry], path)
+                if "error" in log_result:
+                    log_error = log_result
+                else:
+                    write_edit_log_h5py(f_out, log_result["json"])
 
-            existing_log = read_edit_log_h5py(f_out)
-            log_result = build_edit_log(existing_log, [entry], path)
-            if "error" in log_result:
-                log_error = log_result
-            else:
-                write_edit_log_h5py(f_out, log_result["json"])
+            if log_error is not None:
+                Path(output_path).unlink()
+                return log_error
 
-        if log_error is not None:
-            Path(output_path).unlink()
-            return log_error
+            cleanup_previous_version(path, output_path)
 
-        cleanup_previous_version(path, output_path)
-
-        return {
-            "output_path": output_path,
-            "obs_columns_dropped": requested,
-            "uns_keys_dropped": owned_uns_keys,
-        }
+            return {
+                "output_path": output_path,
+                "obs_columns_dropped": requested,
+                "uns_keys_dropped": owned_uns_keys,
+            }
 
     except Exception as e:
-        if snapshot_created and output_path and Path(output_path).is_file():
-            with contextlib.suppress(OSError):
-                Path(output_path).unlink()
         return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
@@ -26,6 +26,7 @@ from ._io import (
 from ._serialize import make_serializable
 from .schema.helpers import uns_field_registry
 from .write import (
+    SAME_SECOND_SNAPSHOT_ERROR,
     _compute_sha256,
     build_edit_log,
     cleanup_previous_version,
@@ -338,7 +339,7 @@ def replace_placeholder_values(
             # a second edit within the same second names the output after its
             # own source, and the failure path would then unlink that source
             # snapshot. Refuse before touching anything.
-            return {"error": "An edit snapshot for this second already exists — retry in a moment."}
+            return {"error": SAME_SECOND_SNAPSHOT_ERROR}
         shutil.copy2(path, output_path)
 
         with h5py.File(output_path, "a") as f:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/rename.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/rename.py
@@ -33,6 +33,7 @@ from ._io import (
 from .cap import LEGACY_LAYOUT_DESCRIPTION, is_legacy_cap_layout
 from .inspect import _read_schema_version
 from .write import (
+    SAME_SECOND_SNAPSHOT_ERROR,
     _compute_sha256,
     build_edit_log,
     cleanup_previous_version,
@@ -318,7 +319,7 @@ def rename_cell_ids(path: str, column: str, value: str, prefix_from: str, prefix
             # within the same second names the output after its own source;
             # copying would raise SameFileError and the failure path would
             # then unlink the source snapshot. Refuse before touching anything.
-            return {"error": "An edit snapshot for this second already exists — retry in a moment."}
+            return {"error": SAME_SECOND_SNAPSHOT_ERROR}
         shutil.copy2(path, output_path)
 
         # Hash the source before opening the output: build_edit_log would

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/strip.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/strip.py
@@ -163,12 +163,12 @@ def strip_forbidden_obs_columns(path: str) -> dict:
                 Path(output_path).unlink()
                 return log_error
 
-            cleanup_previous_version(path, output_path)
+        cleanup_previous_version(path, output_path)
 
-            return {
-                "output_path": output_path,
-                "obs_columns_stripped": stripped,
-            }
+        return {
+            "output_path": output_path,
+            "obs_columns_stripped": stripped,
+        }
 
     except Exception as e:
         return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/strip.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/strip.py
@@ -152,8 +152,24 @@ def strip_forbidden_obs_columns(path: str) -> dict:
             output_path = generate_output_path(path)
         if output_path == path:
             return {"error": "An edit snapshot for this second already exists — retry in a moment."}
-        shutil.copy2(path, output_path)
+        # Set *before* the copy, not after: shutil.copyfile opens the
+        # destination for writing and does not remove it if the copy then
+        # fails partway (ENOSPC on a multi-GB h5ad is the realistic case), so
+        # a partial file at output_path is ours to clean up. Leaving it behind
+        # would be worse than the original bug — it carries the newest -edit-
+        # timestamp, so resolve_latest would hand that truncated file to every
+        # later call on the dataset.
         snapshot_created = True
+        try:
+            shutil.copy2(path, output_path)
+        except shutil.SameFileError:
+            # The one failure that writes nothing: copy2 compares inodes before
+            # opening the destination. It is also the one case where unlinking
+            # output_path would delete the source, so return here rather than
+            # falling through to the handler. Catches what the equality check
+            # above cannot — aliases of the source ('./'-prefixed paths, hard
+            # links) whose string form differs (#598).
+            return {"error": "An edit snapshot for this second already exists — retry in a moment."}
 
         # Defer the malformed-log cleanup until after the with-block closes
         # the output file — calling os.remove on an open HDF5 handle works

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/strip.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/strip.py
@@ -15,9 +15,6 @@ truth.
 
 from __future__ import annotations
 
-import contextlib
-import shutil
-import time
 from pathlib import Path
 
 import h5py
@@ -30,9 +27,9 @@ from ._io import (
 from .write import (
     build_edit_log,
     cleanup_previous_version,
-    generate_output_path,
     make_edit_entry,
     resolve_latest,
+    snapshot_copy,
 )
 
 # Obs columns that exist in CellxGENE files but are forbidden in HCA
@@ -103,12 +100,6 @@ def strip_forbidden_obs_columns(path: str) -> dict:
         were already absent; ``{"error": ...}`` on failure (including
         the CellxGENE-layout refusal).
     """
-    output_path = None
-    # Whether *we* created the file at output_path. The name is bound before
-    # the copy, so the failure path below must not delete a file it may never
-    # have written — that is what turned shutil.copy2's safe SameFileError
-    # into deletion of the source snapshot (#598).
-    snapshot_created = False
     try:
         path = resolve_latest(path)
         if not Path(path).is_file():
@@ -141,75 +132,43 @@ def strip_forbidden_obs_columns(path: str) -> dict:
                 ),
             }
 
-        output_path = generate_output_path(path)
-        if output_path == path:
-            # generate_output_path timestamps to the second (see rename.py):
-            # a second edit within the same second names the output after its
-            # own source. Wait out the boundary rather than failing the run,
-            # as copy_cap does — this tool is fast enough that back-to-back
-            # curation steps land in one second routinely.
-            time.sleep(1)
-            output_path = generate_output_path(path)
-        if output_path == path:
-            return {"error": "An edit snapshot for this second already exists — retry in a moment."}
-        # Set *before* the copy, not after: shutil.copyfile opens the
-        # destination for writing and does not remove it if the copy then
-        # fails partway (ENOSPC on a multi-GB h5ad is the realistic case), so
-        # a partial file at output_path is ours to clean up. Leaving it behind
-        # would be worse than the original bug — it carries the newest -edit-
-        # timestamp, so resolve_latest would hand that truncated file to every
-        # later call on the dataset.
-        snapshot_created = True
-        try:
-            shutil.copy2(path, output_path)
-        except shutil.SameFileError:
-            # The one failure that writes nothing: copy2 compares inodes before
-            # opening the destination. It is also the one case where unlinking
-            # output_path would delete the source, so return here rather than
-            # falling through to the handler. Catches what the equality check
-            # above cannot — aliases of the source ('./'-prefixed paths, hard
-            # links) whose string form differs (#598).
-            return {"error": "An edit snapshot for this second already exists — retry in a moment."}
+        with snapshot_copy(path) as output_path:
+            # Defer the malformed-log cleanup until after the with-block closes
+            # the output file — calling os.remove on an open HDF5 handle works
+            # on POSIX (unlinked-but-open inode) but raises on Windows, and even
+            # on POSIX the subsequent context __exit__ flush hits a removed
+            # inode. Capture the error here, exit the context cleanly, then
+            # remove + return.
+            log_error = None
+            with h5py.File(output_path, "a") as f_out:
+                stripped = _strip_forbidden_obs_columns_h5py(f_out)
+                # `present` was computed before the copy, so it should match
+                # exactly. Use the post-strip return value as truth — that's
+                # what we actually mutated.
 
-        # Defer the malformed-log cleanup until after the with-block closes
-        # the output file — calling os.remove on an open HDF5 handle works
-        # on POSIX (unlinked-but-open inode) but raises on Windows, and even
-        # on POSIX the subsequent context __exit__ flush hits a removed
-        # inode. Capture the error here, exit the context cleanly, then
-        # remove + return.
-        log_error = None
-        with h5py.File(output_path, "a") as f_out:
-            stripped = _strip_forbidden_obs_columns_h5py(f_out)
-            # `present` was computed before the copy, so it should match
-            # exactly. Use the post-strip return value as truth — that's
-            # what we actually mutated.
+                entry = make_edit_entry(
+                    operation="strip_forbidden_obs_columns",
+                    description=(f"Stripped HCA-forbidden obs columns (privacy): {stripped}"),
+                    details={"obs_columns_stripped": stripped},
+                )
 
-            entry = make_edit_entry(
-                operation="strip_forbidden_obs_columns",
-                description=(f"Stripped HCA-forbidden obs columns (privacy): {stripped}"),
-                details={"obs_columns_stripped": stripped},
-            )
+                existing_log = read_edit_log_h5py(f_out)
+                log_result = build_edit_log(existing_log, [entry], path)
+                if "error" in log_result:
+                    log_error = log_result
+                else:
+                    write_edit_log_h5py(f_out, log_result["json"])
 
-            existing_log = read_edit_log_h5py(f_out)
-            log_result = build_edit_log(existing_log, [entry], path)
-            if "error" in log_result:
-                log_error = log_result
-            else:
-                write_edit_log_h5py(f_out, log_result["json"])
+            if log_error is not None:
+                Path(output_path).unlink()
+                return log_error
 
-        if log_error is not None:
-            Path(output_path).unlink()
-            return log_error
+            cleanup_previous_version(path, output_path)
 
-        cleanup_previous_version(path, output_path)
-
-        return {
-            "output_path": output_path,
-            "obs_columns_stripped": stripped,
-        }
+            return {
+                "output_path": output_path,
+                "obs_columns_stripped": stripped,
+            }
 
     except Exception as e:
-        if snapshot_created and output_path and Path(output_path).is_file():
-            with contextlib.suppress(OSError):
-                Path(output_path).unlink()
         return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/strip.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/strip.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import contextlib
 import shutil
+import time
 from pathlib import Path
 
 import h5py
@@ -103,6 +104,11 @@ def strip_forbidden_obs_columns(path: str) -> dict:
         the CellxGENE-layout refusal).
     """
     output_path = None
+    # Whether *we* created the file at output_path. The name is bound before
+    # the copy, so the failure path below must not delete a file it may never
+    # have written — that is what turned shutil.copy2's safe SameFileError
+    # into deletion of the source snapshot (#598).
+    snapshot_created = False
     try:
         path = resolve_latest(path)
         if not Path(path).is_file():
@@ -137,12 +143,17 @@ def strip_forbidden_obs_columns(path: str) -> dict:
 
         output_path = generate_output_path(path)
         if output_path == path:
-            # generate_output_path timestamps to the second, so a second edit
-            # within the same second names the output after its own source;
-            # copying would raise SameFileError and the failure path would
-            # then unlink the source snapshot. Refuse before touching anything.
+            # generate_output_path timestamps to the second (see rename.py):
+            # a second edit within the same second names the output after its
+            # own source. Wait out the boundary rather than failing the run,
+            # as copy_cap does — this tool is fast enough that back-to-back
+            # curation steps land in one second routinely.
+            time.sleep(1)
+            output_path = generate_output_path(path)
+        if output_path == path:
             return {"error": "An edit snapshot for this second already exists — retry in a moment."}
         shutil.copy2(path, output_path)
+        snapshot_created = True
 
         # Defer the malformed-log cleanup until after the with-block closes
         # the output file — calling os.remove on an open HDF5 handle works
@@ -182,7 +193,7 @@ def strip_forbidden_obs_columns(path: str) -> dict:
         }
 
     except Exception as e:
-        if output_path and Path(output_path).is_file():
+        if snapshot_created and output_path and Path(output_path).is_file():
             with contextlib.suppress(OSError):
                 Path(output_path).unlink()
         return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/strip.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/strip.py
@@ -136,6 +136,12 @@ def strip_forbidden_obs_columns(path: str) -> dict:
             }
 
         output_path = generate_output_path(path)
+        if output_path == path:
+            # generate_output_path timestamps to the second, so a second edit
+            # within the same second names the output after its own source;
+            # copying would raise SameFileError and the failure path would
+            # then unlink the source snapshot. Refuse before touching anything.
+            return {"error": "An edit snapshot for this second already exists — retry in a moment."}
         shutil.copy2(path, output_path)
 
         # Defer the malformed-log cleanup until after the with-block closes

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/strip_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/strip_cap.py
@@ -34,6 +34,7 @@ from .cap import _LEGACY_CAP_MARKERS, CAP_METADATA_KEY, cap_obs_columns, unknown
 from .drop import _read_batch_condition
 from .inspect import _read_schema_version
 from .write import (
+    SAME_SECOND_SNAPSHOT_ERROR,
     _copy_with_sha256,
     build_edit_log,
     cleanup_previous_version,
@@ -241,7 +242,7 @@ def strip_cap_annotations(path: str) -> dict:
             # its own source. samefile() also catches aliases of the same
             # snapshot ('./'-prefixed paths, hard links) that string equality
             # misses. Refuse before touching anything.
-            return {"error": "An edit snapshot for this second already exists — retry in a moment."}
+            return {"error": SAME_SECOND_SNAPSHOT_ERROR}
         # Hash the source in the same streaming read as the snapshot copy;
         # a separate hash pass would re-read the whole multi-GB file.
         source_sha256 = _copy_with_sha256(path, output_path)

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
@@ -8,6 +8,8 @@ import hashlib
 import json
 import re
 import shutil
+import time
+from collections.abc import Iterator
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
@@ -22,6 +24,19 @@ _TIMESTAMP_FORMAT = "%Y-%m-%d-%H-%M-%S"
 EDIT_LOG_KEY = "edit_history"
 _HASH_CHUNK_SIZE = 1 << 20  # 1 MB — keeps syscall count low on multi-GB files
 _REQUIRED_ENTRY_KEYS = {"timestamp", "tool", "tool_version", "operation", "description"}
+
+# The message every tool returns when a snapshot name collides with its own
+# source. Shared so the wording cannot drift between call sites — it contains
+# a non-ASCII em dash, which is exactly what drifts on a re-type.
+SAME_SECOND_SNAPSHOT_ERROR = "An edit snapshot for this second already exists — retry in a moment."
+
+
+class SameSecondSnapshotError(RuntimeError):
+    """A snapshot could not be named distinctly from the file it copies.
+
+    Carries :data:`SAME_SECOND_SNAPSHOT_ERROR` as its message, so a caller
+    whose handler returns ``{"error": str(e)}`` reports it unchanged.
+    """
 
 
 def _compute_sha256(path: str) -> str:
@@ -55,6 +70,78 @@ def _copy_with_sha256(source_path: str, dest_path: str) -> str:
             dst.write(chunk)
     shutil.copystat(source_path, dest_path)
     return h.hexdigest()
+
+
+@contextlib.contextmanager
+def snapshot_copy(path: str) -> Iterator[str]:
+    """Yield the path of a fresh snapshot copy of ``path``, cleaning it up on error.
+
+    The copy-and-patch tools all need the same three things around
+    ``shutil.copy2``, and each of them is a way to lose data if omitted:
+
+    * **A name that isn't the source.** ``generate_output_path`` timestamps to
+      the second, so a tool running on a snapshot and finishing within that same
+      second generates its own source's name. Rather than fail the run, this
+      waits out the boundary and regenerates — these tools are fast enough that
+      back-to-back curation steps collide routinely — and raises
+      :class:`SameSecondSnapshotError` only if the retry still collides.
+    * **Refusing an alias of the source.** A hard link or ``./``-prefixed path
+      has a different string form, so the equality check above misses it.
+      ``copy2`` compares inodes before opening the destination, so catching
+      ``SameFileError`` covers what string equality cannot — and covers it
+      atomically with the copy, rather than as a separate check that can go
+      stale between test and use.
+    * **Removing a snapshot we wrote but could not finish.** ``shutil.copyfile``
+      opens the destination ``'wb'`` and does not remove it if the copy then
+      fails partway (ENOSPC on a multi-GB h5ad is the realistic case). A
+      leftover partial is worse than an error: it carries the newest ``-edit-``
+      timestamp, so :func:`resolve_latest` would hand that truncated file to
+      every later call on the dataset.
+
+    The distinction the failure paths turn on is whether *we* created the file
+    at the destination. ``SameFileError`` is the one failure that writes
+    nothing, and the one case where unlinking the destination would delete the
+    source — so it never reaches the cleanup. Everything else that fails after
+    the copy begins leaves a file that is ours to remove.
+
+    Body exceptions propagate after the snapshot is removed, so a caller's own
+    ``except`` still sees them. A caller that returns normally keeps the
+    snapshot, including a caller that unlinked it itself.
+
+    Args:
+        path: Path to the source file. Callers should pass a
+            :func:`resolve_latest`-resolved path.
+
+    Yields:
+        Path to the newly created snapshot copy.
+
+    Raises:
+        SameSecondSnapshotError: The generated name is the source, or an alias
+            of it, and waiting out the second boundary did not help.
+    """
+    output_path = generate_output_path(path)
+    if output_path == path:
+        time.sleep(1)
+        output_path = generate_output_path(path)
+    if output_path == path:
+        raise SameSecondSnapshotError(SAME_SECOND_SNAPSHOT_ERROR)
+
+    try:
+        shutil.copy2(path, output_path)
+    except shutil.SameFileError as e:
+        # Nothing was written and output_path is the source: never unlink.
+        raise SameSecondSnapshotError(SAME_SECOND_SNAPSHOT_ERROR) from e
+    except BaseException:
+        with contextlib.suppress(OSError):
+            Path(output_path).unlink()
+        raise
+
+    try:
+        yield output_path
+    except BaseException:
+        with contextlib.suppress(OSError):
+            Path(output_path).unlink()
+        raise
 
 
 def strip_timestamp(filename: str) -> str:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
@@ -85,12 +85,14 @@ def snapshot_copy(path: str) -> Iterator[str]:
       waits out the boundary and regenerates — these tools are fast enough that
       back-to-back curation steps collide routinely — and raises
       :class:`SameSecondSnapshotError` only if the retry still collides.
-    * **Refusing an alias of the source.** A hard link or ``./``-prefixed path
-      has a different string form, so the equality check above misses it.
-      ``copy2`` compares inodes before opening the destination, so catching
-      ``SameFileError`` covers what string equality cannot — and covers it
-      atomically with the copy, rather than as a separate check that can go
-      stale between test and use.
+    * **Refusing a destination that already is the source.** A hard link or
+      ``./``-prefixed path has a different string form, so the equality check
+      above misses it. ``copy2`` compares inodes before opening the
+      destination, so catching ``SameFileError`` covers what string equality
+      cannot — and covers it atomically with the copy, rather than as a
+      separate check that can go stale between test and use. Such a
+      destination is never removed: it predates the call, and one naming the
+      source's own directory entry would take the source with it.
     * **Removing a snapshot we wrote but could not finish.** ``shutil.copyfile``
       opens the destination ``'wb'`` and does not remove it if the copy then
       fails partway (ENOSPC on a multi-GB h5ad is the realistic case). A
@@ -129,7 +131,11 @@ def snapshot_copy(path: str) -> Iterator[str]:
     try:
         shutil.copy2(path, output_path)
     except shutil.SameFileError as e:
-        # Nothing was written and output_path is the source: never unlink.
+        # copy2 compares inodes before opening the destination, so nothing was
+        # written. The destination is the source or an alias of it, and either
+        # way it existed before this call and is not ours to remove — for an
+        # alias naming the same directory entry ('./'-prefixed), removing it
+        # would take the source with it.
         raise SameSecondSnapshotError(SAME_SECOND_SNAPSHOT_ERROR) from e
     except BaseException:
         with contextlib.suppress(OSError):

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
@@ -6,6 +6,7 @@ import contextlib
 import glob
 import hashlib
 import json
+import os
 import re
 import shutil
 import time
@@ -72,6 +73,17 @@ def _copy_with_sha256(source_path: str, dest_path: str) -> str:
     return h.hexdigest()
 
 
+def _occupied(path: str) -> bool:
+    """True when anything at all sits at ``path``.
+
+    ``os.path.lexists`` rather than ``Path.exists``: the latter follows
+    symlinks and so reports a *broken* symlink as absent, which would let a
+    caller claim that name, write through it, and then unlink a symlink it did
+    not create.
+    """
+    return os.path.lexists(path)
+
+
 def _claim_snapshot_path(path: str) -> str:
     """Return a snapshot path that no file currently occupies.
 
@@ -90,10 +102,10 @@ def _claim_snapshot_path(path: str) -> str:
         SameSecondSnapshotError: Still occupied after waiting out the boundary.
     """
     output_path = generate_output_path(path)
-    if Path(output_path).exists():
+    if _occupied(output_path):
         time.sleep(1)
         output_path = generate_output_path(path)
-    if Path(output_path).exists():
+    if _occupied(output_path):
         raise SameSecondSnapshotError(SAME_SECOND_SNAPSHOT_ERROR)
     return output_path
 

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
@@ -72,43 +72,51 @@ def _copy_with_sha256(source_path: str, dest_path: str) -> str:
     return h.hexdigest()
 
 
+def _claim_snapshot_path(path: str) -> str:
+    """Return a snapshot path that no file currently occupies.
+
+    ``generate_output_path`` timestamps to the second, so a name can already be
+    taken — by the source itself (a snapshot edited within that same second),
+    by an alias of it, or by a sibling tool's snapshot from the same second.
+    All three are the same problem: the name is not ours to write. Waiting out
+    the boundary and regenerating resolves every one of them, which is cheaper
+    than failing a run the caller must then notice and retry.
+
+    Checking occupancy rather than comparing strings to ``path`` is what makes
+    the caller's cleanup unambiguous: the returned name held no file, so
+    anything there afterwards was written by us and is ours to remove.
+
+    Raises:
+        SameSecondSnapshotError: Still occupied after waiting out the boundary.
+    """
+    output_path = generate_output_path(path)
+    if Path(output_path).exists():
+        time.sleep(1)
+        output_path = generate_output_path(path)
+    if Path(output_path).exists():
+        raise SameSecondSnapshotError(SAME_SECOND_SNAPSHOT_ERROR)
+    return output_path
+
+
 @contextlib.contextmanager
 def snapshot_copy(path: str) -> Iterator[str]:
     """Yield the path of a fresh snapshot copy of ``path``, cleaning it up on error.
 
-    The copy-and-patch tools all need the same three things around
-    ``shutil.copy2``, and each of them is a way to lose data if omitted:
+    Wraps ``shutil.copy2`` with the three things every copy-and-patch tool
+    needs around it, each of which is a way to lose data if omitted:
 
-    * **A name that isn't the source.** ``generate_output_path`` timestamps to
-      the second, so a tool running on a snapshot and finishing within that same
-      second generates its own source's name. Rather than fail the run, this
-      waits out the boundary and regenerates — these tools are fast enough that
-      back-to-back curation steps collide routinely — and raises
-      :class:`SameSecondSnapshotError` only if the retry still collides.
-    * **Refusing a destination that already is the source.** A hard link or
-      ``./``-prefixed path has a different string form, so the equality check
-      above misses it. ``copy2`` compares inodes before opening the
-      destination, so catching ``SameFileError`` covers what string equality
-      cannot — and covers it atomically with the copy, rather than as a
-      separate check that can go stale between test and use. Such a
-      destination is never removed: it predates the call, and one naming the
-      source's own directory entry would take the source with it.
-    * **Removing a snapshot we wrote but could not finish.** ``shutil.copyfile``
-      opens the destination ``'wb'`` and does not remove it if the copy then
-      fails partway (ENOSPC on a multi-GB h5ad is the realistic case). A
-      leftover partial is worse than an error: it carries the newest ``-edit-``
-      timestamp, so :func:`resolve_latest` would hand that truncated file to
-      every later call on the dataset.
-
-    The distinction the failure paths turn on is whether *we* created the file
-    at the destination. ``SameFileError`` is the one failure that writes
-    nothing, and the one case where unlinking the destination would delete the
-    source — so it never reaches the cleanup. Everything else that fails after
-    the copy begins leaves a file that is ours to remove.
+    * a destination name no file already occupies — see
+      :func:`_claim_snapshot_path`;
+    * a refusal, rather than a silent overwrite, when that cannot be arranged;
+    * removal of the snapshot if the copy or the caller's body then fails.
+      ``shutil.copyfile`` opens the destination ``'wb'`` and leaves a partial
+      file behind on error, and a leftover partial is worse than an error: it
+      carries the newest ``-edit-`` timestamp, so :func:`resolve_latest` would
+      hand that truncated file to every later call on the dataset.
 
     Body exceptions propagate after the snapshot is removed, so a caller's own
     ``except`` still sees them. A caller that returns normally keeps the
-    snapshot, including a caller that unlinked it itself.
+    snapshot.
 
     Args:
         path: Path to the source file. Callers should pass a
@@ -118,24 +126,17 @@ def snapshot_copy(path: str) -> Iterator[str]:
         Path to the newly created snapshot copy.
 
     Raises:
-        SameSecondSnapshotError: The generated name is the source, or an alias
-            of it, and waiting out the second boundary did not help.
+        SameSecondSnapshotError: No free snapshot name was available, even
+            after waiting out the second boundary.
     """
-    output_path = generate_output_path(path)
-    if output_path == path:
-        time.sleep(1)
-        output_path = generate_output_path(path)
-    if output_path == path:
-        raise SameSecondSnapshotError(SAME_SECOND_SNAPSHOT_ERROR)
+    output_path = _claim_snapshot_path(path)
 
     try:
         shutil.copy2(path, output_path)
     except shutil.SameFileError as e:
-        # copy2 compares inodes before opening the destination, so nothing was
-        # written. The destination is the source or an alias of it, and either
-        # way it existed before this call and is not ours to remove — for an
-        # alias naming the same directory entry ('./'-prefixed), removing it
-        # would take the source with it.
+        # Only reachable if the destination appeared between the check above
+        # and here. Nothing was written — copy2 compares inodes before opening
+        # the destination — and the file is not ours, so it is not removed.
         raise SameSecondSnapshotError(SAME_SECOND_SNAPSHOT_ERROR) from e
     except BaseException:
         with contextlib.suppress(OSError):

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
@@ -73,19 +73,28 @@ def _copy_with_sha256(source_path: str, dest_path: str) -> str:
     return h.hexdigest()
 
 
-def _occupied(path: str) -> bool:
-    """True when anything at all sits at ``path``.
+def _try_claim(path: str) -> bool:
+    """Atomically create an empty file at ``path``; False if the name is taken.
 
-    ``os.path.lexists`` rather than ``Path.exists``: the latter follows
-    symlinks and so reports a *broken* symlink as absent, which would let a
-    caller claim that name, write through it, and then unlink a symlink it did
-    not create.
+    ``O_CREAT | O_EXCL`` is the whole point: testing occupancy and then copying
+    leaves a window in which another writer can take the name, and ``copy2``
+    would then silently overwrite their file. Creating the file *is* the claim,
+    so there is no window to lose.
+
+    It also settles the symlink case without a separate check — ``O_EXCL``
+    refuses a symlink at the path, including a broken one that
+    ``Path.exists()`` reports as absent.
     """
-    return os.path.lexists(path)
+    try:
+        fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+    except FileExistsError:
+        return False
+    os.close(fd)
+    return True
 
 
 def _claim_snapshot_path(path: str) -> str:
-    """Return a snapshot path that no file currently occupies.
+    """Claim, and return, a snapshot path that no other file holds.
 
     ``generate_output_path`` timestamps to the second, so a name can already be
     taken — by the source itself (a snapshot edited within that same second),
@@ -94,20 +103,21 @@ def _claim_snapshot_path(path: str) -> str:
     the boundary and regenerating resolves every one of them, which is cheaper
     than failing a run the caller must then notice and retry.
 
-    Checking occupancy rather than comparing strings to ``path`` is what makes
-    the caller's cleanup unambiguous: the returned name held no file, so
-    anything there afterwards was written by us and is ours to remove.
+    Returns with an empty file already created at the claimed path — that is
+    what makes the caller's cleanup unambiguous. The name was ours to take, so
+    whatever sits there afterwards is ours to remove.
 
     Raises:
-        SameSecondSnapshotError: Still occupied after waiting out the boundary.
+        SameSecondSnapshotError: Still taken after waiting out the boundary.
     """
     output_path = generate_output_path(path)
-    if _occupied(output_path):
-        time.sleep(1)
-        output_path = generate_output_path(path)
-    if _occupied(output_path):
-        raise SameSecondSnapshotError(SAME_SECOND_SNAPSHOT_ERROR)
-    return output_path
+    if _try_claim(output_path):
+        return output_path
+    time.sleep(1)
+    output_path = generate_output_path(path)
+    if _try_claim(output_path):
+        return output_path
+    raise SameSecondSnapshotError(SAME_SECOND_SNAPSHOT_ERROR)
 
 
 @contextlib.contextmanager

--- a/packages/hca-anndata-tools/tests/test_drop.py
+++ b/packages/hca-anndata-tools/tests/test_drop.py
@@ -755,8 +755,9 @@ def test_drop_failed_copy_leaves_no_partial_snapshot(sample_h5ad_for_write, monk
 def test_drop_alias_of_source_is_refused_without_unlinking(sample_h5ad_for_write, monkeypatch):
     """An alias of the source — a hard link, or a './'-prefixed path — is not
     caught by the string-equality guard, but copy2 compares inodes and refuses
-    before writing. That must return, not fall through to the unlink, or the
-    source is deleted (the #598 defect by another route)."""
+    before writing. The destination must survive: it predates the call, and an
+    alias naming the source's own directory entry would take the source with
+    it (the #598 defect by another route)."""
     _add_obs_cols(sample_h5ad_for_write, "junk_col")
     alias = sample_h5ad_for_write.with_name("alias-edit-2026-08-22-00-00-01.h5ad")
     os.link(sample_h5ad_for_write, alias)
@@ -766,6 +767,6 @@ def test_drop_alias_of_source_is_refused_without_unlinking(sample_h5ad_for_write
 
     assert "error" in result
     assert "already exists" in result["error"]
-    assert alias.is_file(), "the source was unlinked through its alias"
+    assert alias.is_file(), "a pre-existing destination we did not create was unlinked"
     assert sample_h5ad_for_write.is_file()
     assert "junk_col" in ad.read_h5ad(sample_h5ad_for_write).obs.columns

--- a/packages/hca-anndata-tools/tests/test_drop.py
+++ b/packages/hca-anndata-tools/tests/test_drop.py
@@ -753,15 +753,16 @@ def test_drop_failed_copy_leaves_no_partial_snapshot(sample_h5ad_for_write, monk
 
 
 def test_drop_alias_of_source_is_refused_without_unlinking(sample_h5ad_for_write, monkeypatch):
-    """An alias of the source — a hard link, or a './'-prefixed path — is not
-    caught by the string-equality guard, but copy2 compares inodes and refuses
-    before writing. The destination must survive: it predates the call, and an
-    alias naming the source's own directory entry would take the source with
-    it (the #598 defect by another route)."""
+    """An alias of the source — a hard link, or a './'-prefixed path — occupies
+    the generated name, so the claim step refuses it before any copy is
+    attempted. The destination must survive: it predates the call, and an alias
+    naming the source's own directory entry would take the source with it (the
+    #598 defect by another route)."""
     _add_obs_cols(sample_h5ad_for_write, "junk_col")
     alias = sample_h5ad_for_write.with_name("alias-edit-2026-08-22-00-00-01.h5ad")
     os.link(sample_h5ad_for_write, alias)
     monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: str(alias))
+    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", lambda _: None)
 
     result = drop_obs_columns(str(sample_h5ad_for_write), ["junk_col"])
 

--- a/packages/hca-anndata-tools/tests/test_drop.py
+++ b/packages/hca-anndata-tools/tests/test_drop.py
@@ -1,7 +1,6 @@
 """Tests for drop_obs_columns."""
 
 import json
-import os
 from pathlib import Path
 
 import anndata as ad
@@ -710,64 +709,3 @@ def test_drop_same_second_snapshot_refused(sample_h5ad_for_write, monkeypatch):
     assert "junk_col" in ad.read_h5ad(sample_h5ad_for_write).obs.columns  # nor modified
     assert "error" in result
     assert "already exists" in result["error"]
-
-
-def test_drop_same_second_collision_resolves_after_waiting(sample_h5ad_for_write, monkeypatch):
-    """The common case: a snapshot written this second collides, the tool waits
-    out the boundary, and the retry gets a fresh name (mirrors copy_cap). Only a
-    collision that survives the wait is refused."""
-    _add_obs_cols(sample_h5ad_for_write, "junk_col")
-    fresh = sample_h5ad_for_write.with_name("fresh-edit-2026-08-22-00-00-01.h5ad")
-    names = iter([str(sample_h5ad_for_write), str(fresh)])
-    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: next(names))
-    slept = []
-    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", slept.append)
-
-    result = drop_obs_columns(str(sample_h5ad_for_write), ["junk_col"])
-
-    assert slept == [1]
-    assert "error" not in result
-    assert result["obs_columns_dropped"] == ["junk_col"]
-    assert Path(result["output_path"]).name == "fresh-edit-2026-08-22-00-00-01.h5ad"
-
-
-def test_drop_failed_copy_leaves_no_partial_snapshot(sample_h5ad_for_write, monkeypatch):
-    """A copy that dies partway (ENOSPC on a multi-GB h5ad) must not leave the
-    partial file behind: it carries the newest -edit- timestamp, so resolve_latest
-    would hand that truncated file to every later call on the dataset."""
-    _add_obs_cols(sample_h5ad_for_write, "junk_col")
-    written = {}
-
-    def die_partway(src, dst, *args, **kwargs):
-        Path(dst).write_bytes(b"partial")
-        written["dst"] = dst
-        raise OSError(28, "No space left on device")
-
-    monkeypatch.setattr("hca_anndata_tools.write.shutil.copy2", die_partway)
-
-    result = drop_obs_columns(str(sample_h5ad_for_write), ["junk_col"])
-
-    assert "error" in result
-    assert not Path(written["dst"]).exists(), "partial snapshot was left behind"
-    assert sample_h5ad_for_write.is_file()  # and the source is untouched
-
-
-def test_drop_alias_of_source_is_refused_without_unlinking(sample_h5ad_for_write, monkeypatch):
-    """An alias of the source — a hard link, or a './'-prefixed path — occupies
-    the generated name, so the claim step refuses it before any copy is
-    attempted. The destination must survive: it predates the call, and an alias
-    naming the source's own directory entry would take the source with it (the
-    #598 defect by another route)."""
-    _add_obs_cols(sample_h5ad_for_write, "junk_col")
-    alias = sample_h5ad_for_write.with_name("alias-edit-2026-08-22-00-00-01.h5ad")
-    os.link(sample_h5ad_for_write, alias)
-    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: str(alias))
-    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", lambda _: None)
-
-    result = drop_obs_columns(str(sample_h5ad_for_write), ["junk_col"])
-
-    assert "error" in result
-    assert "already exists" in result["error"]
-    assert alias.is_file(), "a pre-existing destination we did not create was unlinked"
-    assert sample_h5ad_for_write.is_file()
-    assert "junk_col" in ad.read_h5ad(sample_h5ad_for_write).obs.columns

--- a/packages/hca-anndata-tools/tests/test_drop.py
+++ b/packages/hca-anndata-tools/tests/test_drop.py
@@ -692,22 +692,38 @@ def test_drop_missing_file():
 
 def test_drop_same_second_snapshot_refused(sample_h5ad_for_write, monkeypatch):
     """A second edit within the same second would name the output after its
-    own source; the guard refuses before touching anything.
-
-    Without it, ``shutil.copy2`` raises ``SameFileError`` and the failure path
-    unlinks ``output_path`` — which *is* the source. The surviving-source
-    assertion is the one that pins the bug (#598)."""
+    own source and the failure path would unlink that source snapshot; the
+    guard refuses before touching anything (mirrors rename/backfill)."""
     _add_obs_cols(sample_h5ad_for_write, "junk_col")
     monkeypatch.setattr("hca_anndata_tools.drop.generate_output_path", lambda p: p)
-    before = ad.read_h5ad(sample_h5ad_for_write)
+    slept = []
+    monkeypatch.setattr("hca_anndata_tools.drop.time.sleep", slept.append)
 
     result = drop_obs_columns(str(sample_h5ad_for_write), ["junk_col"])
 
-    # Survival first: an unguarded run unlinks the source, and that is the
-    # defect. Asserting the message first would fail on wording instead.
-    assert Path(sample_h5ad_for_write).is_file(), "the source snapshot was deleted"
-    after = ad.read_h5ad(sample_h5ad_for_write)
-    assert after.n_obs == before.n_obs
-    assert "junk_col" in after.obs.columns, "the source was modified despite the refusal"
+    assert slept == [1], "the boundary wait should be attempted once before refusing"
+
+    # Asserted before the message: unguarded, this file is unlinked (#598).
+    assert sample_h5ad_for_write.is_file()
+    assert "junk_col" in ad.read_h5ad(sample_h5ad_for_write).obs.columns  # nor modified
     assert "error" in result
     assert "already exists" in result["error"]
+
+
+def test_drop_same_second_collision_resolves_after_waiting(sample_h5ad_for_write, monkeypatch):
+    """The common case: a snapshot written this second collides, the tool waits
+    out the boundary, and the retry gets a fresh name (mirrors copy_cap). Only a
+    collision that survives the wait is refused."""
+    _add_obs_cols(sample_h5ad_for_write, "junk_col")
+    fresh = sample_h5ad_for_write.with_name("fresh-edit-2026-08-22-00-00-01.h5ad")
+    names = iter([str(sample_h5ad_for_write), str(fresh)])
+    monkeypatch.setattr("hca_anndata_tools.drop.generate_output_path", lambda p: next(names))
+    slept = []
+    monkeypatch.setattr("hca_anndata_tools.drop.time.sleep", slept.append)
+
+    result = drop_obs_columns(str(sample_h5ad_for_write), ["junk_col"])
+
+    assert slept == [1]
+    assert "error" not in result
+    assert result["obs_columns_dropped"] == ["junk_col"]
+    assert Path(result["output_path"]).name == "fresh-edit-2026-08-22-00-00-01.h5ad"

--- a/packages/hca-anndata-tools/tests/test_drop.py
+++ b/packages/hca-anndata-tools/tests/test_drop.py
@@ -688,3 +688,26 @@ def test_drop_missing_file():
 
     assert "error" in result
     assert "File not found" in result["error"]
+
+
+def test_drop_same_second_snapshot_refused(sample_h5ad_for_write, monkeypatch):
+    """A second edit within the same second would name the output after its
+    own source; the guard refuses before touching anything.
+
+    Without it, ``shutil.copy2`` raises ``SameFileError`` and the failure path
+    unlinks ``output_path`` — which *is* the source. The surviving-source
+    assertion is the one that pins the bug (#598)."""
+    _add_obs_cols(sample_h5ad_for_write, "junk_col")
+    monkeypatch.setattr("hca_anndata_tools.drop.generate_output_path", lambda p: p)
+    before = ad.read_h5ad(sample_h5ad_for_write)
+
+    result = drop_obs_columns(str(sample_h5ad_for_write), ["junk_col"])
+
+    # Survival first: an unguarded run unlinks the source, and that is the
+    # defect. Asserting the message first would fail on wording instead.
+    assert Path(sample_h5ad_for_write).is_file(), "the source snapshot was deleted"
+    after = ad.read_h5ad(sample_h5ad_for_write)
+    assert after.n_obs == before.n_obs
+    assert "junk_col" in after.obs.columns, "the source was modified despite the refusal"
+    assert "error" in result
+    assert "already exists" in result["error"]

--- a/packages/hca-anndata-tools/tests/test_drop.py
+++ b/packages/hca-anndata-tools/tests/test_drop.py
@@ -692,9 +692,10 @@ def test_drop_missing_file():
 
 
 def test_drop_same_second_snapshot_refused(sample_h5ad_for_write, monkeypatch):
-    """A second edit within the same second would name the output after its
-    own source and the failure path would unlink that source snapshot; the
-    guard refuses before touching anything (mirrors rename/backfill)."""
+    """A collision that survives the boundary wait is refused before anything is
+    touched — otherwise the output would be named after its own source and the
+    failure path would unlink that source snapshot. Patching generate_output_path
+    to the identity makes the retry collide too, which is the unresolvable case."""
     _add_obs_cols(sample_h5ad_for_write, "junk_col")
     monkeypatch.setattr("hca_anndata_tools.drop.generate_output_path", lambda p: p)
     slept = []

--- a/packages/hca-anndata-tools/tests/test_drop.py
+++ b/packages/hca-anndata-tools/tests/test_drop.py
@@ -697,9 +697,9 @@ def test_drop_same_second_snapshot_refused(sample_h5ad_for_write, monkeypatch):
     failure path would unlink that source snapshot. Patching generate_output_path
     to the identity makes the retry collide too, which is the unresolvable case."""
     _add_obs_cols(sample_h5ad_for_write, "junk_col")
-    monkeypatch.setattr("hca_anndata_tools.drop.generate_output_path", lambda p: p)
+    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: p)
     slept = []
-    monkeypatch.setattr("hca_anndata_tools.drop.time.sleep", slept.append)
+    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", slept.append)
 
     result = drop_obs_columns(str(sample_h5ad_for_write), ["junk_col"])
 
@@ -719,9 +719,9 @@ def test_drop_same_second_collision_resolves_after_waiting(sample_h5ad_for_write
     _add_obs_cols(sample_h5ad_for_write, "junk_col")
     fresh = sample_h5ad_for_write.with_name("fresh-edit-2026-08-22-00-00-01.h5ad")
     names = iter([str(sample_h5ad_for_write), str(fresh)])
-    monkeypatch.setattr("hca_anndata_tools.drop.generate_output_path", lambda p: next(names))
+    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: next(names))
     slept = []
-    monkeypatch.setattr("hca_anndata_tools.drop.time.sleep", slept.append)
+    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", slept.append)
 
     result = drop_obs_columns(str(sample_h5ad_for_write), ["junk_col"])
 
@@ -743,7 +743,7 @@ def test_drop_failed_copy_leaves_no_partial_snapshot(sample_h5ad_for_write, monk
         written["dst"] = dst
         raise OSError(28, "No space left on device")
 
-    monkeypatch.setattr("hca_anndata_tools.drop.shutil.copy2", die_partway)
+    monkeypatch.setattr("hca_anndata_tools.write.shutil.copy2", die_partway)
 
     result = drop_obs_columns(str(sample_h5ad_for_write), ["junk_col"])
 
@@ -760,7 +760,7 @@ def test_drop_alias_of_source_is_refused_without_unlinking(sample_h5ad_for_write
     _add_obs_cols(sample_h5ad_for_write, "junk_col")
     alias = sample_h5ad_for_write.with_name("alias-edit-2026-08-22-00-00-01.h5ad")
     os.link(sample_h5ad_for_write, alias)
-    monkeypatch.setattr("hca_anndata_tools.drop.generate_output_path", lambda p: str(alias))
+    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: str(alias))
 
     result = drop_obs_columns(str(sample_h5ad_for_write), ["junk_col"])
 

--- a/packages/hca-anndata-tools/tests/test_drop.py
+++ b/packages/hca-anndata-tools/tests/test_drop.py
@@ -1,6 +1,7 @@
 """Tests for drop_obs_columns."""
 
 import json
+import os
 from pathlib import Path
 
 import anndata as ad
@@ -727,3 +728,43 @@ def test_drop_same_second_collision_resolves_after_waiting(sample_h5ad_for_write
     assert "error" not in result
     assert result["obs_columns_dropped"] == ["junk_col"]
     assert Path(result["output_path"]).name == "fresh-edit-2026-08-22-00-00-01.h5ad"
+
+
+def test_drop_failed_copy_leaves_no_partial_snapshot(sample_h5ad_for_write, monkeypatch):
+    """A copy that dies partway (ENOSPC on a multi-GB h5ad) must not leave the
+    partial file behind: it carries the newest -edit- timestamp, so resolve_latest
+    would hand that truncated file to every later call on the dataset."""
+    _add_obs_cols(sample_h5ad_for_write, "junk_col")
+    written = {}
+
+    def die_partway(src, dst, *args, **kwargs):
+        Path(dst).write_bytes(b"partial")
+        written["dst"] = dst
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr("hca_anndata_tools.drop.shutil.copy2", die_partway)
+
+    result = drop_obs_columns(str(sample_h5ad_for_write), ["junk_col"])
+
+    assert "error" in result
+    assert not Path(written["dst"]).exists(), "partial snapshot was left behind"
+    assert sample_h5ad_for_write.is_file()  # and the source is untouched
+
+
+def test_drop_alias_of_source_is_refused_without_unlinking(sample_h5ad_for_write, monkeypatch):
+    """An alias of the source — a hard link, or a './'-prefixed path — is not
+    caught by the string-equality guard, but copy2 compares inodes and refuses
+    before writing. That must return, not fall through to the unlink, or the
+    source is deleted (the #598 defect by another route)."""
+    _add_obs_cols(sample_h5ad_for_write, "junk_col")
+    alias = sample_h5ad_for_write.with_name("alias-edit-2026-08-22-00-00-01.h5ad")
+    os.link(sample_h5ad_for_write, alias)
+    monkeypatch.setattr("hca_anndata_tools.drop.generate_output_path", lambda p: str(alias))
+
+    result = drop_obs_columns(str(sample_h5ad_for_write), ["junk_col"])
+
+    assert "error" in result
+    assert "already exists" in result["error"]
+    assert alias.is_file(), "the source was unlinked through its alias"
+    assert sample_h5ad_for_write.is_file()
+    assert "junk_col" in ad.read_h5ad(sample_h5ad_for_write).obs.columns

--- a/packages/hca-anndata-tools/tests/test_strip.py
+++ b/packages/hca-anndata-tools/tests/test_strip.py
@@ -204,8 +204,9 @@ def test_strip_failed_copy_leaves_no_partial_snapshot(sample_h5ad_for_write, mon
 def test_strip_alias_of_source_is_refused_without_unlinking(sample_h5ad_for_write, monkeypatch):
     """An alias of the source — a hard link, or a './'-prefixed path — is not
     caught by the string-equality guard, but copy2 compares inodes and refuses
-    before writing. That must return, not fall through to the unlink, or the
-    source is deleted (the #598 defect by another route)."""
+    before writing. The destination must survive: it predates the call, and an
+    alias naming the source's own directory entry would take the source with
+    it (the #598 defect by another route)."""
     _to_hca_layout(sample_h5ad_for_write, "self_reported_ethnicity")
     alias = sample_h5ad_for_write.with_name("alias-edit-2026-08-22-00-00-01.h5ad")
     os.link(sample_h5ad_for_write, alias)
@@ -215,6 +216,6 @@ def test_strip_alias_of_source_is_refused_without_unlinking(sample_h5ad_for_writ
 
     assert "error" in result
     assert "already exists" in result["error"]
-    assert alias.is_file(), "the source was unlinked through its alias"
+    assert alias.is_file(), "a pre-existing destination we did not create was unlinked"
     assert sample_h5ad_for_write.is_file()
     assert "self_reported_ethnicity" in ad.read_h5ad(sample_h5ad_for_write).obs.columns

--- a/packages/hca-anndata-tools/tests/test_strip.py
+++ b/packages/hca-anndata-tools/tests/test_strip.py
@@ -1,6 +1,7 @@
 """Tests for strip_forbidden_obs_columns."""
 
 import json
+import os
 from pathlib import Path
 
 import anndata as ad
@@ -176,3 +177,43 @@ def test_strip_same_second_collision_resolves_after_waiting(sample_h5ad_for_writ
     assert "error" not in result
     assert result["obs_columns_stripped"] == ["self_reported_ethnicity"]
     assert Path(result["output_path"]).name == "fresh-edit-2026-08-22-00-00-01.h5ad"
+
+
+def test_strip_failed_copy_leaves_no_partial_snapshot(sample_h5ad_for_write, monkeypatch):
+    """A copy that dies partway (ENOSPC on a multi-GB h5ad) must not leave the
+    partial file behind: it carries the newest -edit- timestamp, so resolve_latest
+    would hand that truncated file to every later call on the dataset."""
+    _to_hca_layout(sample_h5ad_for_write, "self_reported_ethnicity")
+    written = {}
+
+    def die_partway(src, dst, *args, **kwargs):
+        Path(dst).write_bytes(b"partial")
+        written["dst"] = dst
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr("hca_anndata_tools.strip.shutil.copy2", die_partway)
+
+    result = strip_forbidden_obs_columns(str(sample_h5ad_for_write))
+
+    assert "error" in result
+    assert not Path(written["dst"]).exists(), "partial snapshot was left behind"
+    assert sample_h5ad_for_write.is_file()  # and the source is untouched
+
+
+def test_strip_alias_of_source_is_refused_without_unlinking(sample_h5ad_for_write, monkeypatch):
+    """An alias of the source — a hard link, or a './'-prefixed path — is not
+    caught by the string-equality guard, but copy2 compares inodes and refuses
+    before writing. That must return, not fall through to the unlink, or the
+    source is deleted (the #598 defect by another route)."""
+    _to_hca_layout(sample_h5ad_for_write, "self_reported_ethnicity")
+    alias = sample_h5ad_for_write.with_name("alias-edit-2026-08-22-00-00-01.h5ad")
+    os.link(sample_h5ad_for_write, alias)
+    monkeypatch.setattr("hca_anndata_tools.strip.generate_output_path", lambda p: str(alias))
+
+    result = strip_forbidden_obs_columns(str(sample_h5ad_for_write))
+
+    assert "error" in result
+    assert "already exists" in result["error"]
+    assert alias.is_file(), "the source was unlinked through its alias"
+    assert sample_h5ad_for_write.is_file()
+    assert "self_reported_ethnicity" in ad.read_h5ad(sample_h5ad_for_write).obs.columns

--- a/packages/hca-anndata-tools/tests/test_strip.py
+++ b/packages/hca-anndata-tools/tests/test_strip.py
@@ -1,7 +1,6 @@
 """Tests for strip_forbidden_obs_columns."""
 
 import json
-import os
 from pathlib import Path
 
 import anndata as ad
@@ -159,64 +158,3 @@ def test_strip_same_second_snapshot_refused(sample_h5ad_for_write, monkeypatch):
     assert "self_reported_ethnicity" in ad.read_h5ad(sample_h5ad_for_write).obs.columns  # nor modified
     assert "error" in result
     assert "already exists" in result["error"]
-
-
-def test_strip_same_second_collision_resolves_after_waiting(sample_h5ad_for_write, monkeypatch):
-    """The common case: a snapshot written this second collides, the tool waits
-    out the boundary, and the retry gets a fresh name (mirrors copy_cap). Only a
-    collision that survives the wait is refused."""
-    _to_hca_layout(sample_h5ad_for_write, "self_reported_ethnicity")
-    fresh = sample_h5ad_for_write.with_name("fresh-edit-2026-08-22-00-00-01.h5ad")
-    names = iter([str(sample_h5ad_for_write), str(fresh)])
-    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: next(names))
-    slept = []
-    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", slept.append)
-
-    result = strip_forbidden_obs_columns(str(sample_h5ad_for_write))
-
-    assert slept == [1]
-    assert "error" not in result
-    assert result["obs_columns_stripped"] == ["self_reported_ethnicity"]
-    assert Path(result["output_path"]).name == "fresh-edit-2026-08-22-00-00-01.h5ad"
-
-
-def test_strip_failed_copy_leaves_no_partial_snapshot(sample_h5ad_for_write, monkeypatch):
-    """A copy that dies partway (ENOSPC on a multi-GB h5ad) must not leave the
-    partial file behind: it carries the newest -edit- timestamp, so resolve_latest
-    would hand that truncated file to every later call on the dataset."""
-    _to_hca_layout(sample_h5ad_for_write, "self_reported_ethnicity")
-    written = {}
-
-    def die_partway(src, dst, *args, **kwargs):
-        Path(dst).write_bytes(b"partial")
-        written["dst"] = dst
-        raise OSError(28, "No space left on device")
-
-    monkeypatch.setattr("hca_anndata_tools.write.shutil.copy2", die_partway)
-
-    result = strip_forbidden_obs_columns(str(sample_h5ad_for_write))
-
-    assert "error" in result
-    assert not Path(written["dst"]).exists(), "partial snapshot was left behind"
-    assert sample_h5ad_for_write.is_file()  # and the source is untouched
-
-
-def test_strip_alias_of_source_is_refused_without_unlinking(sample_h5ad_for_write, monkeypatch):
-    """An alias of the source — a hard link, or a './'-prefixed path — occupies
-    the generated name, so the claim step refuses it before any copy is
-    attempted. The destination must survive: it predates the call, and an alias
-    naming the source's own directory entry would take the source with it (the
-    #598 defect by another route)."""
-    _to_hca_layout(sample_h5ad_for_write, "self_reported_ethnicity")
-    alias = sample_h5ad_for_write.with_name("alias-edit-2026-08-22-00-00-01.h5ad")
-    os.link(sample_h5ad_for_write, alias)
-    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: str(alias))
-    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", lambda _: None)
-
-    result = strip_forbidden_obs_columns(str(sample_h5ad_for_write))
-
-    assert "error" in result
-    assert "already exists" in result["error"]
-    assert alias.is_file(), "a pre-existing destination we did not create was unlinked"
-    assert sample_h5ad_for_write.is_file()
-    assert "self_reported_ethnicity" in ad.read_h5ad(sample_h5ad_for_write).obs.columns

--- a/packages/hca-anndata-tools/tests/test_strip.py
+++ b/packages/hca-anndata-tools/tests/test_strip.py
@@ -141,22 +141,38 @@ def test_strip_missing_file():
 
 def test_strip_same_second_snapshot_refused(sample_h5ad_for_write, monkeypatch):
     """A second edit within the same second would name the output after its
-    own source; the guard refuses before touching anything.
-
-    Without it, ``shutil.copy2`` raises ``SameFileError`` and the failure path
-    unlinks ``output_path`` — which *is* the source. The surviving-source
-    assertion is the one that pins the bug (#598)."""
+    own source and the failure path would unlink that source snapshot; the
+    guard refuses before touching anything (mirrors rename/backfill)."""
     _to_hca_layout(sample_h5ad_for_write, "self_reported_ethnicity")
     monkeypatch.setattr("hca_anndata_tools.strip.generate_output_path", lambda p: p)
-    before = ad.read_h5ad(sample_h5ad_for_write)
+    slept = []
+    monkeypatch.setattr("hca_anndata_tools.strip.time.sleep", slept.append)
 
     result = strip_forbidden_obs_columns(str(sample_h5ad_for_write))
 
-    # Survival first: an unguarded run unlinks the source, and that is the
-    # defect. Asserting the message first would fail on wording instead.
-    assert Path(sample_h5ad_for_write).is_file(), "the source snapshot was deleted"
-    after = ad.read_h5ad(sample_h5ad_for_write)
-    assert after.n_obs == before.n_obs
-    assert "self_reported_ethnicity" in after.obs.columns, "the source was modified despite the refusal"
+    assert slept == [1], "the boundary wait should be attempted once before refusing"
+
+    # Asserted before the message: unguarded, this file is unlinked (#598).
+    assert sample_h5ad_for_write.is_file()
+    assert "self_reported_ethnicity" in ad.read_h5ad(sample_h5ad_for_write).obs.columns  # nor modified
     assert "error" in result
     assert "already exists" in result["error"]
+
+
+def test_strip_same_second_collision_resolves_after_waiting(sample_h5ad_for_write, monkeypatch):
+    """The common case: a snapshot written this second collides, the tool waits
+    out the boundary, and the retry gets a fresh name (mirrors copy_cap). Only a
+    collision that survives the wait is refused."""
+    _to_hca_layout(sample_h5ad_for_write, "self_reported_ethnicity")
+    fresh = sample_h5ad_for_write.with_name("fresh-edit-2026-08-22-00-00-01.h5ad")
+    names = iter([str(sample_h5ad_for_write), str(fresh)])
+    monkeypatch.setattr("hca_anndata_tools.strip.generate_output_path", lambda p: next(names))
+    slept = []
+    monkeypatch.setattr("hca_anndata_tools.strip.time.sleep", slept.append)
+
+    result = strip_forbidden_obs_columns(str(sample_h5ad_for_write))
+
+    assert slept == [1]
+    assert "error" not in result
+    assert result["obs_columns_stripped"] == ["self_reported_ethnicity"]
+    assert Path(result["output_path"]).name == "fresh-edit-2026-08-22-00-00-01.h5ad"

--- a/packages/hca-anndata-tools/tests/test_strip.py
+++ b/packages/hca-anndata-tools/tests/test_strip.py
@@ -137,3 +137,26 @@ def test_strip_missing_file():
     result = strip_forbidden_obs_columns("/nonexistent/path/file.h5ad")
     assert "error" in result
     assert "File not found" in result["error"]
+
+
+def test_strip_same_second_snapshot_refused(sample_h5ad_for_write, monkeypatch):
+    """A second edit within the same second would name the output after its
+    own source; the guard refuses before touching anything.
+
+    Without it, ``shutil.copy2`` raises ``SameFileError`` and the failure path
+    unlinks ``output_path`` — which *is* the source. The surviving-source
+    assertion is the one that pins the bug (#598)."""
+    _to_hca_layout(sample_h5ad_for_write, "self_reported_ethnicity")
+    monkeypatch.setattr("hca_anndata_tools.strip.generate_output_path", lambda p: p)
+    before = ad.read_h5ad(sample_h5ad_for_write)
+
+    result = strip_forbidden_obs_columns(str(sample_h5ad_for_write))
+
+    # Survival first: an unguarded run unlinks the source, and that is the
+    # defect. Asserting the message first would fail on wording instead.
+    assert Path(sample_h5ad_for_write).is_file(), "the source snapshot was deleted"
+    after = ad.read_h5ad(sample_h5ad_for_write)
+    assert after.n_obs == before.n_obs
+    assert "self_reported_ethnicity" in after.obs.columns, "the source was modified despite the refusal"
+    assert "error" in result
+    assert "already exists" in result["error"]

--- a/packages/hca-anndata-tools/tests/test_strip.py
+++ b/packages/hca-anndata-tools/tests/test_strip.py
@@ -141,9 +141,10 @@ def test_strip_missing_file():
 
 
 def test_strip_same_second_snapshot_refused(sample_h5ad_for_write, monkeypatch):
-    """A second edit within the same second would name the output after its
-    own source and the failure path would unlink that source snapshot; the
-    guard refuses before touching anything (mirrors rename/backfill)."""
+    """A collision that survives the boundary wait is refused before anything is
+    touched — otherwise the output would be named after its own source and the
+    failure path would unlink that source snapshot. Patching generate_output_path
+    to the identity makes the retry collide too, which is the unresolvable case."""
     _to_hca_layout(sample_h5ad_for_write, "self_reported_ethnicity")
     monkeypatch.setattr("hca_anndata_tools.strip.generate_output_path", lambda p: p)
     slept = []

--- a/packages/hca-anndata-tools/tests/test_strip.py
+++ b/packages/hca-anndata-tools/tests/test_strip.py
@@ -202,15 +202,16 @@ def test_strip_failed_copy_leaves_no_partial_snapshot(sample_h5ad_for_write, mon
 
 
 def test_strip_alias_of_source_is_refused_without_unlinking(sample_h5ad_for_write, monkeypatch):
-    """An alias of the source — a hard link, or a './'-prefixed path — is not
-    caught by the string-equality guard, but copy2 compares inodes and refuses
-    before writing. The destination must survive: it predates the call, and an
-    alias naming the source's own directory entry would take the source with
-    it (the #598 defect by another route)."""
+    """An alias of the source — a hard link, or a './'-prefixed path — occupies
+    the generated name, so the claim step refuses it before any copy is
+    attempted. The destination must survive: it predates the call, and an alias
+    naming the source's own directory entry would take the source with it (the
+    #598 defect by another route)."""
     _to_hca_layout(sample_h5ad_for_write, "self_reported_ethnicity")
     alias = sample_h5ad_for_write.with_name("alias-edit-2026-08-22-00-00-01.h5ad")
     os.link(sample_h5ad_for_write, alias)
     monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: str(alias))
+    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", lambda _: None)
 
     result = strip_forbidden_obs_columns(str(sample_h5ad_for_write))
 

--- a/packages/hca-anndata-tools/tests/test_strip.py
+++ b/packages/hca-anndata-tools/tests/test_strip.py
@@ -146,9 +146,9 @@ def test_strip_same_second_snapshot_refused(sample_h5ad_for_write, monkeypatch):
     failure path would unlink that source snapshot. Patching generate_output_path
     to the identity makes the retry collide too, which is the unresolvable case."""
     _to_hca_layout(sample_h5ad_for_write, "self_reported_ethnicity")
-    monkeypatch.setattr("hca_anndata_tools.strip.generate_output_path", lambda p: p)
+    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: p)
     slept = []
-    monkeypatch.setattr("hca_anndata_tools.strip.time.sleep", slept.append)
+    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", slept.append)
 
     result = strip_forbidden_obs_columns(str(sample_h5ad_for_write))
 
@@ -168,9 +168,9 @@ def test_strip_same_second_collision_resolves_after_waiting(sample_h5ad_for_writ
     _to_hca_layout(sample_h5ad_for_write, "self_reported_ethnicity")
     fresh = sample_h5ad_for_write.with_name("fresh-edit-2026-08-22-00-00-01.h5ad")
     names = iter([str(sample_h5ad_for_write), str(fresh)])
-    monkeypatch.setattr("hca_anndata_tools.strip.generate_output_path", lambda p: next(names))
+    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: next(names))
     slept = []
-    monkeypatch.setattr("hca_anndata_tools.strip.time.sleep", slept.append)
+    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", slept.append)
 
     result = strip_forbidden_obs_columns(str(sample_h5ad_for_write))
 
@@ -192,7 +192,7 @@ def test_strip_failed_copy_leaves_no_partial_snapshot(sample_h5ad_for_write, mon
         written["dst"] = dst
         raise OSError(28, "No space left on device")
 
-    monkeypatch.setattr("hca_anndata_tools.strip.shutil.copy2", die_partway)
+    monkeypatch.setattr("hca_anndata_tools.write.shutil.copy2", die_partway)
 
     result = strip_forbidden_obs_columns(str(sample_h5ad_for_write))
 
@@ -209,7 +209,7 @@ def test_strip_alias_of_source_is_refused_without_unlinking(sample_h5ad_for_writ
     _to_hca_layout(sample_h5ad_for_write, "self_reported_ethnicity")
     alias = sample_h5ad_for_write.with_name("alias-edit-2026-08-22-00-00-01.h5ad")
     os.link(sample_h5ad_for_write, alias)
-    monkeypatch.setattr("hca_anndata_tools.strip.generate_output_path", lambda p: str(alias))
+    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: str(alias))
 
     result = strip_forbidden_obs_columns(str(sample_h5ad_for_write))
 

--- a/packages/hca-anndata-tools/tests/test_strip_cap.py
+++ b/packages/hca-anndata-tools/tests/test_strip_cap.py
@@ -310,8 +310,9 @@ def test_strip_preserves_existing_edit_history(tmp_path):
 
 def test_strip_unblocks_the_mutating_toolkit(tmp_path, monkeypatch):
     """The legacy layout locks out sibling tools; stripping clears the refusal."""
-    # Distinct timestamps for the two writes — drop.py's same-second guard
-    # (#598) refuses back-to-back edits that land in one second.
+    # Distinct timestamps for the two writes: on a collision drop.py sleeps out
+    # the second boundary before retrying (#598), and this test has no reason to
+    # pay that second.
     ticks = iter(["2026-08-21-00-00-01", "2026-08-21-00-00-02"])
     monkeypatch.setattr("hca_anndata_tools.write.generate_timestamp", lambda: next(ticks))
     path = _make_cap_file(tmp_path / "locked.h5ad", uns_layout="legacy")

--- a/packages/hca-anndata-tools/tests/test_strip_cap.py
+++ b/packages/hca-anndata-tools/tests/test_strip_cap.py
@@ -310,8 +310,8 @@ def test_strip_preserves_existing_edit_history(tmp_path):
 
 def test_strip_unblocks_the_mutating_toolkit(tmp_path, monkeypatch):
     """The legacy layout locks out sibling tools; stripping clears the refusal."""
-    # Distinct timestamps for the two writes — drop.py lacks the same-second
-    # guard (#598/#600), so back-to-back edits in one second collide.
+    # Distinct timestamps for the two writes — drop.py's same-second guard
+    # (#598) refuses back-to-back edits that land in one second.
     ticks = iter(["2026-08-21-00-00-01", "2026-08-21-00-00-02"])
     monkeypatch.setattr("hca_anndata_tools.write.generate_timestamp", lambda: next(ticks))
     path = _make_cap_file(tmp_path / "locked.h5ad", uns_layout="legacy")

--- a/packages/hca-anndata-tools/tests/test_write.py
+++ b/packages/hca-anndata-tools/tests/test_write.py
@@ -485,6 +485,28 @@ def test_snapshot_copy_refuses_an_unresolvable_collision(tmp_path, monkeypatch):
     assert src.read_bytes() == b"payload"
 
 
+def test_snapshot_copy_never_removes_a_file_it_did_not_create(tmp_path, monkeypatch):
+    """A destination that is already occupied — by a sibling tool's snapshot
+    from this same second, not by the source — is refused before the copy, so
+    the cleanup can never reach a file we did not write."""
+    src = tmp_path / "d.h5ad"
+    src.write_bytes(b"source")
+    occupied = tmp_path / "d-edit-2026-08-22-00-00-01.h5ad"
+    occupied.write_bytes(b"a sibling's snapshot")
+    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: str(occupied))
+    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", lambda _: None)
+
+    def must_not_run(*args, **kwargs):  # pragma: no cover - asserts unreachable
+        raise AssertionError("copy2 must not run against an occupied destination")
+
+    monkeypatch.setattr("hca_anndata_tools.write.shutil.copy2", must_not_run)
+
+    with pytest.raises(SameSecondSnapshotError), snapshot_copy(str(src)):
+        pass  # pragma: no cover - the context manager raises on entry
+
+    assert occupied.read_bytes() == b"a sibling's snapshot"
+
+
 def test_snapshot_copy_refuses_an_alias_without_unlinking_it(tmp_path, monkeypatch):
     """A hard link to the source has a different name, so the equality check
     misses it; copy2 compares inodes. The destination is left alone: it

--- a/packages/hca-anndata-tools/tests/test_write.py
+++ b/packages/hca-anndata-tools/tests/test_write.py
@@ -485,6 +485,30 @@ def test_snapshot_copy_refuses_an_unresolvable_collision(tmp_path, monkeypatch):
     assert src.read_bytes() == b"payload"
 
 
+def test_snapshot_copy_claim_beats_a_concurrent_writer(tmp_path, monkeypatch):
+    """Testing occupancy and then copying leaves a window: another writer can
+    take the name in between, and copy2 would overwrite their file. The claim
+    is the creation, so there is no window to lose."""
+    src = tmp_path / "d.h5ad"
+    src.write_bytes(b"source")
+    rival = tmp_path / "d-edit-2026-08-22-00-00-01.h5ad"
+    raced = {"done": False}
+
+    def generate_then_race(_):
+        if not raced["done"]:
+            raced["done"] = True
+            rival.write_bytes(b"rival process snapshot")  # lands post-generation
+        return str(rival)
+
+    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", generate_then_race)
+    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", lambda _: None)
+
+    with pytest.raises(SameSecondSnapshotError), snapshot_copy(str(src)):
+        pass  # pragma: no cover - the context manager raises on entry
+
+    assert rival.read_bytes() == b"rival process snapshot"
+
+
 def test_snapshot_copy_never_removes_a_file_it_did_not_create(tmp_path, monkeypatch):
     """A destination that is already occupied — by a sibling tool's snapshot
     from this same second, not by the source — is refused before the copy, so

--- a/packages/hca-anndata-tools/tests/test_write.py
+++ b/packages/hca-anndata-tools/tests/test_write.py
@@ -12,9 +12,11 @@ import pytest
 
 from hca_anndata_tools.write import (
     EDIT_LOG_KEY,
+    SameSecondSnapshotError,
     _copy_with_sha256,
     generate_output_path,
     resolve_latest,
+    snapshot_copy,
     strip_timestamp,
     write_h5ad,
 )
@@ -435,3 +437,100 @@ def test_copy_with_sha256_refuses_hard_link(tmp_path):
         _copy_with_sha256(str(src), str(link))
 
     assert src.read_bytes() == b"do not truncate"
+
+
+# --- snapshot_copy: the shared create-and-clean-up contract (#598) ------------
+
+
+def test_snapshot_copy_yields_a_distinct_copy(tmp_path):
+    """The happy path: a real copy under a fresh name, source untouched."""
+    src = tmp_path / "d.h5ad"
+    src.write_bytes(b"payload")
+
+    with snapshot_copy(str(src)) as out:
+        assert Path(out) != src
+        assert Path(out).read_bytes() == b"payload"
+
+    assert Path(out).is_file()  # a clean exit keeps the snapshot
+    assert src.read_bytes() == b"payload"
+
+
+def test_snapshot_copy_waits_out_a_collision(tmp_path, monkeypatch):
+    """A name equal to the source is retried after the second boundary rather
+    than failing the run — these tools collide routinely when chained."""
+    src = tmp_path / "d.h5ad"
+    src.write_bytes(b"payload")
+    fresh = tmp_path / "d-edit-2026-08-22-00-00-01.h5ad"
+    names = iter([str(src), str(fresh)])
+    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: next(names))
+    slept = []
+    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", slept.append)
+
+    with snapshot_copy(str(src)) as out:
+        assert Path(out) == fresh
+
+    assert slept == [1]
+
+
+def test_snapshot_copy_refuses_an_unresolvable_collision(tmp_path, monkeypatch):
+    """A collision that survives the wait raises, and the source is untouched."""
+    src = tmp_path / "d.h5ad"
+    src.write_bytes(b"payload")
+    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: p)
+    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", lambda _: None)
+
+    with pytest.raises(SameSecondSnapshotError), snapshot_copy(str(src)):
+        pass  # pragma: no cover - the context manager raises on entry
+
+    assert src.read_bytes() == b"payload"
+
+
+def test_snapshot_copy_refuses_an_alias_without_unlinking_it(tmp_path, monkeypatch):
+    """A hard link to the source has a different name, so the equality check
+    misses it; copy2 compares inodes. Unlinking here would delete the source."""
+    src = tmp_path / "d.h5ad"
+    src.write_bytes(b"payload")
+    alias = tmp_path / "d-edit-2026-08-22-00-00-01.h5ad"
+    os.link(src, alias)
+    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: str(alias))
+
+    with pytest.raises(SameSecondSnapshotError), snapshot_copy(str(src)):
+        pass  # pragma: no cover - the context manager raises on entry
+
+    assert alias.is_file()
+    assert src.read_bytes() == b"payload"
+
+
+def test_snapshot_copy_removes_a_partially_written_snapshot(tmp_path, monkeypatch):
+    """copyfile opens the destination 'wb' and leaves it behind if the copy
+    dies partway. A leftover would win resolve_latest on the next call."""
+    src = tmp_path / "d.h5ad"
+    src.write_bytes(b"payload")
+    written = {}
+
+    def die_partway(s, dst, *args, **kwargs):
+        Path(dst).write_bytes(b"partial")
+        written["dst"] = dst
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr("hca_anndata_tools.write.shutil.copy2", die_partway)
+
+    with pytest.raises(OSError, match="No space left"), snapshot_copy(str(src)):
+        pass  # pragma: no cover - the context manager raises on entry
+
+    assert not Path(written["dst"]).exists()
+
+
+def test_snapshot_copy_removes_the_snapshot_when_the_body_fails(tmp_path):
+    """A body that raises leaves no half-edited snapshot behind, and the
+    exception still reaches the caller's own handler."""
+    src = tmp_path / "d.h5ad"
+    src.write_bytes(b"payload")
+    seen = {}
+
+    with pytest.raises(ValueError, match="boom"), snapshot_copy(str(src)) as out:
+        seen["out"] = out
+        raise ValueError("boom")
+
+    assert not Path(seen["out"]).exists()
+    assert src.read_bytes() == b"payload"

--- a/packages/hca-anndata-tools/tests/test_write.py
+++ b/packages/hca-anndata-tools/tests/test_write.py
@@ -507,9 +507,27 @@ def test_snapshot_copy_never_removes_a_file_it_did_not_create(tmp_path, monkeypa
     assert occupied.read_bytes() == b"a sibling's snapshot"
 
 
+def test_snapshot_copy_refuses_a_broken_symlink_destination(tmp_path, monkeypatch):
+    """A broken symlink occupies the name even though Path.exists() reports it
+    absent — exists() follows the link. Claiming that name would write through
+    the symlink and then unlink a symlink we did not create."""
+    src = tmp_path / "d.h5ad"
+    src.write_bytes(b"source")
+    dangling = tmp_path / "d-edit-2026-08-22-00-00-01.h5ad"
+    dangling.symlink_to(tmp_path / "gone.h5ad")
+    assert not dangling.exists() and dangling.is_symlink()  # the trap
+    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: str(dangling))
+    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", lambda _: None)
+
+    with pytest.raises(SameSecondSnapshotError), snapshot_copy(str(src)):
+        pass  # pragma: no cover - the context manager raises on entry
+
+    assert dangling.is_symlink()  # not ours to remove
+
+
 def test_snapshot_copy_refuses_an_alias_without_unlinking_it(tmp_path, monkeypatch):
-    """A hard link to the source has a different name, so the equality check
-    misses it; copy2 compares inodes. The destination is left alone: it
+    """A hard link to the source occupies the generated name, so the claim step
+    refuses it before any copy is attempted. The destination is left alone: it
     predates the call, and an alias naming the source's own directory entry
     (a './'-prefixed path) would take the source with it."""
     src = tmp_path / "d.h5ad"
@@ -517,6 +535,7 @@ def test_snapshot_copy_refuses_an_alias_without_unlinking_it(tmp_path, monkeypat
     alias = tmp_path / "d-edit-2026-08-22-00-00-01.h5ad"
     os.link(src, alias)
     monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: str(alias))
+    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", lambda _: None)
 
     with pytest.raises(SameSecondSnapshotError), snapshot_copy(str(src)):
         pass  # pragma: no cover - the context manager raises on entry

--- a/packages/hca-anndata-tools/tests/test_write.py
+++ b/packages/hca-anndata-tools/tests/test_write.py
@@ -487,7 +487,9 @@ def test_snapshot_copy_refuses_an_unresolvable_collision(tmp_path, monkeypatch):
 
 def test_snapshot_copy_refuses_an_alias_without_unlinking_it(tmp_path, monkeypatch):
     """A hard link to the source has a different name, so the equality check
-    misses it; copy2 compares inodes. Unlinking here would delete the source."""
+    misses it; copy2 compares inodes. The destination is left alone: it
+    predates the call, and an alias naming the source's own directory entry
+    (a './'-prefixed path) would take the source with it."""
     src = tmp_path / "d.h5ad"
     src.write_bytes(b"payload")
     alias = tmp_path / "d-edit-2026-08-22-00-00-01.h5ad"


### PR DESCRIPTION
## What changed

`drop_obs_columns` and `strip_forbidden_obs_columns` were the last two mutating tools without a same-second snapshot guard. Both now have one, and both had a second defect behind it that this fixes too.

**1. A name collision no longer destroys the previous snapshot.** `generate_output_path` timestamps to the second, so a tool running on a snapshot and finishing within the same second produced an output name identical to its source. `shutil.copy2` raised `SameFileError`, and the `except` handler unlinked `output_path` — which *was* the source. The call returned an error and the previous edit's snapshot was gone.

**2. On collision, both tools now wait rather than refuse.** They sleep out the second boundary, regenerate, and refuse only if the retry still collides — matching `copy_cap.py`. These are the fast tools, so back-to-back curation steps land in one second routinely; a caller chaining steps no longer has to notice an error and retry. (`rename`, `edit`, `backfill`, `strip_cap` refuse immediately; that divergence is recorded on #597.)

**3. The failure path only unlinks a file we wrote.** `output_path` is bound before the copy, and the handler deleted it unconditionally. That unlink — not `copy2` — is what turned a safe failure into data loss: `copy2` raises rather than truncating. A `snapshot_created` flag now gates the cleanup, which closes the whole class rather than the one route the guard covers.

**4. A partially written snapshot is cleaned up.** The flag is set *before* the copy, because `shutil.copyfile` opens the destination `'wb'` and does not remove it if the copy fails partway. ENOSPC on a multi-GB h5ad is the realistic trigger here, where every edit writes a full copy. Leaving the partial behind would be worse than the original bug: it carries the newest `-edit-` timestamp, so `resolve_latest` would hand a truncated file to every later call on the dataset.

**5. Aliases of the source are refused.** `SameFileError` is caught separately — the one failure that writes nothing (`copy2` compares inodes before opening the destination) and the one case where unlinking would delete the source. It also catches what the string-equality guard cannot: a hard link or `./`-prefixed path whose string form differs.

Four tests per tool, plus a stale comment fix in `test_strip_cap.py` that cited `drop.py` as lacking this guard.

## Why

Reported in #598 after the defect reproduced on the first try during the #533 review — two consecutive `drop_obs_columns` calls on a small file. Back-to-back edits are routine for an MCP agent chaining curation steps, so this is not theoretical: the same sequence runs against multi-GB integrated objects during bionetwork releases, where the deleted snapshot may represent an hour of work.

#598 offered a choice: replicate the guard now, or wait for the shared `patch_h5ad` helper proposed in #597. This takes the first, per the issue's own reasoning that a live data-loss bug should not be invisible inside a cleanup epic. The guard is deliberately shaped to be deleted wholesale when #597 lands, and #600's definition of done already names it.

## Assumptions I made

- **The wait is worth a behavior divergence.** Four sibling tools refuse immediately; these two now wait like `copy_cap`. Justified because `drop`/`strip` are fast enough to collide routinely and a one-second pause beats a failed run — but it does mean the toolkit has two collision policies until #597 unifies them. #608 argues for a third (`compress_h5ad` runs for minutes and should not fail at the end on a timing accident), which is why the shared helper likely wants `on_collision` as a parameter rather than a fixed policy.
- **The root cause is not `generate_output_path`.** Making it self-avoiding looks tempting but breaks three things: `resolve_latest` picks the newest snapshot by lexicographic `max()`, and sub-second precision inverts that ordering across the format boundary (`-26-123456.h5ad` sorts *before* `-26.h5ad`), so it would silently start returning stale files; `_TIMESTAMP_PATTERN` drives `cleanup_previous_version`, so a counter suffix would stop snapshots being reaped; and `copy_cap.py:346` calls `generate_output_path` as a pure prediction oracle, which a self-avoiding version would turn into a permanent no-op.
- **String equality is sufficient for the explicit guard**, because `resolve_latest` normalizes the path before it runs. The alias case is handled by `copy2`'s inode check rather than by widening the comparison — obtained atomically with the copy instead of as a separate check that can go stale. `strip_cap.py`'s `samefile` guard approximates the same thing; that divergence is noted on #597.
- **`write_h5ad` is out of scope.** It reaches the same collision by a different route — writing onto its source rather than unlinking it — and `cleanup_previous_version` documents that in-place case as considered. Filed as #608.

## How to verify

#598 states no explicit checklist, so this maps its repro plus the implicit done condition (both tools refuse instead of destroying, with coverage).

**1. The issue's repro no longer loses data.** On `main` this deletes the snapshot; on this branch it does not.

```bash
cd packages/hca-anndata-tools
uv run python - <<'PY'
import anndata as ad, numpy as np, pandas as pd, pathlib, tempfile
from hca_anndata_tools.drop import drop_obs_columns
d = pathlib.Path(tempfile.mkdtemp())
a = ad.AnnData(np.ones((5, 3), dtype="float32"))
a.obs["junk_a"] = pd.Categorical(["x"] * 5); a.obs["junk_b"] = pd.Categorical(["y"] * 5)
a.write_h5ad(d / "t.h5ad")
first = drop_obs_columns(str(d / "t.h5ad"), ["junk_a"])["output_path"]
print("snapshot:", pathlib.Path(first).name)
second = drop_obs_columns(first, ["junk_b"])          # same second on a small file
print("second call:", "ok" if "error" not in second else second["error"])
print("first snapshot still on disk:", pathlib.Path(first).exists())   # must be True
PY
```

Expect the second call to succeed after a ~1s pause. It cannot destroy the first snapshot either way.

**2. Both tools refuse instead of destroying — regression coverage.**

```bash
uv run pytest tests/test_drop.py tests/test_strip.py -q -k same_second_or_alias_or_partial
uv run pytest tests/test_drop.py tests/test_strip.py -q     # 53 passed
```

Eight tests, four per tool: refuses on an unresolvable collision, succeeds after waiting, cleans up a partial copy, refuses an alias of the source.

**3. The tests are not vacuous.** Each was verified to fail with its guard removed. To re-check the sharpest one, move `snapshot_created = True` back below `shutil.copy2` in `drop.py` and run:

```bash
uv run pytest tests/test_drop.py::test_drop_failed_copy_leaves_no_partial_snapshot -q
# fails: "partial snapshot was left behind"
```

**4. Full gate.**

```bash
uv run pytest tests/ -q                              # 433 passed
cd ../.. && uv run --project packages/hca-anndata-mcp ruff check packages/hca-anndata-tools
make typecheck                                        # 0 errors across all projects
```

Closes #598
