### PR TITLE
fix(hca-anndata-tools): remap the palette when a category is dropped

### DIFF
--- a/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
@@ -8,7 +8,6 @@
 from __future__ import annotations
 
 import gc
-from collections.abc import Sequence
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Literal
 
@@ -18,6 +17,8 @@ import pandas as pd
 from anndata.io import write_elem
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     import numpy as np
 
 # The HCA placeholder vocabulary (case-insensitive): obs values that mean
@@ -423,7 +424,7 @@ def compact_categories(categories: list[str], codes: np.ndarray) -> tuple[list[s
     lookup[used] = np.arange(len(used))
     new_codes = np.full(codes.shape, -1, dtype=np.int64)
     new_codes[valid] = lookup[codes[valid]]
-    return kept, new_codes, [int(i) for i in used]
+    return kept, new_codes, used.tolist()
 
 
 def direct_members(group: h5py.Group) -> set[str]:
@@ -431,13 +432,13 @@ def direct_members(group: h5py.Group) -> set[str]:
 
     Membership against this set, not ``name in group`` — h5py's
     ``__contains__`` resolves link paths, so it accepts names that point
-    outside the group entirely (the ``/`` trap :func:`is_malformed_name`
+    outside the group entirely (the ``/`` trap ``guards.is_malformed_name``
     rejects). True of any group, which is why uns lookups use it too.
     """
     return set(group.keys())
 
 
-def remap_palette(uns: h5py.Group | None, key: str | None, kept: Sequence[int], n_before: int) -> bool:
+def remap_palette(uns: h5py.Group | None, key: str | None, kept: Sequence[int], n_before: int) -> str | None:
     """Keep only the colours of the categories that survived, by position.
 
     ``uns['<column>_colors']`` is positionally aligned to the column's
@@ -451,19 +452,27 @@ def remap_palette(uns: h5py.Group | None, key: str | None, kept: Sequence[int], 
     function: ``merge_obs_categories`` must not, since it drops every
     unreferenced category and would discard one left empty for its own reasons.
 
-    Does nothing, and returns False, when there is no palette to remap or when
-    its length already disagrees with ``n_before`` — an already-broken palette
-    is the validator's to report, not this function's to guess at.
+    Returns the key it rewrote, or None when there was nothing to do: no
+    palette, or one this function cannot safely interpret — a length that
+    already disagrees with ``n_before``, or a node that is not a string array.
+    An already-broken palette is the validator's to report, not this
+    function's to guess at.
     """
     import numpy as np
 
     if uns is None or key is None or key not in direct_members(uns):
-        return False
+        return None
+    node = uns[key]
+    # A palette that is not a string array is not one we can realign — and
+    # read_string_dataset's asstr() would raise on it, after the snapshot has
+    # already been copied. Treated like a mismatched length: left alone.
+    if not isinstance(node, h5py.Dataset) or not h5py.check_string_dtype(node.dtype):
+        return None
     colors = list(read_string_dataset(uns, key))
     if len(colors) != n_before:
-        return False
+        return None
     write_elem(uns, key, np.array([colors[i] for i in kept], dtype=object))
-    return True
+    return key
 
 
 def _codes_dtype(n_categories: int, original: np.dtype) -> np.dtype:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
@@ -466,7 +466,7 @@ def remap_palette(uns: h5py.Group | None, key: str | None, kept: Sequence[int], 
     # A palette that is not a string array is not one we can realign — and
     # read_string_dataset's asstr() would raise on it, after the snapshot has
     # already been copied. Treated like a mismatched length: left alone.
-    if not isinstance(node, h5py.Dataset) or not h5py.check_string_dtype(node.dtype):
+    if not isinstance(node, h5py.Dataset) or node.ndim != 1 or not h5py.check_string_dtype(node.dtype):
         return None
     colors = list(read_string_dataset(uns, key))
     if len(colors) != n_before:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import gc
+from collections.abc import Sequence
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Literal
 
@@ -398,12 +399,13 @@ def replace_string_dataset(parent: h5py.Group, name: str, data: np.ndarray) -> N
         new_ds.attrs[key] = attr_value
 
 
-def compact_categories(categories: list[str], codes: np.ndarray) -> tuple[list[str], np.ndarray]:
+def compact_categories(categories: list[str], codes: np.ndarray) -> tuple[list[str], np.ndarray, list[int]]:
     """Drop categories no code references and remap the codes accordingly.
 
-    Codes below 0 (NaN) stay -1. Returns the kept categories and the remapped
-    codes as int64 — :func:`replace_categorical_column` sizes the on-disk
-    dtype itself.
+    Codes below 0 (NaN) stay -1. Returns the kept categories, the remapped
+    codes as int64 (:func:`replace_categorical_column` sizes the on-disk dtype
+    itself), and the *positions* the kept categories held before — which
+    :func:`remap_palette` needs to keep a per-category palette aligned.
     """
     import numpy as np
 
@@ -421,7 +423,47 @@ def compact_categories(categories: list[str], codes: np.ndarray) -> tuple[list[s
     lookup[used] = np.arange(len(used))
     new_codes = np.full(codes.shape, -1, dtype=np.int64)
     new_codes[valid] = lookup[codes[valid]]
-    return kept, new_codes
+    return kept, new_codes, [int(i) for i in used]
+
+
+def direct_members(group: h5py.Group) -> set[str]:
+    """A group's direct children, for membership tests.
+
+    Membership against this set, not ``name in group`` — h5py's
+    ``__contains__`` resolves link paths, so it accepts names that point
+    outside the group entirely (the ``/`` trap :func:`is_malformed_name`
+    rejects). True of any group, which is why uns lookups use it too.
+    """
+    return set(group.keys())
+
+
+def remap_palette(uns: h5py.Group | None, key: str | None, kept: Sequence[int], n_before: int) -> bool:
+    """Keep only the colours of the categories that survived, by position.
+
+    ``uns['<column>_colors']`` is positionally aligned to the column's
+    categories, so removing a category shifts every colour after it — and the
+    HCA validator checks only the palette's *length*, so a file whose lengths
+    happen to still agree is simply mis-coloured with nothing reported. Every
+    tool that removes a category owes this remap (#624).
+
+    Takes the surviving positions rather than calling
+    :func:`compact_categories` itself, because not every caller may use that
+    function: ``merge_obs_categories`` must not, since it drops every
+    unreferenced category and would discard one left empty for its own reasons.
+
+    Does nothing, and returns False, when there is no palette to remap or when
+    its length already disagrees with ``n_before`` — an already-broken palette
+    is the validator's to report, not this function's to guess at.
+    """
+    import numpy as np
+
+    if uns is None or key is None or key not in direct_members(uns):
+        return False
+    colors = list(read_string_dataset(uns, key))
+    if len(colors) != n_before:
+        return False
+    write_elem(uns, key, np.array([colors[i] for i in kept], dtype=object))
+    return True
 
 
 def _codes_dtype(n_categories: int, original: np.dtype) -> np.dtype:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/backfill.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/backfill.py
@@ -27,6 +27,7 @@ import pandas as pd
 from ._io import (
     DEFAULT_PLACEHOLDERS,
     check_duplicate_ids,
+    direct_members,
     is_missing_value,
     obs_index_name,
     read_categorical_data,
@@ -39,7 +40,7 @@ from ._io import (
     verify_categorical_integrity,
     write_edit_log_h5py,
 )
-from .guards import direct_members, is_malformed_name, legacy_layout_problems
+from .guards import is_malformed_name, legacy_layout_problems
 from .write import (
     SAME_SECOND_SNAPSHOT_ERROR,
     _compute_sha256,

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/drop.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/drop.py
@@ -24,6 +24,7 @@ from pathlib import Path
 import h5py
 
 from ._io import (
+    direct_members,
     read_edit_log_h5py,
     read_uns,
     update_column_order,
@@ -34,7 +35,6 @@ from .guards import (
     ObsColumnReferences,
     batch_condition_refusal,
     detect_obs_references,
-    direct_members,
     is_malformed_name,
     legacy_layout_problems,
     malformed_name_problems,

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
@@ -19,11 +19,14 @@ from ._io import (
     read_categorical_data,
     read_column_order,
     read_edit_log_h5py,
+    read_uns,
+    remap_palette,
     replace_categorical_column,
     verify_categorical_integrity,
     write_edit_log_h5py,
 )
 from ._serialize import make_serializable
+from .guards import detect_obs_references
 from .schema.helpers import uns_field_registry
 from .write import (
     SAME_SECOND_SNAPSHOT_ERROR,
@@ -342,7 +345,10 @@ def replace_placeholder_values(
             return {"error": SAME_SECOND_SNAPSHOT_ERROR}
         shutil.copy2(path, output_path)
 
+        palettes_remapped = []
         with h5py.File(output_path, "a") as f:
+            uns = read_uns(f)
+            palettes = detect_obs_references(uns, list(columns_fixed)).palettes
             for col in columns_fixed:
                 item = f["obs"][col]
                 cats, codes = read_categorical_data(item)  # pyright: ignore[reportArgumentType]
@@ -352,8 +358,13 @@ def replace_placeholder_values(
                 for i in blocked:
                     codes[codes == i] = -1
 
-                new_cats, new_codes = compact_categories(list(cats), codes)
+                new_cats, new_codes, kept = compact_categories(list(cats), codes)
                 replace_categorical_column(f["obs"], col, new_cats, new_codes)  # pyright: ignore[reportArgumentType]
+                # Blanking a placeholder empties its category, so compaction
+                # removes it — and the palette must lose the same position or
+                # every colour after it shifts onto the wrong category (#624).
+                if remap_palette(uns, palettes.get(col), kept, len(cats)):
+                    palettes_remapped.append(palettes[col])
 
             write_edit_log_h5py(f, log_result["json"])
 
@@ -368,6 +379,7 @@ def replace_placeholder_values(
             "output_path": output_path,
             "columns_fixed": {col: dict(vals) for col, vals in columns_fixed.items()},
             "total_cells_affected": total_affected,
+            "palettes_remapped": palettes_remapped,
         }
 
     except Exception as e:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
@@ -277,8 +277,9 @@ def replace_placeholder_values(
         placeholders: Values to replace. Defaults to the HCA placeholder list.
 
     Returns:
-        Dict with 'output_path', 'columns_fixed', 'total_cells_affected'
-        on success, or 'error' on failure.
+        Dict with 'output_path', 'columns_fixed', 'total_cells_affected' and
+        'palettes_remapped' (the uns palette keys realigned to the surviving
+        categories) on success, or 'error' on failure.
     """
     output_path = None
     try:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/guards.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/guards.py
@@ -38,7 +38,6 @@ __all__ = [
     "ObsColumnReferences",
     "batch_condition_refusal",
     "detect_obs_references",
-    "direct_members",
     "is_malformed_name",
     "legacy_layout_problems",
     "malformed_name_problems",

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/guards.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/guards.py
@@ -30,7 +30,7 @@ from dataclasses import dataclass
 
 import h5py
 
-from ._io import obs_index_name, read_batch_condition
+from ._io import direct_members, obs_index_name, read_batch_condition
 from .cap import LEGACY_LAYOUT_DESCRIPTION, cap_obs_columns, is_cap_declared, is_legacy_cap_layout
 
 __all__ = [
@@ -110,17 +110,6 @@ def obs_index_problems(obs: h5py.Group, names: Iterable[str], *, verbing: str) -
     if index_name in names:
         return [f"'{index_name}' is the obs index, not a column — {verbing} it would destroy the file"]
     return []
-
-
-def direct_members(group: h5py.Group) -> set[str]:
-    """A group's direct children, for membership tests.
-
-    Membership against this set, not ``name in group`` — h5py's
-    ``__contains__`` resolves link paths, so it accepts names that point
-    outside the group entirely (the ``/`` trap :func:`is_malformed_name`
-    rejects). True of any group, which is why uns lookups use it too.
-    """
-    return set(group.keys())
 
 
 def obs_name_problems(obs: h5py.Group, names: Iterable[str], *, verbing: str) -> list[str]:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/merge_categories.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/merge_categories.py
@@ -18,12 +18,12 @@ from pathlib import Path
 
 import h5py
 import numpy as np
-from anndata.io import write_elem
 
 from ._io import (
     read_edit_log_h5py,
     read_string_dataset,
     read_uns,
+    remap_palette,
     replace_categorical_column,
     verify_categorical_integrity,
     write_edit_log_h5py,
@@ -223,12 +223,7 @@ def merge_obs_categories(path: str, column: str, from_value: str, to_value: str)
             stale_label_column = column.removesuffix(_TERM_ID_SUFFIX)
             if stale_label_column == column or stale_label_column not in direct_members(obs):
                 stale_label_column = None
-            # The palette's fate is decided here too: a length that already
-            # disagrees with the categories is not ours to interpret, so it is
-            # left for the validator to report rather than guessed at.
             palette = refs.palettes.get(column)
-            palette_colors = list(read_string_dataset(uns, palette)) if uns and palette else []
-            trim_palette = palette if len(palette_colors) == len(categories) else None
 
         from_index, to_index = categories.index(from_value), categories.index(to_value)
         new_categories = categories[:from_index] + categories[from_index + 1 :]
@@ -255,15 +250,12 @@ def merge_obs_categories(path: str, column: str, from_value: str, to_value: str)
 
             replace_categorical_column(obs_out, column, new_categories, codes)
 
-            # uns['<col>_colors'] is positionally aligned to the categories, so
-            # the entry to drop is exactly from_index — the cascade
-            # rename_obs_column performs by moving the key, expressed here on
-            # its contents. Left alone it would recolour every category after
-            # the merged-away one, and the validator checks only the palette's
-            # *length*, so the mis-colouring would pass silently.
-            if trim_palette:
-                trimmed = palette_colors[:from_index] + palette_colors[from_index + 1 :]
-                write_elem(f_out["uns"], trim_palette, np.array(trimmed, dtype=object))
+            # The merged-away category takes its colour with it: the palette is
+            # positionally aligned, so the surviving positions are every index
+            # but from_index. Shared with replace_placeholder_values, which
+            # removes categories the same way for a different reason (#624).
+            kept = [i for i in range(len(categories)) if i != from_index]
+            palette_trimmed = palette if remap_palette(read_uns(f_out), palette, kept, len(categories)) else None
 
             entry = make_edit_entry(
                 operation="merge_obs_categories",
@@ -301,7 +293,7 @@ def merge_obs_categories(path: str, column: str, from_value: str, to_value: str)
             "cells_recoded": cells_recoded,
             "categories_remaining": len(new_categories),
             "stale_label_column": stale_label_column,
-            "palette_trimmed": trim_palette,
+            "palette_trimmed": palette_trimmed,
         }
 
     except Exception as e:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/merge_categories.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/merge_categories.py
@@ -20,6 +20,7 @@ import h5py
 import numpy as np
 
 from ._io import (
+    direct_members,
     read_edit_log_h5py,
     read_string_dataset,
     read_uns,
@@ -31,7 +32,6 @@ from ._io import (
 from .guards import (
     ObsColumnReferences,
     detect_obs_references,
-    direct_members,
     legacy_layout_problems,
     obs_name_problems,
     require_obs_group,

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/rename.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/rename.py
@@ -24,6 +24,7 @@ import pandas as pd
 
 from ._io import (
     _decode_bytes,
+    direct_members,
     obs_index_name,
     read_categorical_data,
     read_edit_log_h5py,
@@ -33,7 +34,7 @@ from ._io import (
     replace_string_dataset,
     write_edit_log_h5py,
 )
-from .guards import direct_members, is_malformed_name, legacy_layout_problems, require_obs_group
+from .guards import is_malformed_name, legacy_layout_problems, require_obs_group
 from .inspect import _read_schema_version
 from .write import (
     SAME_SECOND_SNAPSHOT_ERROR,

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/rename_column.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/rename_column.py
@@ -23,6 +23,7 @@ import numpy as np
 from anndata.io import write_elem
 
 from ._io import (
+    direct_members,
     read_column_order,
     read_edit_log_h5py,
     read_uns,
@@ -32,7 +33,6 @@ from .cap import CAP_METADATA_KEY
 from .guards import (
     ObsColumnReferences,
     detect_obs_references,
-    direct_members,
     is_malformed_name,
     legacy_layout_problems,
     malformed_name_problems,

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/strip_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/strip_cap.py
@@ -24,6 +24,7 @@ from pathlib import Path
 import h5py
 
 from ._io import (
+    direct_members,
     obs_index_name,
     read_column_order,
     read_edit_log_h5py,
@@ -42,7 +43,6 @@ from .cap import (
 from .guards import (
     batch_condition_refusal,
     detect_obs_references,
-    direct_members,
     obs_name_problems,
     require_obs_group,
 )

--- a/packages/hca-anndata-tools/tests/test_edit.py
+++ b/packages/hca-anndata-tools/tests/test_edit.py
@@ -403,3 +403,78 @@ def test_view_edit_log_auto_resolves_latest(sample_h5ad_for_write):
 def test_view_edit_log_bad_path():
     result = view_edit_log("/nonexistent/file.h5ad")
     assert "error" in result
+
+
+# --- #624: the palette must lose the positions the categories lost ----------
+
+
+def _placeholder_file(tmp_path, uns=None, **extra_obs):
+    """A file whose 'grade' column holds a placeholder among real values, with
+    a palette aligned to its four categories (sorted: a, b, unknown, z)."""
+    values = ["a", "a", "b", "unknown", "z", "z"]
+    obs = pd.DataFrame(
+        {"grade": pd.Categorical(values), **extra_obs},
+        index=pd.Index([f"c{i}" for i in range(len(values))], name="cellID"),
+    )
+    adata = ad.AnnData(X=np.zeros((len(values), 2), dtype=np.float32), obs=obs)
+    adata.uns.update({"grade_colors": np.array(["#aaa", "#bbb", "#unk", "#zzz"], dtype=object), **(uns or {})})
+    path = tmp_path / "placeholders.h5ad"
+    adata.write_h5ad(path, compression="gzip")
+    return str(path)
+
+
+def test_replace_placeholders_keeps_each_survivor_s_colour(tmp_path):
+    """The bug: blanking 'unknown' drops its category, and without a remap the
+    colour after it ('#zzz' -> 'z') shifts onto the wrong category. Asserted as
+    a mapping, not a length — the length is what the validator already checks,
+    and checking only that is what made this silent."""
+    path = _placeholder_file(tmp_path)
+
+    result = replace_placeholder_values(path, ["grade"])
+
+    assert "error" not in result
+    assert result["palettes_remapped"] == ["grade_colors"]
+    out = ad.read_h5ad(result["output_path"])
+    cats = list(out.obs["grade"].cat.categories)
+    colors = list(out.uns["grade_colors"])
+    assert dict(zip(cats, colors, strict=True)) == {"a": "#aaa", "b": "#bbb", "z": "#zzz"}
+    assert "#unk" not in colors
+
+
+def test_replace_placeholders_leaves_another_column_s_palette_alone(tmp_path):
+    """Only the rewritten column's palette is positionally invalidated."""
+    path = _placeholder_file(
+        tmp_path,
+        uns={"other_colors": np.array(["#111", "#222"], dtype=object)},
+        other=pd.Categorical(["x", "y"] * 3),
+    )
+
+    result = replace_placeholder_values(path, ["grade"])
+
+    assert "error" not in result
+    assert result["palettes_remapped"] == ["grade_colors"]
+    assert list(ad.read_h5ad(result["output_path"]).uns["other_colors"]) == ["#111", "#222"]
+
+
+def test_replace_placeholders_leaves_a_mismatched_palette_alone(tmp_path):
+    """A palette whose length already disagrees is the validator's to report,
+    not this tool's to guess at."""
+    path = _placeholder_file(tmp_path, uns={"grade_colors": np.array(["#111", "#222"], dtype=object)})
+
+    result = replace_placeholder_values(path, ["grade"])
+
+    assert "error" not in result
+    assert result["palettes_remapped"] == []
+    assert list(ad.read_h5ad(result["output_path"]).uns["grade_colors"]) == ["#111", "#222"]
+
+
+def test_replace_placeholders_reports_no_remap_without_a_palette(tmp_path):
+    path = _placeholder_file(tmp_path)
+    adata = ad.read_h5ad(path)
+    del adata.uns["grade_colors"]
+    adata.write_h5ad(path)
+
+    result = replace_placeholder_values(path, ["grade"])
+
+    assert "error" not in result
+    assert result["palettes_remapped"] == []

--- a/packages/hca-anndata-tools/tests/test_edit.py
+++ b/packages/hca-anndata-tools/tests/test_edit.py
@@ -243,17 +243,18 @@ def test_set_uns_string_to_list_field_rejected(sample_h5ad_for_write):
 # --- replace_placeholder_values ---
 
 
-def _make_placeholder_h5ad(tmp_path, col_values, col_name="test_col"):
+def _make_placeholder_h5ad(tmp_path, col_values, col_name="test_col", uns=None, **extra_obs):
     """Create a test h5ad with a categorical column containing given values."""
     n = len(col_values)
     obs = pd.DataFrame(
-        {col_name: pd.Categorical(col_values)},
+        {col_name: pd.Categorical(col_values), **extra_obs},
         index=[f"cell_{i}" for i in range(n)],
     )
     adata = ad.AnnData(
         X=sp.csr_matrix((n, 2), dtype=np.float32),
         obs=obs,
     )
+    adata.uns.update(uns or {})
     path = tmp_path / "placeholders_test.h5ad"
     adata.write_h5ad(path)
     return path
@@ -408,73 +409,57 @@ def test_view_edit_log_bad_path():
 # --- #624: the palette must lose the positions the categories lost ----------
 
 
-def _placeholder_file(tmp_path, uns=None, **extra_obs):
-    """A file whose 'grade' column holds a placeholder among real values, with
-    a palette aligned to its four categories (sorted: a, b, unknown, z)."""
-    values = ["a", "a", "b", "unknown", "z", "z"]
-    obs = pd.DataFrame(
-        {"grade": pd.Categorical(values), **extra_obs},
-        index=pd.Index([f"c{i}" for i in range(len(values))], name="cellID"),
+_GRADES = ["a", "a", "b", "unknown", "z", "z"]  # sorted categories: a, b, unknown, z
+_GRADE_COLORS = np.array(["#aaa", "#bbb", "#unk", "#zzz"], dtype=object)
+
+
+def _graded(tmp_path, uns=None, **extra_obs):
+    return _make_placeholder_h5ad(
+        tmp_path, _GRADES, col_name="grade", uns={"grade_colors": _GRADE_COLORS, **(uns or {})}, **extra_obs
     )
-    adata = ad.AnnData(X=np.zeros((len(values), 2), dtype=np.float32), obs=obs)
-    adata.uns.update({"grade_colors": np.array(["#aaa", "#bbb", "#unk", "#zzz"], dtype=object), **(uns or {})})
-    path = tmp_path / "placeholders.h5ad"
-    adata.write_h5ad(path, compression="gzip")
-    return str(path)
 
 
-def test_replace_placeholders_keeps_each_survivor_s_colour(tmp_path):
-    """The bug: blanking 'unknown' drops its category, and without a remap the
-    colour after it ('#zzz' -> 'z') shifts onto the wrong category. Asserted as
-    a mapping, not a length — the length is what the validator already checks,
-    and checking only that is what made this silent."""
-    path = _placeholder_file(tmp_path)
-
-    result = replace_placeholder_values(path, ["grade"])
+def test_replace_placeholders_recolours_by_position(tmp_path):
+    """Blanking 'unknown' drops its category, so '#zzz' must move with 'z'
+    rather than shifting onto it. Asserted as a mapping, not a length — see
+    remap_palette for why the length is what made this silent."""
+    result = replace_placeholder_values(str(_graded(tmp_path)), ["grade"])
 
     assert "error" not in result
     assert result["palettes_remapped"] == ["grade_colors"]
     out = ad.read_h5ad(result["output_path"])
     cats = list(out.obs["grade"].cat.categories)
-    colors = list(out.uns["grade_colors"])
-    assert dict(zip(cats, colors, strict=True)) == {"a": "#aaa", "b": "#bbb", "z": "#zzz"}
-    assert "#unk" not in colors
+    assert dict(zip(cats, out.uns["grade_colors"], strict=True)) == {"a": "#aaa", "b": "#bbb", "z": "#zzz"}
 
 
-def test_replace_placeholders_leaves_another_column_s_palette_alone(tmp_path):
+def test_replace_placeholders_leaves_another_columns_palette_alone(tmp_path):
     """Only the rewritten column's palette is positionally invalidated."""
-    path = _placeholder_file(
+    path = _graded(
         tmp_path,
         uns={"other_colors": np.array(["#111", "#222"], dtype=object)},
         other=pd.Categorical(["x", "y"] * 3),
     )
 
-    result = replace_placeholder_values(path, ["grade"])
+    result = replace_placeholder_values(str(path), ["grade"])
 
-    assert "error" not in result
     assert result["palettes_remapped"] == ["grade_colors"]
     assert list(ad.read_h5ad(result["output_path"]).uns["other_colors"]) == ["#111", "#222"]
 
 
 def test_replace_placeholders_leaves_a_mismatched_palette_alone(tmp_path):
-    """A palette whose length already disagrees is the validator's to report,
-    not this tool's to guess at."""
-    path = _placeholder_file(tmp_path, uns={"grade_colors": np.array(["#111", "#222"], dtype=object)})
+    """An already-broken palette is the validator's to report, not ours."""
+    path = _graded(tmp_path, uns={"grade_colors": np.array(["#111", "#222"], dtype=object)})
 
-    result = replace_placeholder_values(path, ["grade"])
+    result = replace_placeholder_values(str(path), ["grade"])
 
-    assert "error" not in result
     assert result["palettes_remapped"] == []
     assert list(ad.read_h5ad(result["output_path"]).uns["grade_colors"]) == ["#111", "#222"]
 
 
 def test_replace_placeholders_reports_no_remap_without_a_palette(tmp_path):
-    path = _placeholder_file(tmp_path)
-    adata = ad.read_h5ad(path)
-    del adata.uns["grade_colors"]
-    adata.write_h5ad(path)
+    path = _make_placeholder_h5ad(tmp_path, _GRADES, col_name="grade")
 
-    result = replace_placeholder_values(path, ["grade"])
+    result = replace_placeholder_values(str(path), ["grade"])
 
     assert "error" not in result
     assert result["palettes_remapped"] == []

--- a/packages/hca-anndata-tools/tests/test_guards.py
+++ b/packages/hca-anndata-tools/tests/test_guards.py
@@ -6,14 +6,13 @@ each tool's *policy* — what it does with what these find.
 
 import pytest
 
-from hca_anndata_tools._io import obs_index_name
+from hca_anndata_tools._io import direct_members, obs_index_name
 from hca_anndata_tools.cap import cap_palette_keys
 from hca_anndata_tools.guards import (
     GuardRefusal,
     ObsColumnReferences,
     batch_condition_refusal,
     detect_obs_references,
-    direct_members,
     is_malformed_name,
     legacy_layout_problems,
     malformed_name_problems,

--- a/packages/hca-anndata-tools/tests/test_io.py
+++ b/packages/hca-anndata-tools/tests/test_io.py
@@ -6,6 +6,7 @@ import pytest
 from anndata.io import write_elem
 
 from hca_anndata_tools._io import (
+    _decode_bytes,
     compact_categories,
     read_batch_condition,
     read_edit_log_h5py,
@@ -195,3 +196,13 @@ def test_compact_categories_reports_the_surviving_positions():
     assert kept_cats == ["a", "c"]
     assert kept == [0, 2]
     assert list(codes) == [0, 0, 1, -1]
+
+
+def test_remap_palette_leaves_a_scalar_palette_alone(h5):
+    """check_string_dtype passes for a shape-() dataset, but asstr()[:] raises
+    on it — so the scalar case needs its own rejection, not a crash."""
+    uns = h5.require_group("uns")
+    write_elem(uns, "grade_colors", "#aaa")
+
+    assert remap_palette(uns, "grade_colors", [0], 1) is None
+    assert _decode_bytes(uns["grade_colors"][()]) == "#aaa"

--- a/packages/hca-anndata-tools/tests/test_io.py
+++ b/packages/hca-anndata-tools/tests/test_io.py
@@ -6,11 +6,11 @@ import pytest
 from anndata.io import write_elem
 
 from hca_anndata_tools._io import (
-    _decode_bytes,
     compact_categories,
     read_batch_condition,
     read_edit_log_h5py,
     read_provenance,
+    read_string_dataset,
     read_uns,
     remap_palette,
     require_stamped_group,
@@ -117,10 +117,8 @@ def test_read_schema_version_group_at_leaf(h5):
 
 # --- remap_palette (#624) ----------------------------------------------------
 #
-# uns['<col>_colors'] is positionally aligned to the categories, so every tool
-# that removes a category owes this remap. Asserted as which colours survive in
-# which order — the length is what the HCA validator already checks, and
-# checking only the length is what let the bug ship silently.
+# Asserted as which colours survive in which order, never as a length — see
+# remap_palette's docstring for why the length is what made the bug silent.
 
 _COLORS = ["#aaa", "#bbb", "#ccc", "#ddd"]
 
@@ -145,8 +143,8 @@ def _palette(h5, colors=_COLORS):
 def test_remap_palette_keeps_the_surviving_positions(h5, kept, expected):
     uns = _palette(h5)
 
-    assert remap_palette(uns, "grade_colors", kept, len(_COLORS)) is True
-    assert [_decode_bytes(c) for c in uns["grade_colors"][:]] == expected
+    assert remap_palette(uns, "grade_colors", kept, len(_COLORS)) == "grade_colors"
+    assert list(read_string_dataset(uns, "grade_colors")) == expected
 
 
 def test_remap_palette_leaves_a_mismatched_length_alone(h5):
@@ -154,20 +152,20 @@ def test_remap_palette_leaves_a_mismatched_length_alone(h5):
     guess at — we cannot know which position each colour was meant for."""
     uns = _palette(h5, ["#111", "#222"])  # 2 against 4 categories
 
-    assert remap_palette(uns, "grade_colors", [0, 2], 4) is False
-    assert [_decode_bytes(c) for c in uns["grade_colors"][:]] == ["#111", "#222"]
+    assert remap_palette(uns, "grade_colors", [0, 2], 4) is None
+    assert list(read_string_dataset(uns, "grade_colors")) == ["#111", "#222"]
 
 
 def test_remap_palette_no_palette_key(h5):
-    assert remap_palette(h5.require_group("uns"), "grade_colors", [0], 1) is False
+    assert remap_palette(h5.require_group("uns"), "grade_colors", [0], 1) is None
 
 
 def test_remap_palette_no_key_named(h5):
-    assert remap_palette(_palette(h5), None, [0], 4) is False
+    assert remap_palette(_palette(h5), None, [0], 4) is None
 
 
 def test_remap_palette_no_uns():
-    assert remap_palette(None, "grade_colors", [0], 4) is False
+    assert remap_palette(None, "grade_colors", [0], 4) is None
 
 
 def test_remap_palette_does_not_resolve_link_paths(h5):
@@ -176,8 +174,8 @@ def test_remap_palette_does_not_resolve_link_paths(h5):
     write_elem(h5, "grade_colors", np.array(["#zzz"], dtype=object))
     uns = h5.require_group("uns")
 
-    assert remap_palette(uns, "/grade_colors", [0], 1) is False
-    assert [_decode_bytes(c) for c in h5["grade_colors"][:]] == ["#zzz"]
+    assert remap_palette(uns, "/grade_colors", [0], 1) is None
+    assert list(read_string_dataset(h5, "grade_colors")) == ["#zzz"]
 
 
 def test_remap_palette_keeps_the_string_encoding(h5):

--- a/packages/hca-anndata-tools/tests/test_io.py
+++ b/packages/hca-anndata-tools/tests/test_io.py
@@ -1,12 +1,18 @@
 """Tests for the _io helpers that narrow uns access (#617)."""
 
 import h5py
+import numpy as np
+import pytest
+from anndata.io import write_elem
 
 from hca_anndata_tools._io import (
+    _decode_bytes,
+    compact_categories,
     read_batch_condition,
     read_edit_log_h5py,
     read_provenance,
     read_uns,
+    remap_palette,
     require_stamped_group,
 )
 from hca_anndata_tools.inspect import _read_schema_version
@@ -107,3 +113,87 @@ def test_read_schema_version_group_at_leaf(h5):
     h5.create_group("uns/schema_version")
 
     assert _read_schema_version(h5) is None
+
+
+# --- remap_palette (#624) ----------------------------------------------------
+#
+# uns['<col>_colors'] is positionally aligned to the categories, so every tool
+# that removes a category owes this remap. Asserted as which colours survive in
+# which order — the length is what the HCA validator already checks, and
+# checking only the length is what let the bug ship silently.
+
+_COLORS = ["#aaa", "#bbb", "#ccc", "#ddd"]
+
+
+def _palette(h5, colors=_COLORS):
+    uns = h5.require_group("uns")
+    write_elem(uns, "grade_colors", np.array(colors, dtype=object))
+    return uns
+
+
+@pytest.mark.parametrize(
+    ("kept", "expected"),
+    [
+        ([1, 2, 3], ["#bbb", "#ccc", "#ddd"]),  # first removed
+        ([0, 2, 3], ["#aaa", "#ccc", "#ddd"]),  # middle removed
+        ([0, 1, 2], ["#aaa", "#bbb", "#ccc"]),  # last removed
+        ([0, 3], ["#aaa", "#ddd"]),  # two non-adjacent — the case a single-index slice cannot express
+        ([2], ["#ccc"]),  # all but one
+        ([0, 1, 2, 3], _COLORS),  # nothing removed
+    ],
+)
+def test_remap_palette_keeps_the_surviving_positions(h5, kept, expected):
+    uns = _palette(h5)
+
+    assert remap_palette(uns, "grade_colors", kept, len(_COLORS)) is True
+    assert [_decode_bytes(c) for c in uns["grade_colors"][:]] == expected
+
+
+def test_remap_palette_leaves_a_mismatched_length_alone(h5):
+    """An already-broken palette is the validator's to report, not ours to
+    guess at — we cannot know which position each colour was meant for."""
+    uns = _palette(h5, ["#111", "#222"])  # 2 against 4 categories
+
+    assert remap_palette(uns, "grade_colors", [0, 2], 4) is False
+    assert [_decode_bytes(c) for c in uns["grade_colors"][:]] == ["#111", "#222"]
+
+
+def test_remap_palette_no_palette_key(h5):
+    assert remap_palette(h5.require_group("uns"), "grade_colors", [0], 1) is False
+
+
+def test_remap_palette_no_key_named(h5):
+    assert remap_palette(_palette(h5), None, [0], 4) is False
+
+
+def test_remap_palette_no_uns():
+    assert remap_palette(None, "grade_colors", [0], 4) is False
+
+
+def test_remap_palette_does_not_resolve_link_paths(h5):
+    """Membership goes through direct_members, so a '/'-prefixed key cannot
+    reach a root dataset (the #623 trap)."""
+    write_elem(h5, "grade_colors", np.array(["#zzz"], dtype=object))
+    uns = h5.require_group("uns")
+
+    assert remap_palette(uns, "/grade_colors", [0], 1) is False
+    assert [_decode_bytes(c) for c in h5["grade_colors"][:]] == ["#zzz"]
+
+
+def test_remap_palette_keeps_the_string_encoding(h5):
+    uns = _palette(h5)
+    before = dict(uns["grade_colors"].attrs)
+
+    remap_palette(uns, "grade_colors", [0, 1], len(_COLORS))
+
+    assert dict(uns["grade_colors"].attrs) == before
+
+
+def test_compact_categories_reports_the_surviving_positions():
+    """The positions remap_palette needs; compact_categories always computed
+    them and used to discard them."""
+    kept_cats, codes, kept = compact_categories(["a", "b", "c", "d"], np.array([0, 0, 2, -1]))
+
+    assert kept_cats == ["a", "c"]
+    assert kept == [0, 2]
+    assert list(codes) == [0, 0, 1, -1]


### PR DESCRIPTION
## What changed

**The bug.** `replace_placeholder_values` blanks placeholder values to NaN, then compacts the categories — and never touched `uns['<column>_colors']`. The palette is positionally aligned to the categories, so every category after a removed one silently inherited its neighbour's colour. It passes validation: the HCA validator checks only that the palette's *length* matches the category count, so a file whose lengths happen to still agree is simply mis-coloured with nothing reported. Colour is how a reader tells cell types apart in every portal UMAP, and this tool runs in the standard curation sequence.

**One implementation, two callers.** `remap_palette(uns, key, kept, n_before)` in `_io.py` keeps only the colours of the surviving positions, returning the key it rewrote or `None`. `compact_categories` now returns the `used` indices it always computed and discarded — it has exactly one caller, so the signature change was nearly free.

`merge_obs_categories`' inline slice (from #625) is **deleted**; it calls the shared helper with `[i for i in range(n) if i != from_index]`. Its four parametrized position tests and their mutation discipline now guard shared code rather than a private copy.

`direct_members` moved from `guards.py` to `_io.py` so the helper could reach it without an import cycle — a reader, not a guard, the same argument that moved `obs_index_name` in #623. Its six importers point at `_io` and `guards.__all__` no longer claims it.

## Why

Found while reviewing #606: `merge_obs_categories` hit the identical case and fixed it locally, which meant the fix existed in the tree while a shipped tool still had the bug. Rather than write a second implementation, this generalizes the one that already works.

## Assumptions I made

- **A palette this function cannot safely interpret is left for the validator**, never guessed at: a length that already disagrees with `n_before`, a node that is not a string array, or a scalar. The last two are guards the review round added — `check_string_dtype` passes for a shape-`()` dataset, and `asstr()[:]` then raises on it.
- **`n_before` is a parameter, not derived.** `kept` cannot distinguish "nothing dropped" from "trailing categories dropped" — `max(kept) + 1` is only a lower bound.
- **The helper takes kept-indices rather than calling `compact_categories`.** `merge_obs_categories` must not use that function: it drops *every* unreferenced category, which would discard one left empty for its own reasons — the bug caught in #625's review.
- **`backfill_obs_from_source` is deliberately not converted**, and is filed as #626 with a reproduction. It both adds and removes categories, so a surviving category can be new and have no colour — a case `remap_palette` cannot express, needing a policy decision (delete the palette, or leave the mixed case) that the two callers here did not. It is a pre-existing bug, so shipping without it regresses nothing. Note for whoever takes it: these palettes are Tableau 10, not scanpy defaults, so "delete and let scanpy regenerate" would discard a deliberate choice.

## How to verify

1. `cd packages/hca-anndata-tools && uv run pytest tests/test_io.py tests/test_edit.py tests/test_merge_categories.py -v`
2. **The bug itself**: `test_edit.py::test_replace_placeholders_recolours_by_position` — blanking `unknown` drops its category, and each survivor keeps its own colour, asserted as a **category → colour mapping**. Never a length: the length is what the validator already checks, and checking only the length is what made this silent.
3. **Mutation-verified, not asserted.** Four wrong implementations, each caught: dropping an extra colour (12 tests), an off-by-one on the index (12), removing the alignment guard (3), and `compact_categories` reporting every index as surviving (2).
4. `remap_palette`'s own unit tests cover first/middle/last removal, **two non-adjacent removals** (the case a single-index slice cannot express and `merge` never had), all-but-one, nothing removed, no palette, no key, no `uns`, a mismatched length, a scalar, the `/`-link-path trap, and the string encoding surviving the rewrite.
5. `grep -rn 'from .guards import direct_members' packages/` — nothing; the move is complete.
6. `make typecheck` from repo root — 0 errors.

Full gate: 556 + 57 tests, ruff, format, pyright.

Closes #624

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017S1imq17nD5Y3qaovNmBuX
