### PR TITLE
fix(hca-anndata-tools): narrow every uns read through read_uns

### DIFF
--- a/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
@@ -161,22 +161,63 @@ def read_var_gene_names(path: str) -> tuple[set[str], dict[str, str]]:
         return gene_names, eid_to_var_name
 
 
-def ensure_provenance_group(f: h5py.File) -> h5py.Group:
-    """Get or create the uns/provenance group with correct encoding attrs.
+def require_stamped_group(f: h5py.File, path: str) -> h5py.Group:
+    """``require_group`` plus the dict encoding attrs anndata expects.
 
-    Stamps ``uns`` itself as well as the provenance group. ``require_group``
-    creates a missing parent implicitly and leaves it bare, and anndata reads a
-    group with no encoding metadata under an OldFormatWarning — so writing an
-    edit log to a file that has no ``uns`` would otherwise leave every later
-    read of it complaining.
+    ``require_group`` leaves a group it creates bare, and anndata reads a group
+    with no encoding metadata under an OldFormatWarning — so every site that
+    may create a group stamps it here, at the creation, rather than relying on
+    some later call to do it as a side effect. ``setdefault`` leaves the attrs
+    of an existing group untouched.
     """
-    uns = f.require_group("uns")
-    uns.attrs.setdefault("encoding-type", "dict")
-    uns.attrs.setdefault("encoding-version", "0.1.0")
-    group = f.require_group("uns/provenance")
+    group = f.require_group(path)
     group.attrs.setdefault("encoding-type", "dict")
     group.attrs.setdefault("encoding-version", "0.1.0")
     return group
+
+
+def ensure_provenance_group(f: h5py.File) -> h5py.Group:
+    """Get or create the uns/provenance group with correct encoding attrs.
+
+    Stamps ``uns`` itself as well as the provenance group: ``require_group``
+    creates a missing parent implicitly, so ``uns`` may be born here too.
+    """
+    require_stamped_group(f, "uns")
+    return require_stamped_group(f, "uns/provenance")
+
+
+def read_uns(f: h5py.File) -> h5py.Group | None:
+    """The file's uns group, or None when it is absent or not a group.
+
+    ``File.get`` can hand back a Dataset on a malformed file, and every caller
+    treats uns as a mapping — where h5py's answers on a Dataset range from
+    AttributeError to a silently wrong ``in`` (#617). Narrowing here, once,
+    is what keeps the call sites honest.
+    """
+    uns = f.get("uns")
+    return uns if isinstance(uns, h5py.Group) else None
+
+
+def read_batch_condition(uns: h5py.Group | None) -> list[str]:
+    """Read ``uns['batch_condition']`` as a list of obs column names.
+
+    The HCA schema types it ``element_type: match_obs_columns``, so every entry
+    must name an obs column. Returns an empty list when absent or unreadable —
+    an unreadable value is the validator's problem to report, not a reason for
+    a mutating tool to refuse.
+    """
+    if uns is None or "batch_condition" not in uns:
+        return []
+    try:
+        raw = uns["batch_condition"][()]  # pyright: ignore[reportIndexIssue]
+    except (OSError, TypeError, ValueError):
+        return []
+    if isinstance(raw, bytes | str):
+        return [_decode_bytes(raw)]
+    try:
+        return [_decode_bytes(v) for v in raw]
+    except TypeError:
+        return []
 
 
 def read_edit_log_h5py(f: h5py.File) -> str:
@@ -184,13 +225,10 @@ def read_edit_log_h5py(f: h5py.File) -> str:
 
     Returns "[]" if no edit log exists.
     """
-    uns = f.get("uns")
-    # isinstance, not truthiness: a malformed file can hold a Dataset at "uns",
-    # which is truthy and has no .get, so `if uns` would raise AttributeError
-    # rather than falling through to the no-log answer.
-    if isinstance(uns, h5py.Group):
+    uns = read_uns(f)
+    if uns is not None:
         prov = uns.get("provenance")
-        if prov and isinstance(prov, h5py.Group) and "edit_history" in prov:
+        if isinstance(prov, h5py.Group) and "edit_history" in prov:
             return _decode_bytes(prov["edit_history"][()])
     return "[]"
 

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
@@ -237,8 +237,11 @@ def read_edit_log_h5py(f: h5py.File) -> str:
     Returns "[]" if no edit log exists.
     """
     prov = read_provenance(read_uns(f))
-    if prov is not None and "edit_history" in prov:
-        return _decode_bytes(prov["edit_history"][()])
+    log = prov.get("edit_history") if prov is not None else None
+    if isinstance(log, h5py.Dataset):
+        raw = log[()]
+        if isinstance(raw, bytes | str):
+            return _decode_bytes(raw)
     return "[]"
 
 

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
@@ -209,7 +209,7 @@ def read_batch_condition(uns: h5py.Group | None) -> list[str]:
     if uns is None or "batch_condition" not in uns:
         return []
     try:
-        raw = uns["batch_condition"][()]  # pyright: ignore[reportIndexIssue]
+        raw = uns["batch_condition"][()]
     except (OSError, TypeError, ValueError):
         return []
     if isinstance(raw, bytes | str):
@@ -220,16 +220,25 @@ def read_batch_condition(uns: h5py.Group | None) -> list[str]:
         return []
 
 
+def read_provenance(uns: h5py.Group | None) -> h5py.Group | None:
+    """``uns['provenance']`` as a group, or None when absent or not a group.
+
+    The child-level twin of :func:`read_uns`, for the same reason.
+    """
+    if uns is None:
+        return None
+    prov = uns.get("provenance")
+    return prov if isinstance(prov, h5py.Group) else None
+
+
 def read_edit_log_h5py(f: h5py.File) -> str:
     """Read the edit log JSON string from an open h5py File.
 
     Returns "[]" if no edit log exists.
     """
-    uns = read_uns(f)
-    if uns is not None:
-        prov = uns.get("provenance")
-        if isinstance(prov, h5py.Group) and "edit_history" in prov:
-            return _decode_bytes(prov["edit_history"][()])
+    prov = read_provenance(read_uns(f))
+    if prov is not None and "edit_history" in prov:
+        return _decode_bytes(prov["edit_history"][()])
     return "[]"
 
 

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/backfill.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/backfill.py
@@ -32,6 +32,7 @@ from ._io import (
     read_categorical_data,
     read_edit_log_h5py,
     read_string_dataset,
+    read_uns,
     replace_categorical_column,
     replace_string_dataset,
     verify_categorical_integrity,
@@ -149,8 +150,8 @@ def _read_obs_for_backfill(
         if not isinstance(obs, h5py.Group):
             return None, {"error": f"{side} file has no obs group: {path}"}
         if is_target:
-            uns = f.get("uns")
-            if isinstance(uns, h5py.Group) and is_legacy_cap_layout(uns):
+            uns = read_uns(f)
+            if uns is not None and is_legacy_cap_layout(uns):
                 # Parity with drop.py / rename.py (#552): mutating tools
                 # refuse the deprecated top-level CAP layout.
                 return None, {

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/backfill.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/backfill.py
@@ -151,7 +151,7 @@ def _read_obs_for_backfill(
             return None, {"error": f"{side} file has no obs group: {path}"}
         if is_target:
             uns = read_uns(f)
-            if uns is not None and is_legacy_cap_layout(uns):
+            if is_legacy_cap_layout(uns):
                 # Parity with drop.py / rename.py (#552): mutating tools
                 # refuse the deprecated top-level CAP layout.
                 return None, {

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/cap.py
@@ -52,11 +52,16 @@ LEGACY_LAYOUT_ERROR = (
 def is_legacy_cap_layout(uns) -> bool:
     """True if the file carries any deprecated top-level CAP key.
 
+    Accepts None (a file with no uns is not legacy-layout), so callers can
+    pass ``read_uns``'s result without their own guard.
+
     Fires even when a nested ``cap_metadata`` block is also present (a
     mixed-layout file): the strict clean-break contract refuses anything
     carrying deprecated top-level keys rather than silently letting the nested
     block win.
     """
+    if uns is None:
+        return False
     return any(k in uns for k in _LEGACY_CAP_MARKERS)
 
 

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/convert.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/convert.py
@@ -17,7 +17,6 @@ from ._io import (
     ensure_provenance_group,
     open_h5ad,
     read_obs_index,
-    require_stamped_group,
     transplant_obs_columns,
     verify_obs_transplant,
 )
@@ -192,7 +191,9 @@ def convert_cellxgene_to_hca(
             shutil.copy2(path, output_path)
 
             with h5py.File(temp_path, "r") as f_temp, h5py.File(output_path, "a") as f_out:
-                require_stamped_group(f_out, "uns")
+                # Creates and stamps uns (and uns/provenance) up front, so the
+                # key deletions below never meet a bare, unstamped group.
+                prov_out = ensure_provenance_group(f_out)
 
                 # Delete CellxGENE reserved keys from uns
                 for key in _CELLXGENE_RESERVED_UNS:
@@ -203,8 +204,6 @@ def convert_cellxgene_to_hca(
                 for key in _UNS_TO_OBS:
                     if key in f_out["uns"]:
                         del f_out["uns"][key]
-
-                prov_out = ensure_provenance_group(f_out)
 
                 # Transplant provenance/cellxgene from temp (merge, don't replace whole group)
                 if "provenance" in f_temp["uns"] and "cellxgene" in f_temp["uns"]["provenance"]:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/convert.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/convert.py
@@ -17,6 +17,7 @@ from ._io import (
     ensure_provenance_group,
     open_h5ad,
     read_obs_index,
+    require_stamped_group,
     transplant_obs_columns,
     verify_obs_transplant,
 )
@@ -191,7 +192,7 @@ def convert_cellxgene_to_hca(
             shutil.copy2(path, output_path)
 
             with h5py.File(temp_path, "r") as f_temp, h5py.File(output_path, "a") as f_out:
-                f_out.require_group("uns")
+                require_stamped_group(f_out, "uns")
 
                 # Delete CellxGENE reserved keys from uns
                 for key in _CELLXGENE_RESERVED_UNS:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -23,8 +23,8 @@ from ._io import (
     read_categorical_data,
     read_column_order,
     read_edit_log_h5py,
+    read_provenance,
     read_uns,
-    require_stamped_group,
     update_column_order,
     verify_obs_transplant,
 )
@@ -246,8 +246,8 @@ def copy_cap_annotations(
 
                 uns = read_uns(f)
                 uns_keys = set(uns.keys()) if uns is not None else set()
-                prov = uns.get("provenance") if uns is not None else None
-                has_prov_cap = isinstance(prov, h5py.Group) and "cap" in prov
+                prov = read_provenance(uns)
+                has_prov_cap = prov is not None and "cap" in prov
                 log = read_edit_log_h5py(f)
             return obs_columns, index, var_list, uns_keys, has_prov_cap, log
 
@@ -432,7 +432,9 @@ def copy_cap_annotations(
             # removed by the overwrite pre-strip above, so this is always a
             # clean addition.
             with h5py.File(temp_path, "r") as f_temp, h5py.File(output_path, "a") as f_out:
-                require_stamped_group(f_out, "uns")
+                # Creates and stamps uns (and uns/provenance) up front, so the
+                # transplants below never meet a bare, unstamped group.
+                prov_out = ensure_provenance_group(f_out)
 
                 # Transplant new obs columns from temp
                 for col in obs_cols_to_copy:
@@ -447,7 +449,6 @@ def copy_cap_annotations(
                         f_temp.copy(f"uns/{key}", f_out["uns"])
 
                 # Transplant edit_history into provenance
-                prov_out = ensure_provenance_group(f_out)
                 if EDIT_LOG_KEY in prov_out:
                     del prov_out[EDIT_LOG_KEY]
                 if "provenance" in f_temp["uns"] and EDIT_LOG_KEY in f_temp["uns"]["provenance"]:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -23,6 +23,8 @@ from ._io import (
     read_categorical_data,
     read_column_order,
     read_edit_log_h5py,
+    read_uns,
+    require_stamped_group,
     update_column_order,
     verify_obs_transplant,
 )
@@ -242,8 +244,8 @@ def copy_cap_annotations(
                 var_idx_key = _decode_bytes(var_group.attrs.get("_index", "_index"))
                 var_list = [_decode_bytes(v) for v in var_group[var_idx_key][:]]
 
-                uns = f.get("uns")
-                uns_keys = set(uns.keys()) if uns else set()
+                uns = read_uns(f)
+                uns_keys = set(uns.keys()) if uns is not None else set()
                 prov = uns.get("provenance") if uns is not None else None
                 has_prov_cap = isinstance(prov, h5py.Group) and "cap" in prov
                 log = read_edit_log_h5py(f)
@@ -430,7 +432,7 @@ def copy_cap_annotations(
             # removed by the overwrite pre-strip above, so this is always a
             # clean addition.
             with h5py.File(temp_path, "r") as f_temp, h5py.File(output_path, "a") as f_out:
-                f_out.require_group("uns")
+                require_stamped_group(f_out, "uns")
 
                 # Transplant new obs columns from temp
                 for col in obs_cols_to_copy:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/drop.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/drop.py
@@ -23,7 +23,9 @@ import h5py
 
 from ._io import (
     _decode_bytes,
+    read_batch_condition,
     read_edit_log_h5py,
+    read_uns,
     update_column_order,
     write_edit_log_h5py,
 )
@@ -36,28 +38,6 @@ from .write import (
     resolve_latest,
     snapshot_copy,
 )
-
-
-def _read_batch_condition(uns: h5py.Group | None) -> list[str]:
-    """Read ``uns['batch_condition']`` as a list of obs column names.
-
-    The HCA schema types it ``element_type: match_obs_columns``, so every entry
-    must name an obs column. Returns an empty list when absent or unreadable —
-    an unreadable value is the validator's problem to report, not a reason for
-    this tool to refuse a drop.
-    """
-    if uns is None or "batch_condition" not in uns:
-        return []
-    try:
-        raw = uns["batch_condition"][()]  # pyright: ignore[reportIndexIssue]
-    except (OSError, TypeError, ValueError):
-        return []
-    if isinstance(raw, bytes | str):
-        return [_decode_bytes(raw)]
-    try:
-        return [_decode_bytes(v) for v in raw]
-    except TypeError:
-        return []
 
 
 def _validate_request(obs: h5py.Group, uns: h5py.Group | None, columns: list[str]) -> list[str]:
@@ -107,7 +87,7 @@ def _validate_request(obs: h5py.Group, uns: h5py.Group | None, columns: list[str
     # claim the file makes, which is a curation decision and not this tool's
     # to take. Contrast `uns['<col>_colors']`, which the column *owns* and which
     # is therefore deleted alongside it (see :func:`drop_obs_columns`).
-    batched = sorted(set(columns) & set(_read_batch_condition(uns)))
+    batched = sorted(set(columns) & set(read_batch_condition(uns)))
     if batched:
         problems.append(
             f"referenced by uns['batch_condition']: {batched} — that list declares "
@@ -261,9 +241,7 @@ def drop_obs_columns(path: str, columns: list[str] | tuple[str, ...]) -> dict:
                 return {"error": "File has no obs group"}
             if not isinstance(obs, h5py.Group):
                 return {"error": "obs is not a group — the file predates the modern h5ad layout"}
-            uns = f_in.get("uns")
-            if not isinstance(uns, h5py.Group):
-                uns = None
+            uns = read_uns(f_in)
             problems = _validate_request(obs, uns, requested)
             # Palettes to remove with their columns. Resolved here, from the
             # same read that validated, so the write phase does no discovery.

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/drop.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/drop.py
@@ -100,7 +100,7 @@ def _validate_request(obs: h5py.Group, uns: h5py.Group | None, columns: list[str
     # request names is the point: the check below reads uns['cap_metadata'], so
     # in this layout it sees no declaration and every CAP column looks
     # droppable — the bug this exists to close (#552).
-    if uns is not None and is_legacy_cap_layout(uns):
+    if is_legacy_cap_layout(uns):
         problems.append(f"the file uses {LEGACY_LAYOUT_DESCRIPTION}, which is not supported")
 
     # CAP annotation sets declare themselves in uns['cap_metadata'] and require

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/inspect.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/inspect.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import h5py
 import numpy as np
 
-from ._io import _decode_bytes
+from ._io import _decode_bytes, read_uns
 from .write import resolve_latest
 
 _DEFAULT_SAMPLE_SIZE = 2000
@@ -281,8 +281,8 @@ def _read_schema_version(f: h5py.File) -> str | None:
     ``schema_version`` is stored as a scalar string dataset in AnnData's
     h5ad format.
     """
-    uns = f.get("uns")
-    if not isinstance(uns, h5py.Group) or "schema_version" not in uns:
+    uns = read_uns(f)
+    if uns is None or "schema_version" not in uns:
         return None
     raw = uns["schema_version"][()]  # pyright: ignore[reportIndexIssue]
     value = _decode_bytes(raw)

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/inspect.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/inspect.py
@@ -284,7 +284,7 @@ def _read_schema_version(f: h5py.File) -> str | None:
     uns = read_uns(f)
     if uns is None or "schema_version" not in uns:
         return None
-    raw = uns["schema_version"][()]  # pyright: ignore[reportIndexIssue]
+    raw = uns["schema_version"][()]
     value = _decode_bytes(raw)
     if not isinstance(value, str):
         return None

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/inspect.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/inspect.py
@@ -282,9 +282,12 @@ def _read_schema_version(f: h5py.File) -> str | None:
     h5ad format.
     """
     uns = read_uns(f)
-    if uns is None or "schema_version" not in uns:
+    if uns is None:
         return None
-    raw = uns["schema_version"][()]
+    version = uns.get("schema_version")
+    if not isinstance(version, h5py.Dataset):
+        return None
+    raw = version[()]
     value = _decode_bytes(raw)
     if not isinstance(value, str):
         return None

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/rename.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/rename.py
@@ -205,7 +205,7 @@ def rename_cell_ids(path: str, column: str, value: str, prefix_from: str, prefix
                 }
 
             uns = read_uns(f_in)
-            if uns is not None and is_legacy_cap_layout(uns):
+            if is_legacy_cap_layout(uns):
                 # Parity with drop.py / copy_cap.py (#552): the legacy layout
                 # marks a CAP export even when uns['schema_version'] is absent,
                 # and renaming a CAP export is exactly what the gate above

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/rename.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/rename.py
@@ -27,6 +27,7 @@ from ._io import (
     read_categorical_data,
     read_edit_log_h5py,
     read_string_dataset,
+    read_uns,
     replace_string_dataset,
     write_edit_log_h5py,
 )
@@ -203,8 +204,8 @@ def rename_cell_ids(path: str, column: str, value: str, prefix_from: str, prefix
                     )
                 }
 
-            uns = f_in.get("uns")
-            if isinstance(uns, h5py.Group) and is_legacy_cap_layout(uns):
+            uns = read_uns(f_in)
+            if uns is not None and is_legacy_cap_layout(uns):
                 # Parity with drop.py / copy_cap.py (#552): the legacy layout
                 # marks a CAP export even when uns['schema_version'] is absent,
                 # and renaming a CAP export is exactly what the gate above

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/rename_column.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/rename_column.py
@@ -25,12 +25,13 @@ import numpy as np
 
 from ._io import (
     _decode_bytes,
+    read_batch_condition,
     read_column_order,
     read_edit_log_h5py,
+    read_uns,
     write_edit_log_h5py,
 )
 from .cap import CAP_METADATA_KEY, LEGACY_LAYOUT_DESCRIPTION, is_legacy_cap_layout
-from .drop import _read_batch_condition
 from .write import (
     build_edit_log,
     cleanup_previous_version,
@@ -251,12 +252,10 @@ def rename_obs_column(path: str, column: str, new_name: str) -> dict:
             obs = f_in.get("obs")
             if not isinstance(obs, h5py.Group):
                 return {"error": "File has no obs group, or obs is not a group"}
-            uns = f_in.get("uns")
-            if not isinstance(uns, h5py.Group):
-                uns = None
+            uns = read_uns(f_in)
             problems = _validate_request(obs, uns, column, new_name)
             palette = f"{column}_colors" if uns is not None and f"{column}_colors" in uns else None
-            batch_condition = _read_batch_condition(uns)
+            batch_condition = read_batch_condition(uns)
 
         if problems:
             return {"error": "Refusing to rename: " + "; ".join(problems)}
@@ -264,11 +263,7 @@ def rename_obs_column(path: str, column: str, new_name: str) -> dict:
         # h5py closes before snapshot_copy's cleanup runs, which is the ordering
         # the unlink needs: removing an open HDF5 handle raises on Windows.
         with snapshot_copy(path) as output_path, h5py.File(output_path, "a") as f_out:
-            # Mirrors the read phase's coercion: File.get can hand back a
-            # Dataset on a malformed file, and every use below is a mapping.
-            uns_out = f_out.get("uns")
-            if not isinstance(uns_out, h5py.Group):
-                uns_out = None
+            uns_out = read_uns(f_out)
 
             # Anything already under the destination's palette key goes, whether
             # it belonged to an empty column being replaced or was orphaned by an

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/rename_column.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/rename_column.py
@@ -100,7 +100,7 @@ def _validate_request(obs: h5py.Group, uns: h5py.Group | None, column: str, new_
     # names is the point: the CAP check below reads uns['cap_metadata'], so in
     # this layout it sees no declaration and every CAP column looks renamable —
     # the shape of #552.
-    if uns is not None and is_legacy_cap_layout(uns):
+    if is_legacy_cap_layout(uns):
         problems.append(f"the file uses {LEGACY_LAYOUT_DESCRIPTION}, which is not supported")
 
     # CAP annotation sets declare themselves in uns['cap_metadata'] and require

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/strip.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/strip.py
@@ -108,14 +108,18 @@ def strip_forbidden_obs_columns(path: str) -> dict:
 
         # Peek first: layout check + presence check. Both via h5py so we
         # don't load the full anndata just to decide whether to mutate.
+        # The layout gate matches rename.py / strip_cap.py: a file is
+        # CellxGENE when uns['schema_version'] holds a non-empty string, so
+        # an empty or non-string value no longer trips the refusal the way
+        # the old bare presence check did.
         with h5py.File(path, "r") as f_in:
             if _read_schema_version(f_in):
                 return {
                     "error": (
-                        "Input is CellxGENE-layout (uns['schema_version'] is "
-                        "present). Use convert_cellxgene_to_hca instead — "
-                        "it strips these columns as a side-effect of "
-                        "converting to HCA layout."
+                        "Input is CellxGENE-layout (uns['schema_version'] "
+                        "declares a version). Use convert_cellxgene_to_hca "
+                        "instead — it strips these columns as a side-effect "
+                        "of converting to HCA layout."
                     )
                 }
             obs = f_in.get("obs")

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/strip.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/strip.py
@@ -21,6 +21,7 @@ import h5py
 
 from ._io import (
     read_edit_log_h5py,
+    read_uns,
     update_column_order,
     write_edit_log_h5py,
 )
@@ -108,7 +109,7 @@ def strip_forbidden_obs_columns(path: str) -> dict:
         # Peek first: layout check + presence check. Both via h5py so we
         # don't load the full anndata just to decide whether to mutate.
         with h5py.File(path, "r") as f_in:
-            uns = f_in.get("uns")
+            uns = read_uns(f_in)
             if uns is not None and "schema_version" in uns:
                 return {
                     "error": (

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/strip.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/strip.py
@@ -21,10 +21,10 @@ import h5py
 
 from ._io import (
     read_edit_log_h5py,
-    read_uns,
     update_column_order,
     write_edit_log_h5py,
 )
+from .inspect import _read_schema_version
 from .write import (
     build_edit_log,
     cleanup_previous_version,
@@ -109,8 +109,7 @@ def strip_forbidden_obs_columns(path: str) -> dict:
         # Peek first: layout check + presence check. Both via h5py so we
         # don't load the full anndata just to decide whether to mutate.
         with h5py.File(path, "r") as f_in:
-            uns = read_uns(f_in)
-            if uns is not None and "schema_version" in uns:
+            if _read_schema_version(f_in):
                 return {
                     "error": (
                         "Input is CellxGENE-layout (uns['schema_version'] is "
@@ -120,7 +119,7 @@ def strip_forbidden_obs_columns(path: str) -> dict:
                     )
                 }
             obs = f_in.get("obs")
-            if obs is None:
+            if not isinstance(obs, h5py.Group):
                 return {"error": "File has no obs group"}
             present = [c for c in _OBS_COLUMNS_TO_STRIP if c in obs]
 

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/strip_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/strip_cap.py
@@ -25,13 +25,14 @@ import h5py
 
 from ._io import (
     _decode_bytes,
+    read_batch_condition,
     read_column_order,
     read_edit_log_h5py,
+    read_uns,
     update_column_order,
     write_edit_log_h5py,
 )
 from .cap import _LEGACY_CAP_MARKERS, CAP_METADATA_KEY, cap_obs_columns, unknown_cap_suffix_columns
-from .drop import _read_batch_condition
 from .inspect import _read_schema_version
 from .write import (
     SAME_SECOND_SNAPSHOT_ERROR,
@@ -168,8 +169,8 @@ def strip_cap_annotations(path: str) -> dict:
                     )
                 }
             unknown_suffixes = unknown_cap_suffix_columns(obs_columns_present)
-            uns_for_bc = f_in.get("uns")
-            batched = sorted(set(obs_columns_present) & set(_read_batch_condition(uns_for_bc)))  # pyright: ignore[reportArgumentType]
+            uns = read_uns(f_in)
+            batched = sorted(set(obs_columns_present) & set(read_batch_condition(uns)))
             if batched:
                 # Parity with drop.py: a dangling batch_condition reference
                 # turns a valid file invalid, and rewriting the declaration
@@ -182,7 +183,6 @@ def strip_cap_annotations(path: str) -> dict:
                         f"first if that is intended."
                     )
                 }
-            uns = f_in.get("uns")
             uns_keys_present: list[str] = []
             if uns is not None:
                 uns_keys_present += [k for k in _CAP_UNS_KEYS if k in uns]
@@ -220,7 +220,14 @@ def strip_cap_annotations(path: str) -> dict:
                 # orphan them (the validator flags colors without a matching
                 # obs column) — and those ALREADY orphaned by an earlier
                 # era's overwrite, which deleted columns but left palettes.
-                uns_keys_present += [k for k in uns if k.endswith("_colors") and "--" in k.removesuffix("_colors")]
+                # .keys(), not bare iteration: h5py stubs type Group.__iter__
+                # as yielding str | None, while .keys() yields str. SIM118
+                # assumes dict semantics a Group does not have.
+                uns_keys_present += [
+                    k
+                    for k in uns.keys()  # noqa: SIM118
+                    if k.endswith("_colors") and "--" in k.removesuffix("_colors")
+                ]
 
         if not uns_keys_present and not obs_columns_present:
             # nothing_to_strip lets a caller composing this tool (copy_cap's

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/strip_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/strip_cap.py
@@ -28,6 +28,7 @@ from ._io import (
     read_batch_condition,
     read_column_order,
     read_edit_log_h5py,
+    read_provenance,
     read_uns,
     update_column_order,
     write_edit_log_h5py,
@@ -189,8 +190,8 @@ def strip_cap_annotations(path: str) -> dict:
                 uns_keys_present += [k for k in _LEGACY_TOP_LEVEL_PROVENANCE if k in uns]
                 # 'provenance/cap' is an HDF5 path, so the shared deletion
                 # loop below removes the nested block like any other key.
-                prov = uns.get("provenance")
-                if isinstance(prov, h5py.Group) and "cap" in prov:
+                prov = read_provenance(uns)
+                if prov is not None and "cap" in prov:
                     uns_keys_present.append("provenance/cap")
             if uns_keys_present:
                 # This tool only undoes what our own import wrote. A file
@@ -220,13 +221,8 @@ def strip_cap_annotations(path: str) -> dict:
                 # orphan them (the validator flags colors without a matching
                 # obs column) — and those ALREADY orphaned by an earlier
                 # era's overwrite, which deleted columns but left palettes.
-                # .keys(), not bare iteration: h5py stubs type Group.__iter__
-                # as yielding str | None, while .keys() yields str. SIM118
-                # assumes dict semantics a Group does not have.
                 uns_keys_present += [
-                    k
-                    for k in uns.keys()  # noqa: SIM118
-                    if k.endswith("_colors") and "--" in k.removesuffix("_colors")
+                    k for k in sorted(uns.keys()) if k.endswith("_colors") and "--" in k.removesuffix("_colors")
                 ]
 
         if not uns_keys_present and not obs_columns_present:

--- a/packages/hca-anndata-tools/tests/conftest.py
+++ b/packages/hca-anndata-tools/tests/conftest.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import anndata as ad
+import h5py
 import pytest
 
 from hca_anndata_tools.testing import create_cellxgene_h5ad, create_sample_h5ad
@@ -53,3 +54,18 @@ def cellxgene_h5ad(tmp_path) -> Path:
     """Create a CellxGENE-style h5ad file in a writable tmp dir."""
     path = tmp_path / "d394204c-dc6f-4c82-ae66-c6d00addbf43.h5ad"
     return create_cellxgene_h5ad(path)
+
+
+@pytest.fixture
+def put_dataset_at_uns():
+    """Replace a file's uns group with a scalar string Dataset — the malformed
+    shape read_uns narrows to None (#617)."""
+
+    def _put(path):
+        with h5py.File(path, "a") as f:
+            if "uns" in f:
+                del f["uns"]
+            f["uns"] = "not a group"
+        return path
+
+    return _put

--- a/packages/hca-anndata-tools/tests/test_copy_cap.py
+++ b/packages/hca-anndata-tools/tests/test_copy_cap.py
@@ -670,12 +670,14 @@ def test_missing_file():
 
 def test_copy_survives_dataset_at_uns_in_target(cap_source, hca_target, put_dataset_at_uns):
     """A Dataset at the target's 'uns' used to crash inspection at uns.keys()
-    (#617); narrowed to None, the failure moves to the write boundary — a
-    legible refusal with the target left untouched."""
+    (#617); narrowed to None, the read phase completes and the failure moves
+    to the write boundary (require_group meeting the Dataset), with the
+    target file left byte-identical."""
     put_dataset_at_uns(hca_target)
+    before = hca_target.read_bytes()
 
     result = copy_cap_annotations(str(cap_source), str(hca_target))
 
     assert "error" in result
-    assert "no attribute" not in result["error"]
-    assert hca_target.is_file()
+    assert "no attribute" not in result["error"]  # the pre-#617 crash shape
+    assert hca_target.read_bytes() == before

--- a/packages/hca-anndata-tools/tests/test_copy_cap.py
+++ b/packages/hca-anndata-tools/tests/test_copy_cap.py
@@ -434,8 +434,6 @@ def test_copy_rejects_non_categorical_source_column(cap_source, hca_target):
     # Rewrite one CAP column in the source as a plain string dataset (via h5py,
     # bypassing anndata's auto-coercion to categorical) to simulate a source
     # that violates CAP's categorical-everywhere serialization contract.
-    import h5py
-
     col = "author_cell_type--rationale"
     with h5py.File(cap_source, "a") as f:
         del f["obs"][col]
@@ -670,15 +668,11 @@ def test_missing_file():
     assert "error" in result
 
 
-def test_copy_survives_dataset_at_uns_in_target(cap_source, hca_target):
-    """A scalar Dataset at the target's 'uns' used to crash the read phase
-    with AttributeError at uns.keys() (#617). read_uns narrows it to None so
-    inspection completes; the write phase then refuses when require_group
-    meets the Dataset — a failure at the write boundary, with the target
-    left untouched, instead of a crash while merely reading."""
-    with h5py.File(hca_target, "a") as f:
-        del f["uns"]
-        f["uns"] = "not a group"
+def test_copy_survives_dataset_at_uns_in_target(cap_source, hca_target, put_dataset_at_uns):
+    """A Dataset at the target's 'uns' used to crash inspection at uns.keys()
+    (#617); narrowed to None, the failure moves to the write boundary — a
+    legible refusal with the target left untouched."""
+    put_dataset_at_uns(hca_target)
 
     result = copy_cap_annotations(str(cap_source), str(hca_target))
 

--- a/packages/hca-anndata-tools/tests/test_copy_cap.py
+++ b/packages/hca-anndata-tools/tests/test_copy_cap.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 import anndata as ad
+import h5py
 import numpy as np
 import pandas as pd
 import pytest
@@ -667,3 +668,20 @@ def test_copy_obs_index_reordered(cap_source, tmp_path):
 def test_missing_file():
     result = copy_cap_annotations("/nonexistent/source.h5ad", "/nonexistent/target.h5ad")
     assert "error" in result
+
+
+def test_copy_survives_dataset_at_uns_in_target(cap_source, hca_target):
+    """A scalar Dataset at the target's 'uns' used to crash the read phase
+    with AttributeError at uns.keys() (#617). read_uns narrows it to None so
+    inspection completes; the write phase then refuses when require_group
+    meets the Dataset — a failure at the write boundary, with the target
+    left untouched, instead of a crash while merely reading."""
+    with h5py.File(hca_target, "a") as f:
+        del f["uns"]
+        f["uns"] = "not a group"
+
+    result = copy_cap_annotations(str(cap_source), str(hca_target))
+
+    assert "error" in result
+    assert "no attribute" not in result["error"]
+    assert hca_target.is_file()

--- a/packages/hca-anndata-tools/tests/test_io.py
+++ b/packages/hca-anndata-tools/tests/test_io.py
@@ -1,16 +1,11 @@
-"""Tests for the _io helpers that narrow uns access (#617).
-
-``File.get("uns")`` can hand back a Dataset on a malformed file, and h5py's
-answers when a Dataset is used as a mapping range from AttributeError to a
-silently wrong ``in``. ``read_uns`` is the single narrowing point; these tests
-pin its contract and the two helpers promoted alongside it.
-"""
+"""Tests for the _io helpers that narrow uns access (#617)."""
 
 import h5py
 import pytest
 
 from hca_anndata_tools._io import (
     read_batch_condition,
+    read_provenance,
     read_uns,
     require_stamped_group,
 )
@@ -74,3 +69,22 @@ def test_read_batch_condition_scalar(h5):
     uns = h5.create_group("uns")
     uns["batch_condition"] = "donor_id"
     assert read_batch_condition(uns) == ["donor_id"]
+
+
+def test_read_provenance_none():
+    assert read_provenance(None) is None
+
+
+def test_read_provenance_absent(h5):
+    assert read_provenance(h5.create_group("uns")) is None
+
+
+def test_read_provenance_dataset(h5):
+    uns = h5.create_group("uns")
+    uns["provenance"] = "not a group"
+    assert read_provenance(uns) is None
+
+
+def test_read_provenance_group(h5):
+    prov = h5.create_group("uns/provenance")
+    assert read_provenance(h5["uns"]) == prov

--- a/packages/hca-anndata-tools/tests/test_io.py
+++ b/packages/hca-anndata-tools/tests/test_io.py
@@ -5,10 +5,12 @@ import pytest
 
 from hca_anndata_tools._io import (
     read_batch_condition,
+    read_edit_log_h5py,
     read_provenance,
     read_uns,
     require_stamped_group,
 )
+from hca_anndata_tools.inspect import _read_schema_version
 
 
 @pytest.fixture
@@ -88,3 +90,27 @@ def test_read_provenance_dataset(h5):
 def test_read_provenance_group(h5):
     prov = h5.create_group("uns/provenance")
     assert read_provenance(h5["uns"]) == prov
+
+
+def test_read_edit_log_group_at_edit_history(h5):
+    """A Group at uns/provenance/edit_history is narrowed to the no-log
+    answer instead of raising through every caller."""
+    h5.create_group("uns/provenance/edit_history")
+
+    assert read_edit_log_h5py(h5) == "[]"
+
+
+def test_read_edit_log_numeric_at_edit_history(h5):
+    """A numeric scalar there is not a log either — narrowed to "[]" rather
+    than handing a float to json.loads downstream."""
+    h5.create_group("uns/provenance")["edit_history"] = 3.14
+
+    assert read_edit_log_h5py(h5) == "[]"
+
+
+def test_read_schema_version_group_at_leaf(h5):
+    """A Group at uns['schema_version'] is narrowed to None instead of
+    raising TypeError from the scalar read."""
+    h5.create_group("uns/schema_version")
+
+    assert _read_schema_version(h5) is None

--- a/packages/hca-anndata-tools/tests/test_io.py
+++ b/packages/hca-anndata-tools/tests/test_io.py
@@ -1,0 +1,76 @@
+"""Tests for the _io helpers that narrow uns access (#617).
+
+``File.get("uns")`` can hand back a Dataset on a malformed file, and h5py's
+answers when a Dataset is used as a mapping range from AttributeError to a
+silently wrong ``in``. ``read_uns`` is the single narrowing point; these tests
+pin its contract and the two helpers promoted alongside it.
+"""
+
+import h5py
+import pytest
+
+from hca_anndata_tools._io import (
+    read_batch_condition,
+    read_uns,
+    require_stamped_group,
+)
+
+
+@pytest.fixture
+def h5(tmp_path):
+    with h5py.File(tmp_path / "f.h5", "a") as f:
+        yield f
+
+
+def test_read_uns_absent(h5):
+    assert read_uns(h5) is None
+
+
+def test_read_uns_group(h5):
+    group = h5.create_group("uns")
+    assert read_uns(h5) == group
+
+
+def test_read_uns_dataset(h5):
+    """A scalar Dataset at 'uns' is the malformed shape that made membership
+    tests raise TypeError and attribute access raise AttributeError."""
+    h5["uns"] = "not a group"
+    assert read_uns(h5) is None
+
+
+def test_require_stamped_group_stamps_a_new_group(h5):
+    group = require_stamped_group(h5, "uns")
+    assert isinstance(group, h5py.Group)
+    assert group.attrs["encoding-type"] == "dict"
+    assert group.attrs["encoding-version"] == "0.1.0"
+
+
+def test_require_stamped_group_preserves_existing_attrs(h5):
+    """setdefault semantics: an already-stamped group keeps its attrs, so a
+    re-run never rewrites what anndata wrote."""
+    h5.create_group("uns").attrs["encoding-version"] = "0.2.0"
+
+    group = require_stamped_group(h5, "uns")
+
+    assert group.attrs["encoding-version"] == "0.2.0"
+    assert group.attrs["encoding-type"] == "dict"  # missing attr still filled
+
+
+def test_read_batch_condition_none():
+    assert read_batch_condition(None) == []
+
+
+def test_read_batch_condition_absent(h5):
+    assert read_batch_condition(h5.create_group("uns")) == []
+
+
+def test_read_batch_condition_array(h5):
+    uns = h5.create_group("uns")
+    uns.create_dataset("batch_condition", data=["donor_id", "sample_id"])
+    assert read_batch_condition(uns) == ["donor_id", "sample_id"]
+
+
+def test_read_batch_condition_scalar(h5):
+    uns = h5.create_group("uns")
+    uns["batch_condition"] = "donor_id"
+    assert read_batch_condition(uns) == ["donor_id"]

--- a/packages/hca-anndata-tools/tests/test_strip.py
+++ b/packages/hca-anndata-tools/tests/test_strip.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 import anndata as ad
+import h5py
 import pandas as pd
 
 from hca_anndata_tools.strip import (
@@ -158,3 +159,20 @@ def test_strip_same_second_snapshot_refused(sample_h5ad_for_write, monkeypatch):
     assert "self_reported_ethnicity" in ad.read_h5ad(sample_h5ad_for_write).obs.columns  # nor modified
     assert "error" in result
     assert "already exists" in result["error"]
+
+
+def test_strip_skips_cleanly_with_dataset_at_uns(sample_h5ad_for_write):
+    """A malformed file can hold a scalar Dataset at 'uns'. The CellxGENE
+    gate used to ask `"schema_version" in <Dataset>`, which raises TypeError
+    on a scalar and silently answers False otherwise — read_uns narrows the
+    Dataset to None, so the gate falls through and the no-op path answers
+    normally (#617)."""
+    _to_hca_layout(sample_h5ad_for_write)  # HCA layout, no SRE columns
+    with h5py.File(sample_h5ad_for_write, "a") as f:
+        del f["uns"]
+        f["uns"] = "not a group"
+
+    result = strip_forbidden_obs_columns(str(sample_h5ad_for_write))
+
+    assert "error" not in result
+    assert result["skipped"] is True

--- a/packages/hca-anndata-tools/tests/test_strip.py
+++ b/packages/hca-anndata-tools/tests/test_strip.py
@@ -4,7 +4,6 @@ import json
 from pathlib import Path
 
 import anndata as ad
-import h5py
 import pandas as pd
 
 from hca_anndata_tools.strip import (
@@ -161,16 +160,11 @@ def test_strip_same_second_snapshot_refused(sample_h5ad_for_write, monkeypatch):
     assert "already exists" in result["error"]
 
 
-def test_strip_skips_cleanly_with_dataset_at_uns(sample_h5ad_for_write):
-    """A malformed file can hold a scalar Dataset at 'uns'. The CellxGENE
-    gate used to ask `"schema_version" in <Dataset>`, which raises TypeError
-    on a scalar and silently answers False otherwise — read_uns narrows the
-    Dataset to None, so the gate falls through and the no-op path answers
-    normally (#617)."""
+def test_strip_skips_cleanly_with_dataset_at_uns(sample_h5ad_for_write, put_dataset_at_uns):
+    """The CellxGENE gate used to probe a possible Dataset with `in` (#617);
+    narrowed to None, the gate falls through and the no-op path answers."""
     _to_hca_layout(sample_h5ad_for_write)  # HCA layout, no SRE columns
-    with h5py.File(sample_h5ad_for_write, "a") as f:
-        del f["uns"]
-        f["uns"] = "not a group"
+    put_dataset_at_uns(sample_h5ad_for_write)
 
     result = strip_forbidden_obs_columns(str(sample_h5ad_for_write))
 

--- a/packages/hca-anndata-tools/tests/test_strip_cap.py
+++ b/packages/hca-anndata-tools/tests/test_strip_cap.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 import anndata as ad
+import h5py
 import numpy as np
 import pandas as pd
 
@@ -413,3 +414,19 @@ def test_strip_missing_file():
     result = strip_cap_annotations("/nonexistent/file.h5ad")
     assert "error" in result
     assert "File not found" in result["error"]
+
+
+def test_strip_answers_legibly_with_dataset_at_uns(tmp_path):
+    """A scalar Dataset at 'uns' used to raise TypeError inside the
+    batch_condition read (`"batch_condition" not in <Dataset>`) and surface
+    as that exception's text; read_uns narrows it to None so the tool reaches
+    its normal nothing-to-strip answer (#617)."""
+    path = _make_cap_file(tmp_path / "clean.h5ad", uns_layout="none", cap_columns=False)
+    with h5py.File(path, "a") as f:
+        del f["uns"]
+        f["uns"] = "not a group"
+
+    result = strip_cap_annotations(path)
+
+    assert "error" in result
+    assert "Nothing to strip" in result["error"]

--- a/packages/hca-anndata-tools/tests/test_strip_cap.py
+++ b/packages/hca-anndata-tools/tests/test_strip_cap.py
@@ -152,8 +152,6 @@ def test_strip_refuses_slash_in_column_order(tmp_path):
     """A '/' in a column-order entry would make h5py resolve a link path on
     deletion — a malformed file is refused before any write."""
     path = _make_cap_file(tmp_path / "slash.h5ad", uns_layout="legacy")
-    import h5py
-
     with h5py.File(path, "a") as f:
         cols = [c.decode() if isinstance(c, bytes) else c for c in f["obs"].attrs["column-order"]]
         f["obs"].attrs["column-order"] = [*cols, "bad/name--cell_fullname"]
@@ -169,8 +167,6 @@ def test_strip_refuses_index_or_ghost_in_column_order(tmp_path):
     """A malformed column-order listing the obs index (here named with '--')
     or a non-existent column is refused — deleting either would corrupt the
     output (parity with drop.py/rename.py's validators)."""
-    import h5py
-
     obs = pd.DataFrame(
         {"set--cell_fullname": pd.Categorical(["a", "b"])},
         index=pd.Index(["c1", "c2"], name="cell--id"),
@@ -416,15 +412,11 @@ def test_strip_missing_file():
     assert "File not found" in result["error"]
 
 
-def test_strip_answers_legibly_with_dataset_at_uns(tmp_path):
-    """A scalar Dataset at 'uns' used to raise TypeError inside the
-    batch_condition read (`"batch_condition" not in <Dataset>`) and surface
-    as that exception's text; read_uns narrows it to None so the tool reaches
-    its normal nothing-to-strip answer (#617)."""
+def test_strip_answers_legibly_with_dataset_at_uns(tmp_path, put_dataset_at_uns):
+    """A Dataset at 'uns' used to surface as a raw TypeError (#617); narrowed
+    to None, the tool reaches its normal nothing-to-strip answer."""
     path = _make_cap_file(tmp_path / "clean.h5ad", uns_layout="none", cap_columns=False)
-    with h5py.File(path, "a") as f:
-        del f["uns"]
-        f["uns"] = "not a group"
+    put_dataset_at_uns(path)
 
     result = strip_cap_annotations(path)
 

--- a/packages/hca-anndata-tools/tests/test_strip_cap.py
+++ b/packages/hca-anndata-tools/tests/test_strip_cap.py
@@ -420,5 +420,4 @@ def test_strip_answers_legibly_with_dataset_at_uns(tmp_path, put_dataset_at_uns)
 
     result = strip_cap_annotations(path)
 
-    assert "error" in result
-    assert "Nothing to strip" in result["error"]
+    assert result.get("nothing_to_strip") is True


### PR DESCRIPTION
## What changed

- **`read_uns(f) -> h5py.Group | None`** in `_io.py`: the single narrowing point for `f.get("uns")`, which returns `Group | Dataset | Datatype | None` while every caller treats the result as a mapping. All ten read sites converted; five ad-hoc idioms collapsed. The four unguarded sites are fixed: `strip.py`'s CellxGENE gate no longer silently mis-answers or raises `TypeError` on a Dataset-at-`uns` file, `strip_cap.py`'s two sites and `copy_cap.py`'s `.keys()` crash are gone, and the `pyright: ignore` on the batch-condition read is deleted because the `Group | None` contract is now enforced by construction.
- **`read_provenance(uns)`** — the child-level twin, collapsing three copies of the get-provenance-and-prove-it dance.
- **Leaf narrowing** (from code review): `_read_schema_version` and `read_edit_log_h5py` narrow their leaf datasets too — a Group at `uns['schema_version']` or `provenance['edit_history']` previously raised raw h5py `TypeError`s through every caller.
- **`require_stamped_group(f, path)`**: `require_group` + the dict encoding attrs, now `_io`-internal; `convert.py` and `copy_cap.py` hoist `ensure_provenance_group` to the top of their write blocks instead of a bare `require_group("uns")` saved only by a later side effect.
- **`read_batch_condition`** promoted from `drop.py` (a private helper with three cross-module importers) into `_io.py`.
- **`is_legacy_cap_layout` accepts `None`**, retiring the `uns is not None and` guard copy-pasted at four call sites.
- `strip.py` now gates CellxGENE layout via the shared `_read_schema_version` instead of a hand-rolled membership test.

## Why

`f.get("uns")` used as a mapping splits into three failure shapes on a malformed file: `AttributeError` from `.get`/`.keys`, `TypeError` from `in` on a scalar Dataset, and — worst — a silent `False` from `in` on a non-scalar Dataset, which made `strip.py`'s layout gate return a wrong answer instead of failing. #616 fixed one instance locally; this fixes the family and the level below it. Every reference-integrity check planned in #614 reads `uns` first, so this is that work's precondition.

## Assumptions I made

- **A non-group `uns` is treated as absent, not refused.** This matches what `rename_column`/`drop`/`read_edit_log_h5py` already shipped. The write path still fails loudly if it must create `uns` where a Dataset sits (`require_group` raises `TypeError`), so nothing silently overwrites the malformed node.
- **`strip.py`'s CellxGENE gate is now "non-empty schema_version string", not "key present".** Deliberate: `rename.py` and `strip_cap.py` already gate this way, and the divergence meant the same file got different layout verdicts per tool. A present-but-empty `schema_version` is no longer refused by strip.
- Generalizing `read_uns` to a `read_group` over `obs`/`obsm` (six more hand-rolled sites) is deferred to #614's structural-invariants work item, noted there. `strip.py`'s `obs` guard — the only one that stopped at `is None` — was fixed minimally here.
- `sorted(uns.keys())` in strip_cap's palette scan exists to satisfy ruff (SIM118) and pyright (h5py stubs type bare Group iteration as `str | None`) simultaneously without a suppression.

## How to verify

The issue's definition of done is the unguarded-sites table; each maps to a test:

1. `cd packages/hca-anndata-tools && uv run pytest tests/ -v` — 482 tests. The #617-specific ones:
   - `tests/test_io.py` — 16 unit tests pinning `read_uns` / `read_provenance` / `require_stamped_group` / `read_batch_condition` contracts, including the Dataset-at-`uns` and Dataset-at-leaf shapes.
   - `test_strip.py::test_strip_skips_cleanly_with_dataset_at_uns` — the silent-wrong-answer site (`strip.py:112` in the issue).
   - `test_strip_cap.py::test_strip_answers_legibly_with_dataset_at_uns` — the `TypeError` site.
   - `test_copy_cap.py::test_copy_survives_dataset_at_uns_in_target` — the `.keys()` `AttributeError` site.
2. `grep -rn 'get("uns")' packages/hca-anndata-tools/src/` — exactly one hit, inside `read_uns` itself.
3. `grep -n 'pyright: ignore' packages/hca-anndata-tools/src/hca_anndata_tools/strip_cap.py` — the suppression the issue called out is gone.
4. `make typecheck` from repo root — 0 errors.

Each regression test was verified load-bearing by reverting the fix under it and watching it fail.

Closes #617

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017S1imq17nD5Y3qaovNmBuX
