### PR TITLE
feat(hca-anndata-tools): add set_producer_uns for nested, producer-owned uns fields

### DIFF
--- a/packages/hca-anndata-mcp/src/hca_anndata_mcp/server.py
+++ b/packages/hca-anndata-mcp/src/hca_anndata_mcp/server.py
@@ -8,6 +8,7 @@ from hca_anndata_mcp.tools.label import label_h5ad
 from hca_anndata_mcp.tools.merge_categories import merge_obs_categories
 from hca_anndata_mcp.tools.plot import plot_embedding_mcp
 from hca_anndata_mcp.tools.populate import populate_labels
+from hca_anndata_mcp.tools.producer_uns import set_producer_uns
 from hca_anndata_mcp.tools.rename import rename_cell_ids
 from hca_anndata_mcp.tools.rename_column import rename_obs_column
 from hca_anndata_mcp.tools.strip import strip_forbidden_obs_columns
@@ -44,6 +45,16 @@ mcp = FastMCP(
         "get_cap_annotations to inspect CAP cell annotation metadata, "
         "list_uns_fields to see HCA dataset metadata and what's missing, "
         "set_uns to update HCA dataset metadata fields with schema validation, "
+        "set_producer_uns to correct a producer-owned uns field that set_uns cannot "
+        "reach — a nested, non-schema namespace such as uns['ihbca_provenance'] — "
+        "addressed by path segments (['ihbca_provenance', 'git_dirty']) rather than a "
+        "slash-joined string; it overwrites existing scalars only (never creates a key, so "
+        "a misspelled segment is an error rather than junk metadata), and refuses a value "
+        "whose type differs from the stored dtype — writing False into a string field would "
+        "store 'false' and no validator would object, because the namespace has no schema; "
+        "it writes the whole batch in one snapshot with one edit-log entry, reads every "
+        "field back (value and dtype) before accepting the result, and refuses HCA schema "
+        "fields (use set_uns) and our own uns['provenance'] namespace, "
         "convert_cellxgene_to_hca to convert CellxGENE files to HCA format, "
         "strip_forbidden_obs_columns to remove HCA-forbidden obs columns "
         "(self_reported_ethnicity*) from HCA-layout files — use this when "
@@ -144,6 +155,7 @@ mcp.tool()(plot_embedding_mcp)
 mcp.tool()(get_cap_annotations)
 mcp.tool()(list_uns_fields)
 mcp.tool()(set_uns)
+mcp.tool()(set_producer_uns)
 mcp.tool()(convert_cellxgene_to_hca)
 mcp.tool()(strip_forbidden_obs_columns)
 mcp.tool()(drop_obs_columns)

--- a/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/producer_uns.py
+++ b/packages/hca-anndata-mcp/src/hca_anndata_mcp/tools/producer_uns.py
@@ -1,0 +1,11 @@
+"""MCP wrapper for hca_anndata_tools.set_producer_uns.
+
+Thin re-export to keep parity with the other MCP tools (each gets its
+own wrapper file). The underlying function already returns a dict-shaped
+result; this module exists so future wrapper-only behavior lands here
+without touching the tools layer.
+"""
+
+from hca_anndata_tools import set_producer_uns
+
+__all__ = ["set_producer_uns"]

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/__init__.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/__init__.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     from .merge_categories import merge_obs_categories
     from .normalize import normalize_raw
     from .plot import plot_embedding
+    from .producer_uns import set_producer_uns
     from .rename import rename_cell_ids
     from .rename_column import rename_obs_column
     from .stats import get_descriptive_stats
@@ -69,6 +70,7 @@ _LAZY_IMPORTS = {
     "strip_cap_annotations": ".strip_cap",
     "drop_obs_columns": ".drop",
     "merge_obs_categories": ".merge_categories",
+    "set_producer_uns": ".producer_uns",
     "rename_obs_column": ".rename_column",
     "rename_cell_ids": ".rename",
     "backfill_obs_from_source": ".backfill",

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/producer_uns.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/producer_uns.py
@@ -34,7 +34,7 @@ from typing import Any
 import h5py
 import numpy as np
 
-from ._io import read_edit_log_h5py, read_uns, write_edit_log_h5py
+from ._io import read_edit_log_h5py, read_group, read_uns, write_edit_log_h5py
 from ._serialize import make_serializable
 from .guards import is_malformed_name
 from .schema.helpers import uns_field_registry
@@ -160,6 +160,27 @@ def _namespace_problem(field: tuple[str, ...]) -> str | None:
     # one that checks less.
     if root in uns_field_registry():
         return f"'{root}' is an HCA schema uns field — use set_uns, which validates it against the schema"
+    return None
+
+
+def _edit_log_target_problem(f: h5py.File) -> str | None:
+    """Refuse now if the edit log could not be written later.
+
+    Every write ends by stamping ``uns/provenance/edit_history``, and
+    ``ensure_provenance_group`` needs ``uns['provenance']`` to be a group or
+    absent. A producer who used that unnamespaced key for something else (#576)
+    would otherwise get a raw h5py "Incompatible object (Dataset) already
+    exists" *after* the copy — the same late refusal the ``parse_edit_log``
+    check exists to avoid, so it belongs in the same read-only pass.
+    """
+    uns = read_uns(f)
+    if uns is None:
+        return None
+    if _RESERVED_ROOT in uns and read_group(uns, _RESERVED_ROOT) is None:
+        return (
+            f"uns[{_RESERVED_ROOT!r}] is a value, not a group — the edit log is written inside it, so this "
+            f"file cannot record the write"
+        )
     return None
 
 
@@ -440,6 +461,8 @@ def set_producer_uns(path: str, updates: list[dict]) -> dict:
         if not problems:
             with h5py.File(path, "r") as f_in:
                 plans, problems = _plan(f_in, parsed)
+                if problem := _edit_log_target_problem(f_in):
+                    problems.append(problem)
                 # Read here, not from the snapshot: a corrupt log is a refusal,
                 # and refusing it now costs a metadata read rather than a full
                 # copy of a file that can run to tens of gigabytes (#597).

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/producer_uns.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/producer_uns.py
@@ -1,0 +1,431 @@
+"""Write scalar values into producer-owned, nested ``uns`` namespaces.
+
+The remedy for a correction a producer asks us to apply to their own metadata:
+``clevercanary/hca-ingest-coordination#23`` corrects three fields inside
+``uns['ihbca_provenance']`` on seven breast-v1 source datasets, and nothing in
+the toolkit could reach them. The alternative was a hand-written h5py snippet
+run once against files up to 27 GB — untested, and outside the HCA schema, so
+``validate_schema`` has no opinion on whether it wrote the right thing.
+
+Deliberately not an extension of :func:`~hca_anndata_tools.edit.set_uns`.
+That tool addresses a flat top-level key, so a nested path is inexpressible in
+its signature under any flag; it also validates against the HCA schema
+registry, materializes the whole file, and writes one field per call. Only the
+registry gate is about schema — the rest are why this is a separate entry
+point (#629). Where scope is only "write a non-schema top-level key", a flag on
+``set_uns`` would have been the right answer.
+
+The guards here are **coherence** guards, not validity guards, which is what
+keeps this on the right side of #614. That principle defers validity to
+``validate_schema`` — but it presumes a validator with an opinion, and for a
+producer-owned namespace there is none: an extra or wrongly-typed uns key is
+not a schema violation, so nothing downstream would catch it. Refusing a path
+that does not exist, and a value that would change the stored dtype, is what
+replaces that missing backstop.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import h5py
+import numpy as np
+
+from ._io import read_edit_log_h5py, read_uns, write_edit_log_h5py
+from ._serialize import make_serializable
+from .guards import is_malformed_name
+from .schema.helpers import uns_field_registry
+from .write import (
+    build_edit_log,
+    cleanup_previous_version,
+    make_edit_entry,
+    resolve_latest,
+    snapshot_copy_hashed,
+)
+
+# Our own audit trail lives at uns/provenance/edit_history. A tool that could
+# write arbitrary scalars in there could rewrite the record every other tool's
+# guarantees rest on, so the whole namespace is off limits — including for a
+# producer who put their own keys there (#576). Costs the motivating case
+# nothing: its namespace is 'ihbca_provenance', a different key.
+_RESERVED_ROOT = "provenance"
+
+
+@dataclass(frozen=True)
+class _PlannedWrite:
+    """One validated field write, carried from validation to the write phase.
+
+    Validation reads the source read-only and the write happens on a snapshot,
+    so no h5py object survives between the two — the path segments and the
+    already-coerced value do.
+    """
+
+    field: tuple[str, ...]
+    value: Any  # what gets assigned
+    expected: Any  # what the read-back must see, JSON-shaped
+    old_value: Any
+    dtype: np.dtype
+
+
+def _display(field: tuple[str, ...] | list[str]) -> str:
+    """A field path as the caller would subscript it: ``uns['a']['b']``."""
+    return "uns" + "".join(f"[{segment!r}]" for segment in field)
+
+
+def _parse_updates(updates: Any) -> tuple[list[tuple[str, ...]], list[Any], list[str]]:
+    """Normalize the caller's ``updates`` into field paths and values.
+
+    MCP-exposed, so this arrives as decoded JSON and may hold anything.
+    Structural problems are collected rather than raised so a caller who got
+    two entries wrong learns both in one round trip.
+
+    Returns:
+        ``(fields, values, problems)``. Only well-formed entries appear in
+        ``fields``/``values``; positions do not correspond to the input.
+    """
+    problems: list[str] = []
+    if not isinstance(updates, list):
+        return (
+            [],
+            [],
+            [f"updates must be a list of {{'field': [...], 'value': ...}} entries, got {type(updates).__name__}"],
+        )
+    if not updates:
+        return [], [], ["updates must not be empty — every write should change something"]
+
+    fields: list[tuple[str, ...]] = []
+    values: list[Any] = []
+    for i, entry in enumerate(updates):
+        if not isinstance(entry, dict):
+            problems.append(f"updates[{i}] must be an object with 'field' and 'value', got {type(entry).__name__}")
+            continue
+        if missing := {"field", "value"} - entry.keys():
+            problems.append(f"updates[{i}] is missing {sorted(missing)}")
+            continue
+        field = entry["field"]
+        # A slash-joined string is the likely mistake — it is how the path
+        # reads in prose, and it is what a flat-key tool would take. Say so
+        # rather than reporting a type error, because the fix is not obvious.
+        if isinstance(field, str):
+            problems.append(
+                f"updates[{i}]['field'] must be a list of path segments, not the string {field!r} — "
+                f"pass {[s for s in field.split('/') if s] or [field]} instead"
+            )
+            continue
+        if not isinstance(field, list) or not field:
+            problems.append(f"updates[{i}]['field'] must be a non-empty list of path segments")
+            continue
+        if bad := [s for s in field if not isinstance(s, str)]:
+            problems.append(f"updates[{i}]['field'] segments must be strings; got {bad}")
+            continue
+        # Same predicate the obs guards use, different message: a segment
+        # containing '/' would be resolved by h5py as a further link path, so
+        # the check that runs and the walk that follows would disagree about
+        # what was addressed.
+        if malformed := [s for s in field if is_malformed_name(s)]:
+            problems.append(
+                f"updates[{i}]['field'] has segments that cannot name a uns key "
+                f"(a segment cannot contain '/' or be blank): {malformed}"
+            )
+            continue
+        fields.append(tuple(field))
+        values.append(entry["value"])
+
+    seen: set[tuple[str, ...]] = set()
+    for field in fields:
+        if field in seen:
+            problems.append(f"{_display(field)} appears more than once in updates — the intended value is ambiguous")
+        seen.add(field)
+
+    return fields, values, problems
+
+
+def _namespace_problem(field: tuple[str, ...]) -> str | None:
+    """Refuse a path this tool does not own: our provenance, or an HCA field."""
+    root = field[0]
+    if root == _RESERVED_ROOT:
+        return (
+            f"{_display(field)} is inside our own provenance namespace, which carries the edit log — "
+            f"this tool will not write there"
+        )
+    # Routing, not a validity judgment: set_uns exists, validates the value
+    # against the schema, and cross-checks fields like batch_condition and
+    # default_embedding against the rest of the file. Two doors to the same
+    # field would let a caller pick the one that checks less.
+    if root in uns_field_registry():
+        return f"'{root}' is an HCA schema uns field — use set_uns, which validates it against the schema"
+    return None
+
+
+def _resolve(f: h5py.File, field: tuple[str, ...]) -> tuple[h5py.Dataset | None, str | None]:
+    """The scalar dataset ``field`` names, or the reason it cannot be reached.
+
+    Overwrite-only: every segment must already exist. Every target of a
+    producer's correction does, so nothing is lost — and it means a misspelled
+    segment is an error rather than a silently created key, which is the
+    typo protection the schema registry gives ``set_uns`` and this tool,
+    by definition, cannot have.
+    """
+    node: h5py.Group | None = read_uns(f)
+    if node is None:
+        return None, f"the file has no uns group, so {_display(field)} cannot be reached"
+
+    for depth, segment in enumerate(field[:-1]):
+        child = node.get(segment)
+        if child is None:
+            return None, f"{_display(field[: depth + 1])} does not exist (reaching {_display(field)})"
+        if not isinstance(child, h5py.Group):
+            return None, f"{_display(field[: depth + 1])} is a value, not a group, so {_display(field)} has no parent"
+        node = child
+
+    leaf = node.get(field[-1])
+    if leaf is None:
+        return None, f"{_display(field)} does not exist — this tool overwrites existing fields, it does not create them"
+    if isinstance(leaf, h5py.Group):
+        return None, f"{_display(field)} is a group, not a value"
+    if not isinstance(leaf, h5py.Dataset):
+        return None, f"{_display(field)} is neither a group nor a value ({type(leaf).__name__})"
+    if leaf.shape != ():
+        return None, (
+            f"{_display(field)} holds an array of shape {leaf.shape}, not a scalar — "
+            f"this tool writes scalar values only"
+        )
+    return leaf, None
+
+
+def _coerce(ds: h5py.Dataset, value: Any, disp: str) -> tuple[Any, Any, str | None]:
+    """The value to assign and to expect on read-back, or why the type is wrong.
+
+    The stored dtype is the contract. Writing ``False`` into a string field
+    would store ``'false'`` and pass every downstream check, because a
+    producer-owned field has no schema to violate — that silent mis-write is
+    the whole reason this tool exists.
+    """
+    dtype = ds.dtype
+    string_info = h5py.check_string_dtype(dtype)
+    if string_info is not None:
+        if not isinstance(value, str):
+            return None, None, f"{disp} holds a string; got {type(value).__name__}"
+        if string_info.length is not None:
+            # Fixed-length strings truncate on assignment with no error at all:
+            # a 19-byte value into an |S3 stores three bytes and returns
+            # success. Verified, not theorized.
+            encoded = value.encode(string_info.encoding or "utf-8")
+            if len(encoded) > string_info.length:
+                return (
+                    None,
+                    None,
+                    (
+                        f"{disp} is a fixed-length string of {string_info.length} bytes and {value!r} needs "
+                        f"{len(encoded)} — HDF5 would truncate it silently"
+                    ),
+                )
+        return value, value, None
+
+    kind = dtype.kind
+    # bool before int, always: isinstance(True, int) is True in Python, so an
+    # int branch reached first would accept True and store it as 1.
+    if kind == "b":
+        if not isinstance(value, bool):
+            return None, None, f"{disp} holds a boolean; got {type(value).__name__}"
+        return value, value, None
+    if kind in "iu":
+        if isinstance(value, bool) or not isinstance(value, int):
+            return None, None, f"{disp} holds an integer; got {type(value).__name__}"
+        # Range, not just type: an out-of-bounds int either raises here or
+        # wraps silently depending on the numpy version, and a wrapped value
+        # is a wrong value that nothing downstream would question.
+        try:
+            coerced = np.asarray(value, dtype=dtype)
+        except (OverflowError, ValueError, TypeError) as e:
+            return None, None, f"{disp} has dtype {dtype} and cannot hold {value!r}: {e}"
+        stored = make_serializable(coerced[()])
+        if stored != value:
+            return None, None, f"{disp} has dtype {dtype}, which would store {value!r} as {stored!r}"
+        return value, stored, None
+    if kind == "f":
+        if isinstance(value, bool) or not isinstance(value, int | float):
+            return None, None, f"{disp} holds a float; got {type(value).__name__}"
+        # Int accepted as a widening: JSON has one number type, so a whole
+        # float arrives as an int. Precision loss on a narrow float dtype is
+        # allowed rather than refused — every float32 field would otherwise
+        # reject most decimals — so the read-back expects the coerced value.
+        try:
+            coerced = np.asarray(value, dtype=dtype)
+        except (OverflowError, ValueError, TypeError) as e:
+            return None, None, f"{disp} has dtype {dtype} and cannot hold {value!r}: {e}"
+        return value, make_serializable(coerced[()]), None
+
+    return (
+        None,
+        None,
+        (
+            f"{disp} has dtype {dtype}, which this tool cannot write — it writes string, boolean, "
+            f"integer and float scalars"
+        ),
+    )
+
+
+def _plan(f: h5py.File, fields: list[tuple[str, ...]], values: list[Any]) -> tuple[list[_PlannedWrite], list[str]]:
+    """Validate every requested write against the source file.
+
+    Runs to completion rather than short-circuiting: a caller who named one
+    missing path and mistyped another value should learn both at once.
+    """
+    plans: list[_PlannedWrite] = []
+    problems: list[str] = []
+    for field, value in zip(fields, values, strict=True):
+        if problem := _namespace_problem(field):
+            problems.append(problem)
+            continue
+        ds, problem = _resolve(f, field)
+        if ds is None:
+            problems.append(problem or f"{_display(field)} could not be resolved")
+            continue
+        assign, expected, problem = _coerce(ds, value, _display(field))
+        if problem:
+            problems.append(problem)
+            continue
+        plans.append(
+            _PlannedWrite(
+                field=field,
+                value=assign,
+                expected=expected,
+                old_value=make_serializable(ds[()]),
+                dtype=ds.dtype,
+            )
+        )
+    return plans, problems
+
+
+def set_producer_uns(path: str, updates: list[dict]) -> dict:
+    """Overwrite scalar values at nested ``uns`` paths outside the HCA schema.
+
+    All-or-nothing: every requested write is validated against the file before
+    anything is copied, and the file is left untouched if any check fails.
+    The whole batch then lands in one snapshot with one edit-log entry, which
+    matters when the alternative is one full rewrite per field on a file of
+    tens of gigabytes.
+
+    Addresses by path segments (``["ihbca_provenance", "git_dirty"]``) rather
+    than a slash-joined string, because ``/`` is how h5py spells a link path:
+    a string form would make the checks and the walk capable of disagreeing
+    about what was addressed.
+
+    Values are assigned in place, which is what preserves the stored dtype and
+    the ``encoding-type`` attrs anndata reads. Each write is read back and
+    compared — value and dtype — before the snapshot is accepted, so a write
+    that did not land the way it was asked for never becomes the latest
+    version.
+
+    Refuses a path that does not exist (it overwrites, it never creates), a
+    value whose type does not match the stored dtype, a non-scalar or
+    group-valued target, a segment containing ``/``, our own ``provenance``
+    namespace, and any HCA schema field — those belong to ``set_uns``, which
+    validates them. Whether the *result* is valid is ``validate_schema``'s
+    verdict, not this tool's (#614) — though note that for a producer-owned
+    namespace it will not have one, which is why the guards above are stricter
+    than a schema-backed tool's would need to be.
+
+    Args:
+        path: Path to an .h5ad file. Auto-resolves to the latest timestamped
+            edit snapshot before operating.
+        updates: Entries of ``{"field": [segment, ...], "value": scalar}``.
+            Each field must already exist and hold a scalar string, boolean,
+            integer or float.
+
+    Returns:
+        Dict with ``output_path``, ``fields_written`` and ``updates`` (each
+        with ``field``, ``old_value``, ``new_value`` and ``dtype``), or
+        ``{"error": ...}``.
+    """
+    try:
+        # MCP-exposed, so the arguments arrive as decoded JSON; checked before
+        # resolve_latest, which does path arithmetic on it.
+        if not isinstance(path, str):
+            return {"error": f"path must be a string, got {type(path).__name__}"}
+        path = resolve_latest(path)
+        if not Path(path).is_file():
+            return {"error": f"File not found: {path}"}
+
+        fields, values, problems = _parse_updates(updates)
+
+        plans: list[_PlannedWrite] = []
+        if not problems:
+            with h5py.File(path, "r") as f_in:
+                plans, problems = _plan(f_in, fields, values)
+        if problems:
+            return {"error": "Refusing to write: " + "; ".join(problems)}
+
+        with (
+            snapshot_copy_hashed(path) as (output_path, source_sha256),
+            h5py.File(output_path, "a") as f_out,
+        ):
+            for plan in plans:
+                # Re-resolved in the snapshot rather than trusting the source
+                # walk: the copy is byte-identical, so a failure here means the
+                # copy is not what we validated, and shipping it would be worse
+                # than raising.
+                ds, problem = _resolve(f_out, plan.field)
+                if ds is None:
+                    raise RuntimeError(f"snapshot does not match the validated source: {problem}")
+                ds[()] = plan.value
+
+            entry = make_edit_entry(
+                operation="set_producer_uns",
+                description=(
+                    f"Set {len(plans)} producer uns field(s): "
+                    + ", ".join(f"{_display(p.field)} {p.old_value!r} -> {p.expected!r}" for p in plans)
+                ),
+                details={
+                    "fields": [
+                        {
+                            "field": list(p.field),
+                            "old_value": p.old_value,
+                            "new_value": p.expected,
+                            "dtype": str(p.dtype),
+                        }
+                        for p in plans
+                    ]
+                },
+            )
+            log_result = build_edit_log(read_edit_log_h5py(f_out), [entry], path, source_sha256)
+            if "error" in log_result:
+                raise RuntimeError(log_result["error"])
+            write_edit_log_h5py(f_out, log_result["json"])
+
+            # Read back before the snapshot is accepted. Value *and* dtype:
+            # checking the value alone is what lets a bool-written-as-a-string
+            # through, and this namespace has no validator behind it.
+            for plan in plans:
+                ds, problem = _resolve(f_out, plan.field)
+                if ds is None:
+                    raise RuntimeError(f"{_display(plan.field)} vanished during the write: {problem}")
+                stored = make_serializable(ds[()])
+                if stored != plan.expected:
+                    raise RuntimeError(f"{_display(plan.field)} read back as {stored!r}, expected {plan.expected!r}")
+                if ds.dtype != plan.dtype:
+                    raise RuntimeError(
+                        f"{_display(plan.field)} changed dtype from {plan.dtype} to {ds.dtype} during the write"
+                    )
+
+        cleanup_previous_version(path, output_path)
+
+        return {
+            "output_path": output_path,
+            "fields_written": len(plans),
+            "updates": [
+                {
+                    "field": list(p.field),
+                    "old_value": p.old_value,
+                    "new_value": p.expected,
+                    "dtype": str(p.dtype),
+                }
+                for p in plans
+            ],
+        }
+
+    except Exception as e:
+        return {"error": str(e)}

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/producer_uns.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/producer_uns.py
@@ -26,6 +26,7 @@ replaces that missing backstop.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -41,6 +42,7 @@ from .write import (
     build_edit_log,
     cleanup_previous_version,
     make_edit_entry,
+    parse_edit_log,
     resolve_latest,
     snapshot_copy_hashed,
 )
@@ -60,43 +62,41 @@ class _PlannedWrite:
     Validation reads the source read-only and the write happens on a snapshot,
     so no h5py object survives between the two — the path segments and the
     already-coerced value do.
+
+    ``expected`` is both what gets assigned and what the read-back must see:
+    every value is coerced through the target dtype during validation, so
+    assigning it is what makes the two agree by construction.
     """
 
     field: tuple[str, ...]
-    value: Any  # what gets assigned
-    expected: Any  # what the read-back must see, JSON-shaped
+    expected: Any  # assigned, and what the read-back must see; JSON-shaped
     old_value: Any
     dtype: np.dtype
 
 
-def _display(field: tuple[str, ...] | list[str]) -> str:
+def _display(field: tuple[str, ...]) -> str:
     """A field path as the caller would subscript it: ``uns['a']['b']``."""
     return "uns" + "".join(f"[{segment!r}]" for segment in field)
 
 
-def _parse_updates(updates: Any) -> tuple[list[tuple[str, ...]], list[Any], list[str]]:
-    """Normalize the caller's ``updates`` into field paths and values.
+def _parse_updates(updates: Any) -> tuple[list[tuple[tuple[str, ...], Any]], list[str]]:
+    """Normalize the caller's ``updates`` into ``(field, value)`` pairs.
 
     MCP-exposed, so this arrives as decoded JSON and may hold anything.
     Structural problems are collected rather than raised so a caller who got
     two entries wrong learns both in one round trip.
 
     Returns:
-        ``(fields, values, problems)``. Only well-formed entries appear in
-        ``fields``/``values``; positions do not correspond to the input.
+        ``(parsed, problems)``. Only well-formed entries appear in ``parsed``;
+        positions do not correspond to the input.
     """
     problems: list[str] = []
     if not isinstance(updates, list):
-        return (
-            [],
-            [],
-            [f"updates must be a list of {{'field': [...], 'value': ...}} entries, got {type(updates).__name__}"],
-        )
+        return [], [f"updates must be a list of {{'field': [...], 'value': ...}} entries, got {type(updates).__name__}"]
     if not updates:
-        return [], [], ["updates must not be empty — every write should change something"]
+        return [], ["updates must not be empty — every write should change something"]
 
-    fields: list[tuple[str, ...]] = []
-    values: list[Any] = []
+    parsed: list[tuple[tuple[str, ...], Any]] = []
     for i, entry in enumerate(updates):
         if not isinstance(entry, dict):
             problems.append(f"updates[{i}] must be an object with 'field' and 'value', got {type(entry).__name__}")
@@ -130,16 +130,15 @@ def _parse_updates(updates: Any) -> tuple[list[tuple[str, ...]], list[Any], list
                 f"(a segment cannot contain '/' or be blank): {malformed}"
             )
             continue
-        fields.append(tuple(field))
-        values.append(entry["value"])
+        parsed.append((tuple(field), entry["value"]))
 
     seen: set[tuple[str, ...]] = set()
-    for field in fields:
+    for field, _ in parsed:
         if field in seen:
             problems.append(f"{_display(field)} appears more than once in updates — the intended value is ambiguous")
         seen.add(field)
 
-    return fields, values, problems
+    return parsed, problems
 
 
 def _namespace_problem(field: tuple[str, ...]) -> str | None:
@@ -150,29 +149,68 @@ def _namespace_problem(field: tuple[str, ...]) -> str | None:
             f"{_display(field)} is inside our own provenance namespace, which carries the edit log — "
             f"this tool will not write there"
         )
-    # Routing, not a validity judgment: set_uns exists, validates the value
-    # against the schema, and cross-checks fields like batch_condition and
-    # default_embedding against the rest of the file. Two doors to the same
-    # field would let a caller pick the one that checks less.
+    # Coherence, not only routing — the distinction matters, because #621
+    # removed a guard defended on routing grounds alone. Two of the five
+    # registry fields hold *references into other groups*: set_uns checks
+    # batch_condition against obs.columns and default_embedding against
+    # obsm.keys(). Writing either raw through this tool could leave a
+    # batch_condition naming an obs column that does not exist — a dangling
+    # reference, which #614 puts squarely in the keep column. Routing is the
+    # secondary reason: two doors to one field would let a caller pick the
+    # one that checks less.
     if root in uns_field_registry():
         return f"'{root}' is an HCA schema uns field — use set_uns, which validates it against the schema"
     return None
 
 
-def _resolve(f: h5py.File, field: tuple[str, ...]) -> tuple[h5py.Dataset | None, str | None]:
+def _external_link_problem(node: h5py.Group, segment: str, field: tuple[str, ...], depth: int) -> str | None:
+    """Refuse a member that is an HDF5 external link into another file.
+
+    h5py resolves external links transparently — ``get`` returns the target,
+    and ``isinstance(..., h5py.Group)`` / ``h5py.Dataset`` are both True for
+    one — so nothing else in this walk can tell the difference. HDF5 also
+    propagates the parent's access flags to the target, so under the snapshot's
+    ``"a"`` mode the foreign file is opened read-write and ``ds[()] = value``
+    lands *there*.
+
+    Verified: with ``uns['ns']`` linked into another h5ad, the tool reported
+    success, the snapshot kept the link unchanged, and the other file was
+    modified. The read-back could not catch it — it re-resolves through the
+    same link and sees the value it just wrote into the foreign file. So the
+    refusal has to happen here, before the link is ever followed.
+    """
+    link = node.get(segment, getlink=True)
+    if isinstance(link, h5py.ExternalLink):
+        return (
+            f"{_display(field[: depth + 1])} is an external link into {link.filename!r} — writing through it "
+            f"would modify that file instead of this one, leaving no record in either"
+        )
+    return None
+
+
+def _resolve(f: h5py.File, field: tuple[str, ...]) -> tuple[h5py.Dataset | None, str]:
     """The scalar dataset ``field`` names, or the reason it cannot be reached.
+
+    The message is empty exactly when a dataset is returned, so a caller
+    that checks the dataset never has to invent a fallback string.
 
     Overwrite-only: every segment must already exist. Every target of a
     producer's correction does, so nothing is lost — and it means a misspelled
     segment is an error rather than a silently created key, which is the
     typo protection the schema registry gives ``set_uns`` and this tool,
     by definition, cannot have.
+
+    Every step is also checked for an external link, including the leaf: the
+    files this runs on come from third-party producers and from CAP, so the
+    structure being walked is not ours.
     """
     node: h5py.Group | None = read_uns(f)
     if node is None:
         return None, f"the file has no uns group, so {_display(field)} cannot be reached"
 
     for depth, segment in enumerate(field[:-1]):
+        if problem := _external_link_problem(node, segment, field, depth):
+            return None, problem
         child = node.get(segment)
         if child is None:
             return None, f"{_display(field[: depth + 1])} does not exist (reaching {_display(field)})"
@@ -180,6 +218,8 @@ def _resolve(f: h5py.File, field: tuple[str, ...]) -> tuple[h5py.Dataset | None,
             return None, f"{_display(field[: depth + 1])} is a value, not a group, so {_display(field)} has no parent"
         node = child
 
+    if problem := _external_link_problem(node, field[-1], field, len(field) - 1):
+        return None, problem
     leaf = node.get(field[-1])
     if leaf is None:
         return None, f"{_display(field)} does not exist — this tool overwrites existing fields, it does not create them"
@@ -192,11 +232,35 @@ def _resolve(f: h5py.File, field: tuple[str, ...]) -> tuple[h5py.Dataset | None,
             f"{_display(field)} holds an array of shape {leaf.shape}, not a scalar — "
             f"this tool writes scalar values only"
         )
-    return leaf, None
+    # Belt and braces over the per-segment check above: whatever mechanism got
+    # us here, the node we are about to write must live in the file we opened.
+    if leaf.file.filename != f.filename:
+        return None, (
+            f"{_display(field)} resolves into {leaf.file.filename!r}, not the file being edited — refusing to "
+            f"write outside it"
+        )
+    return leaf, ""
 
 
-def _coerce(ds: h5py.Dataset, value: Any, disp: str) -> tuple[Any, Any, str | None]:
-    """The value to assign and to expect on read-back, or why the type is wrong.
+def _as_dtype(value: Any, dtype: np.dtype, disp: str) -> tuple[Any, str | None]:
+    """``value`` put through ``dtype``, or why it does not fit.
+
+    Shared by the int and float branches, which differ in what they do with
+    the result — the int branch demands it round-trip exactly, the float
+    branch accepts the precision the dtype has.
+    """
+    try:
+        # The cast is the probe, so its overflow warning is expected output,
+        # not a problem to surface — the caller checks the result instead.
+        with np.errstate(over="ignore", invalid="ignore"):
+            coerced = np.asarray(value, dtype=dtype)
+    except (OverflowError, ValueError, TypeError) as e:
+        return None, f"{disp} has dtype {dtype} and cannot hold {value!r}: {e}"
+    return make_serializable(coerced[()]), None
+
+
+def _coerce(ds: h5py.Dataset, value: Any, disp: str) -> tuple[Any, str | None]:
+    """The value to assign and expect on read-back, or why the type is wrong.
 
     The stored dtype is the contract. Writing ``False`` into a string field
     would store ``'false'`` and pass every downstream check, because a
@@ -206,69 +270,74 @@ def _coerce(ds: h5py.Dataset, value: Any, disp: str) -> tuple[Any, Any, str | No
     dtype = ds.dtype
     string_info = h5py.check_string_dtype(dtype)
     if string_info is not None:
-        if not isinstance(value, str):
-            return None, None, f"{disp} holds a string; got {type(value).__name__}"
+        # Refused as a dtype, not case by case. anndata writes every string as
+        # variable-length; a fixed-length one means the field was written by
+        # something else, and supporting it would mean owning two hazards it
+        # brings with it — HDF5 truncates an over-long value on assignment with
+        # no error at all, and h5py reports these as ascii, so a non-ASCII
+        # value raises out of the type check instead of being refused by it.
+        # Scanned the eight real breast objects: 1,244 scalar uns datasets,
+        # 1,041 of them strings, and not one is fixed-length. Nothing to gain.
         if string_info.length is not None:
-            # Fixed-length strings truncate on assignment with no error at all:
-            # a 19-byte value into an |S3 stores three bytes and returns
-            # success. Verified, not theorized.
-            encoded = value.encode(string_info.encoding or "utf-8")
-            if len(encoded) > string_info.length:
-                return (
-                    None,
-                    None,
-                    (
-                        f"{disp} is a fixed-length string of {string_info.length} bytes and {value!r} needs "
-                        f"{len(encoded)} — HDF5 would truncate it silently"
-                    ),
-                )
-        return value, value, None
+            return None, (
+                f"{disp} is a fixed-length string ({dtype}) — anndata writes strings as variable-length, "
+                f"so this field was not written by anndata and HDF5 would truncate an over-long value "
+                f"into it without reporting anything"
+            )
+        if not isinstance(value, str):
+            return None, f"{disp} holds a string; got {type(value).__name__}"
+        return value, None
 
     kind = dtype.kind
     # bool before int, always: isinstance(True, int) is True in Python, so an
     # int branch reached first would accept True and store it as 1.
     if kind == "b":
         if not isinstance(value, bool):
-            return None, None, f"{disp} holds a boolean; got {type(value).__name__}"
-        return value, value, None
+            return None, f"{disp} holds a boolean; got {type(value).__name__}"
+        return value, None
     if kind in "iu":
         if isinstance(value, bool) or not isinstance(value, int):
-            return None, None, f"{disp} holds an integer; got {type(value).__name__}"
-        # Range, not just type: an out-of-bounds int either raises here or
-        # wraps silently depending on the numpy version, and a wrapped value
-        # is a wrong value that nothing downstream would question.
-        try:
-            coerced = np.asarray(value, dtype=dtype)
-        except (OverflowError, ValueError, TypeError) as e:
-            return None, None, f"{disp} has dtype {dtype} and cannot hold {value!r}: {e}"
-        stored = make_serializable(coerced[()])
+            return None, f"{disp} holds an integer; got {type(value).__name__}"
+        # Range, not just type: an out-of-bounds int either raises in _as_dtype
+        # or wraps silently depending on the numpy version, and a wrapped value
+        # is a wrong value that nothing downstream would question — so the
+        # coerced result has to come back equal, not merely exist.
+        stored, problem = _as_dtype(value, dtype, disp)
+        if problem:
+            return None, problem
         if stored != value:
-            return None, None, f"{disp} has dtype {dtype}, which would store {value!r} as {stored!r}"
-        return value, stored, None
+            return None, f"{disp} has dtype {dtype}, which would store {value!r} as {stored!r}"
+        return stored, None
     if kind == "f":
         if isinstance(value, bool) or not isinstance(value, int | float):
-            return None, None, f"{disp} holds a float; got {type(value).__name__}"
+            return None, f"{disp} holds a float; got {type(value).__name__}"
+        # Non-finite is refused at both ends, and for two reasons that compound.
+        # A wrong value: nan and inf mean nothing as a provenance scalar, and
+        # 1e40 into a float32 silently becomes inf rather than the number asked
+        # for. And an unreadable file: json.dumps writes them as the bare tokens
+        # NaN and Infinity, which RFC 8259 does not allow — that entry would
+        # make the file's *whole* edit_history unparseable to a strict reader,
+        # including every entry written by every other tool. nan also defeats
+        # the read-back by construction, since nan != nan.
+        if not math.isfinite(value):
+            return None, f"{disp}: {value!r} is not a finite number"
         # Int accepted as a widening: JSON has one number type, so a whole
         # float arrives as an int. Precision loss on a narrow float dtype is
         # allowed rather than refused — every float32 field would otherwise
-        # reject most decimals — so the read-back expects the coerced value.
-        try:
-            coerced = np.asarray(value, dtype=dtype)
-        except (OverflowError, ValueError, TypeError) as e:
-            return None, None, f"{disp} has dtype {dtype} and cannot hold {value!r}: {e}"
-        return value, make_serializable(coerced[()]), None
+        # reject most decimals — so the value that lands is the coerced one.
+        stored, problem = _as_dtype(value, dtype, disp)
+        if problem:
+            return None, problem
+        if not math.isfinite(stored):
+            return None, f"{disp} has dtype {dtype}, which cannot hold {value!r} — it would overflow to {stored!r}"
+        return stored, None
 
-    return (
-        None,
-        None,
-        (
-            f"{disp} has dtype {dtype}, which this tool cannot write — it writes string, boolean, "
-            f"integer and float scalars"
-        ),
+    return None, (
+        f"{disp} has dtype {dtype}, which this tool cannot write — it writes string, boolean, integer and float scalars"
     )
 
 
-def _plan(f: h5py.File, fields: list[tuple[str, ...]], values: list[Any]) -> tuple[list[_PlannedWrite], list[str]]:
+def _plan(f: h5py.File, parsed: list[tuple[tuple[str, ...], Any]]) -> tuple[list[_PlannedWrite], list[str]]:
     """Validate every requested write against the source file.
 
     Runs to completion rather than short-circuiting: a caller who named one
@@ -276,22 +345,21 @@ def _plan(f: h5py.File, fields: list[tuple[str, ...]], values: list[Any]) -> tup
     """
     plans: list[_PlannedWrite] = []
     problems: list[str] = []
-    for field, value in zip(fields, values, strict=True):
+    for field, value in parsed:
         if problem := _namespace_problem(field):
             problems.append(problem)
             continue
         ds, problem = _resolve(f, field)
         if ds is None:
-            problems.append(problem or f"{_display(field)} could not be resolved")
+            problems.append(problem)
             continue
-        assign, expected, problem = _coerce(ds, value, _display(field))
+        expected, problem = _coerce(ds, value, _display(field))
         if problem:
             problems.append(problem)
             continue
         plans.append(
             _PlannedWrite(
                 field=field,
-                value=assign,
                 expected=expected,
                 old_value=make_serializable(ds[()]),
                 dtype=ds.dtype,
@@ -321,9 +389,10 @@ def set_producer_uns(path: str, updates: list[dict]) -> dict:
     version.
 
     Refuses a path that does not exist (it overwrites, it never creates), a
-    value whose type does not match the stored dtype, a non-scalar or
-    group-valued target, a segment containing ``/``, our own ``provenance``
-    namespace, and any HCA schema field — those belong to ``set_uns``, which
+    value whose type does not match the stored dtype, a non-finite float, a
+    fixed-length string field, an external link into another file, a
+    non-scalar or group-valued target, a segment containing ``/``, our own
+    ``provenance`` namespace, and any HCA schema field — those belong to ``set_uns``, which
     validates them. Whether the *result* is valid is ``validate_schema``'s
     verdict, not this tool's (#614) — though note that for a producer-owned
     namespace it will not have one, which is why the guards above are stricter
@@ -350,14 +419,32 @@ def set_producer_uns(path: str, updates: list[dict]) -> dict:
         if not Path(path).is_file():
             return {"error": f"File not found: {path}"}
 
-        fields, values, problems = _parse_updates(updates)
+        parsed, problems = _parse_updates(updates)
 
         plans: list[_PlannedWrite] = []
+        raw_log: str = "[]"
         if not problems:
             with h5py.File(path, "r") as f_in:
-                plans, problems = _plan(f_in, fields, values)
+                plans, problems = _plan(f_in, parsed)
+                # Read here, not from the snapshot: a corrupt log is a refusal,
+                # and refusing it now costs a metadata read rather than a full
+                # copy of a file that can run to tens of gigabytes (#597).
+                raw_log = read_edit_log_h5py(f_in)
         if problems:
             return {"error": "Refusing to write: " + "; ".join(problems)}
+        parsed_log = parse_edit_log(raw_log)
+        if "error" in parsed_log:
+            return parsed_log
+
+        records = [
+            {
+                "field": list(p.field),
+                "old_value": p.old_value,
+                "new_value": p.expected,
+                "dtype": str(p.dtype),
+            }
+            for p in plans
+        ]
 
         with (
             snapshot_copy_hashed(path) as (output_path, source_sha256),
@@ -371,7 +458,7 @@ def set_producer_uns(path: str, updates: list[dict]) -> dict:
                 ds, problem = _resolve(f_out, plan.field)
                 if ds is None:
                     raise RuntimeError(f"snapshot does not match the validated source: {problem}")
-                ds[()] = plan.value
+                ds[()] = plan.expected
 
             entry = make_edit_entry(
                 operation="set_producer_uns",
@@ -379,19 +466,9 @@ def set_producer_uns(path: str, updates: list[dict]) -> dict:
                     f"Set {len(plans)} producer uns field(s): "
                     + ", ".join(f"{_display(p.field)} {p.old_value!r} -> {p.expected!r}" for p in plans)
                 ),
-                details={
-                    "fields": [
-                        {
-                            "field": list(p.field),
-                            "old_value": p.old_value,
-                            "new_value": p.expected,
-                            "dtype": str(p.dtype),
-                        }
-                        for p in plans
-                    ]
-                },
+                details={"fields": records},
             )
-            log_result = build_edit_log(read_edit_log_h5py(f_out), [entry], path, source_sha256)
+            log_result = build_edit_log(raw_log, [entry], path, source_sha256)
             if "error" in log_result:
                 raise RuntimeError(log_result["error"])
             write_edit_log_h5py(f_out, log_result["json"])
@@ -399,6 +476,12 @@ def set_producer_uns(path: str, updates: list[dict]) -> dict:
             # Read back before the snapshot is accepted. Value *and* dtype:
             # checking the value alone is what lets a bool-written-as-a-string
             # through, and this namespace has no validator behind it.
+            #
+            # A second pass, deliberately, not a check folded into the write
+            # loop above: two distinct paths can name one dataset through an
+            # HDF5 hard link, and only a pass that runs after every write
+            # catches the second write clobbering the first. Duplicate *paths*
+            # are already refused; aliases are not detectable up front.
             for plan in plans:
                 ds, problem = _resolve(f_out, plan.field)
                 if ds is None:
@@ -416,15 +499,7 @@ def set_producer_uns(path: str, updates: list[dict]) -> dict:
         return {
             "output_path": output_path,
             "fields_written": len(plans),
-            "updates": [
-                {
-                    "field": list(p.field),
-                    "old_value": p.old_value,
-                    "new_value": p.expected,
-                    "dtype": str(p.dtype),
-                }
-                for p in plans
-            ],
+            "updates": records,
         }
 
     except Exception as e:

--- a/packages/hca-anndata-tools/src/hca_anndata_tools/producer_uns.py
+++ b/packages/hca-anndata-tools/src/hca_anndata_tools/producer_uns.py
@@ -163,27 +163,41 @@ def _namespace_problem(field: tuple[str, ...]) -> str | None:
     return None
 
 
-def _external_link_problem(node: h5py.Group, segment: str, field: tuple[str, ...], depth: int) -> str | None:
-    """Refuse a member that is an HDF5 external link into another file.
+def _link_problem(node: h5py.Group, segment: str, field: tuple[str, ...], depth: int) -> str | None:
+    """Refuse a member that is an HDF5 link, external or soft.
 
-    h5py resolves external links transparently — ``get`` returns the target,
-    and ``isinstance(..., h5py.Group)`` / ``h5py.Dataset`` are both True for
-    one — so nothing else in this walk can tell the difference. HDF5 also
-    propagates the parent's access flags to the target, so under the snapshot's
-    ``"a"`` mode the foreign file is opened read-write and ``ds[()] = value``
-    lands *there*.
+    h5py resolves both transparently — ``get`` returns the target, and the
+    ``isinstance`` checks in :func:`_resolve` are True for it — so nothing else
+    in the walk can tell a link from a real member. Both were verified to
+    redirect a write, and neither is caught by anything else:
 
-    Verified: with ``uns['ns']`` linked into another h5ad, the tool reported
-    success, the snapshot kept the link unchanged, and the other file was
-    modified. The read-back could not catch it — it re-resolves through the
-    same link and sees the value it just wrote into the foreign file. So the
-    refusal has to happen here, before the link is ever followed.
+    * **External**: HDF5 propagates the parent's access flags to the target, so
+      under the snapshot's ``"a"`` mode the foreign file is opened read-write
+      and the assignment lands *there*. The tool reported success, the snapshot
+      stayed byte-identical, and another h5ad was silently modified.
+    * **Soft**: the target is elsewhere in *this* file, so the
+      ``leaf.file.filename`` backstop cannot see it, and
+      :func:`_namespace_problem` cannot either — it matches ``field[0]`` as a
+      string, and a link never presents the string it resolves to. A soft link
+      from a producer namespace to ``uns['title']`` wrote an HCA schema field
+      through this tool, bypassing the registry refusal and ``set_uns``'s
+      validation entirely.
+
+    The read-back cannot substitute for this: it re-resolves through the same
+    link and sees exactly what it wrote. So the refusal happens here, before
+    the link is followed. Scanned the eight real breast objects — 1,443 ``uns``
+    members, not one link of either kind — so nothing legitimate is lost.
     """
     link = node.get(segment, getlink=True)
     if isinstance(link, h5py.ExternalLink):
         return (
             f"{_display(field[: depth + 1])} is an external link into {link.filename!r} — writing through it "
             f"would modify that file instead of this one, leaving no record in either"
+        )
+    if isinstance(link, h5py.SoftLink):
+        return (
+            f"{_display(field[: depth + 1])} is a soft link to {link.path!r} — the guards here check the path "
+            f"you named, so writing through it would edit something you did not name"
         )
     return None
 
@@ -200,16 +214,16 @@ def _resolve(f: h5py.File, field: tuple[str, ...]) -> tuple[h5py.Dataset | None,
     typo protection the schema registry gives ``set_uns`` and this tool,
     by definition, cannot have.
 
-    Every step is also checked for an external link, including the leaf: the
-    files this runs on come from third-party producers and from CAP, so the
-    structure being walked is not ours.
+    Every step is also checked for an HDF5 link, including the leaf: the files
+    this runs on come from third-party producers and from CAP, so the structure
+    being walked is not ours.
     """
     node: h5py.Group | None = read_uns(f)
     if node is None:
         return None, f"the file has no uns group, so {_display(field)} cannot be reached"
 
     for depth, segment in enumerate(field[:-1]):
-        if problem := _external_link_problem(node, segment, field, depth):
+        if problem := _link_problem(node, segment, field, depth):
             return None, problem
         child = node.get(segment)
         if child is None:
@@ -218,7 +232,7 @@ def _resolve(f: h5py.File, field: tuple[str, ...]) -> tuple[h5py.Dataset | None,
             return None, f"{_display(field[: depth + 1])} is a value, not a group, so {_display(field)} has no parent"
         node = child
 
-    if problem := _external_link_problem(node, field[-1], field, len(field) - 1):
+    if problem := _link_problem(node, field[-1], field, len(field) - 1):
         return None, problem
     leaf = node.get(field[-1])
     if leaf is None:

--- a/packages/hca-anndata-tools/tests/test_producer_uns.py
+++ b/packages/hca-anndata-tools/tests/test_producer_uns.py
@@ -372,6 +372,38 @@ class TestOwnership:
         assert "edit log" in result["error"]
 
 
+class TestRefusesBeforeCopying:
+    """The expensive half is the snapshot copy — up to 27 GB. Anything
+    knowable from the source read-only should refuse before paying it."""
+
+    def test_provenance_as_a_value_refuses_before_the_copy(self, producer_h5ad, no_snapshot):
+        """#576: uns['provenance'] is unnamespaced and shared with producers.
+        One that used it for a string would otherwise get a raw h5py
+        'Incompatible object' error after the whole file had been copied."""
+        with h5py.File(producer_h5ad, "a") as f:
+            if "provenance" in f["uns"]:
+                del f["uns"]["provenance"]
+            f["uns"]["provenance"] = "a producer put a string here"
+
+        result = _set(producer_h5ad, ["ihbca_provenance", "git_branch"], "main")
+
+        assert result["error"].startswith("Refusing to write:")
+        assert "edit log is written inside it" in result["error"]
+        assert no_snapshot(producer_h5ad)
+
+    def test_corrupt_edit_log_refuses_before_the_copy(self, producer_h5ad, no_snapshot):
+        with h5py.File(producer_h5ad, "a") as f:
+            prov = f["uns"].require_group("provenance")
+            if "edit_history" in prov:
+                del prov["edit_history"]
+            prov["edit_history"] = "{not json"
+
+        result = _set(producer_h5ad, ["ihbca_provenance", "git_branch"], "main")
+
+        assert "error" in result
+        assert no_snapshot(producer_h5ad)
+
+
 class TestAllOrNothing:
     def test_one_bad_entry_leaves_the_file_untouched(self, producer_h5ad, no_snapshot):
         before = producer_h5ad.read_bytes()

--- a/packages/hca-anndata-tools/tests/test_producer_uns.py
+++ b/packages/hca-anndata-tools/tests/test_producer_uns.py
@@ -268,7 +268,7 @@ class TestPathGuards:
         assert "['ihbca_provenance', 'git_dirty']" in result["error"]
 
 
-class TestExternalLinks:
+class TestLinks:
     """h5py resolves an external link transparently, so without an explicit
     refusal the walk follows it into another file — and because the snapshot is
     opened "a", HDF5 opens that file read-write and the assignment lands there.
@@ -312,6 +312,33 @@ class TestExternalLinks:
         assert no_snapshot(producer_h5ad)
         with h5py.File(victim, "r") as f:
             assert f["uns/ihbca_provenance/git_branch"][()] == b"PRISTINE"
+
+    def test_soft_linked_leaf_is_refused(self, producer_h5ad, no_snapshot):
+        """A soft link stays inside this file, so the file-identity backstop
+        cannot see it — and _namespace_problem cannot either, because it
+        matches field[0] as a string and a link never presents the string it
+        resolves to. Verified before the guard: this wrote uns['title'], an
+        HCA schema field, straight through the producer tool."""
+        with h5py.File(producer_h5ad, "a") as f:
+            del f["uns"]["ihbca_provenance"]["git_branch"]
+            f["uns"]["ihbca_provenance"]["git_branch"] = h5py.SoftLink("/uns/title")
+
+        result = _set(producer_h5ad, ["ihbca_provenance", "git_branch"], "HIJACKED")
+
+        assert "soft link" in result["error"]
+        assert no_snapshot(producer_h5ad)
+        with h5py.File(producer_h5ad, "r") as f:
+            assert f["uns/title"][()] != b"HIJACKED"
+
+    def test_soft_linked_group_is_refused(self, producer_h5ad, no_snapshot):
+        """The same at an intermediate segment, not just the leaf."""
+        with h5py.File(producer_h5ad, "a") as f:
+            f["uns"]["aliased"] = h5py.SoftLink("/uns/ihbca_provenance")
+
+        result = _set(producer_h5ad, ["aliased", "git_branch"], "HIJACKED")
+
+        assert "soft link" in result["error"]
+        assert no_snapshot(producer_h5ad)
 
     def test_linked_leaf_is_not_read_either(self, producer_h5ad, victim):
         """The refusal also closes the read side: old_value travels back in the

--- a/packages/hca-anndata-tools/tests/test_producer_uns.py
+++ b/packages/hca-anndata-tools/tests/test_producer_uns.py
@@ -1,0 +1,351 @@
+"""Tests for set_producer_uns — writing scalars into producer-owned uns namespaces.
+
+Every assertion on a written value also asserts its dtype. That is the point of
+the tool: a producer namespace has no schema, so ``validate_schema`` has no
+opinion on it, and a test that checked the value alone would pass on exactly
+the mis-write this exists to prevent (a bool stored as the string 'false').
+"""
+
+import hashlib
+import json
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+
+from hca_anndata_tools import set_producer_uns, view_edit_log
+from hca_anndata_tools._io import require_stamped_group
+
+
+def _scalar(group: h5py.Group, name: str, value) -> None:
+    """Create a scalar dataset stamped the way anndata stamps one."""
+    group.create_dataset(name, data=value)
+    encoding = "string" if isinstance(value, str) else "numeric-scalar"
+    group[name].attrs["encoding-type"] = encoding
+    group[name].attrs["encoding-version"] = "0.2.0"
+
+
+@pytest.fixture
+def producer_h5ad(sample_h5ad_for_write: Path) -> Path:
+    """A file carrying a nested producer namespace shaped like the real one.
+
+    Mirrors ``uns['ihbca_provenance']`` on the breast-v1 source datasets: a
+    variable-length string, a bool, an int, a nested subgroup with a float,
+    plus a fixed-length string and a non-scalar array as the shapes the tool
+    has to refuse.
+    """
+    with h5py.File(sample_h5ad_for_write, "a") as f:
+        group = require_stamped_group(f, "uns/ihbca_provenance")
+        _scalar(group, "git_branch", "dev")
+        _scalar(group, "git_hash", "f78d0212f9d8bd86e3cbbb47a269a33981346956")
+        _scalar(group, "git_dirty", True)
+        _scalar(group, "cell_count", np.int64(52681))
+        _scalar(group, "small_count", np.int8(5))
+        group.create_dataset("short_code", data=np.bytes_("dev"))
+        group.create_dataset("unmapped_examples", data=np.array([b"ENSG1", b"ENSG2"]))
+        nested = require_stamped_group(f, "uns/ihbca_provenance/mapping_stats")
+        _scalar(nested, "pct_mapped", np.float64(90.385))
+    return sample_h5ad_for_write
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _read(path: str, *segments: str):
+    """``(value, dtype, attrs)`` at a uns path in the written file."""
+    with h5py.File(path, "r") as f:
+        ds = f["uns"]
+        for segment in segments:
+            ds = ds[segment]
+        return ds[()], ds.dtype, dict(ds.attrs)
+
+
+THE_CORRECTION = [
+    {"field": ["ihbca_provenance", "git_hash"], "value": "0454dde01415d16382d355f7d5d64325ef47ca65"},
+    {"field": ["ihbca_provenance", "git_branch"], "value": "main"},
+    {"field": ["ihbca_provenance", "git_dirty"], "value": False},
+]
+
+
+class TestTheCorrection:
+    """The motivating case: hca-ingest-coordination#23's three-field patch."""
+
+    def test_writes_every_field_with_its_dtype_intact(self, producer_h5ad):
+        result = set_producer_uns(str(producer_h5ad), THE_CORRECTION)
+
+        assert "error" not in result, result.get("error")
+        assert result["fields_written"] == 3
+
+        value, dtype, attrs = _read(result["output_path"], "ihbca_provenance", "git_dirty")
+        assert bool(value) is False
+        assert dtype == np.dtype(bool), "a bool stored as anything else is the failure this tool exists to prevent"
+        assert attrs["encoding-type"] == "numeric-scalar"
+
+        value, dtype, attrs = _read(result["output_path"], "ihbca_provenance", "git_branch")
+        assert value == b"main"
+        assert h5py.check_string_dtype(dtype) is not None
+        assert attrs["encoding-type"] == "string"
+
+        value, _, _ = _read(result["output_path"], "ihbca_provenance", "git_hash")
+        assert value == b"0454dde01415d16382d355f7d5d64325ef47ca65"
+
+    def test_reports_old_and_new_values(self, producer_h5ad):
+        result = set_producer_uns(str(producer_h5ad), THE_CORRECTION)
+
+        by_field = {tuple(u["field"]): u for u in result["updates"]}
+        dirty = by_field[("ihbca_provenance", "git_dirty")]
+        assert dirty["old_value"] is True
+        assert dirty["new_value"] is False
+        assert dirty["dtype"] == "bool"
+        assert by_field[("ihbca_provenance", "git_branch")]["old_value"] == "dev"
+
+    def test_batch_is_one_snapshot_and_one_edit_log_entry(self, producer_h5ad):
+        before = len(view_edit_log(str(producer_h5ad)).get("entries", []))
+
+        result = set_producer_uns(str(producer_h5ad), THE_CORRECTION)
+
+        written = sorted(p.name for p in producer_h5ad.parent.glob("*.h5ad"))
+        assert len(written) == 2, f"expected the source plus one snapshot, got {written}"
+        entries = view_edit_log(result["output_path"])["entries"]
+        assert len(entries) == before + 1, "three fields must not produce three log entries"
+        assert entries[-1]["operation"] == "set_producer_uns"
+
+    def test_edit_log_details_carry_every_field(self, producer_h5ad):
+        result = set_producer_uns(str(producer_h5ad), THE_CORRECTION)
+
+        entry = view_edit_log(result["output_path"])["entries"][-1]
+        fields = entry["details"]["fields"]
+        assert {tuple(f["field"]) for f in fields} == {
+            ("ihbca_provenance", "git_hash"),
+            ("ihbca_provenance", "git_branch"),
+            ("ihbca_provenance", "git_dirty"),
+        }
+        dirty = next(f for f in fields if f["field"][-1] == "git_dirty")
+        assert (dirty["old_value"], dirty["new_value"], dirty["dtype"]) == (True, False, "bool")
+        # The entry has to survive the JSON round trip the log is stored as —
+        # a numpy scalar left in details would raise on write, not on read.
+        json.dumps(entry)
+
+    def test_nested_subgroup_is_reachable(self, producer_h5ad):
+        result = set_producer_uns(
+            str(producer_h5ad),
+            [{"field": ["ihbca_provenance", "mapping_stats", "pct_mapped"], "value": 91.5}],
+        )
+
+        assert "error" not in result, result.get("error")
+        value, dtype, _ = _read(result["output_path"], "ihbca_provenance", "mapping_stats", "pct_mapped")
+        assert value == pytest.approx(91.5)
+        assert dtype == np.dtype(np.float64)
+
+
+class TestTypeGuards:
+    """The stored dtype is the contract; nothing downstream would catch a breach."""
+
+    def test_bool_into_a_string_field_is_refused(self, producer_h5ad):
+        result = set_producer_uns(str(producer_h5ad), [{"field": ["ihbca_provenance", "git_branch"], "value": False}])
+
+        assert "holds a string" in result["error"]
+        assert "bool" in result["error"]
+
+    def test_string_into_a_bool_field_is_refused(self, producer_h5ad):
+        result = set_producer_uns(str(producer_h5ad), [{"field": ["ihbca_provenance", "git_dirty"], "value": "false"}])
+
+        assert "holds a boolean" in result["error"]
+
+    def test_true_into_an_int_field_is_refused(self, producer_h5ad):
+        """isinstance(True, int) is True in Python — an int check reached first
+        would accept this and store 1."""
+        result = set_producer_uns(str(producer_h5ad), [{"field": ["ihbca_provenance", "cell_count"], "value": True}])
+
+        assert "holds an integer" in result["error"]
+        assert "bool" in result["error"]
+
+    def test_float_into_an_int_field_is_refused(self, producer_h5ad):
+        result = set_producer_uns(str(producer_h5ad), [{"field": ["ihbca_provenance", "cell_count"], "value": 7.9}])
+
+        assert "holds an integer" in result["error"]
+
+    def test_out_of_range_int_is_refused(self, producer_h5ad):
+        """Type alone is not enough: 999 is an int, and int8 cannot hold it."""
+        result = set_producer_uns(str(producer_h5ad), [{"field": ["ihbca_provenance", "small_count"], "value": 999}])
+
+        assert "int8" in result["error"]
+
+    def test_int_widens_into_a_float_field(self, producer_h5ad):
+        """JSON has one number type, so a whole float arrives as an int."""
+        result = set_producer_uns(
+            str(producer_h5ad),
+            [{"field": ["ihbca_provenance", "mapping_stats", "pct_mapped"], "value": 90}],
+        )
+
+        assert "error" not in result, result.get("error")
+        value, dtype, _ = _read(result["output_path"], "ihbca_provenance", "mapping_stats", "pct_mapped")
+        assert value == pytest.approx(90.0)
+        assert dtype == np.dtype(np.float64)
+        assert result["updates"][0]["new_value"] == 90.0
+
+    def test_fixed_length_string_truncation_is_refused(self, producer_h5ad):
+        """HDF5 truncates a too-long value into a fixed-length string and
+        reports success — the exact silent mis-write this tool guards."""
+        result = set_producer_uns(
+            str(producer_h5ad),
+            [{"field": ["ihbca_provenance", "short_code"], "value": "a-much-longer-value"}],
+        )
+
+        assert "truncate" in result["error"]
+        assert "3 bytes" in result["error"]
+
+    def test_none_is_refused(self, producer_h5ad):
+        result = set_producer_uns(str(producer_h5ad), [{"field": ["ihbca_provenance", "git_branch"], "value": None}])
+
+        assert "holds a string" in result["error"]
+
+
+class TestPathGuards:
+    """Overwrite-only: every segment must already exist."""
+
+    def test_missing_leaf_is_refused(self, producer_h5ad):
+        result = set_producer_uns(str(producer_h5ad), [{"field": ["ihbca_provenance", "git_dity"], "value": "x"}])
+
+        assert "does not exist" in result["error"]
+        assert "does not create them" in result["error"]
+
+    def test_missing_intermediate_is_refused(self, producer_h5ad):
+        result = set_producer_uns(str(producer_h5ad), [{"field": ["ihbca_provnance", "git_dirty"], "value": False}])
+
+        assert "does not exist" in result["error"]
+        assert "ihbca_provnance" in result["error"]
+
+    def test_intermediate_that_is_a_value_is_refused(self, producer_h5ad):
+        result = set_producer_uns(
+            str(producer_h5ad),
+            [{"field": ["ihbca_provenance", "git_branch", "deeper"], "value": "x"}],
+        )
+
+        assert "is a value, not a group" in result["error"]
+
+    def test_group_valued_target_is_refused(self, producer_h5ad):
+        result = set_producer_uns(str(producer_h5ad), [{"field": ["ihbca_provenance", "mapping_stats"], "value": 1}])
+
+        assert "is a group, not a value" in result["error"]
+
+    def test_non_scalar_target_is_refused(self, producer_h5ad):
+        result = set_producer_uns(
+            str(producer_h5ad),
+            [{"field": ["ihbca_provenance", "unmapped_examples"], "value": "x"}],
+        )
+
+        assert "not a scalar" in result["error"]
+
+    def test_segment_containing_a_slash_is_refused(self, producer_h5ad):
+        """h5py would resolve it as a further link path, so the check that runs
+        and the walk that follows could disagree about what was addressed."""
+        result = set_producer_uns(
+            str(producer_h5ad),
+            [{"field": ["ihbca_provenance/git_dirty"], "value": False}],
+        )
+
+        assert "cannot contain '/'" in result["error"]
+
+    def test_slash_joined_string_is_refused_with_the_list_form(self, producer_h5ad):
+        result = set_producer_uns(
+            str(producer_h5ad),
+            [{"field": "ihbca_provenance/git_dirty", "value": False}],
+        )
+
+        assert "must be a list of path segments" in result["error"]
+        assert "['ihbca_provenance', 'git_dirty']" in result["error"]
+
+
+class TestOwnership:
+    """Paths this tool does not own."""
+
+    def test_hca_schema_field_is_refused_and_names_set_uns(self, producer_h5ad):
+        result = set_producer_uns(str(producer_h5ad), [{"field": ["title"], "value": "New title"}])
+
+        assert "HCA schema uns field" in result["error"]
+        assert "set_uns" in result["error"]
+
+    def test_our_provenance_namespace_is_refused(self, producer_h5ad):
+        """The edit log lives there; a tool that could rewrite it would undo
+        every other tool's guarantee."""
+        result = set_producer_uns(
+            str(producer_h5ad),
+            [{"field": ["provenance", "edit_history"], "value": "[]"}],
+        )
+
+        assert "provenance namespace" in result["error"]
+        assert "edit log" in result["error"]
+
+
+class TestAllOrNothing:
+    def test_one_bad_entry_leaves_the_file_untouched(self, producer_h5ad):
+        before = _sha256(producer_h5ad)
+
+        result = set_producer_uns(
+            str(producer_h5ad),
+            [
+                {"field": ["ihbca_provenance", "git_branch"], "value": "main"},
+                {"field": ["ihbca_provenance", "git_dirty"], "value": "false"},
+            ],
+        )
+
+        assert "error" in result
+        assert _sha256(producer_h5ad) == before
+        assert sorted(p.name for p in producer_h5ad.parent.glob("*.h5ad")) == [producer_h5ad.name]
+
+    def test_every_problem_is_reported_in_one_pass(self, producer_h5ad):
+        result = set_producer_uns(
+            str(producer_h5ad),
+            [
+                {"field": ["ihbca_provenance", "nope"], "value": "x"},
+                {"field": ["ihbca_provenance", "git_dirty"], "value": "false"},
+            ],
+        )
+
+        assert "does not exist" in result["error"]
+        assert "holds a boolean" in result["error"]
+
+    def test_duplicate_field_is_refused(self, producer_h5ad):
+        result = set_producer_uns(
+            str(producer_h5ad),
+            [
+                {"field": ["ihbca_provenance", "git_branch"], "value": "main"},
+                {"field": ["ihbca_provenance", "git_branch"], "value": "dev"},
+            ],
+        )
+
+        assert "more than once" in result["error"]
+
+
+class TestRequestShape:
+    def test_empty_updates_is_refused(self, producer_h5ad):
+        assert "must not be empty" in set_producer_uns(str(producer_h5ad), [])["error"]
+
+    def test_non_list_updates_is_refused(self, producer_h5ad):
+        assert "must be a list" in set_producer_uns(str(producer_h5ad), {"field": ["a"], "value": 1})["error"]
+
+    def test_entry_missing_a_key_is_refused(self, producer_h5ad):
+        result = set_producer_uns(str(producer_h5ad), [{"field": ["ihbca_provenance", "git_dirty"]}])
+
+        assert "missing ['value']" in result["error"]
+
+    def test_non_string_segments_are_refused(self, producer_h5ad):
+        result = set_producer_uns(str(producer_h5ad), [{"field": ["ihbca_provenance", 3], "value": 1}])
+
+        assert "segments must be strings" in result["error"]
+
+    def test_missing_file_is_reported(self, tmp_path):
+        result = set_producer_uns(str(tmp_path / "nope.h5ad"), THE_CORRECTION)
+
+        assert "File not found" in result["error"]
+
+    def test_file_with_no_uns_group_is_refused(self, producer_h5ad):
+        with h5py.File(producer_h5ad, "a") as f:
+            del f["uns"]
+
+        result = set_producer_uns(str(producer_h5ad), THE_CORRECTION)
+
+        assert "no uns group" in result["error"]

--- a/packages/hca-anndata-tools/tests/test_producer_uns.py
+++ b/packages/hca-anndata-tools/tests/test_producer_uns.py
@@ -6,7 +6,6 @@ opinion on it, and a test that checked the value alone would pass on exactly
 the mis-write this exists to prevent (a bool stored as the string 'false').
 """
 
-import hashlib
 import json
 from pathlib import Path
 
@@ -16,6 +15,8 @@ import pytest
 
 from hca_anndata_tools import set_producer_uns, view_edit_log
 from hca_anndata_tools._io import require_stamped_group
+from hca_anndata_tools.edit import _type_display
+from hca_anndata_tools.schema.helpers import uns_field_registry
 
 
 def _scalar(group: h5py.Group, name: str, value) -> None:
@@ -49,8 +50,9 @@ def producer_h5ad(sample_h5ad_for_write: Path) -> Path:
     return sample_h5ad_for_write
 
 
-def _sha256(path: Path) -> str:
-    return hashlib.sha256(path.read_bytes()).hexdigest()
+def _set(h5ad: Path, field, value):
+    """One-update call — the shape most tests here need."""
+    return set_producer_uns(str(h5ad), [{"field": field, "value": value}])
 
 
 def _read(path: str, *segments: str):
@@ -129,10 +131,7 @@ class TestTheCorrection:
         json.dumps(entry)
 
     def test_nested_subgroup_is_reachable(self, producer_h5ad):
-        result = set_producer_uns(
-            str(producer_h5ad),
-            [{"field": ["ihbca_provenance", "mapping_stats", "pct_mapped"], "value": 91.5}],
-        )
+        result = _set(producer_h5ad, ["ihbca_provenance", "mapping_stats", "pct_mapped"], 91.5)
 
         assert "error" not in result, result.get("error")
         value, dtype, _ = _read(result["output_path"], "ihbca_provenance", "mapping_stats", "pct_mapped")
@@ -144,41 +143,38 @@ class TestTypeGuards:
     """The stored dtype is the contract; nothing downstream would catch a breach."""
 
     def test_bool_into_a_string_field_is_refused(self, producer_h5ad):
-        result = set_producer_uns(str(producer_h5ad), [{"field": ["ihbca_provenance", "git_branch"], "value": False}])
+        result = _set(producer_h5ad, ["ihbca_provenance", "git_branch"], False)
 
         assert "holds a string" in result["error"]
         assert "bool" in result["error"]
 
     def test_string_into_a_bool_field_is_refused(self, producer_h5ad):
-        result = set_producer_uns(str(producer_h5ad), [{"field": ["ihbca_provenance", "git_dirty"], "value": "false"}])
+        result = _set(producer_h5ad, ["ihbca_provenance", "git_dirty"], "false")
 
         assert "holds a boolean" in result["error"]
 
     def test_true_into_an_int_field_is_refused(self, producer_h5ad):
         """isinstance(True, int) is True in Python — an int check reached first
         would accept this and store 1."""
-        result = set_producer_uns(str(producer_h5ad), [{"field": ["ihbca_provenance", "cell_count"], "value": True}])
+        result = _set(producer_h5ad, ["ihbca_provenance", "cell_count"], True)
 
         assert "holds an integer" in result["error"]
         assert "bool" in result["error"]
 
     def test_float_into_an_int_field_is_refused(self, producer_h5ad):
-        result = set_producer_uns(str(producer_h5ad), [{"field": ["ihbca_provenance", "cell_count"], "value": 7.9}])
+        result = _set(producer_h5ad, ["ihbca_provenance", "cell_count"], 7.9)
 
         assert "holds an integer" in result["error"]
 
     def test_out_of_range_int_is_refused(self, producer_h5ad):
         """Type alone is not enough: 999 is an int, and int8 cannot hold it."""
-        result = set_producer_uns(str(producer_h5ad), [{"field": ["ihbca_provenance", "small_count"], "value": 999}])
+        result = _set(producer_h5ad, ["ihbca_provenance", "small_count"], 999)
 
         assert "int8" in result["error"]
 
     def test_int_widens_into_a_float_field(self, producer_h5ad):
         """JSON has one number type, so a whole float arrives as an int."""
-        result = set_producer_uns(
-            str(producer_h5ad),
-            [{"field": ["ihbca_provenance", "mapping_stats", "pct_mapped"], "value": 90}],
-        )
+        result = _set(producer_h5ad, ["ihbca_provenance", "mapping_stats", "pct_mapped"], 90)
 
         assert "error" not in result, result.get("error")
         value, dtype, _ = _read(result["output_path"], "ihbca_provenance", "mapping_stats", "pct_mapped")
@@ -186,19 +182,44 @@ class TestTypeGuards:
         assert dtype == np.dtype(np.float64)
         assert result["updates"][0]["new_value"] == 90.0
 
-    def test_fixed_length_string_truncation_is_refused(self, producer_h5ad):
-        """HDF5 truncates a too-long value into a fixed-length string and
-        reports success — the exact silent mis-write this tool guards."""
-        result = set_producer_uns(
-            str(producer_h5ad),
-            [{"field": ["ihbca_provenance", "short_code"], "value": "a-much-longer-value"}],
-        )
+    def test_fixed_length_string_field_is_refused(self, producer_h5ad):
+        """Refused as a dtype rather than supported. anndata writes every
+        string as variable-length, so a fixed-length one was written by
+        something else — and HDF5 truncates an over-long value into it with no
+        error at all. None of the eight real breast objects has one."""
+        result = _set(producer_h5ad, ["ihbca_provenance", "short_code"], "abc")
 
+        assert "fixed-length string" in result["error"]
         assert "truncate" in result["error"]
-        assert "3 bytes" in result["error"]
+
+    def test_fixed_length_refusal_does_not_depend_on_the_value(self, producer_h5ad):
+        """Including a non-ASCII one — h5py reports |S as ascii, so encoding it
+        to measure a length would raise out of the type check instead of being
+        refused by it. Refusing the dtype means never reaching that."""
+        result = _set(producer_h5ad, ["ihbca_provenance", "short_code"], "é")
+
+        assert "fixed-length string" in result["error"]
+
+    def test_nan_is_refused(self, producer_h5ad):
+        """nan defeats the read-back by construction (nan != nan), and
+        json.dumps writes it as the bare token NaN, which is not valid JSON."""
+        result = _set(producer_h5ad, ["ihbca_provenance", "mapping_stats", "pct_mapped"], float("nan"))
+
+        assert "not a finite number" in result["error"]
+
+    def test_float_overflow_is_refused(self, producer_h5ad, tmp_path):
+        """A finite input that the dtype turns into inf is a wrong value, and
+        it would write Infinity into the shared edit log."""
+        with h5py.File(producer_h5ad, "a") as f:
+            _scalar(f["uns/ihbca_provenance"], "narrow", np.float32(1.5))
+
+        result = _set(producer_h5ad, ["ihbca_provenance", "narrow"], 1e40)
+
+        assert "overflow" in result["error"]
+        assert "float32" in result["error"]
 
     def test_none_is_refused(self, producer_h5ad):
-        result = set_producer_uns(str(producer_h5ad), [{"field": ["ihbca_provenance", "git_branch"], "value": None}])
+        result = _set(producer_h5ad, ["ihbca_provenance", "git_branch"], None)
 
         assert "holds a string" in result["error"]
 
@@ -207,63 +228,110 @@ class TestPathGuards:
     """Overwrite-only: every segment must already exist."""
 
     def test_missing_leaf_is_refused(self, producer_h5ad):
-        result = set_producer_uns(str(producer_h5ad), [{"field": ["ihbca_provenance", "git_dity"], "value": "x"}])
+        result = _set(producer_h5ad, ["ihbca_provenance", "git_dity"], "x")
 
         assert "does not exist" in result["error"]
         assert "does not create them" in result["error"]
 
     def test_missing_intermediate_is_refused(self, producer_h5ad):
-        result = set_producer_uns(str(producer_h5ad), [{"field": ["ihbca_provnance", "git_dirty"], "value": False}])
+        result = _set(producer_h5ad, ["ihbca_provnance", "git_dirty"], False)
 
         assert "does not exist" in result["error"]
         assert "ihbca_provnance" in result["error"]
 
     def test_intermediate_that_is_a_value_is_refused(self, producer_h5ad):
-        result = set_producer_uns(
-            str(producer_h5ad),
-            [{"field": ["ihbca_provenance", "git_branch", "deeper"], "value": "x"}],
-        )
+        result = _set(producer_h5ad, ["ihbca_provenance", "git_branch", "deeper"], "x")
 
         assert "is a value, not a group" in result["error"]
 
     def test_group_valued_target_is_refused(self, producer_h5ad):
-        result = set_producer_uns(str(producer_h5ad), [{"field": ["ihbca_provenance", "mapping_stats"], "value": 1}])
+        result = _set(producer_h5ad, ["ihbca_provenance", "mapping_stats"], 1)
 
         assert "is a group, not a value" in result["error"]
 
     def test_non_scalar_target_is_refused(self, producer_h5ad):
-        result = set_producer_uns(
-            str(producer_h5ad),
-            [{"field": ["ihbca_provenance", "unmapped_examples"], "value": "x"}],
-        )
+        result = _set(producer_h5ad, ["ihbca_provenance", "unmapped_examples"], "x")
 
         assert "not a scalar" in result["error"]
 
     def test_segment_containing_a_slash_is_refused(self, producer_h5ad):
         """h5py would resolve it as a further link path, so the check that runs
         and the walk that follows could disagree about what was addressed."""
-        result = set_producer_uns(
-            str(producer_h5ad),
-            [{"field": ["ihbca_provenance/git_dirty"], "value": False}],
-        )
+        result = _set(producer_h5ad, ["ihbca_provenance/git_dirty"], False)
 
         assert "cannot contain '/'" in result["error"]
 
     def test_slash_joined_string_is_refused_with_the_list_form(self, producer_h5ad):
-        result = set_producer_uns(
-            str(producer_h5ad),
-            [{"field": "ihbca_provenance/git_dirty", "value": False}],
-        )
+        result = _set(producer_h5ad, "ihbca_provenance/git_dirty", False)
 
         assert "must be a list of path segments" in result["error"]
         assert "['ihbca_provenance', 'git_dirty']" in result["error"]
+
+
+class TestExternalLinks:
+    """h5py resolves an external link transparently, so without an explicit
+    refusal the walk follows it into another file — and because the snapshot is
+    opened "a", HDF5 opens that file read-write and the assignment lands there.
+    Verified before the guard existed: the tool reported success, the snapshot
+    kept the link unchanged, and a different h5ad was modified. The read-back
+    could not catch it; it re-resolves through the same link. These files come
+    from third-party producers and from CAP, so the structure is not ours.
+    """
+
+    @pytest.fixture
+    def victim(self, tmp_path) -> Path:
+        path = tmp_path / "victim.h5ad"
+        with h5py.File(path, "w") as f:
+            group = require_stamped_group(f, "uns/ihbca_provenance")
+            _scalar(group, "git_branch", "PRISTINE")
+        return path
+
+    def test_linked_namespace_is_refused(self, producer_h5ad, victim, no_snapshot):
+        with h5py.File(producer_h5ad, "a") as f:
+            del f["uns"]["ihbca_provenance"]
+            f["uns"]["ihbca_provenance"] = h5py.ExternalLink(str(victim), "/uns/ihbca_provenance")
+
+        result = _set(producer_h5ad, ["ihbca_provenance", "git_branch"], "TAMPERED")
+
+        assert "external link" in result["error"]
+        assert no_snapshot(producer_h5ad)
+        with h5py.File(victim, "r") as f:
+            assert f["uns/ihbca_provenance/git_branch"][()] == b"PRISTINE"
+
+    def test_linked_leaf_is_refused(self, producer_h5ad, victim, no_snapshot):
+        """A single crafted scalar is enough — the walk never sees a group."""
+        with h5py.File(producer_h5ad, "a") as f:
+            del f["uns"]["ihbca_provenance"]["git_branch"]
+            f["uns"]["ihbca_provenance"]["git_branch"] = h5py.ExternalLink(
+                str(victim), "/uns/ihbca_provenance/git_branch"
+            )
+
+        result = _set(producer_h5ad, ["ihbca_provenance", "git_branch"], "TAMPERED")
+
+        assert "external link" in result["error"]
+        assert no_snapshot(producer_h5ad)
+        with h5py.File(victim, "r") as f:
+            assert f["uns/ihbca_provenance/git_branch"][()] == b"PRISTINE"
+
+    def test_linked_leaf_is_not_read_either(self, producer_h5ad, victim):
+        """The refusal also closes the read side: old_value travels back in the
+        MCP response, so following a link would leak a foreign file's scalar."""
+        with h5py.File(producer_h5ad, "a") as f:
+            del f["uns"]["ihbca_provenance"]["git_branch"]
+            f["uns"]["ihbca_provenance"]["git_branch"] = h5py.ExternalLink(
+                str(victim), "/uns/ihbca_provenance/git_branch"
+            )
+
+        result = _set(producer_h5ad, ["ihbca_provenance", "git_branch"], "TAMPERED")
+
+        assert "PRISTINE" not in str(result)
 
 
 class TestOwnership:
     """Paths this tool does not own."""
 
     def test_hca_schema_field_is_refused_and_names_set_uns(self, producer_h5ad):
-        result = set_producer_uns(str(producer_h5ad), [{"field": ["title"], "value": "New title"}])
+        result = _set(producer_h5ad, ["title"], "New title")
 
         assert "HCA schema uns field" in result["error"]
         assert "set_uns" in result["error"]
@@ -271,18 +339,15 @@ class TestOwnership:
     def test_our_provenance_namespace_is_refused(self, producer_h5ad):
         """The edit log lives there; a tool that could rewrite it would undo
         every other tool's guarantee."""
-        result = set_producer_uns(
-            str(producer_h5ad),
-            [{"field": ["provenance", "edit_history"], "value": "[]"}],
-        )
+        result = _set(producer_h5ad, ["provenance", "edit_history"], "[]")
 
         assert "provenance namespace" in result["error"]
         assert "edit log" in result["error"]
 
 
 class TestAllOrNothing:
-    def test_one_bad_entry_leaves_the_file_untouched(self, producer_h5ad):
-        before = _sha256(producer_h5ad)
+    def test_one_bad_entry_leaves_the_file_untouched(self, producer_h5ad, no_snapshot):
+        before = producer_h5ad.read_bytes()
 
         result = set_producer_uns(
             str(producer_h5ad),
@@ -293,8 +358,8 @@ class TestAllOrNothing:
         )
 
         assert "error" in result
-        assert _sha256(producer_h5ad) == before
-        assert sorted(p.name for p in producer_h5ad.parent.glob("*.h5ad")) == [producer_h5ad.name]
+        assert producer_h5ad.read_bytes() == before
+        assert no_snapshot(producer_h5ad)
 
     def test_every_problem_is_reported_in_one_pass(self, producer_h5ad):
         result = set_producer_uns(
@@ -333,7 +398,7 @@ class TestRequestShape:
         assert "missing ['value']" in result["error"]
 
     def test_non_string_segments_are_refused(self, producer_h5ad):
-        result = set_producer_uns(str(producer_h5ad), [{"field": ["ihbca_provenance", 3], "value": 1}])
+        result = _set(producer_h5ad, ["ihbca_provenance", 3], 1)
 
         assert "segments must be strings" in result["error"]
 
@@ -349,3 +414,24 @@ class TestRequestShape:
         result = set_producer_uns(str(producer_h5ad), THE_CORRECTION)
 
         assert "no uns group" in result["error"]
+
+
+class TestRedirectStaysHonest:
+    """set_producer_uns refuses HCA registry roots and tells the caller to use
+    set_uns. That advice is only good while set_uns can actually handle every
+    field it refuses — set_uns takes ``str | list[str]`` at the top level only.
+    The first registry field that is a scalar bool/int, or nested, would be
+    reachable by neither tool, and the caller would follow the redirect into a
+    second refusal. Pin it here so a schema change fails a test, not a curator.
+    """
+
+    def test_every_registry_field_is_flat_and_set_uns_typed(self):
+        unreachable = {
+            name: info.annotation
+            for name, info in uns_field_registry().items()
+            if _type_display(info.annotation) not in {"str", "list[str]"}
+        }
+        assert not unreachable, (
+            f"these HCA uns fields are refused by set_producer_uns but set_uns cannot take them, "
+            f"so the 'use set_uns' redirect is a dead end: {unreachable}"
+        )


### PR DESCRIPTION
Closes #629

## What changed

A new tool, `set_producer_uns(path, updates)`, that overwrites scalar values at **nested `uns` paths outside the HCA schema** — the producer-owned namespaces `set_uns` cannot reach. Addressed by path segments rather than a slash-joined string:

```python
set_producer_uns(path, updates=[
    {"field": ["ihbca_provenance", "git_hash"],   "value": "0454dde01415d16382d355f7d5d64325ef47ca65"},
    {"field": ["ihbca_provenance", "git_branch"], "value": "main"},
    {"field": ["ihbca_provenance", "git_dirty"],  "value": False},
])
```

The whole batch lands in one snapshot with one edit-log entry. Values are assigned in place, which is what preserves the stored dtype **and** the `encoding-type` attrs anndata reads — delete-and-recreate would lose both. Every field is read back, value *and* dtype, before the snapshot is accepted.

Also: the MCP wrapper and registration, and `hca-ingest-coordination#24`'s `git_dirty` step repointed at the tool so the raw-h5py one-liner comes out of the plan.

## Why

The breast-v1 source-dataset pass has to apply the atlas team's provenance correction (`hca-ingest-coordination#23`) to three fields inside `uns['ihbca_provenance']` on seven files, and nothing in the toolkit could reach them. The plan called for a hand-written h5py snippet run once against files up to 27 GB — untested, and outside the HCA schema, so `validate_schema` has no opinion on whether it wrote the right thing. The goal was to make that operation repeatable and testable.

**Why not extend `set_uns`.** `set_uns` addresses a flat top-level key, so a nested path is inexpressible in its signature *under any flag* — the signature has to diverge regardless of how the schema question is answered. It also materializes the whole file (`open_h5ad(backed=None)`) and writes one field per call, which would be 21 full rewrites across the seven files. Only its registry gate is about schema; the rest are why this is a separate entry point. Recorded for the future: if scope had been "write a non-schema *top-level* key", a flag on `set_uns` would have been right and a second tool indefensible. The nesting requirement is what forces it.

## Assumptions I made

- **Overwrite-only — it never creates a path.** Every target of a provenance *correction* already exists, so nothing is lost, and it means a misspelled segment errors instead of silently creating junk metadata. That is the typo protection the schema registry gives `set_uns`, which this tool by definition cannot have.
- **The stored dtype is the contract.** Writing `False` into a string field would store `'false'` and nothing downstream would object, because a producer-owned namespace has no schema to violate. Hence bool-before-int dispatch (`isinstance(True, int)` is `True` in Python), exact int round-tripping, and int-widens-into-float but not the reverse.
- **Guards are coherence guards, but deliberately stricter than #614 alone would ask.** That principle defers validity to `validate_schema` — but it *presumes a validator with an opinion*. For a producer namespace there is none, so there is no backstop to defer to. This is recorded in the module docstring so a future reviewer applying #614 doesn't read the guards as usurpation.
- **The registry refusal is coherence, not just routing.** Two of the five HCA uns fields hold references into other groups (`batch_condition` → obs columns, `default_embedding` → obsm keys). Writing them raw could leave a dangling reference — #614's "keep" column. `TestRedirectStaysHonest` pins the assumption that every registry field is still reachable by `set_uns`, so a schema change that turns the "use set_uns" advice into a dead end fails a test rather than a curator.
- **`uns['provenance']` is off limits**, including to a producer who put keys there (#576). The edit log lives there; a tool that could write arbitrary scalars into it could rewrite the record every other tool's guarantees rest on.
- **Fixed-length strings and non-finite floats are refused as out-of-band**, not supported. anndata writes every string as variable-length; I scanned the eight real breast objects — 1,244 scalar `uns` datasets, 1,041 of them strings, **not one fixed-length**, and no non-finite floats. Supporting `|S` would have meant owning silent HDF5 truncation and an ascii-encoding trap for no live use case.
- **The read-back is a second pass on purpose**, not folded into the write loop: two distinct paths can alias one dataset through an HDF5 hard link, and only a pass that runs after every write catches the second clobbering the first.
- **Still uses h5py internally**, on a snapshot copy, the way `replace_placeholder_values` does. What "eliminate h5py" meant here was removing bespoke per-run h5py from the curation chain — not from the library.

### Found and fixed during review

- **External links (security).** `_resolve` followed an HDF5 external link into another file; because the snapshot is opened `"a"`, HDF5 opened that file read-write and the assignment landed *there*. The tool reported success, the snapshot stayed byte-identical, and a different h5ad was silently modified — and the read-back could not catch it, because it re-resolves through the same link. Reproduced, then refused at every segment and the leaf plus a `leaf.file.filename` backstop. These files come from third-party producers and from CAP, so the structure being walked is not ours.
- Fixed-length string fields were unwritable with a confusing internal error, and a non-ASCII value raised `UnicodeEncodeError` out of the type check, losing every other problem in the batch. Both closed by refusing the dtype.
- `1e40` into a `float32` silently stored `inf`, and `json.dumps` writes `NaN`/`Infinity` as bare tokens, which RFC 8259 forbids — one such entry would make that file's *entire* `edit_history` unparseable to a strict reader, including entries from every other tool.
- The edit log is now validated with `parse_edit_log` **before** the copy, so a corrupt log costs a metadata read instead of copying 27 GB (#597).

### Known, not addressed here

`_serialize.make_serializable` renders `np.bytes_` through `str()`, producing `"b'dev'"` instead of `'dev'`, because `np.bytes_` is matched before the `bytes` decode branch. This tool no longer reaches it (fixed-length strings are refused), but it is latent for other callers. Left out of scope rather than widening this diff — worth its own issue.

## How to verify

The issue's definition of done, mapped to steps.

**1 · "A three-field batch produces one snapshot, one rewrite, and one edit-log entry."**

```bash
cd packages/hca-anndata-tools
uv run pytest tests/test_producer_uns.py -q          # 38 tests
uv run pytest tests/test_producer_uns.py -q -k "batch_is_one_snapshot or edit_log_details"
```

**2 · "Tests assert value and dtype, not value alone."**

```bash
uv run pytest tests/test_producer_uns.py -q -k "dtype_intact" -v
```
`TestTheCorrection::test_writes_every_field_with_its_dtype_intact` asserts the bool comes back as `np.dtype(bool)` and the strings keep `encoding-type`. Checking the value alone is exactly what would pass on the `'false'`-for-`False` mis-write.

**3 · "A missing path is refused; a type change is refused. Both tested."**

```bash
uv run pytest tests/test_producer_uns.py -q -k "TestPathGuards or TestTypeGuards" -v
```

**4 · Against a real file** — the strongest check, and it needs a local copy of `gray2022-r1-wip-2.h5ad`. Build a small h5ad, copy the real `uns/ihbca_provenance` group into it verbatim with `h5py`'s `src.copy(...)` so every dtype, attr and nesting level is the production one, then run the three-field correction. Expect: `git_hash`/`git_branch` corrected with `dtype=object` and `encoding-type: string`; `git_dirty` → `np.False_` with `dtype=bool` and `encoding-type: numeric-scalar`; every sibling — including nested `inputs/counts/path` and `mapping_stats/pct_mapped` — byte-identical to source; `anndata.read_h5ad` reading `git_dirty` back as a real `bool`; and one `set_producer_uns` edit-log entry. That is what I ran.

**5 · The external-link refusal.** `tests/test_producer_uns.py::TestExternalLinks` covers the linked-namespace, linked-leaf, and read-side-leak cases; each asserts the victim file is untouched and no snapshot is left behind.

**6 · "#24's git_dirty step repoints at this tool and the h5py one-liner comes out of the plan."**
Already done — see the `git_dirty` bullet on clevercanary/hca-ingest-coordination#24.

**7 · "Read-back verification asserts dtype."**
Stronger than asked: it is *inside* the tool. Every field is re-read and compared on value and dtype before the snapshot is accepted, so a bad write fails the call rather than requiring a per-file manual check.

**Full gate:**
```bash
cd /Users/dave/projects/hca-validation-tools
uvx ruff@0.11.8 check packages/hca-anndata-tools packages/hca-anndata-mcp
uvx ruff@0.11.8 format --check packages/hca-anndata-tools packages/hca-anndata-mcp
make typecheck
cd packages/hca-anndata-tools && uv run pytest tests/ -q     # 603 passed
cd ../hca-anndata-mcp      && uv run pytest tests/ -q        # 57 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017S1imq17nD5Y3qaovNmBuX
