### PR TITLE
refactor(hca-anndata-tools): adopt the shared snapshot helper in the five hand-rolled tools

### DIFF
--- a/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
@@ -378,12 +378,15 @@ def read_string_dataset(group: h5py.Group, name: str) -> np.ndarray:
 # only where there is. These two carry the original dataset's compression,
 # chunks and maxshape — and, for a categorical, the narrowed codes dtype —
 # forward across a delete-and-recreate, which write_elem would discard.
-def replace_string_dataset(parent: h5py.Group, name: str, data: np.ndarray) -> None:
-    """Delete and recreate a string dataset, preserving its attrs and storage
-    properties (compression, chunks, shuffle, fletcher32, maxshape)."""
-    ds = parent[name]
-    attrs = dict(ds.attrs)
-    storage = {
+def storage_like(ds: h5py.Dataset) -> dict:
+    """The storage properties to carry across a delete-and-recreate.
+
+    One definition, because the two callers had drifted: the string-dataset
+    replacement carried all of these while the categorical one carried only
+    compression and chunks, silently dropping a source file's shuffle and
+    fletcher32 filters (#597).
+    """
+    return {
         "compression": ds.compression,
         "compression_opts": ds.compression_opts,
         "chunks": ds.chunks,
@@ -394,6 +397,13 @@ def replace_string_dataset(parent: h5py.Group, name: str, data: np.ndarray) -> N
         # only carry it when the dataset is actually resizable.
         "maxshape": ds.maxshape if ds.maxshape != ds.shape else None,
     }
+
+
+def replace_string_dataset(parent: h5py.Group, name: str, data: np.ndarray) -> None:
+    """Delete and recreate a string dataset, preserving its attrs and storage."""
+    ds = parent[name]
+    attrs = dict(ds.attrs)
+    storage = storage_like(ds)
     del parent[name]
     new_ds = parent.create_dataset(name, data=data, dtype=h5py.string_dtype(encoding="utf-8"), **storage)
     for key, attr_value in attrs.items():
@@ -488,7 +498,7 @@ def _codes_dtype(n_categories: int, original: np.dtype) -> np.dtype:
 
 def replace_categorical_column(parent: h5py.Group, col: str, categories: list[str], codes: np.ndarray) -> None:
     """Delete and recreate a categorical column group, preserving its encoding
-    attrs and the codes dataset's storage settings (compression, chunks).
+    attrs and the codes dataset's storage settings (see storage_like).
 
     The codes are written at the smallest dtype that holds the new category
     count without narrowing the original — a caller that extended the
@@ -500,9 +510,7 @@ def replace_categorical_column(parent: h5py.Group, col: str, categories: list[st
     encoding_type = item.attrs["encoding-type"]
     encoding_version = item.attrs["encoding-version"]
     ordered = bool(item.attrs["ordered"])
-    codes_compression = item["codes"].compression
-    codes_compression_opts = item["codes"].compression_opts
-    codes_chunks = item["codes"].chunks
+    codes_storage = storage_like(item["codes"])
     codes = codes.astype(_codes_dtype(len(categories), item["codes"].dtype))
 
     del parent[col]
@@ -514,13 +522,7 @@ def replace_categorical_column(parent: h5py.Group, col: str, categories: list[st
     cat_ds = grp.create_dataset("categories", data=cat_data)
     cat_ds.attrs["encoding-type"] = "string-array"
     cat_ds.attrs["encoding-version"] = "0.2.0"
-    codes_ds = grp.create_dataset(
-        "codes",
-        data=codes,
-        compression=codes_compression,
-        compression_opts=codes_compression_opts,
-        chunks=codes_chunks,
-    )
+    codes_ds = grp.create_dataset("codes", data=codes, **codes_storage)
     codes_ds.attrs["encoding-type"] = "array"
     codes_ds.attrs["encoding-version"] = "0.2.0"
 

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/_io.py
@@ -379,13 +379,7 @@ def read_string_dataset(group: h5py.Group, name: str) -> np.ndarray:
 # chunks and maxshape — and, for a categorical, the narrowed codes dtype —
 # forward across a delete-and-recreate, which write_elem would discard.
 def storage_like(ds: h5py.Dataset) -> dict:
-    """The storage properties to carry across a delete-and-recreate.
-
-    One definition, because the two callers had drifted: the string-dataset
-    replacement carried all of these while the categorical one carried only
-    compression and chunks, silently dropping a source file's shuffle and
-    fletcher32 filters (#597).
-    """
+    """The storage properties to carry across a delete-and-recreate."""
     return {
         "compression": ds.compression,
         "compression_opts": ds.compression_opts,

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/backfill.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/backfill.py
@@ -282,7 +282,6 @@ def backfill_obs_from_source(target_path: str, source_path: str, columns: list[s
         ``missing_after`` over all target cells, and ``pct_full_after`` —
         or ``{"error": ...}``.
     """
-    output_path = None
     try:
         problems = _check_arguments(columns)
         if problems:
@@ -394,9 +393,7 @@ def backfill_obs_from_source(target_path: str, source_path: str, columns: list[s
             }
 
         # --- Copy (hashing the target in the same read), then patch ---
-        # Already streamed the target's hash; the shared helper adds the
-        # O_CREAT|O_EXCL claim and waits out a same-second collision (#597).
-        # The *source* hash is a separate file and stays a separate read.
+        # The source is a different file, so its digest is its own read.
         source_basename = Path(source_path).name
         source_sha256 = _compute_sha256(source_path)
 
@@ -446,6 +443,5 @@ def backfill_obs_from_source(target_path: str, source_path: str, columns: list[s
         }
 
     except Exception as e:
-        # No unlink here: snapshot_copy_hashed removes the snapshot itself on
-        # any exception raised inside its body.
+        # No unlink here: snapshot_copy_hashed removes the snapshot itself.
         return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/backfill.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/backfill.py
@@ -45,6 +45,7 @@ from .write import (
     build_edit_log,
     cleanup_previous_version,
     make_edit_entry,
+    parse_edit_log,
     resolve_latest,
     snapshot_copy_hashed,
 )
@@ -393,26 +394,29 @@ def backfill_obs_from_source(target_path: str, source_path: str, columns: list[s
             }
 
         # --- Copy (hashing the target in the same read), then patch ---
-        # The source is a different file, so its digest is its own read.
+        if "error" in (parsed := parse_edit_log(target["raw_log"])):
+            return parsed
         source_basename = Path(source_path).name
-        source_sha256 = _compute_sha256(source_path)
 
-        entry = make_edit_entry(
-            operation="backfill_obs_from_source",
-            description=(
-                f"Backfilled {total_filled} missing obs values in "
-                f"{len(fills)} of {len(columns)} columns from {source_basename}"
-            ),
-            details={
-                "backfill_source_file": source_basename,
-                "backfill_source_sha256": source_sha256,
-                "columns": columns,
-                **overlap,
-                "total_filled": total_filled,
-                "per_column": per_column,
-            },
-        )
         with snapshot_copy_hashed(target_path) as (output_path, target_sha256), h5py.File(output_path, "a") as f_out:
+            # A full read of a different file; ordered after the claim so an
+            # unresolvable collision is refused without paying for it (#597).
+            source_sha256 = _compute_sha256(source_path)
+            entry = make_edit_entry(
+                operation="backfill_obs_from_source",
+                description=(
+                    f"Backfilled {total_filled} missing obs values in "
+                    f"{len(fills)} of {len(columns)} columns from {source_basename}"
+                ),
+                details={
+                    "backfill_source_file": source_basename,
+                    "backfill_source_sha256": source_sha256,
+                    "columns": columns,
+                    **overlap,
+                    "total_filled": total_filled,
+                    "per_column": per_column,
+                },
+            )
             obs_out = f_out["obs"]
             for col, (fill_rows, fill_values) in fills.items():
                 tgt = target["columns"][col]

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/backfill.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/backfill.py
@@ -17,7 +17,6 @@ repeated runs chain without accumulating file copies.
 
 from __future__ import annotations
 
-import contextlib
 from pathlib import Path
 
 import h5py
@@ -42,14 +41,12 @@ from ._io import (
 )
 from .guards import is_malformed_name, legacy_layout_problems
 from .write import (
-    SAME_SECOND_SNAPSHOT_ERROR,
     _compute_sha256,
-    _copy_with_sha256,
     build_edit_log,
     cleanup_previous_version,
-    generate_output_path,
     make_edit_entry,
     resolve_latest,
+    snapshot_copy_hashed,
 )
 
 # Cap on the conflict examples quoted per column, and on the duplicate IDs
@@ -397,16 +394,11 @@ def backfill_obs_from_source(target_path: str, source_path: str, columns: list[s
             }
 
         # --- Copy (hashing the target in the same read), then patch ---
-        output_path = generate_output_path(target_path)
-        if output_path == target_path:
-            # generate_output_path timestamps to the second (see rename.py):
-            # a second edit within the same second would name the output after
-            # its own source. Refuse before touching anything — and before the
-            # source hash below, which reads the whole source file.
-            return {"error": SAME_SECOND_SNAPSHOT_ERROR}
+        # Already streamed the target's hash; the shared helper adds the
+        # O_CREAT|O_EXCL claim and waits out a same-second collision (#597).
+        # The *source* hash is a separate file and stays a separate read.
         source_basename = Path(source_path).name
         source_sha256 = _compute_sha256(source_path)
-        target_sha256 = _copy_with_sha256(target_path, output_path)
 
         entry = make_edit_entry(
             operation="backfill_obs_from_source",
@@ -423,12 +415,7 @@ def backfill_obs_from_source(target_path: str, source_path: str, columns: list[s
                 "per_column": per_column,
             },
         )
-        log_result = build_edit_log(target["raw_log"], [entry], target_path, target_sha256)
-        if "error" in log_result:
-            Path(output_path).unlink()
-            return log_result
-
-        with h5py.File(output_path, "a") as f_out:
+        with snapshot_copy_hashed(target_path) as (output_path, target_sha256), h5py.File(output_path, "a") as f_out:
             obs_out = f_out["obs"]
             for col, (fill_rows, fill_values) in fills.items():
                 tgt = target["columns"][col]
@@ -438,6 +425,9 @@ def backfill_obs_from_source(target_path: str, source_path: str, columns: list[s
                     new_values = tgt["values"].copy()
                     new_values[fill_rows] = fill_values
                     replace_string_dataset(obs_out, col, new_values)  # pyright: ignore[reportArgumentType]
+            log_result = build_edit_log(target["raw_log"], [entry], target_path, target_sha256)
+            if "error" in log_result:
+                raise RuntimeError(log_result["error"])
             write_edit_log_h5py(f_out, log_result["json"])
 
             verify_err = verify_categorical_integrity(f_out, list(fills))
@@ -456,7 +446,6 @@ def backfill_obs_from_source(target_path: str, source_path: str, columns: list[s
         }
 
     except Exception as e:
-        if output_path and Path(output_path).is_file():
-            with contextlib.suppress(OSError):
-                Path(output_path).unlink()
+        # No unlink here: snapshot_copy_hashed removes the snapshot itself on
+        # any exception raised inside its body.
         return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/cap.py
@@ -2,7 +2,9 @@
 
 from collections.abc import Mapping
 
-from ._io import open_h5ad
+import h5py
+
+from ._io import _decode_bytes, open_h5ad, read_uns
 from ._serialize import make_serializable as _make_serializable
 from .write import resolve_latest
 
@@ -47,6 +49,28 @@ LEGACY_LAYOUT_ERROR = (
     "Only the nested uns['cap_metadata'] layout is accepted; re-export the CAP "
     "file with its metadata nested under uns['cap_metadata']."
 )
+
+
+def cellxgene_schema_version(f: h5py.File) -> str | None:
+    """The CellxGENE schema version this file declares, or None.
+
+    ``uns['schema_version']`` holding a non-empty string is what marks a
+    CellxGENE-layout file — the canonical predicate `check_schema_type` uses.
+    Mere key presence is not enough: an empty value would otherwise give one
+    tool a CellxGENE verdict and another an HCA verdict on the same file
+    (#597). Public here, beside the CAP layout predicates, so the mutating
+    tools stop importing inspect's private (#597).
+    """
+    uns = read_uns(f)
+    if uns is None:
+        return None
+    version = uns.get("schema_version")
+    if not isinstance(version, h5py.Dataset):
+        return None
+    value = _decode_bytes(version[()])
+    if not isinstance(value, str):
+        return None
+    return value.strip() or None
 
 
 def is_legacy_cap_layout(uns) -> bool:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -46,6 +46,7 @@ from .write import (
     build_edit_log,
     cleanup_previous_version,
     make_edit_entry,
+    parse_edit_log,
     resolve_latest,
     snapshot_copy_hashed,
 )
@@ -364,6 +365,8 @@ def copy_cap_annotations(
 
         source_basename = Path(source_path).name
         source_sha256 = _compute_sha256(source_path)
+        if "error" in (parsed := parse_edit_log(raw_log)):
+            return parsed
 
         entry_details = {
             "cap_source_file": source_basename,

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -2,10 +2,7 @@
 
 from __future__ import annotations
 
-import contextlib
-import shutil
 import tempfile
-import time
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -45,13 +42,12 @@ from .marker_genes import validate_marker_genes
 from .strip_cap import _LEGACY_TOP_LEVEL_PROVENANCE, strip_cap_annotations
 from .write import (
     EDIT_LOG_KEY,
-    SAME_SECOND_SNAPSHOT_ERROR,
     _compute_sha256,
     build_edit_log,
     cleanup_previous_version,
-    generate_output_path,
     make_edit_entry,
     resolve_latest,
+    snapshot_copy_hashed,
 )
 
 # Demographic annotation sets — not real CAP annotations, just renamed CXG columns
@@ -331,11 +327,6 @@ def copy_cap_annotations(
                 "cells": cell_stats,
             }
 
-        def is_target_alias(candidate: str) -> bool:
-            # String equality misses aliases of the same snapshot ('./'-
-            # prefixed paths, hard links); samefile() catches them.
-            return candidate == target_path or (Path(candidate).exists() and Path(candidate).samefile(target_path))
-
         if overwrite:
             # Overwrite = strip, then a clean import: one shared removal
             # implementation and two audit entries in the edit log instead of
@@ -344,11 +335,9 @@ def copy_cap_annotations(
             # (legacy keys, cap_metadata, provenance/cap, orphan palettes),
             # so no separate detection can drift from it; a clean target
             # reports nothing_to_strip and the import proceeds directly.
-            # The strip refuses a same-second snapshot collision (its output
-            # would be named after its input); if the target snapshot was
-            # written this very second, wait out the boundary first.
-            if is_target_alias(generate_output_path(target_path)):
-                time.sleep(1)
+            # No boundary wait before the strip any more: it waits out a
+            # same-second collision itself since #597, so chaining a strip and
+            # this import within one second needs nothing from the caller.
             strip_result = strip_cap_annotations(target_path)
             if "error" in strip_result:
                 if not strip_result.get("nothing_to_strip"):
@@ -411,23 +400,16 @@ def copy_cap_annotations(
         del aligned_obs
 
         # --- Step 4: Write temp, copy target, transplant via h5py ---
-        output_path = generate_output_path(target_path)
-        if is_target_alias(output_path):
-            # generate_output_path timestamps to the second, and the overwrite
-            # path chains a strip and this import within one second — wait out
-            # the boundary rather than failing the run (see rename.py for the
-            # hazard the equality signals).
-            time.sleep(1)
-            output_path = generate_output_path(target_path)
-        if is_target_alias(output_path):
-            return {"error": SAME_SECOND_SNAPSHOT_ERROR}
-
-        with tempfile.TemporaryDirectory() as tmpdir:
+        # This tool's own retry-then-refuse and samefile alias check are what
+        # the shared helper does — with an O_CREAT|O_EXCL claim instead of a
+        # test-then-copy, so the name cannot be taken in between (#597).
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            snapshot_copy_hashed(target_path) as (output_path, target_sha256),
+        ):
             temp_path = str(Path(tmpdir) / "cap_temp.h5ad")
             temp_adata.write_h5ad(temp_path)
             del temp_adata
-
-            shutil.copy2(target_path, output_path)
 
             # Transplant from temp into output. Any pre-existing CAP data was
             # removed by the overwrite pre-strip above, so this is always a
@@ -458,8 +440,7 @@ def copy_cap_annotations(
             # --- Step 5: Verify transplant — full column comparison ---
             verify_err = verify_obs_transplant(temp_path, output_path, obs_cols_to_copy)
             if verify_err:
-                Path(output_path).unlink()
-                return {"error": verify_err}
+                raise RuntimeError(verify_err)
 
         # --- Step 6: Cleanup + validate marker genes ---
         cleanup_previous_version(target_path, output_path)
@@ -481,10 +462,7 @@ def copy_cap_annotations(
         return result
 
     except Exception as e:
-        if output_path and Path(output_path).is_file():
-            with contextlib.suppress(OSError):
-                # Never unlink an alias of the target snapshot: same-inode
-                # output would delete the source (see strip_cap.py).
-                if not Path(output_path).samefile(target_path):
-                    Path(output_path).unlink()
+        # No unlink here: snapshot_copy_hashed only ever removes a snapshot it
+        # claimed itself, so the alias-of-the-target case this used to guard
+        # cannot arise.
         return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/copy_cap.py
@@ -147,7 +147,6 @@ def copy_cap_annotations(
         Dict with output_path, copied columns/keys, and marker gene
         validation results, or 'error' on failure.
     """
-    output_path = None
     try:
         target_path = resolve_latest(target_path)
         # Same-file guard (parity with backfill.py): with overwrite=True the
@@ -335,9 +334,6 @@ def copy_cap_annotations(
             # (legacy keys, cap_metadata, provenance/cap, orphan palettes),
             # so no separate detection can drift from it; a clean target
             # reports nothing_to_strip and the import proceeds directly.
-            # No boundary wait before the strip any more: it waits out a
-            # same-second collision itself since #597, so chaining a strip and
-            # this import within one second needs nothing from the caller.
             strip_result = strip_cap_annotations(target_path)
             if "error" in strip_result:
                 if not strip_result.get("nothing_to_strip"):
@@ -368,45 +364,42 @@ def copy_cap_annotations(
 
         source_basename = Path(source_path).name
         source_sha256 = _compute_sha256(source_path)
-        target_sha256 = _compute_sha256(target_path)
 
-        entry = make_edit_entry(
-            operation="import_cap_annotations",
-            description=f"Copied CAP annotations from {source_basename}",
-            details={
-                "cap_source_file": source_basename,
-                "cap_source_sha256": source_sha256,
-                "cap_schema_version": cap_schema_version,
-                "annotation_sets": annotation_sets,
-                "obs_columns_added": obs_cols_to_copy,
-                "uns_keys_added": uns_keys_added,
-                "cells": cell_stats,
-                "genes": gene_stats,
-            },
-        )
-
-        log_result = build_edit_log(raw_log, [entry], target_path, target_sha256)
-        if "error" in log_result:
-            return log_result
-
-        temp_uns.setdefault("provenance", {})[EDIT_LOG_KEY] = log_result["json"]
-
-        n_obs = len(target_index)
-        temp_adata = ad.AnnData(
-            X=np.empty((n_obs, 0), dtype=np.float32),
-            obs=aligned_obs,
-            uns=temp_uns,
-        )
-        del aligned_obs
+        entry_details = {
+            "cap_source_file": source_basename,
+            "cap_source_sha256": source_sha256,
+            "cap_schema_version": cap_schema_version,
+            "annotation_sets": annotation_sets,
+            "obs_columns_added": obs_cols_to_copy,
+            "uns_keys_added": uns_keys_added,
+            "cells": cell_stats,
+            "genes": gene_stats,
+        }
 
         # --- Step 4: Write temp, copy target, transplant via h5py ---
-        # This tool's own retry-then-refuse and samefile alias check are what
-        # the shared helper does — with an O_CREAT|O_EXCL claim instead of a
-        # test-then-copy, so the name cannot be taken in between (#597).
         with (
             tempfile.TemporaryDirectory() as tmpdir,
             snapshot_copy_hashed(target_path) as (output_path, target_sha256),
         ):
+            # The edit log is built here because the target digest comes from
+            # the copy above, and it must reach temp_uns before the temp file
+            # is written.
+            entry = make_edit_entry(
+                operation="import_cap_annotations",
+                description=f"Copied CAP annotations from {source_basename}",
+                details=entry_details,
+            )
+            log_result = build_edit_log(raw_log, [entry], target_path, target_sha256)
+            if "error" in log_result:
+                raise RuntimeError(log_result["error"])
+            temp_uns.setdefault("provenance", {})[EDIT_LOG_KEY] = log_result["json"]
+
+            temp_adata = ad.AnnData(
+                X=np.empty((len(target_index), 0), dtype=np.float32),
+                obs=aligned_obs,
+                uns=temp_uns,
+            )
+            del aligned_obs
             temp_path = str(Path(tmpdir) / "cap_temp.h5ad")
             temp_adata.write_h5ad(temp_path)
             del temp_adata
@@ -462,7 +455,5 @@ def copy_cap_annotations(
         return result
 
     except Exception as e:
-        # No unlink here: snapshot_copy_hashed only ever removes a snapshot it
-        # claimed itself, so the alias-of-the-target case this used to guard
-        # cannot arise.
+        # No unlink here: snapshot_copy_hashed removes the snapshot itself.
         return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
@@ -30,6 +30,7 @@ from .write import (
     build_edit_log,
     cleanup_previous_version,
     make_edit_entry,
+    parse_edit_log,
     resolve_latest,
     snapshot_copy_hashed,
     write_h5ad,
@@ -325,6 +326,11 @@ def replace_placeholder_values(
                 "total_cells_affected": total_affected,
             },
         )
+
+        # Refuse a corrupt edit log before copying the file, not after the
+        # copy and the rewrites — the digest is not needed to read it.
+        if "error" in (parsed := parse_edit_log(raw_log)):
+            return parsed
 
         palettes_remapped = []
         with snapshot_copy_hashed(path) as (output_path, target_sha256), h5py.File(output_path, "a") as f:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import contextlib
 import json
-import shutil
 import types
 import typing
 from pathlib import Path
@@ -29,13 +27,11 @@ from ._serialize import make_serializable
 from .guards import detect_obs_references
 from .schema.helpers import uns_field_registry
 from .write import (
-    SAME_SECOND_SNAPSHOT_ERROR,
-    _compute_sha256,
     build_edit_log,
     cleanup_previous_version,
-    generate_output_path,
     make_edit_entry,
     resolve_latest,
+    snapshot_copy_hashed,
     write_h5ad,
 )
 
@@ -322,7 +318,6 @@ def replace_placeholder_values(
 
         total_affected = sum(sum(v.values()) for v in columns_fixed.values())
 
-        target_sha256 = _compute_sha256(path)
         entry = make_edit_entry(
             operation="replace_placeholder_values",
             description=f"Replaced placeholder values with NaN in {len(columns_fixed)} columns",
@@ -332,22 +327,12 @@ def replace_placeholder_values(
             },
         )
 
-        log_result = build_edit_log(raw_log, [entry], path, target_sha256)
-        if "error" in log_result:
-            return log_result
-
-        # Copy and patch
-        output_path = generate_output_path(path)
-        if output_path == path:
-            # generate_output_path timestamps to the second (see rename.py):
-            # a second edit within the same second names the output after its
-            # own source, and the failure path would then unlink that source
-            # snapshot. Refuse before touching anything.
-            return {"error": SAME_SECOND_SNAPSHOT_ERROR}
-        shutil.copy2(path, output_path)
-
         palettes_remapped = []
-        with h5py.File(output_path, "a") as f:
+        # The hashed snapshot: claims a free name, copies, and computes the
+        # source digest in the same pass, so build_edit_log below does not
+        # re-read the whole file. Waits out a same-second collision rather
+        # than refusing it (#597), and removes the snapshot on any failure.
+        with snapshot_copy_hashed(path) as (output_path, target_sha256), h5py.File(output_path, "a") as f:
             uns = read_uns(f)
             palettes = detect_obs_references(uns, list(columns_fixed)).palettes
             for col in columns_fixed:
@@ -367,6 +352,9 @@ def replace_placeholder_values(
                 if remap_palette(uns, palettes.get(col), kept, len(cats)):
                     palettes_remapped.append(palettes[col])
 
+            log_result = build_edit_log(raw_log, [entry], path, target_sha256)
+            if "error" in log_result:
+                raise RuntimeError(log_result["error"])
             write_edit_log_h5py(f, log_result["json"])
 
             # Verify integrity after rewrite
@@ -384,7 +372,6 @@ def replace_placeholder_values(
         }
 
     except Exception as e:
-        if output_path and Path(output_path).is_file():
-            with contextlib.suppress(OSError):
-                Path(output_path).unlink()
+        # No unlink here: snapshot_copy_hashed removes the snapshot itself on
+        # any exception raised inside its body.
         return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/edit.py
@@ -277,7 +277,6 @@ def replace_placeholder_values(
         'palettes_remapped' (the uns palette keys realigned to the surviving
         categories) on success, or 'error' on failure.
     """
-    output_path = None
     try:
         path = resolve_latest(path)
         if not columns:
@@ -328,10 +327,6 @@ def replace_placeholder_values(
         )
 
         palettes_remapped = []
-        # The hashed snapshot: claims a free name, copies, and computes the
-        # source digest in the same pass, so build_edit_log below does not
-        # re-read the whole file. Waits out a same-second collision rather
-        # than refusing it (#597), and removes the snapshot on any failure.
         with snapshot_copy_hashed(path) as (output_path, target_sha256), h5py.File(output_path, "a") as f:
             uns = read_uns(f)
             palettes = detect_obs_references(uns, list(columns_fixed)).palettes
@@ -372,6 +367,5 @@ def replace_placeholder_values(
         }
 
     except Exception as e:
-        # No unlink here: snapshot_copy_hashed removes the snapshot itself on
-        # any exception raised inside its body.
+        # No unlink here: snapshot_copy_hashed removes the snapshot itself.
         return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/inspect.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/inspect.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import h5py
 import numpy as np
 
-from ._io import _decode_bytes, read_uns
+from .cap import cellxgene_schema_version
 from .write import resolve_latest
 
 _DEFAULT_SAMPLE_SIZE = 2000
@@ -274,27 +274,6 @@ def check_x_normalization(path: str, sample_size: int = _DEFAULT_SAMPLE_SIZE) ->
         return {"error": str(e)}
 
 
-def _read_schema_version(f: h5py.File) -> str | None:
-    """Read and decode ``uns['schema_version']`` from an open h5py File.
-
-    Returns the stripped string, or None if absent or empty.
-    ``schema_version`` is stored as a scalar string dataset in AnnData's
-    h5ad format.
-    """
-    uns = read_uns(f)
-    if uns is None:
-        return None
-    version = uns.get("schema_version")
-    if not isinstance(version, h5py.Dataset):
-        return None
-    raw = version[()]
-    value = _decode_bytes(raw)
-    if not isinstance(value, str):
-        return None
-    value = value.strip()
-    return value or None
-
-
 def check_schema_type(path: str) -> dict:
     """Report whether an h5ad file declares the CellxGENE or HCA schema.
 
@@ -315,7 +294,7 @@ def check_schema_type(path: str) -> dict:
     try:
         path = resolve_latest(path)
         with h5py.File(path, "r") as f:
-            version = _read_schema_version(f)
+            version = cellxgene_schema_version(f)
         if version:
             return {
                 "filename": Path(path).name,

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/rename.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/rename.py
@@ -34,8 +34,8 @@ from ._io import (
     replace_string_dataset,
     write_edit_log_h5py,
 )
+from .cap import cellxgene_schema_version
 from .guards import is_malformed_name, legacy_layout_problems, require_obs_group
-from .inspect import _read_schema_version
 from .write import (
     SAME_SECOND_SNAPSHOT_ERROR,
     _compute_sha256,
@@ -192,7 +192,7 @@ def rename_cell_ids(path: str, column: str, value: str, prefix_from: str, prefix
         with h5py.File(path, "r") as f_in:
             obs = require_obs_group(f_in)
 
-            version = _read_schema_version(f_in)
+            version = cellxgene_schema_version(f_in)
             if version:
                 return {
                     "error": (

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/rename.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/rename.py
@@ -305,10 +305,6 @@ def rename_cell_ids(path: str, column: str, value: str, prefix_from: str, prefix
                 )
             }
 
-        # The hashed snapshot: claims a free name, copies, and computes the
-        # source digest in the same pass, so build_edit_log does not re-read
-        # the whole file. Waits out a same-second collision rather than
-        # refusing it (#597), and removes the snapshot on any failure below.
         with snapshot_copy_hashed(path) as (output_path, source_sha256), h5py.File(output_path, "a") as f_out:
             replace_string_dataset(f_out["obs"], index_name, new_ids)  # pyright: ignore[reportArgumentType]
             for obsm_key, sub_name in obsm_df_indexes:
@@ -334,9 +330,6 @@ def rename_cell_ids(path: str, column: str, value: str, prefix_from: str, prefix
             existing_log = read_edit_log_h5py(f_out)
             log_result = build_edit_log(existing_log, [entry], path, source_sha256)
             if "error" in log_result:
-                # Raising inside the context is what removes the snapshot;
-                # the deferred-unlink dance the copy2 version needed is gone
-                # with it (matching rename_column and merge_categories).
                 raise RuntimeError(log_result["error"])
             write_edit_log_h5py(f_out, log_result["json"])
 
@@ -350,6 +343,5 @@ def rename_cell_ids(path: str, column: str, value: str, prefix_from: str, prefix
         }
 
     except Exception as e:
-        # No unlink here: snapshot_copy_hashed removes the snapshot itself on
-        # any exception raised inside its body.
+        # No unlink here: snapshot_copy_hashed removes the snapshot itself.
         return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/rename.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/rename.py
@@ -14,8 +14,6 @@ form-independent and would carry over.
 
 from __future__ import annotations
 
-import contextlib
-import shutil
 from pathlib import Path
 
 import h5py
@@ -37,13 +35,11 @@ from ._io import (
 from .cap import cellxgene_schema_version
 from .guards import is_malformed_name, legacy_layout_problems, require_obs_group
 from .write import (
-    SAME_SECOND_SNAPSHOT_ERROR,
-    _compute_sha256,
     build_edit_log,
     cleanup_previous_version,
-    generate_output_path,
     make_edit_entry,
     resolve_latest,
+    snapshot_copy_hashed,
 )
 
 # Before/after pairs returned for eyeball confirmation, and the cap on IDs
@@ -179,7 +175,6 @@ def rename_cell_ids(path: str, column: str, value: str, prefix_from: str, prefix
         broader-than-intended selector stays visible), and ``examples`` (up to
         five ``[before, after]`` pairs), or ``{"error": ...}``.
     """
-    output_path = None
     try:
         problems = _check_arguments(column, value, prefix_from, prefix_to)
         if problems:
@@ -310,21 +305,11 @@ def rename_cell_ids(path: str, column: str, value: str, prefix_from: str, prefix
                 )
             }
 
-        output_path = generate_output_path(path)
-        if output_path == path:
-            # generate_output_path timestamps to the second, so a second edit
-            # within the same second names the output after its own source;
-            # copying would raise SameFileError and the failure path would
-            # then unlink the source snapshot. Refuse before touching anything.
-            return {"error": SAME_SECOND_SNAPSHOT_ERROR}
-        shutil.copy2(path, output_path)
-
-        # Hash the source before opening the output: build_edit_log would
-        # otherwise re-read the whole file while the output handle is open.
-        source_sha256 = _compute_sha256(path)
-
-        log_error = None
-        with h5py.File(output_path, "a") as f_out:
+        # The hashed snapshot: claims a free name, copies, and computes the
+        # source digest in the same pass, so build_edit_log does not re-read
+        # the whole file. Waits out a same-second collision rather than
+        # refusing it (#597), and removes the snapshot on any failure below.
+        with snapshot_copy_hashed(path) as (output_path, source_sha256), h5py.File(output_path, "a") as f_out:
             replace_string_dataset(f_out["obs"], index_name, new_ids)  # pyright: ignore[reportArgumentType]
             for obsm_key, sub_name in obsm_df_indexes:
                 replace_string_dataset(f_out["obsm"][obsm_key], sub_name, new_ids)  # pyright: ignore[reportArgumentType, reportIndexIssue]
@@ -349,17 +334,11 @@ def rename_cell_ids(path: str, column: str, value: str, prefix_from: str, prefix
             existing_log = read_edit_log_h5py(f_out)
             log_result = build_edit_log(existing_log, [entry], path, source_sha256)
             if "error" in log_result:
-                log_error = log_result
-            else:
-                write_edit_log_h5py(f_out, log_result["json"])
-
-        # Deferred until the with-block has closed the output handle,
-        # matching drop.py: unlinking an open HDF5 file works on POSIX but
-        # raises on Windows, and the context __exit__ flush would hit a
-        # removed inode either way.
-        if log_error is not None:
-            Path(output_path).unlink()
-            return log_error
+                # Raising inside the context is what removes the snapshot;
+                # the deferred-unlink dance the copy2 version needed is gone
+                # with it (matching rename_column and merge_categories).
+                raise RuntimeError(log_result["error"])
+            write_edit_log_h5py(f_out, log_result["json"])
 
         cleanup_previous_version(path, output_path)
 
@@ -371,7 +350,6 @@ def rename_cell_ids(path: str, column: str, value: str, prefix_from: str, prefix
         }
 
     except Exception as e:
-        if output_path and Path(output_path).is_file():
-            with contextlib.suppress(OSError):
-                Path(output_path).unlink()
+        # No unlink here: snapshot_copy_hashed removes the snapshot itself on
+        # any exception raised inside its body.
         return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/strip.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/strip.py
@@ -25,7 +25,7 @@ from ._io import (
     update_column_order,
     write_edit_log_h5py,
 )
-from .inspect import _read_schema_version
+from .cap import cellxgene_schema_version
 from .write import (
     build_edit_log,
     cleanup_previous_version,
@@ -114,7 +114,7 @@ def strip_forbidden_obs_columns(path: str) -> dict:
         # an empty or non-string value no longer trips the refusal the way
         # the old bare presence check did.
         with h5py.File(path, "r") as f_in:
-            if _read_schema_version(f_in):
+            if cellxgene_schema_version(f_in):
                 return {
                     "error": (
                         "Input is CellxGENE-layout (uns['schema_version'] "

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/strip_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/strip_cap.py
@@ -48,13 +48,11 @@ from .guards import (
     require_obs_group,
 )
 from .write import (
-    SAME_SECOND_SNAPSHOT_ERROR,
-    _copy_with_sha256,
     build_edit_log,
     cleanup_previous_version,
-    generate_output_path,
     make_edit_entry,
     resolve_latest,
+    snapshot_copy_hashed,
 )
 
 # Every CAP-written uns key across both layout eras: the deprecated top-level
@@ -243,22 +241,10 @@ def strip_cap_annotations(path: str) -> dict:
                 "nothing_to_strip": True,
             }
 
-        output_path = generate_output_path(path)
-        if output_path == path or (Path(output_path).exists() and Path(output_path).samefile(path)):
-            # generate_output_path timestamps to the second (see rename.py):
-            # a second edit within the same second would name the output after
-            # its own source. samefile() also catches aliases of the same
-            # snapshot ('./'-prefixed paths, hard links) that string equality
-            # misses. Refuse before touching anything.
-            return {"error": SAME_SECOND_SNAPSHOT_ERROR}
-        # Hash the source in the same streaming read as the snapshot copy;
-        # a separate hash pass would re-read the whole multi-GB file.
-        source_sha256 = _copy_with_sha256(path, output_path)
-
-        # Defer the malformed-log cleanup until after the with-block closes
-        # the output handle (see strip.py for the POSIX/Windows rationale).
-        log_error = None
-        with h5py.File(output_path, "a") as f_out:
+        # Already streamed its hash; the shared helper adds the O_CREAT|O_EXCL
+        # claim (which subsumes the samefile alias check this used to make by
+        # hand) and waits out a same-second collision rather than refusing it.
+        with snapshot_copy_hashed(path) as (output_path, source_sha256), h5py.File(output_path, "a") as f_out:
             for key in uns_keys_present:
                 del f_out["uns"][key]
             if obs_columns_present:
@@ -281,13 +267,8 @@ def strip_cap_annotations(path: str) -> dict:
             existing_log = read_edit_log_h5py(f_out)
             log_result = build_edit_log(existing_log, [entry], path, source_sha256)
             if "error" in log_result:
-                log_error = log_result
-            else:
-                write_edit_log_h5py(f_out, log_result["json"])
-
-        if log_error is not None:
-            Path(output_path).unlink()
-            return log_error
+                raise RuntimeError(log_result["error"])
+            write_edit_log_h5py(f_out, log_result["json"])
 
         cleanup_previous_version(path, output_path)
 

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/strip_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/strip_cap.py
@@ -38,6 +38,7 @@ from .cap import (
     CAP_METADATA_KEY,
     cap_obs_columns,
     cap_palette_keys,
+    cellxgene_schema_version,
     unknown_cap_suffix_columns,
 )
 from .guards import (
@@ -46,7 +47,6 @@ from .guards import (
     obs_name_problems,
     require_obs_group,
 )
-from .inspect import _read_schema_version
 from .write import (
     SAME_SECOND_SNAPSHOT_ERROR,
     _copy_with_sha256,
@@ -148,7 +148,7 @@ def strip_cap_annotations(path: str) -> dict:
         # Peek first via h5py: layout check + inventory of what is present,
         # without loading the full anndata just to decide whether to mutate.
         with h5py.File(path, "r") as f_in:
-            version = _read_schema_version(f_in)
+            version = cellxgene_schema_version(f_in)
             if version:
                 return {
                     "error": (

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/strip_cap.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/strip_cap.py
@@ -17,7 +17,6 @@ replaces rather than removes).
 
 from __future__ import annotations
 
-import contextlib
 import json
 from pathlib import Path
 
@@ -137,7 +136,6 @@ def strip_cap_annotations(path: str) -> dict:
         Dict with ``output_path``, ``uns_keys_removed``, and
         ``obs_columns_removed`` on success, or ``{"error": ...}``.
     """
-    output_path = None
     try:
         path = resolve_latest(path)
         if not Path(path).is_file():
@@ -241,9 +239,6 @@ def strip_cap_annotations(path: str) -> dict:
                 "nothing_to_strip": True,
             }
 
-        # Already streamed its hash; the shared helper adds the O_CREAT|O_EXCL
-        # claim (which subsumes the samefile alias check this used to make by
-        # hand) and waits out a same-second collision rather than refusing it.
         with snapshot_copy_hashed(path) as (output_path, source_sha256), h5py.File(output_path, "a") as f_out:
             for key in uns_keys_present:
                 del f_out["uns"][key]
@@ -287,11 +282,5 @@ def strip_cap_annotations(path: str) -> dict:
         return result
 
     except Exception as e:
-        if output_path and Path(output_path).is_file():
-            with contextlib.suppress(OSError):
-                # Never unlink an alias of the input: if output_path reaches
-                # the same inode (hard link, path alias), deleting it deletes
-                # the source snapshot.
-                if not Path(output_path).samefile(path):
-                    Path(output_path).unlink()
+        # No unlink here: snapshot_copy_hashed removes the snapshot itself.
         return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
@@ -130,13 +130,6 @@ def _claim_snapshot_path(path: str) -> str:
     raise SameSecondSnapshotError(SAME_SECOND_SNAPSHOT_ERROR)
 
 
-# Five tools still hand-roll this sequence (rename, strip_cap, backfill,
-# copy_cap, edit) because they need the source sha256 the context manager does
-# not yield — that gap is the seam #597 has to open. Note the two families are
-# not equivalent today: _claim_snapshot_path waits out the second boundary and
-# retries, while the hand-rolled sites refuse a same-second collision outright.
-# Adopting this wholesale is therefore a behaviour change for those five, not a
-# pure extraction — a decision #597 should make deliberately.
 @contextlib.contextmanager
 def snapshot_copy(path: str) -> Iterator[str]:
     """Yield the path of a fresh snapshot copy of ``path``, cleaning it up on error.

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/write.py
@@ -167,9 +167,13 @@ def snapshot_copy(path: str) -> Iterator[str]:
     try:
         shutil.copy2(path, output_path)
     except shutil.SameFileError as e:
-        # Only reachable if the destination appeared between the check above
-        # and here. Nothing was written — copy2 compares inodes before opening
-        # the destination — and the file is not ours, so it is not removed.
+        # Nothing was written — the copy compares inodes before opening the
+        # destination — but the file at output_path *is* ours: the O_EXCL
+        # claim created it. Leaving it would strand a zero-byte file carrying
+        # the newest -edit- timestamp, which resolve_latest would then hand to
+        # every later call (#597).
+        with contextlib.suppress(OSError):
+            Path(output_path).unlink()
         raise SameSecondSnapshotError(SAME_SECOND_SNAPSHOT_ERROR) from e
     except BaseException:
         with contextlib.suppress(OSError):
@@ -208,6 +212,9 @@ def snapshot_copy_hashed(path: str) -> Iterator[tuple[str, str]]:
     try:
         sha256 = _copy_with_sha256(path, output_path)
     except shutil.SameFileError as e:
+        # The claimed file is ours; see snapshot_copy for why it is removed.
+        with contextlib.suppress(OSError):
+            Path(output_path).unlink()
         raise SameSecondSnapshotError(SAME_SECOND_SNAPSHOT_ERROR) from e
     except BaseException:
         with contextlib.suppress(OSError):
@@ -381,6 +388,34 @@ def make_edit_entry(
     }
 
 
+def parse_edit_log(existing_log_raw: str | list) -> dict:
+    """The existing edit log as a list, or the reason it cannot be used.
+
+    Split out of :func:`build_edit_log` because it needs no digest: a caller
+    holding the raw log can refuse a corrupt one *before* copying a multi-GB
+    file, rather than after the copy and the mutations (#597).
+
+    Returns:
+        Dict with 'log' (the entries) on success, or 'error'.
+    """
+    if isinstance(existing_log_raw, list):
+        return {"log": existing_log_raw}
+    if not isinstance(existing_log_raw, str):
+        return {
+            "error": (
+                f"Existing {EDIT_LOG_KEY} has unsupported type "
+                f"{type(existing_log_raw).__name__}; refusing to overwrite edit log"
+            )
+        }
+    try:
+        existing_log = json.loads(existing_log_raw)
+    except json.JSONDecodeError:
+        return {"error": f"Existing {EDIT_LOG_KEY} contains invalid JSON"}
+    if not isinstance(existing_log, list):
+        return {"error": f"Existing {EDIT_LOG_KEY} decoded to {type(existing_log).__name__}, expected list"}
+    return {"log": existing_log}
+
+
 def build_edit_log(
     existing_log_raw: str | list,
     edit_entries: list[dict],
@@ -417,24 +452,11 @@ def build_edit_log(
 
     stamped_entries = [{**entry, "source_file": source_filename, "source_sha256": sha256} for entry in edit_entries]
 
-    if isinstance(existing_log_raw, str):
-        try:
-            existing_log = json.loads(existing_log_raw)
-        except json.JSONDecodeError:
-            return {"error": f"Existing {EDIT_LOG_KEY} contains invalid JSON"}
-        if not isinstance(existing_log, list):
-            return {"error": f"Existing {EDIT_LOG_KEY} decoded to {type(existing_log).__name__}, expected list"}
-    elif isinstance(existing_log_raw, list):
-        existing_log = existing_log_raw
-    else:
-        return {
-            "error": (
-                f"Existing {EDIT_LOG_KEY} has unsupported type "
-                f"{type(existing_log_raw).__name__}; refusing to overwrite edit log"
-            )
-        }
+    parsed = parse_edit_log(existing_log_raw)
+    if "error" in parsed:
+        return parsed
 
-    return {"json": json.dumps(existing_log + stamped_entries)}
+    return {"json": json.dumps(parsed["log"] + stamped_entries)}
 
 
 def cleanup_previous_version(source_path: str, output_path: str) -> None:

--- a/packages/hca-anndata-tools/tests/conftest.py
+++ b/packages/hca-anndata-tools/tests/conftest.py
@@ -87,3 +87,27 @@ def no_snapshot():
         return not any("-edit-" in p.name for p in Path(path).parent.iterdir())
 
     return _check
+
+
+@pytest.fixture
+def pin_snapshot_names(monkeypatch):
+    """Force the snapshot namer to return the given names in order, and make
+    the boundary wait instant.
+
+    The tools no longer implement collision handling themselves — they call
+    write.snapshot_copy(_hashed) — so a tool test pins only what the *tool*
+    does with the outcome. That the helper waits once and then refuses is its
+    own property, owned by test_write.py.
+    """
+
+    def _pin(*names):
+        if names:
+            it = iter(names)
+            monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: next(it))
+        else:
+            # No names: every attempt lands on the source itself, so the
+            # collision survives the wait and the tool must refuse.
+            monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: p)
+        monkeypatch.setattr("hca_anndata_tools.write.time.sleep", lambda s: None)
+
+    return _pin

--- a/packages/hca-anndata-tools/tests/test_backfill.py
+++ b/packages/hca-anndata-tools/tests/test_backfill.py
@@ -1,6 +1,7 @@
 """Tests for backfill_obs_from_source."""
 
 import json
+from pathlib import Path
 
 import anndata as ad
 import numpy as np
@@ -323,14 +324,32 @@ def test_backfill_runs_chain(tmp_path, monkeypatch):
     assert second["per_column"]["library_id"]["pct_full_after"] == 100.0
 
 
+def test_backfill_same_second_collision_resolves_after_waiting(target_source, tmp_path, monkeypatch):
+    """The common case since #597: waited out, not refused."""
+    target, source = target_source
+    fresh = str(Path(target).parent / "target-edit-2026-08-24-00-00-01.h5ad")
+    names = iter([str(target), fresh])
+    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: next(names))
+    slept = []
+    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", slept.append)
+
+    result = backfill_obs_from_source(target, source, columns=["library_id"])
+
+    assert slept == [1]
+    assert "error" not in result
+    assert result["output_path"] == fresh
+
+
 def test_backfill_same_second_snapshot_refused(target_source, monkeypatch):
-    """A second edit within the same second would name the output after its
-    own source; the guard refuses before touching anything."""
-    monkeypatch.setattr("hca_anndata_tools.backfill.generate_output_path", lambda p: p)
+    """A collision surviving the wait is refused, target untouched."""
+    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: p)
+    slept = []
+    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", slept.append)
     target, source = target_source
 
     result = backfill_obs_from_source(target, source, columns=["library_id"])
 
+    assert slept == [1], "the boundary wait is attempted once before refusing"
     assert "error" in result
     assert "already exists" in result["error"]
     assert ad.read_h5ad(target).n_obs == 7  # target untouched

--- a/packages/hca-anndata-tools/tests/test_backfill.py
+++ b/packages/hca-anndata-tools/tests/test_backfill.py
@@ -324,32 +324,25 @@ def test_backfill_runs_chain(tmp_path, monkeypatch):
     assert second["per_column"]["library_id"]["pct_full_after"] == 100.0
 
 
-def test_backfill_same_second_collision_resolves_after_waiting(target_source, tmp_path, monkeypatch):
+def test_backfill_same_second_collision_resolves_after_waiting(target_source, tmp_path, pin_snapshot_names):
     """The common case since #597: waited out, not refused."""
     target, source = target_source
     fresh = str(Path(target).parent / "target-edit-2026-08-24-00-00-01.h5ad")
-    names = iter([str(target), fresh])
-    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: next(names))
-    slept = []
-    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", slept.append)
+    pin_snapshot_names(str(target), fresh)
 
     result = backfill_obs_from_source(target, source, columns=["library_id"])
 
-    assert slept == [1]
     assert "error" not in result
     assert result["output_path"] == fresh
 
 
-def test_backfill_same_second_snapshot_refused(target_source, monkeypatch):
+def test_backfill_same_second_snapshot_refused(target_source, pin_snapshot_names):
     """A collision surviving the wait is refused, target untouched."""
-    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: p)
-    slept = []
-    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", slept.append)
+    pin_snapshot_names()
     target, source = target_source
 
     result = backfill_obs_from_source(target, source, columns=["library_id"])
 
-    assert slept == [1], "the boundary wait is attempted once before refusing"
     assert "error" in result
     assert "already exists" in result["error"]
     assert ad.read_h5ad(target).n_obs == 7  # target untouched

--- a/packages/hca-anndata-tools/tests/test_copy_cap.py
+++ b/packages/hca-anndata-tools/tests/test_copy_cap.py
@@ -606,11 +606,11 @@ def test_copy_overwrite_overlap_failure_does_not_mutate(cap_source, tmp_path):
 
 
 def test_copy_overwrite_same_second_snapshot_is_safe(cap_source, tmp_path, monkeypatch):
-    """With timestamps pinned to one wall-clock second, the chained
-    strip+import must fail cleanly (via the identity guards) rather than
-    copy over — and lose — the target snapshot."""
+    """With timestamps pinned to one wall-clock second, every retry lands on
+    the same taken name, so the chained strip+import must fail cleanly rather
+    than copy over — and lose — the target snapshot."""
     monkeypatch.setattr("hca_anndata_tools.write.generate_timestamp", lambda: "2026-08-21-00-00-00")
-    monkeypatch.setattr("hca_anndata_tools.copy_cap.time", type("T", (), {"sleep": staticmethod(lambda s: None)}))
+    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", lambda s: None)
     (tmp_path / "snap.h5ad").touch()  # lineage root, so only the same-second guard fires
     target = tmp_path / "snap-edit-2026-08-21-00-00-00.h5ad"
     _make_hca_target(target, CELL_IDS)

--- a/packages/hca-anndata-tools/tests/test_drop.py
+++ b/packages/hca-anndata-tools/tests/test_drop.py
@@ -625,19 +625,15 @@ def test_drop_missing_file():
     assert "File not found" in result["error"]
 
 
-def test_drop_same_second_snapshot_refused(sample_h5ad_for_write, monkeypatch):
+def test_drop_same_second_snapshot_refused(sample_h5ad_for_write, pin_snapshot_names):
     """A collision that survives the boundary wait is refused before anything is
     touched — otherwise the output would be named after its own source and the
     failure path would unlink that source snapshot. Patching generate_output_path
     to the identity makes the retry collide too, which is the unresolvable case."""
     _add_obs_cols(sample_h5ad_for_write, "junk_col")
-    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: p)
-    slept = []
-    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", slept.append)
+    pin_snapshot_names()
 
     result = drop_obs_columns(str(sample_h5ad_for_write), ["junk_col"])
-
-    assert slept == [1], "the boundary wait should be attempted once before refusing"
 
     # Asserted before the message: unguarded, this file is unlinked (#598).
     assert sample_h5ad_for_write.is_file()

--- a/packages/hca-anndata-tools/tests/test_edit.py
+++ b/packages/hca-anndata-tools/tests/test_edit.py
@@ -340,15 +340,34 @@ def test_replace_placeholder_all_values_replaced(tmp_path):
     assert len(written.obs["test_col"].cat.categories) == 0
 
 
+def test_replace_placeholder_same_second_collision_resolves_after_waiting(tmp_path, monkeypatch):
+    """The common case since #597: a name taken this second is resolved by
+    waiting out the boundary rather than failing a run the caller re-issues."""
+    path = _make_placeholder_h5ad(tmp_path, ["valid", "unknown"])
+    fresh = str(tmp_path / "placeholders_test-edit-2026-08-24-00-00-01.h5ad")
+    names = iter([str(path), fresh])
+    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: next(names))
+    slept = []
+    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", slept.append)
+
+    result = replace_placeholder_values(str(path), ["test_col"])
+
+    assert slept == [1]
+    assert "error" not in result
+    assert result["output_path"] == fresh
+
+
 def test_replace_placeholder_same_second_snapshot_refused(tmp_path, monkeypatch):
-    """A second edit within the same second would name the output after its
-    own source and the failure path would unlink that source snapshot; the
-    guard refuses before touching anything (mirrors rename/backfill)."""
-    monkeypatch.setattr("hca_anndata_tools.edit.generate_output_path", lambda p: p)
+    """A collision that survives the boundary wait is refused before anything
+    is touched — the source snapshot must not be unlinked (#598)."""
+    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: p)
+    slept = []
+    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", slept.append)
     path = _make_placeholder_h5ad(tmp_path, ["valid", "unknown"])
 
     result = replace_placeholder_values(str(path), ["test_col"])
 
+    assert slept == [1], "the boundary wait is attempted once before refusing"
     assert "error" in result
     assert "already exists" in result["error"]
     assert path.is_file()  # the source snapshot was not unlinked

--- a/packages/hca-anndata-tools/tests/test_edit.py
+++ b/packages/hca-anndata-tools/tests/test_edit.py
@@ -340,34 +340,27 @@ def test_replace_placeholder_all_values_replaced(tmp_path):
     assert len(written.obs["test_col"].cat.categories) == 0
 
 
-def test_replace_placeholder_same_second_collision_resolves_after_waiting(tmp_path, monkeypatch):
+def test_replace_placeholder_same_second_collision_resolves_after_waiting(tmp_path, pin_snapshot_names):
     """The common case since #597: a name taken this second is resolved by
     waiting out the boundary rather than failing a run the caller re-issues."""
     path = _make_placeholder_h5ad(tmp_path, ["valid", "unknown"])
     fresh = str(tmp_path / "placeholders_test-edit-2026-08-24-00-00-01.h5ad")
-    names = iter([str(path), fresh])
-    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: next(names))
-    slept = []
-    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", slept.append)
+    pin_snapshot_names(str(path), fresh)
 
     result = replace_placeholder_values(str(path), ["test_col"])
 
-    assert slept == [1]
     assert "error" not in result
     assert result["output_path"] == fresh
 
 
-def test_replace_placeholder_same_second_snapshot_refused(tmp_path, monkeypatch):
+def test_replace_placeholder_same_second_snapshot_refused(tmp_path, pin_snapshot_names):
     """A collision that survives the boundary wait is refused before anything
     is touched — the source snapshot must not be unlinked (#598)."""
-    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: p)
-    slept = []
-    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", slept.append)
+    pin_snapshot_names()
     path = _make_placeholder_h5ad(tmp_path, ["valid", "unknown"])
 
     result = replace_placeholder_values(str(path), ["test_col"])
 
-    assert slept == [1], "the boundary wait is attempted once before refusing"
     assert "error" in result
     assert "already exists" in result["error"]
     assert path.is_file()  # the source snapshot was not unlinked

--- a/packages/hca-anndata-tools/tests/test_io.py
+++ b/packages/hca-anndata-tools/tests/test_io.py
@@ -108,7 +108,7 @@ def test_read_edit_log_numeric_at_edit_history(h5):
     assert read_edit_log_h5py(h5) == "[]"
 
 
-def testcellxgene_schema_version_group_at_leaf(h5):
+def test_cellxgene_schema_version_group_at_leaf(h5):
     """A Group at uns['schema_version'] is narrowed to None instead of
     raising TypeError from the scalar read."""
     h5.create_group("uns/schema_version")

--- a/packages/hca-anndata-tools/tests/test_io.py
+++ b/packages/hca-anndata-tools/tests/test_io.py
@@ -16,7 +16,7 @@ from hca_anndata_tools._io import (
     remap_palette,
     require_stamped_group,
 )
-from hca_anndata_tools.inspect import _read_schema_version
+from hca_anndata_tools.cap import cellxgene_schema_version
 
 
 def test_read_uns_absent(h5):
@@ -108,12 +108,12 @@ def test_read_edit_log_numeric_at_edit_history(h5):
     assert read_edit_log_h5py(h5) == "[]"
 
 
-def test_read_schema_version_group_at_leaf(h5):
+def testcellxgene_schema_version_group_at_leaf(h5):
     """A Group at uns['schema_version'] is narrowed to None instead of
     raising TypeError from the scalar read."""
     h5.create_group("uns/schema_version")
 
-    assert _read_schema_version(h5) is None
+    assert cellxgene_schema_version(h5) is None
 
 
 # --- remap_palette (#624) ----------------------------------------------------

--- a/packages/hca-anndata-tools/tests/test_rename.py
+++ b/packages/hca-anndata-tools/tests/test_rename.py
@@ -187,21 +187,46 @@ def test_rename_refuses_mismatched_obsm_dataframe_index(tmp_path):
     assert_no_snapshot_written(path)
 
 
+def test_rename_same_second_collision_resolves_after_waiting(tmp_path, monkeypatch):
+    """The common case since #597: a name taken this second is resolved by
+    waiting out the boundary, not by failing a run the caller must re-issue."""
+    path = create_hca_h5ad(tmp_path / "test.h5ad")
+    first = rename_cell_ids(
+        str(path), column="sample_id", value="B1_0023", prefix_from="MH_mix_", prefix_to="MH_mix_BR1_"
+    )
+    snapshot = Path(first["output_path"])
+    names = iter([str(snapshot), str(tmp_path / "test-edit-2026-08-24-00-00-01.h5ad")])
+    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: next(names))
+    slept = []
+    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", slept.append)
+
+    result = rename_cell_ids(
+        str(snapshot), column="sample_id", value="B1_0023", prefix_from="MH_mix_BR1_", prefix_to="Z_"
+    )
+
+    assert slept == [1]
+    assert "error" not in result
+    assert Path(result["output_path"]).name == "test-edit-2026-08-24-00-00-01.h5ad"
+
+
 def test_rename_same_second_snapshot_refused(tmp_path, monkeypatch):
-    """generate_output_path timestamps to the second; when a second edit would
-    name the output after its own source, refuse — the failure path used to
-    unlink the source snapshot (SameFileError -> except -> unlink)."""
+    """A collision that survives the boundary wait is refused before anything
+    is touched — the source snapshot must not be unlinked (#598)."""
     path = create_hca_h5ad(tmp_path / "test.h5ad")
     first = rename_cell_ids(
         str(path), column="sample_id", value="B1_0023", prefix_from="MH_mix_", prefix_to="MH_mix_BR1_"
     )
     snapshot = Path(first["output_path"])
 
-    monkeypatch.setattr("hca_anndata_tools.rename.generate_output_path", lambda p: p)
+    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: p)
+    slept = []
+    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", slept.append)
+
     result = rename_cell_ids(
         str(snapshot), column="sample_id", value="B1_0023", prefix_from="MH_mix_BR1_", prefix_to="Z_"
     )
 
+    assert slept == [1], "the boundary wait is attempted once before refusing"
     assert "already exists" in result["error"]
     assert snapshot.is_file()  # the source snapshot survived
 

--- a/packages/hca-anndata-tools/tests/test_rename.py
+++ b/packages/hca-anndata-tools/tests/test_rename.py
@@ -187,7 +187,7 @@ def test_rename_refuses_mismatched_obsm_dataframe_index(tmp_path):
     assert_no_snapshot_written(path)
 
 
-def test_rename_same_second_collision_resolves_after_waiting(tmp_path, monkeypatch):
+def test_rename_same_second_collision_resolves_after_waiting(tmp_path, pin_snapshot_names):
     """The common case since #597: a name taken this second is resolved by
     waiting out the boundary, not by failing a run the caller must re-issue."""
     path = create_hca_h5ad(tmp_path / "test.h5ad")
@@ -195,21 +195,17 @@ def test_rename_same_second_collision_resolves_after_waiting(tmp_path, monkeypat
         str(path), column="sample_id", value="B1_0023", prefix_from="MH_mix_", prefix_to="MH_mix_BR1_"
     )
     snapshot = Path(first["output_path"])
-    names = iter([str(snapshot), str(tmp_path / "test-edit-2026-08-24-00-00-01.h5ad")])
-    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: next(names))
-    slept = []
-    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", slept.append)
+    pin_snapshot_names(str(snapshot), str(tmp_path / "test-edit-2026-08-24-00-00-01.h5ad"))
 
     result = rename_cell_ids(
         str(snapshot), column="sample_id", value="B1_0023", prefix_from="MH_mix_BR1_", prefix_to="Z_"
     )
 
-    assert slept == [1]
     assert "error" not in result
     assert Path(result["output_path"]).name == "test-edit-2026-08-24-00-00-01.h5ad"
 
 
-def test_rename_same_second_snapshot_refused(tmp_path, monkeypatch):
+def test_rename_same_second_snapshot_refused(tmp_path, pin_snapshot_names):
     """A collision that survives the boundary wait is refused before anything
     is touched — the source snapshot must not be unlinked (#598)."""
     path = create_hca_h5ad(tmp_path / "test.h5ad")
@@ -218,15 +214,12 @@ def test_rename_same_second_snapshot_refused(tmp_path, monkeypatch):
     )
     snapshot = Path(first["output_path"])
 
-    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: p)
-    slept = []
-    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", slept.append)
+    pin_snapshot_names()
 
     result = rename_cell_ids(
         str(snapshot), column="sample_id", value="B1_0023", prefix_from="MH_mix_BR1_", prefix_to="Z_"
     )
 
-    assert slept == [1], "the boundary wait is attempted once before refusing"
     assert "already exists" in result["error"]
     assert snapshot.is_file()  # the source snapshot survived
 

--- a/packages/hca-anndata-tools/tests/test_strip.py
+++ b/packages/hca-anndata-tools/tests/test_strip.py
@@ -139,19 +139,15 @@ def test_strip_missing_file():
     assert "File not found" in result["error"]
 
 
-def test_strip_same_second_snapshot_refused(sample_h5ad_for_write, monkeypatch):
+def test_strip_same_second_snapshot_refused(sample_h5ad_for_write, pin_snapshot_names):
     """A collision that survives the boundary wait is refused before anything is
     touched — otherwise the output would be named after its own source and the
     failure path would unlink that source snapshot. Patching generate_output_path
     to the identity makes the retry collide too, which is the unresolvable case."""
     _to_hca_layout(sample_h5ad_for_write, "self_reported_ethnicity")
-    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: p)
-    slept = []
-    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", slept.append)
+    pin_snapshot_names()
 
     result = strip_forbidden_obs_columns(str(sample_h5ad_for_write))
-
-    assert slept == [1], "the boundary wait should be attempted once before refusing"
 
     # Asserted before the message: unguarded, this file is unlinked (#598).
     assert sample_h5ad_for_write.is_file()

--- a/packages/hca-anndata-tools/tests/test_strip_cap.py
+++ b/packages/hca-anndata-tools/tests/test_strip_cap.py
@@ -192,7 +192,7 @@ def test_strip_refuses_index_or_ghost_in_column_order(tmp_path):
     assert not list(tmp_path.glob("*-edit-*.h5ad"))
 
 
-def test_strip_alias_output_does_not_unlink_source(tmp_path, monkeypatch):
+def test_strip_alias_output_does_not_unlink_source(tmp_path, pin_snapshot_names):
     """An output path that aliases the source through a hard link must never
     be copied over or unlinked. The O_CREAT|O_EXCL claim subsumes the
     samefile check this used to make by hand: the name is occupied, so it is
@@ -202,8 +202,7 @@ def test_strip_alias_output_does_not_unlink_source(tmp_path, monkeypatch):
     path = _make_cap_file(tmp_path / "aliased.h5ad", uns_layout="legacy")
     alias = tmp_path / "alias-of-source.h5ad"
     os.link(path, alias)
-    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: str(alias))
-    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", lambda s: None)
+    pin_snapshot_names(str(alias), str(alias))
 
     result = strip_cap_annotations(path)
 
@@ -398,32 +397,25 @@ def test_strip_refuses_cellxgene_layout(sample_h5ad):
     assert "CellxGENE" in result["error"]
 
 
-def test_strip_same_second_collision_resolves_after_waiting(tmp_path, monkeypatch):
+def test_strip_same_second_collision_resolves_after_waiting(tmp_path, pin_snapshot_names):
     """The common case since #597: waited out, not refused."""
     path = _make_cap_file(tmp_path / "guard.h5ad", uns_layout="legacy")
     fresh = str(tmp_path / "guard-edit-2026-08-24-00-00-01.h5ad")
-    names = iter([str(path), fresh])
-    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: next(names))
-    slept = []
-    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", slept.append)
+    pin_snapshot_names(str(path), fresh)
 
     result = strip_cap_annotations(path)
 
-    assert slept == [1]
     assert "error" not in result
     assert result["output_path"] == fresh
 
 
-def test_strip_same_second_snapshot_refused(tmp_path, monkeypatch):
+def test_strip_same_second_snapshot_refused(tmp_path, pin_snapshot_names):
     """A collision surviving the wait is refused, source untouched."""
-    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: p)
-    slept = []
-    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", slept.append)
+    pin_snapshot_names()
     path = _make_cap_file(tmp_path / "guard.h5ad", uns_layout="legacy")
 
     result = strip_cap_annotations(path)
 
-    assert slept == [1], "the boundary wait is attempted once before refusing"
     assert "error" in result
     assert "already exists" in result["error"]
     assert ad.read_h5ad(path).uns["cellannotation_schema_version"] == "1.0.0"  # untouched

--- a/packages/hca-anndata-tools/tests/test_strip_cap.py
+++ b/packages/hca-anndata-tools/tests/test_strip_cap.py
@@ -193,14 +193,17 @@ def test_strip_refuses_index_or_ghost_in_column_order(tmp_path):
 
 
 def test_strip_alias_output_does_not_unlink_source(tmp_path, monkeypatch):
-    """An output path that aliases the source through a hard link must be
-    refused by the identity-aware guard — never copied over or unlinked."""
+    """An output path that aliases the source through a hard link must never
+    be copied over or unlinked. The O_CREAT|O_EXCL claim subsumes the
+    samefile check this used to make by hand: the name is occupied, so it is
+    not ours to write, whatever it points at (#597)."""
     import os
 
     path = _make_cap_file(tmp_path / "aliased.h5ad", uns_layout="legacy")
     alias = tmp_path / "alias-of-source.h5ad"
     os.link(path, alias)
-    monkeypatch.setattr("hca_anndata_tools.strip_cap.generate_output_path", lambda p: str(alias))
+    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: str(alias))
+    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", lambda s: None)
 
     result = strip_cap_annotations(path)
 
@@ -395,12 +398,32 @@ def test_strip_refuses_cellxgene_layout(sample_h5ad):
     assert "CellxGENE" in result["error"]
 
 
+def test_strip_same_second_collision_resolves_after_waiting(tmp_path, monkeypatch):
+    """The common case since #597: waited out, not refused."""
+    path = _make_cap_file(tmp_path / "guard.h5ad", uns_layout="legacy")
+    fresh = str(tmp_path / "guard-edit-2026-08-24-00-00-01.h5ad")
+    names = iter([str(path), fresh])
+    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: next(names))
+    slept = []
+    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", slept.append)
+
+    result = strip_cap_annotations(path)
+
+    assert slept == [1]
+    assert "error" not in result
+    assert result["output_path"] == fresh
+
+
 def test_strip_same_second_snapshot_refused(tmp_path, monkeypatch):
-    monkeypatch.setattr("hca_anndata_tools.strip_cap.generate_output_path", lambda p: p)
+    """A collision surviving the wait is refused, source untouched."""
+    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: p)
+    slept = []
+    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", slept.append)
     path = _make_cap_file(tmp_path / "guard.h5ad", uns_layout="legacy")
 
     result = strip_cap_annotations(path)
 
+    assert slept == [1], "the boundary wait is attempted once before refusing"
     assert "error" in result
     assert "already exists" in result["error"]
     assert ad.read_h5ad(path).uns["cellannotation_schema_version"] == "1.0.0"  # untouched

--- a/packages/hca-anndata-tools/tests/test_write.py
+++ b/packages/hca-anndata-tools/tests/test_write.py
@@ -1,5 +1,6 @@
 """Tests for write_h5ad, strip_timestamp, and generate_output_path."""
 
+import contextlib
 import hashlib
 import json
 import os
@@ -14,10 +15,12 @@ from hca_anndata_tools.write import (
     EDIT_LOG_KEY,
     MissingLineageRootError,
     SameSecondSnapshotError,
+    _compute_sha256,
     _copy_with_sha256,
     generate_output_path,
     resolve_latest,
     snapshot_copy,
+    snapshot_copy_hashed,
     strip_timestamp,
     write_h5ad,
 )
@@ -615,3 +618,86 @@ def test_generate_output_path_refuses_a_rootless_snapshot(tmp_path):
 
     with pytest.raises(MissingLineageRootError, match="data.h5ad"):
         generate_output_path(str(source))
+
+
+# --- snapshot_copy_hashed ----------------------------------------------------
+#
+# The hashed variant is a separate code path — _copy_with_sha256 rather than
+# shutil.copy2 — and it is the one all five converted tools use (#597). The
+# properties below are the ones their tool-level tests delegate here rather
+# than re-asserting five times over.
+
+
+def test_snapshot_copy_hashed_yields_the_source_digest(tmp_path):
+    source = tmp_path / "data.h5ad"
+    source.write_bytes(b"payload")
+
+    with snapshot_copy_hashed(str(source)) as (output_path, sha256):
+        assert Path(output_path).read_bytes() == b"payload"
+        assert sha256 == _compute_sha256(str(source))
+
+
+def test_snapshot_copy_hashed_waits_out_a_collision(tmp_path, monkeypatch):
+    """A name taken this second is waited out and regenerated, not refused."""
+    source = tmp_path / "data.h5ad"
+    source.write_bytes(b"x")
+    taken = tmp_path / "data-edit-2026-08-24-00-00-01.h5ad"
+    taken.write_bytes(b"someone else")
+    fresh = tmp_path / "data-edit-2026-08-24-00-00-02.h5ad"
+    names = iter([str(taken), str(fresh)])
+    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: next(names))
+    slept = []
+    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", slept.append)
+
+    with snapshot_copy_hashed(str(source)) as (output_path, _):
+        assert output_path == str(fresh)
+
+    assert slept == [1]
+    assert taken.read_bytes() == b"someone else", "the occupied name was never written over"
+
+
+def test_snapshot_copy_hashed_refuses_an_unresolvable_collision(tmp_path, monkeypatch):
+    source = tmp_path / "data.h5ad"
+    source.write_bytes(b"x")
+    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: str(source))
+    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", lambda s: None)
+
+    with pytest.raises(SameSecondSnapshotError):
+        with snapshot_copy_hashed(str(source)) as _:
+            pytest.fail("the body must not run")
+
+    assert source.read_bytes() == b"x", "the source was neither written nor unlinked"
+
+
+def test_snapshot_copy_hashed_removes_the_snapshot_when_the_body_fails(tmp_path):
+    """What retired the deferred-unlink dance in all five tools: the snapshot
+    is removed on any exception raised inside the body."""
+    source = tmp_path / "data.h5ad"
+    source.write_bytes(b"x")
+
+    claimed = None
+    with contextlib.suppress(RuntimeError):
+        with snapshot_copy_hashed(str(source)) as (output_path, _):
+            claimed = output_path
+            raise RuntimeError("boom")
+
+    assert claimed is not None
+    assert not Path(claimed).exists()
+    assert source.is_file()
+
+
+def test_snapshot_copy_hashed_never_removes_a_file_it_did_not_create(tmp_path, monkeypatch):
+    """The property the converted tools' bespoke samefile guards used to make
+    by hand: only a claimed path is ever unlinked."""
+    source = tmp_path / "data.h5ad"
+    source.write_bytes(b"x")
+    bystander = tmp_path / "data-edit-2026-08-24-00-00-01.h5ad"
+    bystander.write_bytes(b"not mine")
+    monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: str(bystander))
+    monkeypatch.setattr("hca_anndata_tools.write.time.sleep", lambda s: None)
+
+    with pytest.raises(SameSecondSnapshotError):
+        with snapshot_copy_hashed(str(source)) as _:
+            pass
+
+    assert bystander.read_bytes() == b"not mine"

--- a/packages/hca-anndata-tools/tests/test_write.py
+++ b/packages/hca-anndata-tools/tests/test_write.py
@@ -662,9 +662,8 @@ def test_snapshot_copy_hashed_refuses_an_unresolvable_collision(tmp_path, monkey
     monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: str(source))
     monkeypatch.setattr("hca_anndata_tools.write.time.sleep", lambda s: None)
 
-    with pytest.raises(SameSecondSnapshotError):
-        with snapshot_copy_hashed(str(source)) as _:
-            pytest.fail("the body must not run")
+    with pytest.raises(SameSecondSnapshotError), snapshot_copy_hashed(str(source)):
+        pytest.fail("the body must not run")
 
     assert source.read_bytes() == b"x", "the source was neither written nor unlinked"
 
@@ -676,10 +675,9 @@ def test_snapshot_copy_hashed_removes_the_snapshot_when_the_body_fails(tmp_path)
     source.write_bytes(b"x")
 
     claimed = None
-    with contextlib.suppress(RuntimeError):
-        with snapshot_copy_hashed(str(source)) as (output_path, _):
-            claimed = output_path
-            raise RuntimeError("boom")
+    with contextlib.suppress(RuntimeError), snapshot_copy_hashed(str(source)) as (output_path, _):
+        claimed = output_path
+        raise RuntimeError("boom")
 
     assert claimed is not None
     assert not Path(claimed).exists()
@@ -696,8 +694,7 @@ def test_snapshot_copy_hashed_never_removes_a_file_it_did_not_create(tmp_path, m
     monkeypatch.setattr("hca_anndata_tools.write.generate_output_path", lambda p: str(bystander))
     monkeypatch.setattr("hca_anndata_tools.write.time.sleep", lambda s: None)
 
-    with pytest.raises(SameSecondSnapshotError):
-        with snapshot_copy_hashed(str(source)) as _:
-            pass
+    with pytest.raises(SameSecondSnapshotError), snapshot_copy_hashed(str(source)):
+        pass
 
     assert bystander.read_bytes() == b"not mine"


### PR DESCRIPTION
## What changed

**Item 1 — the five hand-rolled snapshot sequences are gone.** `rename`, `replace_placeholder_values`, `strip_cap`, `backfill` and `copy_cap` now go through `write.snapshot_copy_hashed`. Nothing outside `write.py` calls `generate_output_path` except the package's public re-export. Each tool's deferred-unlink dance, log-error sentinel and `except`-branch unlink went with it — raising inside the context is what removes the snapshot now.

They could not adopt the shared helper before because of a return-shape gap: each needs the source SHA-256 for the edit log, and the context manager yielded only a path. #627 closed that with `snapshot_copy_hashed`.

**Item 3 — the CellxGENE predicate is public.** `cap.cellxgene_schema_version` replaces `inspect._read_schema_version`; nothing imports the private any more.

**Item 4 found a real defect, not just drift.** `replace_string_dataset` preserved six HDF5 storage properties; `replace_categorical_column` preserved three — so every categorical rewrite silently dropped a source file's `shuffle` and `fletcher32` filters. `_io.storage_like(ds)` is now the one definition and both use it.

## Why

Correctness-critical h5py plumbing was hand-rolled across six modules, kept in sync by "see drop.py" comments, and had already diverged. This is the last of #597's five items; items 2 and 5 landed earlier (#622/#623/#624 and #609).

## Assumptions I made

**This is a behaviour change, deliberately — all three differences favour the shared version:**

1. **Retry instead of refuse.** A name taken this second is waited out and regenerated, rather than returning an error the caller must notice and re-issue. Settled on the issue: this is wanted everywhere, and is why `drop` and `strip` were changed in #616.
2. **A stricter collision check.** The hand-rolled `output_path == path` fired only when the generated name equalled its own source; the `O_CREAT|O_EXCL` claim catches any occupant.
3. **A silent-overwrite hole closes.** Previously, if the output name was held by anything other than the source, the check passed and `shutil.copy2` overwrote that file without a word. Claiming the name *is* the check, so there is no window.

Other calls:

- **`convert.py` is deliberately not converted**, despite appearing in the issue's original list of six: it builds its output path from a caller-supplied directory and a derived filename, so it is not a timestamped snapshot in the edit chain.
- **`copy_cap`'s pre-strip boundary wait is deleted.** It existed because `strip_cap` refused same-second collisions; `strip_cap` retries internally now. `is_target_alias` and the `time` import went with it.
- **`parse_edit_log` is split out of `build_edit_log`** so the three tools holding the raw log before the copy (`edit`, `backfill`, `copy_cap`) can still refuse a corrupt log *before* copying a multi-GB file. Moving the log build inside the snapshot had cost them that. `rename` and `strip_cap` read theirs from the output copy and never had the property.
- **The `SameFileError` branch now unlinks the claimed file** in both variants. The original comment's "the file is not ours" rationale stopped being true once `_claim_snapshot_path` creates it with `O_EXCL`; leaving it would strand a zero-byte file carrying the newest `-edit-` timestamp, which `resolve_latest` hands to every later call. That was wrong in the pre-existing code too.

## How to verify

1. `cd packages/hca-anndata-tools && uv run pytest tests/ -v` — 565 tests.
2. **The definition of done, as greps:**
   - `grep -rn 'generate_output_path' src/ | grep -v write.py` → only `__init__.py`'s re-export
   - `grep -rn '_read_schema_version' src/ tests/` → nothing
3. **Per-tool collision behaviour** is pinned by a pair per tool — the collision that resolves after waiting, and the one that survives the wait and is refused — all via the new `pin_snapshot_names` conftest fixture.
4. **The shared helper's own properties** are covered directly in `test_write.py` (`snapshot_copy_hashed`: yielded digest, collision wait, unresolvable refusal, body-failure cleanup, never removing a file it did not create). Mutation-verified: removing the retry fails two, breaking the cleanup fails one.
5. **Exercised on real tracker files:**
   - The logged `source_sha256` matches an independently computed hash of the source on both `replace_placeholder_values` (gray2022, 1.5 GB) and `strip_cap_annotations` (gut myeloid, 423 MB) — the digest now comes from the copy stream, so a wrong value would silently corrupt provenance.
   - Eight chained drops on a real object: **five hit genuine same-second collisions, waited, and resolved**; every edit succeeded, where five would previously have errored. The lineage stayed at root + one snapshot throughout, with zero stray zero-byte `-edit-` files.
6. `make typecheck` from repo root — 0 errors.

Closes #597

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017S1imq17nD5Y3qaovNmBuX
